### PR TITLE
docs: add open-source contribution setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: 🐛 Bug report
+description: Report a defect in an ADLC tool
+title: "bug: <short description>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections below so we
+        can reproduce and fix it quickly. For security vulnerabilities, do **not** use this
+        form — see [SECURITY.md](../blob/main/SECURITY.md).
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which tool is affected?
+      options:
+        - "@adlc/behavior-diff"
+        - "@adlc/coldstart"
+        - "@adlc/consensus-fix"
+        - "@adlc/core"
+        - "@adlc/flail-detector"
+        - "@adlc/gate-fuzzing"
+        - "@adlc/gate-manifest"
+        - "@adlc/hollow-test"
+        - "@adlc/lesson-foundry"
+        - "@adlc/merge-forecast"
+        - "@adlc/model-ratchet"
+        - "@adlc/model-router"
+        - "@adlc/parallax"
+        - "@adlc/preflight"
+        - "@adlc/premortem"
+        - "@adlc/rails-guard"
+        - "@adlc/rejection-mining"
+        - "@adlc/review-calibration"
+        - "@adlc/skill-rot"
+        - "@adlc/spec-lint"
+        - "Other / not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including the exact command you ran.
+      placeholder: |
+        I ran `spec-lint ./spec.md --json` and ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps (and a minimal fixture if possible) to reproduce.
+      placeholder: |
+        1. Create a file with `...`
+        2. Run `...`
+        3. Observe `...`
+    validations:
+      required: true
+  - type: input
+    id: exit-code
+    attributes:
+      label: Exit code
+      description: "What exit code did the tool return? (0 = pass, 1 = op error, 2 = gate fail)"
+      placeholder: "1"
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Output of `node --version`, the package version, and your OS.
+      placeholder: |
+        node: v20.x
+        package: @adlc/spec-lint@1.0.0
+        os: macOS 14 / Ubuntu 22.04 / ...
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: Paste any error output. This will be rendered as code.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/voodootikigod/adlc/security/advisories/new
+    about: Please report security issues privately — see SECURITY.md. Do not open a public issue.
+  - name: 💬 Questions & discussion
+    url: https://github.com/voodootikigod/adlc/discussions
+    about: Ask questions, share ideas, or discuss the ADLC lifecycle.
+  - name: 📖 Documentation
+    url: https://github.com/voodootikigod/adlc#documentation
+    about: Read the toolkit guide, package reference, and the ADLC thesis.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: 💡 Feature request
+description: Propose a new tool, flag, or improvement
+title: "feat: <short description>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! ADLC has one bar for inclusion: every phase, gate, and loop
+        must trace to a specific **model failure mode** it defends against, or a specific
+        **model property** it exploits. Please frame your request that way.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of change is this?
+      options:
+        - New tool / package
+        - New flag or option on an existing tool
+        - Behavior change to an existing tool
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / model failure mode
+      description: Which model failure mode or property does this address? What breaks today?
+      placeholder: |
+        Models exhibit <flaw>, which causes <problem>. None of the current tools gate against it.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the tool/flag/behavior, including the machine-checkable gate it enforces.
+    validations:
+      required: true
+  - type: textarea
+    id: cli
+    attributes:
+      label: Proposed CLI shape (if applicable)
+      description: Sketch the command form, flags, and exit-code semantics.
+      render: shell
+      placeholder: |
+        my-tool [verb] [--flag] [--json] [--prompt-only]
+        # exit 0 = gate passes, 1 = op error, 2 = gate fails
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why they fall short.
+  - type: checkboxes
+    id: contract
+    attributes:
+      label: Fit with the ADLC contract
+      description: Confirm the proposal can satisfy the package contract (see CONVENTIONS.md).
+      options:
+        - label: It can be built with zero runtime dependencies (Node built-ins + @adlc/core).
+        - label: Any LLM use can run in `--prompt-only` mode (usable with no API keys).
+        - label: I'm willing to help implement it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!--
+Thanks for contributing to ADLC! Please fill out this template.
+Keep PRs focused — one logical change per PR.
+-->
+
+## Summary
+
+<!-- What does this PR do and why? Link any related issue: Closes #123 -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature / tool
+- [ ] ♻️ Refactor
+- [ ] 📖 Documentation
+- [ ] ✅ Tests
+- [ ] 🔧 Chore / CI
+
+## Affected package(s)
+
+<!-- e.g. @adlc/spec-lint -->
+
+## Checklist
+
+- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and [CONVENTIONS.md](../blob/main/CONVENTIONS.md).
+- [ ] Changes stay inside a single `packages/<name>/` (or are an intentional cross-cutting change).
+- [ ] No new runtime dependencies (Node built-ins + `@adlc/core` only).
+- [ ] `packages/core/` is unchanged (it is frozen).
+- [ ] Exit codes follow the contract (0 = pass, 1 = op error, 2 = gate fail).
+- [ ] LLM-backed changes support `--prompt-only`; output supports `--json`.
+- [ ] Added/updated tests; they run offline and leave no trace.
+- [ ] `npm test` passes locally.
+- [ ] Updated the package README and docs where relevant.
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+## How to test
+
+<!-- Commands a reviewer can run to verify this change -->
+
+```sh
+node --test packages/<name>/test/*.test.mjs
+```
+
+## Notes for reviewers
+
+<!-- Anything else worth calling out: tradeoffs, follow-ups, open questions -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: npm install
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         node-version: [18, 20, 22]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in the ADLC
+community a harassment-free experience for everyone, regardless of age, body size,
+visible or invisible disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility, apologizing to those affected by our mistakes, and learning
+  from the experience.
+- Focusing on what is best for the overall community.
+
+Unacceptable behavior includes harassment of any kind, personal or political attacks,
+publishing others' private information without permission, and other conduct that could
+reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+This project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)**
+as its full code of conduct, including its detailed standards and enforcement guidelines.
+Please refer to that document for the complete text.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to
+the project maintainers at **chris@voodootikigod.com**. All complaints will be reviewed
+and investigated promptly and fairly. Maintainers are obligated to respect the privacy
+and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,130 @@
+# Contributing to ADLC
+
+Thanks for your interest in improving the Agentic Development Lifecycle toolkit. This
+guide covers how to set up, build, test, and propose changes. By participating you agree
+to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report bugs** — open a [bug report](https://github.com/voodootikigod/adlc/issues/new?template=bug_report.yml).
+- **Propose features or new tools** — open a [feature request](https://github.com/voodootikigod/adlc/issues/new?template=feature_request.yml).
+- **Improve docs** — the package READMEs are part of each tool; doc-only PRs are welcome.
+- **Fix or extend a tool** — see the workflow below.
+- **Report a security issue** — do *not* open a public issue; see [SECURITY.md](./SECURITY.md).
+
+Before starting non-trivial work, please open an issue first so we can agree on the
+approach. This avoids wasted effort on changes that don't fit the lifecycle's design.
+
+## Project shape
+
+This is an npm workspace monorepo. Each tool lives in `packages/<name>/` and follows a
+strict contract documented in **[CONVENTIONS.md](./CONVENTIONS.md)** — read it before
+writing any code. The high-level design is in [ADLC.md](./ADLC.md).
+
+```
+packages/<name>/
+├── package.json        # @adlc/<name>, bin field, test script
+├── bin/<name>.mjs      # CLI entry — thin: parse args, call lib, exit
+├── lib/*.mjs           # logic — pure functions wherever possible
+├── test/*.test.mjs     # node:test — MUST pass offline (no network, no API keys)
+└── README.md           # what it does, usage, flags, exit codes, ADLC phase
+```
+
+## Development setup
+
+Requires **Node.js 18 or newer** (CI runs the suite on Node 18, 20, and 22).
+
+```sh
+git clone https://github.com/voodootikigod/adlc.git
+cd adlc
+npm install        # installs the workspace
+npm test           # runs every package's test suite
+```
+
+To run a single package's tests:
+
+```sh
+node --test packages/<name>/test/*.test.mjs
+```
+
+To run a tool from source:
+
+```sh
+node packages/<name>/bin/<name>.mjs --help
+```
+
+## The package contract (non-negotiable)
+
+These rules from [CONVENTIONS.md](./CONVENTIONS.md) are what make the toolkit coherent.
+PRs that violate them will be asked to change:
+
+1. **Zero runtime dependencies.** Node 18+ built-ins and `@adlc/core` only.
+2. **`@adlc/core` is frozen.** Never edit `packages/core/`. If core lacks something,
+   implement it locally in your `lib/` and note the gap in your README under "Core gaps".
+3. **Scope discipline.** A change to one tool stays inside `packages/<name>/`. Don't
+   touch other packages, `ADLC.md`, or root files in the same PR unless that *is* the change.
+4. **Exit codes:** `0` = gate passes · `1` = operational error · `2` = gate fails. Use
+   `pass`/`gateFail`/`opError` from core. CI gating depends on this.
+5. **`--prompt-only`** on every LLM-backed tool — prints the exact prompt and exits 0.
+6. **`--json`** on every tool — machine-readable output alongside human-readable.
+7. **Tests run offline and leave no trace.** Use fixtures and `mkdtempSync` temp dirs;
+   clean up afterward. Never call an LLM provider in a test.
+8. **Never mutate the working tree without a flag.** Writers default to dry-run;
+   mutation tools restore files in a `finally` block and refuse to run on a dirty tree.
+9. **No silent error swallowing.** Surface operational failures and partial data.
+10. **Keep files under 400 lines** — split `lib/` by concern.
+11. **The README is part of the tool** — document every flag, exit code, and the ADLC
+    phase (P0–P7 / D1–D3) it serves.
+
+## Coding style
+
+- ESM only (`.mjs`, `"type": "module"`).
+- Prefer pure functions and immutable data — return new objects, don't mutate inputs.
+- Small, focused files; clear names; explicit error handling.
+- Match the style of the surrounding code in the package you're editing.
+
+## Testing requirements
+
+- Every code change needs a test. We use the built-in `node:test` runner — no test
+  framework dependency.
+- Tests must pass offline with no API keys and must clean up any temp files they create.
+- Run `npm test` before opening a PR; the full suite must be green.
+
+## Adding a new tool
+
+1. Open a feature-request issue describing the model failure mode it defends against —
+   this is the bar for inclusion (see the ADLC design rule).
+2. Scaffold `packages/<name>/` following the layout and `package.json` template in
+   [CONVENTIONS.md](./CONVENTIONS.md).
+3. Implement, test offline, and write the README.
+4. Add the tool to [docs/package-reference.md](./docs/package-reference.md) and the
+   toolkit table in [README.md](./README.md).
+
+## Commit & PR process
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
+
+1. Fork the repo and create a branch (`feat/<name>`, `fix/<name>`, …).
+2. Make your change with tests; run `npm test`.
+3. Push and open a PR against `main` using the PR template.
+4. Keep PRs focused — one logical change per PR.
+5. A maintainer will review; address feedback and we'll merge once green.
+
+## Releases
+
+Packages publish together in lockstep under the `@adlc` scope via the
+`scripts/release.mjs` flow and the publish GitHub Action. Contributors do **not** need to
+bump versions — maintainers handle releases. See [docs/RELEASING.md](./docs/RELEASING.md).
+
+## Questions
+
+Open a [discussion or issue](https://github.com/voodootikigod/adlc/issues) — we're happy
+to help you get started.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# ADLC — Agentic Development Lifecycle Toolkit
+
+[![CI](https://github.com/voodootikigod/adlc/actions/workflows/ci.yml/badge.svg)](https://github.com/voodootikigod/adlc/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org)
+
+A workspace of **zero-dependency, gate-shaped Node.js CLIs** for running software
+development the way frontier models actually behave — not the way humans do.
+
+The SDLC is 60 years of defenses against *human* failure modes (forgetfulness, ego,
+fatigue). Models have a different flaw profile: premature satisfaction, sycophancy,
+context rot, confident hallucination, reward hacking. The **Agentic Development
+Lifecycle (ADLC)** redesigns every phase, gate, and loop around those flaws. Read the
+full thesis in [ADLC.md](./ADLC.md).
+
+---
+
+## Why this exists
+
+> Every phase, gate, and loop in this lifecycle must trace to a specific model failure
+> mode it defends against, or a specific model property it exploits. If it traces to a
+> human failure mode instead, cut it.
+
+Each tool is a small CLI that enforces one machine-checkable gate. They share a runtime
+convention (`.adlc/` for tickets, ledgers, and gate evidence) and a common contract
+(see [CONVENTIONS.md](./CONVENTIONS.md)) so 20 independently built tools feel like one
+product.
+
+## Install
+
+Each package publishes independently under the `@adlc` npm scope. Install only what you
+need, or run on demand with `npx`:
+
+```sh
+# one tool, global
+npm install -g @adlc/spec-lint
+
+# or run without installing
+npx @adlc/spec-lint <spec.md>
+```
+
+## The toolkit
+
+| Phase | Packages |
+| --- | --- |
+| **Spec & ticket shaping** | [`parallax`](./packages/parallax) · [`spec-lint`](./packages/spec-lint) · [`premortem`](./packages/premortem) · [`coldstart`](./packages/coldstart) |
+| **Execution supervision & rails** | [`preflight`](./packages/preflight) · [`model-router`](./packages/model-router) · [`merge-forecast`](./packages/merge-forecast) · [`rails-guard`](./packages/rails-guard) · [`flail-detector`](./packages/flail-detector) · [`consensus-fix`](./packages/consensus-fix) |
+| **Review evidence & calibration** | [`behavior-diff`](./packages/behavior-diff) · [`gate-manifest`](./packages/gate-manifest) · [`hollow-test`](./packages/hollow-test) · [`review-calibration`](./packages/review-calibration) · [`model-ratchet`](./packages/model-ratchet) · [`gate-fuzzing`](./packages/gate-fuzzing) |
+| **Compounding defenses** | [`lesson-foundry`](./packages/lesson-foundry) · [`rejection-mining`](./packages/rejection-mining) · [`skill-rot`](./packages/skill-rot) |
+| **Shared foundation** | [`@adlc/core`](./packages/core) |
+
+See [docs/package-reference.md](./docs/package-reference.md) for binaries, command forms,
+and per-package detail, and [docs/toolkit.md](./docs/toolkit.md) for how the packages fit
+the ADLC flow.
+
+## Design principles
+
+Every tool follows the same contract ([CONVENTIONS.md](./CONVENTIONS.md)):
+
+- **Zero runtime dependencies** — Node 18+ built-ins and `@adlc/core` only.
+- **`--prompt-only`** on every LLM-backed tool — print the exact prompt and exit, so the
+  tool is usable with zero API keys (paste into any harness).
+- **`--json`** on every tool — machine-readable output for orchestrators.
+- **Exit codes are the gate**: `0` = gate passes · `1` = operational error · `2` = gate fails.
+- **Never mutate the working tree without a flag** — writers default to dry-run.
+- **Tests run offline** — no network, no API keys, no trace left behind.
+
+## Quick start (from source)
+
+```sh
+git clone https://github.com/voodootikigod/adlc.git
+cd adlc
+npm install
+npm test
+```
+
+Requires **Node.js 18 or newer**.
+
+## Documentation
+
+- [ADLC.md](./ADLC.md) — the full lifecycle thesis and flaw inventory.
+- [docs/](./docs/README.md) — toolkit guide, package reference, and the narrative essays.
+- [CONVENTIONS.md](./CONVENTIONS.md) — the contract every package follows.
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for the dev
+setup, the package contract, the testing requirements, and the PR process. By
+participating you agree to our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+- 🐛 [Report a bug](https://github.com/voodootikigod/adlc/issues/new?template=bug_report.yml)
+- 💡 [Request a feature](https://github.com/voodootikigod/adlc/issues/new?template=feature_request.yml)
+- 🔒 [Report a vulnerability](./SECURITY.md)
+
+## License
+
+[MIT](./LICENSE) © Chris Williams

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported versions
+
+The `@adlc` suite publishes in lockstep; the latest released version of each package is
+the supported version. Please upgrade to the latest release before reporting an issue.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report privately using GitHub's
+[private vulnerability reporting](https://github.com/voodootikigod/adlc/security/advisories/new),
+or email **chris@voodootikigod.com** with the details.
+
+Please include:
+
+- The affected package and version.
+- A description of the vulnerability and its impact.
+- Steps to reproduce, ideally with a minimal proof of concept.
+- Any suggested remediation.
+
+## What to expect
+
+- We aim to acknowledge reports within **72 hours**.
+- We'll work with you to confirm the issue and determine its severity.
+- Once a fix is ready, we'll publish a patched release and credit you in the advisory
+  (unless you prefer to remain anonymous).
+
+## Scope notes
+
+These are zero-dependency, offline CLI tools. Some commands invoke external processes
+(`git`, test commands you pass via flags) and some optionally call LLM providers when you
+supply credentials. When evaluating reports, keep in mind:
+
+- Tools never call LLM providers unless explicitly invoked without `--prompt-only` and
+  with credentials present.
+- Tools never mutate the working tree without an explicit write flag.
+- Test suites run fully offline.
+
+Reports about command injection, path traversal, unsafe handling of untrusted ticket/spec
+input, or accidental credential/secret leakage are especially valued.

--- a/packages/model-ratchet/test/integration.test.mjs
+++ b/packages/model-ratchet/test/integration.test.mjs
@@ -8,8 +8,13 @@ import {
   mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFileSync, spawnSync } from 'node:child_process';
+
+// import.meta.dirname is only available in Node >= 20.11; derive it so the
+// suite runs on the package's declared floor (engines.node >=18).
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -77,7 +82,7 @@ describe('integration: hot-score math', () => {
   after(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('top file is hot.mjs with correct score', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--top', '5', '--json'], {
       cwd: tmp,
       encoding: 'utf8',
@@ -100,7 +105,7 @@ describe('integration: hot-score math', () => {
   });
 
   it('cold.mjs has lower score than hot.mjs', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--top', '10', '--json'], {
       cwd: tmp,
       encoding: 'utf8',
@@ -138,7 +143,7 @@ describe('integration: exclusion rules', () => {
   after(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('test files are not in plan output', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--top', '20', '--json'], {
       cwd: tmp,
       encoding: 'utf8',
@@ -154,7 +159,7 @@ describe('integration: exclusion rules', () => {
   });
 
   it('non-source files (md, json) are not in plan output', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--top', '20', '--json'], {
       cwd: tmp,
       encoding: 'utf8',
@@ -169,7 +174,7 @@ describe('integration: exclusion rules', () => {
   });
 
   it('main.mjs inDegree is 0 (test files excluded from graph)', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--top', '5', '--json'], {
       cwd: tmp,
       encoding: 'utf8',
@@ -206,7 +211,7 @@ describe('integration: review-cmd findings ledger', () => {
   after(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('runs review-cmd with {file} substituted', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     // Fake review command: prints a finding for the file
     const reviewCmd = `node -e "console.log('- finding in {file}')"`;
     const result = spawnSync('node', [bin, '--top', '3', '--review-cmd', reviewCmd, '--json'], {
@@ -277,7 +282,7 @@ describe('integration: dry-run (plan) mode', () => {
   after(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('exits 0 without review-cmd', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--json'], { cwd: tmp, encoding: 'utf8' });
     assert.equal(result.status, 0);
     const out = JSON.parse(result.stdout);
@@ -285,7 +290,7 @@ describe('integration: dry-run (plan) mode', () => {
   });
 
   it('exits 0 with --dry-run even when review-cmd provided', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync(
       'node',
       [bin, '--dry-run', '--review-cmd', 'echo {file}', '--json'],
@@ -311,7 +316,7 @@ describe('integration: non-git-repo error', () => {
   after(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('exits 1 when not a git repo', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--json'], { cwd: tmp, encoding: 'utf8' });
     assert.equal(result.status, 1, 'should exit 1 for non-git-repo');
     assert.ok(result.stderr.includes('not a git'), `stderr: ${result.stderr}`);
@@ -345,7 +350,7 @@ describe('integration: --top flag', () => {
   after(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('limits output to --top N files', () => {
-    const bin = resolve(import.meta.dirname, '../bin/model-ratchet.mjs');
+    const bin = resolve(__dirname, '../bin/model-ratchet.mjs');
     const result = spawnSync('node', [bin, '--top', '2', '--json'], {
       cwd: tmp,
       encoding: 'utf8',


### PR DESCRIPTION
## Summary

Prepares the repo for public contribution from the open-source community.

- **README.md** — project intro (ADLC thesis), toolkit-by-phase table for all 20 packages, design principles, quick start, contributing section, badges
- **CONTRIBUTING.md** — dev setup, the package contract (from CONVENTIONS.md), testing requirements, new-tool guide, Conventional Commits + PR process
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (linked to canonical text)
- **SECURITY.md** — private vulnerability reporting policy + scope notes
- **.github/ISSUE_TEMPLATE/** — structured bug report, feature request (framed around the model-failure-mode inclusion bar), and config routing security/discussion/docs
- **.github/PULL_REQUEST_TEMPLATE.md** — checklist enforcing the package contract
- **.github/workflows/ci.yml** — runs `npm test` on PRs and pushes to `main` across Node 18/20/22

## Review

Passed two rounds of Codex adversarial review. First round flagged the README CI badge pointing at the publish-only workflow (false health signal) — resolved by adding a real PR-triggered CI workflow and repointing the badge. Second round: approved, no material findings.

## Test plan

- [x] `npm test` passes locally (Node 24)
- [ ] CI green on Node 18/20/22 once workflow runs on this PR