### PR TITLE
chore(release): harden npm publish supply chain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,15 @@
 name: Publish @adlc to npm
 
+# Publish is triggered ONLY by pushing a v* tag. `workflow_dispatch` is
+# intentionally NOT used: a manual dispatch runs the workflow file from the
+# selected ref, so a contributor could dispatch a branch whose publish.yml drops
+# the environment gate and publish ungated. Tag creation is restricted to admins
+# by the `release tags` ruleset (docs/github-rulesets/), so the only code that can
+# trigger a publish is an admin-controlled tagged commit.
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to publish (e.g. 1.0.0, without v prefix)"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -18,9 +18,30 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Gate the publish behind a protected environment with required reviewers and
+    # a v* deployment-tag policy (provisioned by docs/github-rulesets/apply.sh).
+    # The npm credential below MUST be an environment-scoped secret on this
+    # environment (not a repo-level secret): that way it is unreadable from any
+    # job that does not run under `npm-publish`, closing credential-exfiltration
+    # via a modified workflow on a branch.
+    environment: npm-publish
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so the ancestry check below can run
+
+      - name: Verify tag is merged into main
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          # Refuse to publish a tag that points at a commit not reachable from
+          # main — i.e. code that never passed the protected-main PR/CI gates.
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::Tag commit $SHA is not an ancestor of origin/main — refusing to publish unmerged code."
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -31,15 +52,10 @@ jobs:
       - name: Resolve version
         id: ver
         env:
-          INPUT_VERSION: ${{ inputs.version }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            V="$INPUT_VERSION"
-          else
-            V="${REF_NAME#v}"
-          fi
-          echo "version=$V" >> "$GITHUB_OUTPUT"
+          # Only ever runs on a v* tag push (see trigger above).
+          echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Install
         run: npm install
@@ -50,8 +66,10 @@ jobs:
       - name: Publish (core-first, lockstep)
         run: node scripts/release.mjs "${{ steps.ver.outputs.version }}" --publish
         env:
-          # Bootstrap run: set repo secret NPM_TOKEN to create the packages.
-          # After configuring trusted publishing, delete the secret — this var
-          # becomes empty and npm falls through to OIDC provenance publishing.
+          # Bootstrap run: set NPM_TOKEN as an ENVIRONMENT secret on `npm-publish`
+          # (Settings > Environments > npm-publish > Secrets), NOT a repo secret,
+          # so it cannot be read outside the gated environment. After configuring
+          # npm trusted publishing, delete the secret — this var becomes empty and
+          # npm falls through to OIDC provenance publishing.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,18 +8,44 @@ All 20 packages (`@adlc/core` + 19 CLIs) ship under the `@adlc` npm scope on a
 1. **Create the npm org** named `adlc` (the `@adlc` scope requires an org of
    that exact name). Free org = unlimited public packages.
    `https://www.npmjs.com/org/create`
-2. **Bootstrap publish.** Trusted publishing can only be configured on packages
+2. **Create the protected environment.** Run `docs/github-rulesets/apply.sh`
+   (or Settings → Environments) to create **`npm-publish`** with required
+   reviewers and a `v*` deployment-tag policy. The publish job is pinned to it.
+3. **Bootstrap publish.** Trusted publishing can only be configured on packages
    that already exist, so the first release uses a token:
    - Create a granular **automation** token on npm with publish rights to the
      `adlc` scope.
-   - Add it as the repo secret **`NPM_TOKEN`** (Settings → Secrets → Actions).
-3. **First release** — see *Cutting a release* below. The workflow publishes all
-   20 packages using `NPM_TOKEN`.
-4. **Switch to OIDC.** On npmjs.com, configure each package's *Trusted Publisher*
-   to this repo + the `Publish @adlc to npm` workflow (or set it at the org
-   level). Then **delete the `NPM_TOKEN` secret** — the workflow's
-   `NODE_AUTH_TOKEN` becomes empty and npm publishes via OIDC provenance with no
-   stored credential.
+   - Add it as an **environment secret** named **`NPM_TOKEN`** on the
+     `npm-publish` environment (Settings → Environments → npm-publish →
+     Environment secrets) — **not** a repository or organization Actions secret.
+     An environment secret is unreadable from any job that does not run under
+     `npm-publish`, so it cannot be exfiltrated by a modified workflow on a branch.
+   - If a repo- or org-level `NPM_TOKEN` already exists, **delete it** (an org
+     secret scoped to this repo also resolves in `${{ secrets.NPM_TOKEN }}` and
+     would survive outside the environment). Verify all three scopes:
+     ```bash
+     gh secret list                          # repo: must NOT list NPM_TOKEN
+     gh secret list --org <github-org>        # org: must NOT list NPM_TOKEN
+                                              #   (or it must not be scoped to this repo)
+     gh secret list --env npm-publish         # environment: MUST list NPM_TOKEN
+     ```
+4. **First release** — see *Cutting a release* below. The workflow publishes all
+   20 packages using the environment-scoped `NPM_TOKEN`.
+5. **Switch to OIDC.** On npmjs.com, configure each package's *Trusted Publisher*
+   to this repo + the `Publish @adlc to npm` workflow, **and set the Environment
+   field to `npm-publish`.** This binding is mandatory: if the environment field
+   is left blank, npm will accept an OIDC publish from *any* run of `publish.yml`
+   on this repo — including a `v*` tag pointing at an older commit whose workflow
+   predates the `environment:` gate and ancestry guard — bypassing the required
+   reviewer and deployment-ref layers. With the binding set, npm rejects any OIDC
+   identity that did not run under `npm-publish`.
+   - Verify before removing the token: cut a release from a throwaway branch run
+     that is *not* environment-bound (or temporarily blank the env binding on one
+     scratch package) and confirm npm **rejects** the OIDC publish. Restore the
+     binding.
+   - Then **delete the `NPM_TOKEN` environment secret** — the workflow's
+     `NODE_AUTH_TOKEN` becomes empty and npm publishes via OIDC provenance with no
+     stored credential.
 
 ## Cutting a release
 
@@ -40,8 +66,10 @@ The `.github/workflows/publish.yml` workflow then installs, tests, and runs
 (its consumers resolve it) followed by the 19 CLIs — each with
 `--provenance` and `publishConfig.access=public`.
 
-You can also trigger manually via **Actions → Publish @adlc to npm →
-Run workflow** with an explicit version.
+There is no manual trigger: the workflow has no `workflow_dispatch`, so the only
+way to publish is to push a `v*` tag (tag creation is restricted to admins by the
+release-tag ruleset). To re-publish, push a new tag. Each publish still requires
+approval on the `npm-publish` environment.
 
 ## How the wiring works
 

--- a/docs/github-rulesets/README.md
+++ b/docs/github-rulesets/README.md
@@ -1,0 +1,94 @@
+# GitHub Repository Rulesets
+
+Reproducible branch and tag protection for this repository, expressed as GitHub
+[ruleset](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets)
+JSON so the configuration lives in version control instead of only in the GitHub UI.
+
+## Files
+
+- `main-branch-ruleset.json` — protects the default branch (`main`).
+- `release-tag-ruleset.json` — protects `v*` release tags (the publish trigger).
+- `apply.sh` — applies both via `gh api` (requires admin auth).
+
+## What the main-branch ruleset enforces
+
+| Rule | Effect |
+| --- | --- |
+| `pull_request` | No direct pushes — changes land via PR. Stale approvals dismissed on new commits; all review threads must be resolved; squash-only merges. |
+| `required_status_checks` (strict) | CI `test (18)`, `test (20)`, `test (22)` must pass and the branch must be up to date before merge. |
+| `required_linear_history` | No merge commits — pairs with squash merges. |
+| `non_fast_forward` | Blocks force pushes. |
+| `deletion` | Blocks branch deletion. |
+
+`required_approving_review_count` is **0** so a solo maintainer is not blocked
+(GitHub does not allow self-approval). Raise it to `1` once a second maintainer
+exists. Admins (`actor_id: 5`) keep `always` bypass so the maintainer cannot be
+locked out; tighten this once the team grows.
+
+## What the release-tag ruleset enforces
+
+`creation` + `deletion` + `non_fast_forward` on `refs/tags/v*`, with admins as the
+only bypass actors. This restricts who can create release tags.
+
+This rule is load-bearing: `.github/workflows/publish.yml` triggers **only** on a
+`v*` tag push (it deliberately has no `workflow_dispatch`), so the workflow content
+that runs is always the admin-controlled tagged commit. Restricting tag creation to
+admins therefore restricts who can publish to npm.
+
+The **`npm-publish` protected environment** (below) is the second layer — a required
+human approval plus a deployment-ref allowlist on top of the tag gate. The npm
+credential must be an **environment-scoped secret** so it is unreadable outside that
+environment.
+
+## Applying
+
+Requires the `gh` CLI (admin auth) and `jq`.
+
+```sh
+gh auth status            # must have admin on the repo
+REPO=voodootikigod/adlc ./apply.sh
+```
+
+`apply.sh` does two things:
+
+1. **Provisions and verifies the `npm-publish` protected environment** — the real
+   publish gate. It sets required reviewers and a **deployment-ref allowlist**, then
+   **fails closed** unless both are actually present after the API call. This matters
+   because a workflow that references a missing environment silently creates it
+   *unprotected*.
+
+   - **Required reviewers** (`REVIEWER_IDS`, default the authenticated user; 1–6
+     numeric IDs, validated locally and re-checked against the API response) — a
+     human approval gate on every publish.
+   - **Deployment refs** (`ALLOWED_BRANCHES` default `main`, `ALLOWED_TAGS` default
+     `v*`) — constrains *which code* can be published. Even an approved manual
+     `workflow_dispatch` cannot publish from an arbitrary feature branch.
+
+   ```sh
+   REVIEWER_IDS=123,456 ALLOWED_TAGS="v*" ALLOWED_BRANCHES="main" \
+     REPO=voodootikigod/adlc ./apply.sh
+   ```
+
+2. **Applies the branch and tag rulesets idempotently** — it matches each ruleset
+   by name and updates the existing one (`PUT /rulesets/{id}`) instead of creating
+   a duplicate, and refuses to act if two active rulesets already share a name. A
+   re-run never strands a stale active ruleset.
+
+> Required status checks only become matchable after the CI workflow has run once.
+> Merge or run a PR first so the `test (NN)` check contexts exist.
+
+Verify afterward:
+
+```sh
+gh api /repos/voodootikigod/adlc/environments/npm-publish | jq .protection_rules
+gh api /repos/voodootikigod/adlc/rulesets
+```
+
+## Not expressible as rulesets
+
+Set these in the GitHub UI:
+
+- **Settings → Actions → General → Workflow permissions:** default `GITHUB_TOKEN`
+  to read-only. (`publish.yml` already requests its own `id-token: write`.)
+- **Settings → General → Pull Requests:** allow squash merging only; enable
+  automatically delete head branches.

--- a/docs/github-rulesets/apply.sh
+++ b/docs/github-rulesets/apply.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Apply the ADLC repository protections via the GitHub REST API:
+#   1. Provision and VERIFY the `npm-publish` protected environment (the real
+#      publish gate). Referencing a missing environment in a workflow silently
+#      creates it with NO protection, so this script creates it with required
+#      reviewers AND a deployment-ref allowlist, then fails closed unless both
+#      are present.
+#   2. Apply the branch and tag rulesets idempotently (update-or-create, refuse
+#      on duplicate) so a re-run never strands a stale active ruleset.
+#
+# Prerequisites:
+#   - gh CLI authenticated with admin rights on the repo (gh auth status)
+#   - jq on PATH
+#
+# Environment overrides:
+#   - REPO            target repo (default voodootikigod/adlc)
+#   - REVIEWER_IDS    comma-separated numeric GitHub user IDs for required
+#                     reviewers (1-6). Defaults to the authenticated user, so a
+#                     solo maintainer gets a manual approval gate on every publish.
+#   - ALLOWED_BRANCHES space/comma list of branch name patterns allowed to deploy
+#                      to the environment (default "main").
+#   - ALLOWED_TAGS     space/comma list of tag name patterns allowed to deploy
+#                      (default "v*"). Together these constrain which code can be
+#                      published, even via manual workflow_dispatch.
+#
+# IMPORTANT: required status checks can only be selected after the CI workflow
+# has run at least once on the repo. Merge/run a PR first so the
+# "test (18)/(20)/(22)" check contexts exist, otherwise the rule is created but
+# matches nothing.
+set -euo pipefail
+
+REPO="${REPO:-voodootikigod/adlc}"
+ENVIRONMENT="npm-publish"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
+
+# --- 1. Protected environment ------------------------------------------------
+
+# Parse REVIEWER_IDS (or the authenticated user) into a validated JSON array of
+# numeric IDs. Fails closed on empty/non-numeric input so the publish gate can
+# never be created without a real reviewer.
+build_reviewers() {
+  local ids="${REVIEWER_IDS:-}"
+  if [ -z "$ids" ]; then
+    ids="$(gh api /user --jq '.id')"
+    echo "    no REVIEWER_IDS given; using authenticated user id=$ids" >&2
+  fi
+
+  local arr
+  arr="$(echo "$ids" | tr ', ' '\n' | grep -E '^[0-9]+$' | jq -R 'tonumber' | jq -s 'unique')"
+
+  local n
+  n="$(echo "$arr" | jq 'length')"
+  if [ "$n" -lt 1 ] || [ "$n" -gt 6 ]; then
+    echo "    FAIL: need 1-6 numeric reviewer IDs, parsed $n from REVIEWER_IDS='${REVIEWER_IDS:-<auth user>}'" >&2
+    return 1
+  fi
+  echo "$arr"
+}
+
+provision_environment() {
+  echo "==> Environment: $ENVIRONMENT"
+
+  local reviewers
+  reviewers="$(build_reviewers)"
+  REVIEWERS_REQUESTED="$reviewers"   # stash for verification
+
+  local body
+  body="$(jq -n --argjson r "$reviewers" '{
+    wait_timer: 0,
+    prevent_self_review: false,
+    reviewers: ($r | map({type:"User", id:.})),
+    deployment_branch_policy: { protected_branches: false, custom_branch_policies: true }
+  }')"
+
+  echo "$body" | gh api --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    "/repos/$REPO/environments/$ENVIRONMENT" \
+    --input - >/dev/null
+
+  provision_branch_policies
+  verify_environment
+}
+
+# The exact, sorted set of "type:name" deployment policies the environment should
+# have, derived from the allowlist. This is the single source of truth used for
+# both reconciliation and verification.
+desired_policies() {
+  {
+    local b t
+    for b in $(echo "${ALLOWED_BRANCHES:-main}" | tr ', ' ' '); do
+      [ -n "$b" ] && echo "branch:$b"
+    done
+    for t in $(echo "${ALLOWED_TAGS:-v*}" | tr ', ' ' '); do
+      [ -n "$t" ] && echo "tag:$t"
+    done
+  } | grep -v '^$' | sort -u
+}
+
+# Reconcile the environment's deployment ref policies to EXACTLY the allowlist:
+# delete any pre-existing policy not in the desired set (e.g. a broad `branch:*`
+# or `tag:*` that would otherwise keep publishing open), then add any missing.
+provision_branch_policies() {
+  local desired
+  desired="$(desired_policies)"
+  if [ -z "$desired" ]; then
+    echo "    FAIL: no deployment refs configured (ALLOWED_BRANCHES/ALLOWED_TAGS empty)." >&2
+    return 1
+  fi
+
+  local existing
+  existing="$(gh api --paginate "/repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies?per_page=100" \
+    | jq -rs '[.[].branch_policies[]?] | .[] | "\(.id)\t\(.type):\(.name)"')"
+
+  # Delete unexpected policies.
+  local id key
+  while IFS=$'\t' read -r id key; do
+    [ -z "$id" ] && continue
+    if ! echo "$desired" | grep -qxF "$key"; then
+      echo "    removing unexpected deployment policy: $key (id=$id)"
+      gh api --method DELETE \
+        "/repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies/$id" >/dev/null
+    fi
+  done <<< "$existing"
+
+  # Add missing policies.
+  local existing_keys
+  existing_keys="$(echo "$existing" | cut -f2-)"
+  while IFS= read -r key; do
+    [ -z "$key" ] && continue
+    if echo "$existing_keys" | grep -qxF "$key"; then
+      echo "    deployment policy already present: $key"
+    else
+      echo "    adding deployment policy: $key"
+      gh api --method POST \
+        -H "Accept: application/vnd.github+json" \
+        "/repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+        -f "name=${key#*:}" -f "type=${key%%:*}" >/dev/null
+    fi
+  done <<< "$desired"
+}
+
+verify_environment() {
+  local env_json
+  env_json="$(gh api "/repos/$REPO/environments/$ENVIRONMENT")"
+
+  # Required reviewers must exist AND contain every requested ID.
+  local got
+  got="$(echo "$env_json" \
+    | jq '[.protection_rules[]? | select(.type=="required_reviewers")
+           | .reviewers[]? | .reviewer.id] | sort')"
+  local want
+  want="$(echo "$REVIEWERS_REQUESTED" | jq 'sort')"
+
+  if [ "$(echo "$got" | jq 'length')" -lt 1 ]; then
+    echo "    FAIL: $ENVIRONMENT has no required reviewers. Publish is NOT gated." >&2
+    return 1
+  fi
+  if ! jq -n --argjson g "$got" --argjson w "$want" '($w - $g) | length == 0' | grep -qx true; then
+    echo "    FAIL: required reviewers $got do not include all requested $want." >&2
+    return 1
+  fi
+
+  # Deployment ref allowlist must be active.
+  if [ "$(echo "$env_json" | jq '.deployment_branch_policy.custom_branch_policies // false')" != "true" ]; then
+    echo "    FAIL: $ENVIRONMENT allows deployment from any ref (no custom branch policy)." >&2
+    return 1
+  fi
+
+  # The live policy set must EXACTLY equal the desired allowlist — no missing
+  # entries and no stale/broad extras.
+  local desired actual
+  desired="$(desired_policies)"
+  actual="$(gh api --paginate "/repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies?per_page=100" \
+    | jq -rs '[.[].branch_policies[]?] | .[] | "\(.type):\(.name)"' | sort -u)"
+  if [ "$desired" != "$actual" ]; then
+    echo "    FAIL: deployment ref policies do not match the allowlist." >&2
+    echo "      desired: $(echo "$desired" | tr '\n' ' ')" >&2
+    echo "      actual:  $(echo "$actual" | tr '\n' ' ')" >&2
+    return 1
+  fi
+
+  echo "    verified: required reviewers $got, deployment refs [$(echo "$actual" | tr '\n' ' ')]."
+}
+
+# --- 2. Rulesets (idempotent) ------------------------------------------------
+
+apply_ruleset() {
+  local file="$1"
+  local name
+  name="$(jq -r '.name' "$file")"
+
+  echo "==> Ruleset: $name"
+
+  local ids
+  ids="$(gh api "/repos/$REPO/rulesets" --paginate \
+    | jq --arg n "$name" '[.[] | select(.name == $n) | .id]')"
+
+  local count
+  count="$(echo "$ids" | jq 'length')"
+
+  if [ "$count" -gt 1 ]; then
+    echo "    refusing: $count rulesets already named \"$name\" (ids: $(echo "$ids" | jq -c .))." >&2
+    echo "    Resolve the duplicates manually, then re-run." >&2
+    return 1
+  fi
+
+  if [ "$count" -eq 1 ]; then
+    local id
+    id="$(echo "$ids" | jq '.[0]')"
+    echo "    updating existing ruleset id=$id"
+    gh api --method PUT \
+      -H "Accept: application/vnd.github+json" \
+      "/repos/$REPO/rulesets/$id" \
+      --input "$file" >/dev/null
+  else
+    echo "    creating new ruleset"
+    gh api --method POST \
+      -H "Accept: application/vnd.github+json" \
+      "/repos/$REPO/rulesets" \
+      --input "$file" >/dev/null
+  fi
+}
+
+echo "Applying protections to $REPO ..."
+provision_environment
+apply_ruleset "$DIR/main-branch-ruleset.json"
+apply_ruleset "$DIR/release-tag-ruleset.json"
+
+echo
+echo "Done. Verify with:"
+echo "  gh api /repos/$REPO/environments/$ENVIRONMENT | jq .protection_rules"
+echo "  gh api /repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies"
+echo "  gh api /repos/$REPO/rulesets"
+echo
+echo "Also recommended (not scriptable here):"
+echo "  - Settings > Actions > Workflow permissions: default GITHUB_TOKEN to read-only."
+echo "  - Settings > General > Pull Requests: allow squash only, auto-delete head branches."

--- a/docs/github-rulesets/main-branch-ruleset.json
+++ b/docs/github-rulesets/main-branch-ruleset.json
@@ -1,0 +1,46 @@
+{
+  "name": "main protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "test (18)" },
+          { "context": "test (20)" },
+          { "context": "test (22)" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/docs/github-rulesets/release-tag-ruleset.json
+++ b/docs/github-rulesets/release-tag-ruleset.json
@@ -1,0 +1,23 @@
+{
+  "name": "release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "creation" },
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Locks down the path from a release tag to a published npm package, and makes the repo's branch/tag protections reproducible. Distinct concern from the contribution-docs PR (#2), split out for focused review.

### `publish.yml`
- **Remove `workflow_dispatch`** — a manual dispatch runs the workflow file from the selected ref, letting a contributor push a branch that drops the `environment:` gate and publish ungated. Publishing now triggers **only** on a `v*` tag push (tag creation is admin-restricted by the release-tag ruleset, so the workflow that runs is always an admin-controlled tagged commit).
- **Pin the publish job to the `npm-publish` protected environment.**
- **Ancestry guard** — refuse to publish a tag whose commit is not an ancestor of `origin/main` (code that never passed the main PR/CI gates). Uses `fetch-depth: 0`.
- Require `NPM_TOKEN` to be an **environment-scoped** secret.

### `docs/github-rulesets/` (new)
Reproducible GitHub rulesets as `gh api` JSON, so protection config lives in version control:
- `main-branch-ruleset.json` — PR required, strict CI status checks (`test 18/20/22`), linear history, no force-push/deletion, squash-only.
- `release-tag-ruleset.json` — restrict `v*` tag creation/deletion to admins.
- `apply.sh` — **idempotent** (update-or-create, refuse on duplicate); provisions **and verifies** the `npm-publish` environment **fail-closed**: required reviewers (validated locally + re-checked) plus an **exact, paginated** deployment-ref allowlist (deletes stale/broad policies).
- `README.md` — rationale + apply/verify instructions.

### `docs/RELEASING.md`
- Environment-scoped `NPM_TOKEN` with repo/org/env secret verification.
- Mandatory npm **Trusted Publisher → Environment = `npm-publish`** binding to close the OIDC bypass (otherwise any run matching repo+workflow name can publish via OIDC).

## Review

Hardened across **9 rounds** of adversarial review (Codex/GPT, non-Claude model to break monoculture). Final verdict: **approve, no material findings**. Each round surfaced a deeper layer: env gate → deployment refs → credential scope → tag ancestry → OIDC binding.

## Test plan

- [x] `bash -n apply.sh`, `jq empty *.json`, YAML lint all pass
- [ ] Run `apply.sh` against the repo (needs admin `gh` auth + `jq`) and confirm `gh api /repos/.../environments/npm-publish` + `/rulesets` reflect the config
- [ ] Confirm CI status-check contexts exist before marking them required (run a PR first)

> Note: depends on operational setup (create `npm-publish` environment, environment-scoped secret, Trusted Publisher binding) documented in `docs/RELEASING.md`.