### PR TITLE
docs: wire skill-mining into the P7 distill flow

### DIFF
--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -34,6 +34,27 @@ adlc lesson-foundry --prompt-only
      `--write` on its own does NOT apply your prompt-only refinement — that is
      only auto-applied with `--llm` (which needs an API key). So in the keyless
      in-Claude flow you scaffold with `--write`, then refine the wording yourself.
+  3. **For any defense that is a *skill* (a `SKILL.md`), validate it before PR.**
+     lesson-foundry only scaffolds the stub; it does not dedup against the public
+     ecosystem or confirm the skill is usable cold. Hand the scaffolded `SKILL.md`
+     to **skill-mining** for the registry-management half of P7 (see ADLC.md §P7):
+
+     ```
+     npx skills add voodootikigod/skill-mining   # once per machine
+     ```
+     Then ask it to validate the scaffolded skill — it runs:
+     - **dedup** against installed skills + the `skills.sh` registry (via its
+       `find-skills` subagent) → REUSE / EXTEND / BUILD / REJECT. If a maintained
+       public skill already covers it, install that instead of landing a duplicate.
+     - **Gate B** (artifact red-team): a fresh-context agent gets only your
+       `SKILL.md` and attempts a real repo task — proving the skill carries
+       specific commands/paths/invariants, not generic prose.
+
+     Only PR the `SKILL.md` defenses that survive (verdict SHIP). Lint-rule and
+     spec-gap defenses do not go through skill-mining — PR them directly. This step
+     is agentic, not a deterministic gate, so it has no `--prompt-only`/exit-code
+     contract; if skill-mining is unavailable, note that the skill defenses landed
+     **unvalidated** so the coverage stays honest.
 
 ## 2. Rejection mining — mine human PR objections (C13)
 
@@ -52,8 +73,10 @@ adlc rejection-mining --prompt-only
 
 Report: how many finding clusters and rejection lenses were found, the concrete
 defenses proposed, which were written (if any), and which gates were skipped
-(e.g. rejection-mining when `gh` is unavailable) so the coverage is honest. Point
-the user at `/adlc-maintain` for the decay-driven checks.
+(e.g. rejection-mining when `gh` is unavailable) so the coverage is honest. For
+any *skill* defense, report its skill-mining verdict (REUSE/EXTEND/BUILD/REJECT +
+Gate B SHIP/FIX/REJECT), or flag it as landed **unvalidated** if skill-mining was
+not run. Point the user at `/adlc-maintain` for the decay-driven checks.
 
 ## Scheduling
 

--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -42,7 +42,15 @@ adlc lesson-foundry --prompt-only
      ```
      npx skills add voodootikigod/skill-mining   # once per machine
      ```
-     Then ask it to validate the scaffolded skill — it runs:
+     Then hand it the scaffolded stub with a **scoped** request — point it at the
+     specific staged file rather than asking for a full-repo mine, e.g.:
+
+     > "Validate the scaffolded skill at `.adlc/lessons/<name>/SKILL.md`: dedup it
+     > against installed skills and the skills.sh registry, then run Gate B on it.
+     > Report REUSE/EXTEND/BUILD/REJECT and SHIP/FIX/REJECT — do not mine the rest
+     > of the repo."
+
+     It runs:
      - **dedup** against installed skills + the `skills.sh` registry (via its
        `find-skills` subagent) → REUSE / EXTEND / BUILD / REJECT. If a maintained
        public skill already covers it, install that instead of landing a duplicate.
@@ -50,8 +58,17 @@ adlc lesson-foundry --prompt-only
        `SKILL.md` and attempts a real repo task — proving the skill carries
        specific commands/paths/invariants, not generic prose.
 
-     Only PR the `SKILL.md` defenses that survive (verdict SHIP). Lint-rule and
-     spec-gap defenses do not go through skill-mining — PR them directly.
+     (skill-mining today is repo-wide by design; a single-stub scoped mode is a
+     desired enhancement — until then, constrain it via the prompt above.)
+
+     **Placement matters.** `.adlc/lessons/` is a scaffold staging area — it is
+     **not** on Claude Code's skill-discovery path, so a `SKILL.md` left there is
+     inert. A skill defense only becomes live once skill-mining's author step (or
+     `npx skills add`) installs it into the repo's skill directory (e.g. the
+     plugin/workspace `skills/` root). Only PR the `SKILL.md` defenses that survive
+     (verdict SHIP) **and have been placed in a discoverable skills directory**.
+     Lint-rule and spec-gap defenses do not go through skill-mining — PR them
+     directly from `.adlc/lessons/`.
 
      This step is **keyless** (skill-mining is agentic — Claude is the agent, no
      API key), but it is **not** a deterministic gate: no `--prompt-only`/exit-code

--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -62,13 +62,15 @@ adlc lesson-foundry --prompt-only
      desired enhancement — until then, constrain it via the prompt above.)
 
      **Placement matters.** `.adlc/lessons/` is a scaffold staging area — it is
-     **not** on Claude Code's skill-discovery path, so a `SKILL.md` left there is
-     inert. A skill defense only becomes live once skill-mining's author step (or
-     `npx skills add`) installs it into the repo's skill directory (e.g. the
-     plugin/workspace `skills/` root). Only PR the `SKILL.md` defenses that survive
-     (verdict SHIP) **and have been placed in a discoverable skills directory**.
-     Lint-rule and spec-gap defenses do not go through skill-mining — PR them
-     directly from `.adlc/lessons/`.
+     **not** on the skill-discovery path, so a `SKILL.md` left there is inert. A
+     skill defense only becomes live once it is installed into a discoverable
+     skills directory. Do not hand-guess that path — let the **skills CLI** place
+     it (`npx skills add`, or skill-mining's author step, which targets the correct
+     location for the active harness), then **verify discovery** before PR (e.g.
+     the skill shows up in `/help`/skill list, or `npx skills` reports it
+     installed). Only PR the `SKILL.md` defenses that survive (verdict SHIP) **and**
+     are confirmed discoverable. Lint-rule and spec-gap defenses do not go through
+     skill-mining — PR them directly from `.adlc/lessons/`.
 
      This step is **keyless** (skill-mining is agentic — Claude is the agent, no
      API key), but it is **not** a deterministic gate: no `--prompt-only`/exit-code

--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -55,27 +55,33 @@ adlc lesson-foundry --prompt-only
      containing a `SKILL.md`, so to install it you first move the flat file into
      its own subdir: `<name>/SKILL.md`.)
 
-     It runs:
-     - **dedup** against installed skills + the `skills.sh` registry (via its
-       `find-skills` subagent) → REUSE / EXTEND / BUILD / REJECT. If a maintained
-       public skill already covers it, install that instead of landing a duplicate.
-     - **Gate B** (artifact red-team): a fresh-context agent gets only your
-       `SKILL.md` and attempts a real repo task — proving the skill carries
-       specific commands/paths/invariants, not generic prose.
+     Validation reads the **file content** — Gate B hands a fresh agent the
+     `SKILL.md` text directly, so it works on the flat staged file and does **not**
+     require the skill to be installed/discoverable first. Lifecycle, in order:
+
+     1. **Validate the staged flat file** (`.adlc/lessons/<name>.SKILL.md`):
+        - **dedup** against installed skills + the `skills.sh` registry (via its
+          `find-skills` subagent) → REUSE / EXTEND / BUILD / REJECT. If a maintained
+          public skill already covers it, install that and drop the stub.
+        - **Gate B** (artifact red-team): a fresh-context agent gets only the
+          `SKILL.md` and attempts a real repo task → SHIP / FIX / REJECT, proving
+          the skill carries specific commands/paths/invariants, not generic prose.
+     2. **Only for a SHIP verdict, install it** so it becomes live. `.adlc/lessons/`
+        is a staging area, **not** on the skill-discovery path — a `SKILL.md` left
+        there is inert. The skills CLI expects a skill *directory*, so move the flat
+        file into `<name>/SKILL.md` and let the **skills CLI** place it (`npx skills
+        add`, or skill-mining's author step, which targets the correct location for
+        the active harness — don't hand-guess the path).
+     3. **Verify discovery, then PR** — confirm with a real skills-CLI verb (`npx
+        skills check`, or `npx skills find <name>`) that it resolves, then PR only
+        the installed, SHIP-verdict skill. Remove the leftover flat
+        `.adlc/lessons/<name>.SKILL.md` staging copy so it isn't committed twice.
 
      (skill-mining today is repo-wide by design; a single-stub scoped mode is a
      desired enhancement — until then, constrain it via the prompt above.)
 
-     **Placement matters.** `.adlc/lessons/` is a scaffold staging area — it is
-     **not** on the skill-discovery path, so a `SKILL.md` left there is inert. A
-     skill defense only becomes live once it is installed into a discoverable
-     skills directory. Do not hand-guess that path — let the **skills CLI** place
-     it (`npx skills add`, or skill-mining's author step, which targets the correct
-     location for the active harness), then **verify discovery** before PR with a
-     real skills-CLI verb (`npx skills check`, or `npx skills find <name>` to
-     confirm it resolves). Only PR the `SKILL.md` defenses that survive (verdict
-     SHIP) **and** are confirmed discoverable. Lint-rule and spec-gap defenses do
-     not go through skill-mining — PR them directly from `.adlc/lessons/`.
+     Lint-rule and spec-gap defenses do not go through skill-mining — PR them
+     directly from `.adlc/lessons/`.
 
      This step is **keyless** (skill-mining is agentic — Claude is the agent, no
      API key), but it is **not** a deterministic gate: no `--prompt-only`/exit-code

--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -69,13 +69,17 @@ adlc lesson-foundry --prompt-only
      2. **Only for a SHIP verdict, install it** so it becomes live. `.adlc/lessons/`
         is a staging area, **not** on the skill-discovery path — a `SKILL.md` left
         there is inert. The skills CLI expects a skill *directory*, so move the flat
-        file into `<name>/SKILL.md` and let the **skills CLI** place it (`npx skills
-        add`, or skill-mining's author step, which targets the correct location for
-        the active harness — don't hand-guess the path).
-     3. **Verify discovery, then PR** — confirm with a real skills-CLI verb (`npx
-        skills check`, or `npx skills find <name>`) that it resolves, then PR only
-        the installed, SHIP-verdict skill. Remove the leftover flat
-        `.adlc/lessons/<name>.SKILL.md` staging copy so it isn't committed twice.
+        file into `<name>/SKILL.md`, then let **skill-mining's author step** (or the
+        skills CLI) place it in the correct location for the active harness. Don't
+        hand-guess the path or the exact subcommand — run `npx skills --help` for
+        the install verb your CLI version uses; skill-mining's author step does this
+        for you.
+     3. **Verify by outcome, then PR** — the skill is installed correctly only when
+        the **agent can actually discover it** (it shows up in the harness's
+        available-skills list / can be invoked). Confirm that, not a specific CLI
+        string. Then PR only the installed, SHIP-verdict skill, and remove the
+        leftover flat `.adlc/lessons/<name>.SKILL.md` staging copy so it isn't
+        committed twice.
 
      (skill-mining today is repo-wide by design; a single-stub scoped mode is a
      desired enhancement — until then, constrain it via the prompt above.)

--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -45,10 +45,15 @@ adlc lesson-foundry --prompt-only
      Then hand it the scaffolded stub with a **scoped** request — point it at the
      specific staged file rather than asking for a full-repo mine, e.g.:
 
-     > "Validate the scaffolded skill at `.adlc/lessons/<name>/SKILL.md`: dedup it
+     > "Validate the scaffolded skill at `.adlc/lessons/<name>.SKILL.md`: dedup it
      > against installed skills and the skills.sh registry, then run Gate B on it.
      > Report REUSE/EXTEND/BUILD/REJECT and SHIP/FIX/REJECT — do not mine the rest
      > of the repo."
+
+     (lesson-foundry writes a **flat** file, `.adlc/lessons/<name>.SKILL.md` — not
+     a `<name>/SKILL.md` directory. The skills CLI expects a skill *directory*
+     containing a `SKILL.md`, so to install it you first move the flat file into
+     its own subdir: `<name>/SKILL.md`.)
 
      It runs:
      - **dedup** against installed skills + the `skills.sh` registry (via its
@@ -66,11 +71,11 @@ adlc lesson-foundry --prompt-only
      skill defense only becomes live once it is installed into a discoverable
      skills directory. Do not hand-guess that path — let the **skills CLI** place
      it (`npx skills add`, or skill-mining's author step, which targets the correct
-     location for the active harness), then **verify discovery** before PR (e.g.
-     the skill shows up in `/help`/skill list, or `npx skills` reports it
-     installed). Only PR the `SKILL.md` defenses that survive (verdict SHIP) **and**
-     are confirmed discoverable. Lint-rule and spec-gap defenses do not go through
-     skill-mining — PR them directly from `.adlc/lessons/`.
+     location for the active harness), then **verify discovery** before PR with a
+     real skills-CLI verb (`npx skills check`, or `npx skills find <name>` to
+     confirm it resolves). Only PR the `SKILL.md` defenses that survive (verdict
+     SHIP) **and** are confirmed discoverable. Lint-rule and spec-gap defenses do
+     not go through skill-mining — PR them directly from `.adlc/lessons/`.
 
      This step is **keyless** (skill-mining is agentic — Claude is the agent, no
      API key), but it is **not** a deterministic gate: no `--prompt-only`/exit-code

--- a/commands/adlc-distill.md
+++ b/commands/adlc-distill.md
@@ -51,10 +51,16 @@ adlc lesson-foundry --prompt-only
        specific commands/paths/invariants, not generic prose.
 
      Only PR the `SKILL.md` defenses that survive (verdict SHIP). Lint-rule and
-     spec-gap defenses do not go through skill-mining — PR them directly. This step
-     is agentic, not a deterministic gate, so it has no `--prompt-only`/exit-code
-     contract; if skill-mining is unavailable, note that the skill defenses landed
-     **unvalidated** so the coverage stays honest.
+     spec-gap defenses do not go through skill-mining — PR them directly.
+
+     This step is **keyless** (skill-mining is agentic — Claude is the agent, no
+     API key), but it is **not** a deterministic gate: no `--prompt-only`/exit-code
+     contract, and `npx skills add` is an interactive, once-per-machine developer
+     action — never run it from a scheduled/headless `/adlc-distill` (see
+     "Scheduling"). If skill-mining is unavailable, **do not PR the skill stubs** —
+     hold them for explicit human review rather than landing default-worded,
+     un-deduped, cold-untested skills. Report them as held-unvalidated in the
+     summary so the coverage stays honest.
 
 ## 2. Rejection mining — mine human PR objections (C13)
 
@@ -75,8 +81,9 @@ Report: how many finding clusters and rejection lenses were found, the concrete
 defenses proposed, which were written (if any), and which gates were skipped
 (e.g. rejection-mining when `gh` is unavailable) so the coverage is honest. For
 any *skill* defense, report its skill-mining verdict (REUSE/EXTEND/BUILD/REJECT +
-Gate B SHIP/FIX/REJECT), or flag it as landed **unvalidated** if skill-mining was
-not run. Point the user at `/adlc-maintain` for the decay-driven checks.
+Gate B SHIP/FIX/REJECT), or flag it as **held for human review (not PR'd)** if
+skill-mining was not run. Point the user at `/adlc-maintain` for the decay-driven
+checks.
 
 ## Scheduling
 
@@ -90,6 +97,8 @@ without materializing them — that is intentional: auto-writing lint rules/skil
 from clustered findings unattended is risky. A scheduled routine should surface
 the proposals for a human to review and then approve `--write`. Only wire an
 auto-`--write` routine if you have explicitly accepted that the generated
-defenses land without review. The deterministic maintenance checks
-(`/adlc-maintain`) can additionally run in CI on a cron; see
-`docs/ci/adlc-maintenance.yml`.
+defenses land without review. The skill-mining handoff (step 1.3) is likewise
+**interactive only** — a headless run must never `npx skills add` or auto-validate
+skills; it surfaces the scaffolded stubs for a human to validate later. The
+deterministic maintenance checks (`/adlc-maintain`) can additionally run in CI on
+a cron; see `docs/ci/adlc-maintenance.yml`.

--- a/skills/adlc/SKILL.md
+++ b/skills/adlc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adlc
-description: Routes agentic development work to the right Agentic Development Lifecycle (ADLC) gate. Use when shaping a spec or ticket, deciding how to fan out work to models, protecting frozen rails during a build, prosecuting a change before merge, or distilling repeated review findings into defenses. Triggers on "shape this spec", "is this ticket ready", "freeze these tests", "prosecute this change", "is this safe to merge", "ADLC", "which gate", "spec-lint", "premortem", "coldstart", "rails-guard", "hollow-test", "behavior-diff".
+description: Routes agentic development work to the right Agentic Development Lifecycle (ADLC) gate. Use when shaping a spec or ticket, deciding how to fan out work to models, protecting frozen rails during a build, prosecuting a change before merge, or distilling repeated review findings into defenses. Triggers on "shape this spec", "is this ticket ready", "freeze these tests", "prosecute this change", "is this safe to merge", "ADLC", "which gate", "spec-lint", "premortem", "coldstart", "rails-guard", "hollow-test", "behavior-diff", "mine this repo for skills", "skill-mining".
 ---
 
 # ADLC — phase routing
@@ -31,6 +31,7 @@ Hard failing test, need a repair? ───────────→ P4  adlc 
 Change done, pre-merge prosecution? ─────────→ P5  adlc hollow-test · behavior-diff · review-calibration
 Recording / showing gate evidence? ──────────→ —   adlc gate-manifest
 Repeated review findings to bank? ───────────→ P7  /adlc-distill (lesson-foundry · rejection-mining)
+Mine the repo for reusable skills? ──────────→ P7  skill-mining (npx skills add voodootikigod/skill-mining)
 Idle-time / post-drift maintenance? ─────────→ —   /adlc-maintain (skill-rot · model-ratchet · gate-fuzzing)
 ```
 
@@ -95,6 +96,18 @@ let the human decide. Record outcomes with `adlc gate-manifest record <gate>`.
   defenses (lint checks, skills). LLM-backed: answer the printed prompt yourself.
 - `adlc rejection-mining --prompt-only` — mine human PR rejections into reusable
   review lenses (needs the `gh` CLI). `/adlc-distill` runs both.
+
+P7 has a second, complementary axis — mining the *codebase itself* (not its review
+findings) for reusable capabilities:
+- **skill-mining** (`npx skills add voodootikigod/skill-mining`, then "mine this
+  repo for skills") — surveys git churn/conventions/patterns, scores candidates on
+  a five-axis rubric, dedups against installed skills + the `skills.sh` registry,
+  red-teams each authored `SKILL.md` with a fresh-context agent (Gate B), and emits
+  a `SKILLS_MINED.md` report. It is an agentic skill, not a deterministic `adlc`
+  gate (no `--prompt-only`/exit codes). Two uses: (a) standalone, to bootstrap a
+  repo's skill portfolio; (b) as the validation/registry step for `SKILL.md` stubs
+  that `/adlc-distill`'s lesson-foundry scaffolds — dedup + Gate B before they PR.
+  lesson-foundry emits stubs; skill-mining manages the registry.
 
 ### Maintenance (decay-driven, no human trigger) → `/adlc-maintain`
 - `adlc skill-rot [path…]` — flag skill files with stale validation metadata.

--- a/skills/adlc/SKILL.md
+++ b/skills/adlc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adlc
-description: Routes agentic development work to the right Agentic Development Lifecycle (ADLC) gate. Use when shaping a spec or ticket, deciding how to fan out work to models, protecting frozen rails during a build, prosecuting a change before merge, or distilling repeated review findings into defenses. Triggers on "shape this spec", "is this ticket ready", "freeze these tests", "prosecute this change", "is this safe to merge", "ADLC", "which gate", "spec-lint", "premortem", "coldstart", "rails-guard", "hollow-test", "behavior-diff", "mine this repo for skills", "skill-mining".
+description: Routes agentic development work to the right Agentic Development Lifecycle (ADLC) gate. Use when shaping a spec or ticket, deciding how to fan out work to models, protecting frozen rails during a build, prosecuting a change before merge, or distilling repeated review findings into defenses. Triggers on "shape this spec", "is this ticket ready", "freeze these tests", "prosecute this change", "is this safe to merge", "ADLC", "which gate", "spec-lint", "premortem", "coldstart", "rails-guard", "hollow-test", "behavior-diff".
 ---
 
 # ADLC — phase routing


### PR DESCRIPTION
## Summary

Wires the existing **skill-mining** skill (`npx skills add voodootikigod/skill-mining`) into the ADLC P7 distill flow, instead of the prior hand-rolled "scaffold a stub and refine the wording yourself" step. Docs-only — no code, no new tool.

Per ADLC.md §P7 doctrine (*"lesson-foundry emits SKILL.md stubs; skill-mining manages the full skill registry"*), two seams:

- **`commands/adlc-distill.md`** — for any *skill* defense, route the lesson-foundry stub through skill-mining: dedup vs the `skills.sh` registry + Gate B artifact red-team, then install + verify discovery before PR. Explicit numbered lifecycle.
- **`skills/adlc/SKILL.md`** — distinct P7 route + prose for skill-mining as the repo-*capability*-mining axis, complementary to lesson-foundry's finding-*distillation*.

Reference, not reimplementation — skill-mining is cross-harness (`npx skills`), keeping Claude Code / Codex / Cursor DRY.

## The gap this closes

lesson-foundry only scaffolds a `SKILL.md` stub; it never dedups against the public ecosystem or confirms the skill is usable cold. The wiring adds that validation/registry half.

## Review

7 rounds of `adversarial-review` (`agy`, ≠ builder), looped to a clean APPROVE. Substantive fixes verified **against source**, not the reviewer's guesses:
- Corrected stub path to the real flat `.adlc/lessons/<name>.SKILL.md` (per `emit.mjs:150`).
- Removed router/skill-mining trigger overlap.
- Clarified staging (`.adlc/lessons/`) is not on the discovery path; ordered the validate→install→verify→PR lifecycle.
- Rejected hallucinated external-CLI specifics (`npx skills list`, `-g`); defer exact verbs to `npx skills --help` and verify by outcome (agent can discover the skill).

## Test plan

- [x] `npm test` green (docs-only; no behavior change)
- [ ] Manual: run `/adlc-distill` with a skill-category finding cluster; confirm the stub routes through skill-mining and only a SHIP+discoverable skill is PR'd
