### PR TITLE
Codex-native ADLC integration

### DIFF
--- a/.adlc/tickets.example.json
+++ b/.adlc/tickets.example.json
@@ -1,0 +1,42 @@
+{
+  "tickets": [
+    {
+      "id": "T1",
+      "title": "Add authenticated export endpoint",
+      "body": "Implement the export endpoint. Verification: `npm test -- auth-export.test.mjs`. allow-suppression: none",
+      "scope": [
+        "src/export/**",
+        "test/auth-export.test.mjs"
+      ],
+      "rails": [
+        "test/auth-export.test.mjs",
+        "src/contracts/export.schema.json"
+      ],
+      "edges": [
+        {
+          "to": "T2",
+          "contract": "T1 publishes src/contracts/export.schema.json before T2 consumes it."
+        }
+      ],
+      "duration": 2,
+      "category": "feature",
+      "budget": "mid"
+    },
+    {
+      "id": "T2",
+      "title": "Wire export UI",
+      "body": "Use the export contract from T1. Verification: `npm test -- export-ui.test.mjs`.",
+      "scope": [
+        "src/ui/export/**",
+        "test/export-ui.test.mjs"
+      ],
+      "rails": [
+        "test/export-ui.test.mjs"
+      ],
+      "edges": [],
+      "duration": 1,
+      "category": "feature",
+      "budget": "cheap"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "adlc",
+  "interface": {
+    "displayName": "ADLC"
+  },
+  "plugins": [
+    {
+      "name": "adlc-codex",
+      "source": {
+        "source": "local",
+        "path": "./plugins/adlc-codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .worktrees/
-.adlc/
+.adlc/*
+!.adlc/tickets.example.json

--- a/.omo/evidence/p5-inputs.txt
+++ b/.omo/evidence/p5-inputs.txt
@@ -1,0 +1,2 @@
+Fixture input packet for ticket T1 at docs-example-revision.
+Includes src/auth.mjs as a non-production fixture path with the quoted line `return true`.

--- a/.omo/evidence/p5-prompt.txt
+++ b/.omo/evidence/p5-prompt.txt
@@ -1,0 +1,1 @@
+Review ticket T1 at docs-example-revision with security, correctness, tests, and behavior lenses.

--- a/.omo/evidence/p5-review.txt
+++ b/.omo/evidence/p5-review.txt
@@ -1,0 +1,8 @@
+Fixture skeptical-review transcript for docs/examples/p5-passes.json.
+ticket: T1
+reviewed revision: docs-example-revision
+
+security: one medium finding was reviewed and killed because the quoted code is a
+non-production fixture path. correctness: no verified findings. tests: no verified
+test-integrity findings. behavior: no verified behavior findings. This file exists only
+to exercise the evidence contract.

--- a/.omo/plans/codex-adlc-integration.md
+++ b/.omo/plans/codex-adlc-integration.md
@@ -1,0 +1,407 @@
+# Codex ADLC Integration Plan
+
+## TL;DR
+> Summary: This is a decision plan for building an installable Codex plugin that wraps the existing ADLC npm CLIs with phase-specific skills, a small repo marketplace, optional rail-enforcement hooks, and copy-pasteable `codex exec` recipes. Keep the ADLC tools as the execution substrate; Codex should supply invocation, orchestration, and operator ergonomics.
+> Future implementation deliverables:
+> - `plugins/adlc-codex/` Codex plugin with `.codex-plugin/plugin.json`
+> - `plugins/adlc-codex/skills/` with one router skill and four phase skills
+> - `.agents/plugins/marketplace.json` for local/repo install
+> - An installer smoke-test fixture that proves the marketplace root, plugin id, and skill discovery path before the install commands are published as supported
+> - `docs/codex-integration.md` with install, quickstart, phase map, and adoption path
+> - Optional plugin-bundled hooks for P4 rail freeze assistance, always paired with mandatory `rails-guard` proof
+> Effort: Medium
+> Risk: Medium - P5 prosecution is only partially deterministic until a first-party orchestration gate exists.
+
+## Grounding
+Local project facts:
+- `README.md` describes ADLC as zero-dependency, gate-shaped Node.js CLIs with `.adlc/` runtime conventions and independently published `@adlc/*` packages.
+- `docs/toolkit.md` maps tools to P0-P7 and names `.adlc/tickets.json`, `.adlc/manifest.jsonl`, and `.adlc/lessons/` as shared state.
+- `docs/package-reference.md` lists 20 packages, 19 binaries, and exact command forms.
+- `CONVENTIONS.md` establishes the shared CLI contract: Node 18+, no runtime dependencies beyond `@adlc/core`, `--json`, `--prompt-only`, exit codes `0/1/2`, dry-run-by-default writers.
+- The current worktree reports `main...origin/main`, not `feat/codex-integration`; the executor must confirm the intended branch before creating implementation commits.
+
+Public ADLC source facts:
+- The series defines the lifecycle as eight phases, two human gates, and deterministic machine checks between phases.
+- The flaw inventory is load-bearing: premature satisfaction, sycophancy, context rot, hallucination, reward hacking, finding-count prior, generative bloat, and coherence loss.
+- Adoption guidance explicitly says teams should start with prosecution of existing PRs, then rails, then interrogation, then the full loop.
+
+Codex surface facts:
+- Skills are the right surface for reusable workflows; plugins are the distribution unit for reusable skills, app integrations, MCP config, and lifecycle hooks.
+- Codex discovers repo skills from `.agents/skills` and installed plugin skills from plugin bundles.
+- Codex plugin marketplaces can live under `$REPO_ROOT/.agents/plugins/marketplace.json` and point to local plugin folders.
+- Codex hooks can run on `PreToolUse`, `PostToolUse`, `Stop`, and related events, but command hooks must be trusted and cannot fully police arbitrary shell writes.
+- `codex exec` is the right automation surface for scripted gates and CI-like workflows; it supports explicit sandbox and approval settings plus JSONL output.
+
+## Scope
+### Current artifact
+- This file is the planning artifact only. It is not the installable Codex ADLC integration.
+- Do not publish install commands, claim `$adlc` exists, or mark Codex ADLC integration complete from this plan-only branch.
+- A later implementation branch must produce the plugin, marketplace, skills, docs, hooks, fixtures, and installer evidence before any install path is supported.
+- The plan artifact is complete only when its scope, assumptions, risks, verification steps, and future deliverables are internally consistent and executable by a downstream implementer.
+
+### Must have
+- Make ADLC installable in Codex through the documented plugin path, not only as loose repo instructions.
+- Preserve the existing npm CLIs as source of truth; do not reimplement ADLC gate logic inside Codex skills.
+- Provide one obvious user entry point: `$adlc`.
+- Provide phase-specific skills for users who know where they are in the lifecycle.
+- Include a low-friction adoption path that matches the ADLC series without overstating gates: a P5 manual review pilot may come first for trust-building, but strict ADLC gate adoption starts with P3 rails until a deterministic P5 prosecution harness exists.
+- Include exact commands for local development and local marketplace install. Include Git-backed marketplace install only after sparse payload proof exists; before then, docs must use a planned/unsupported placeholder.
+- Include an explicit completeness matrix from P0 through P7.
+- Name gaps where Codex cannot currently enforce ADLC mechanically.
+- Treat install smoke testing as a Wave 0 blocker: no install command may be documented as supported until it passes in a temporary `CODEX_HOME`.
+- Mark P5 as incomplete unless the implementation also adds a deterministic prosecution orchestrator or a tested `codex exec` harness that enforces fan-out, finding verification, dry-pass looping, and `gate-manifest` evidence. All P5-first messaging must say "manual review pilot, not completed ADLC gate" until then.
+
+### Must NOT have
+- Do not add a second CLI framework, daemon, or MCP server in the first integration.
+- Do not require global npm installs. Supported recipes must use local workspace binaries when run from this repo, or pinned per-package `@adlc/<tool>@<PACKAGE_VERSION>` invocations when run outside the repo. Unpinned `npx @adlc/*` is allowed only in explicitly best-effort docs with a version-skew warning.
+- Do not make custom prompts the primary UX; Codex docs mark custom prompts deprecated in favor of skills.
+- Do not promise that hooks fully freeze rails against all write paths. Hooks can assist, but `rails-guard` and file permissions remain the deterministic proof.
+- Do not require users to adopt all P0-P7 phases on day one.
+- Do not ship hook marketing or docs that say "rails are frozen" unless the same workflow also proves `rails-guard` passes after every shell-capable build step.
+
+## Recommended Architecture
+### 1. Plugin as installable wrapper
+Add:
+
+```text
+plugins/adlc-codex/
+  .codex-plugin/plugin.json
+  skills/adlc/SKILL.md
+  skills/adlc-spec/SKILL.md
+  skills/adlc-rail-build/SKILL.md
+  skills/adlc-prosecute/SKILL.md
+  skills/adlc-distill/SKILL.md
+  hooks/hooks.json
+  hooks/adlc-rails-guard.mjs
+  assets/
+.agents/plugins/marketplace.json
+docs/codex-integration.md
+```
+
+Candidate marketplace fixture to test before implementation proceeds. This is not a required schema until Wave 0 proves it unchanged:
+
+```json
+{
+  "name": "adlc",
+  "plugins": [
+    {
+      "name": "adlc-codex",
+      "source": {
+        "source": "local",
+        "path": "./plugins/adlc-codex"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}
+```
+
+Candidate plugin id and manifest fixture to test before implementation proceeds. This is not a required schema until Wave 0 proves it unchanged:
+
+```json
+{
+  "name": "adlc-codex",
+  "version": "1.0.0",
+  "description": "Codex workflows for operating the Agentic Development Lifecycle with the ADLC toolkit.",
+  "skills": "./skills/"
+}
+```
+
+Rationale:
+- The plugin is the installable unit.
+- Skills carry the ADLC operating method through progressive disclosure.
+- Hooks are optional enforcement assists bundled with the plugin, not the only gate.
+- Docs give deterministic install commands and adoption recipes.
+
+### 2. Skill split
+- `$adlc`: router skill. Classifies request risk, chooses direct/bounded/full ADLC route, and tells the user the next gate.
+- `$adlc-spec`: P0-P2. Runs interrogation, `parallax`, `spec-lint`, `premortem`, ticket decomposition, `coldstart`, `merge-forecast`, and `model-router`.
+- `$adlc-rail-build`: P3-P4. Writes rails in a separate context, validates RED-for-right-reasons, runs `hollow-test`, `preflight`, `rails-guard`, and `flail-detector`.
+- `$adlc-prosecute`: P5-P6. Runs refute-chartered review, verifies findings, records evidence with `gate-manifest`, captures behavior with `behavior-diff`, and prepares the human acceptance packet.
+- `$adlc-distill`: P7 and maintenance. Runs simplification planning, `lesson-foundry`, `rejection-mining`, `skill-rot`, `model-ratchet`, and `review-calibration`.
+
+This is easier to use than 8 separate phase skills while still preventing one huge skill from loading every tool description at once.
+
+### 3. Install UX
+These commands are the target UX, not a supported promise until Wave 0 proves them against a temporary `CODEX_HOME`.
+
+Local development target:
+
+```sh
+codex plugin marketplace add .
+codex plugin add adlc-codex --marketplace adlc
+```
+
+Git-backed marketplace target after release: do not publish a command yet. Wave 0 must first prove the exact sparse payload behavior and record the transcript. Until that evidence exists, the only allowed docs text is: "Git-backed install is planned but unsupported; use the local marketplace or pinned per-package `npx @adlc/<tool>@<PACKAGE_VERSION>` fallback."
+
+No-install fallback target. The docs generator must resolve `<SPEC_LINT_VERSION>` and `<RAILS_GUARD_VERSION>` from each CLI package's own `packages/<name>/package.json`, then verify that exact package exists in the registry or local release manifest. Unpinned `npx @adlc/*` must not appear in supported recipes:
+
+```sh
+npx @adlc/spec-lint@<SPEC_LINT_VERSION> spec.md --json
+npx @adlc/rails-guard@<RAILS_GUARD_VERSION> --ticket T1 --tickets .adlc/tickets.json --record --json
+```
+
+The docs must include exact verification:
+
+```sh
+tmp_home="$(mktemp -d)"
+tmp_codex_home="$tmp_home/.codex"
+tmp_xdg_config="$tmp_home/.config"
+tmp_xdg_cache="$tmp_home/.cache"
+tmp_xdg_data="$tmp_home/.local/share"
+mkdir -p "$tmp_codex_home" "$tmp_xdg_config" "$tmp_xdg_cache" "$tmp_xdg_data"
+
+tree_manifest() {
+  {
+    find "$1" -mindepth 1 -printf '%y %m %p -> %l\n' 2>/dev/null
+    find "$1" -type f -exec sha256sum {} + 2>/dev/null
+  } | sort
+}
+
+before_real_home="$(tree_manifest "$HOME/.codex")"
+
+HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_xdg_config" XDG_CACHE_HOME="$tmp_xdg_cache" XDG_DATA_HOME="$tmp_xdg_data" CODEX_HOME="$tmp_codex_home" codex plugin marketplace add .
+HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_xdg_config" XDG_CACHE_HOME="$tmp_xdg_cache" XDG_DATA_HOME="$tmp_xdg_data" CODEX_HOME="$tmp_codex_home" codex plugin add adlc-codex --marketplace adlc
+HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_xdg_config" XDG_CACHE_HOME="$tmp_xdg_cache" XDG_DATA_HOME="$tmp_xdg_data" CODEX_HOME="$tmp_codex_home" codex plugin marketplace list
+HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_xdg_config" XDG_CACHE_HOME="$tmp_xdg_cache" XDG_DATA_HOME="$tmp_xdg_data" CODEX_HOME="$tmp_codex_home" codex plugin list
+find "$tmp_home" -type f -path '*/skills/adlc/SKILL.md' -exec grep -H 'ADLC_CODEX_SENTINEL_PHASE_ROUTER_V1' {} \;
+
+after_real_home="$(tree_manifest "$HOME/.codex")"
+test "$before_real_home" = "$after_real_home"
+```
+
+### 4. Evidence and state
+- Keep `.adlc/` as the ADLC runtime state directory.
+- Keep `.omo/plans/` as planning artifacts only, because this repo already uses OMO planning conventions.
+- Add a docs section explaining the boundary:
+  - `.adlc/`: tickets, ledgers, gate evidence, lessons consumed by ADLC tools.
+  - `.omo/`: Codex planning and execution artifacts when OMO-style plans are used.
+
+## Completeness Evaluation
+| ADLC phase | Existing tool coverage | Codex integration coverage | Completeness |
+| --- | --- | --- | --- |
+| P0 Triage | `preflight`, phase docs | `$adlc` routes trivial/bounded/substantial/architectural | Strong |
+| P1 Interrogate | `parallax`, `spec-lint`, `premortem` | `$adlc-spec` forces executable acceptance criteria and human spec approval | Strong |
+| P2 Decompose | `coldstart`, `merge-forecast`, `model-router`, tickets schema | `$adlc-spec` emits `.adlc/tickets.json` and validates cold-start gaps | Strong |
+| P3 Rail | `hollow-test`, `rails-guard` | `$adlc-rail-build` creates separate-context rails and runs RED/hollow/freeze gates | Strong, with hook caveat |
+| P4 Build | `preflight`, `flail-detector`, `model-router`, worktree guidance | `$adlc-rail-build` wraps fresh-context ticket execution and two-strike regeneration | Medium-strong |
+| P5 Prosecute | `review-calibration`, `gate-fuzzing`, `model-ratchet`; external `adversarial-review` | `$adlc-prosecute` gives refute charter and recipes, but no first-party deterministic fan-out/verify/dry-pass orchestrator exists yet | Incomplete for strict ADLC; medium for adoption |
+| P6 Integrate | `behavior-diff`, `gate-manifest` | `$adlc-prosecute` can produce a manual acceptance packet; strict integrate gate requires verified P5 manifest evidence first | Conditional: strong only after deterministic P5 evidence |
+| P7 Distill | `lesson-foundry`, `rejection-mining`, `skill-rot` | `$adlc-distill` turns repeated findings into skills/lints/templates | Strong |
+
+Overall completeness: good for staged ADLC practice adoption, not yet complete for strict ADLC. The blocker is P5 orchestration: full dimension fan-out, finding verification, loop-until-two-dry-passes, and manifest recording are not yet one deterministic ADLC gate. P6 is therefore conditional: the human acceptance packet is useful for adoption, but strict ADLC integration is strong only when backed by verified P5 manifest evidence. The implementation must either add that orchestrator as a follow-on deliverable or keep the shipped completeness claim at "P0-P4/P7 strong, P5 partially manual, P6 conditional."
+
+## Simplicity Evaluation
+Install simplicity:
+- Good if a repo marketplace is added. Two commands after release are acceptable.
+- Excellent for local development only after Wave 0 proves `codex plugin marketplace add .` from the repo root with a temporary `CODEX_HOME`.
+- Weak if users must manually copy skills into `~/.agents/skills`; that should be fallback only.
+
+Use simplicity:
+- Strong if `$adlc` is the single recommended entry point.
+- Strong if phase skills are discoverable but optional.
+- Medium if users must know every `@adlc/*` binary. The skills must hide most binary selection.
+
+Adoption simplicity:
+- Strong if docs lead with either "manual P5 review pilot, not a completed ADLC gate" for trust-building or "freeze rails" for strict ADLC gate adoption, instead of full lifecycle ceremony.
+- Weak if the first page asks teams to create tickets, hooks, worktrees, behavior snapshots, and distillation artifacts before they see value.
+
+Operational simplicity:
+- Strong because the npm CLIs already share exit codes, `--json`, `--prompt-only`, and `.adlc/`.
+- Medium because provider-backed tools need API keys or prompt-only fallback. The skills must explicitly choose prompt-only when credentials are absent.
+
+## Known Gaps
+1. **No single ADLC orchestrator CLI.** Codex skills can sequence tools, but a deterministic `adlc run <phase>` wrapper would make CI and non-Codex adoption simpler.
+2. **P5 is not fully automated.** `adversarial-review` covers skeptical review, but the repo needs a first-party prosecution orchestrator that fans out lenses, verifies findings, loops until dry, and records `gate-manifest` evidence. Until that exists, all docs, skills, and matrices must say "manual P5 review pilot, not completed ADLC gate."
+3. **Rails freeze cannot rely only on Codex hooks.** Hooks can block direct patch/edit tools, but shell commands can still mutate files unless paired with file permissions, sandbox policy, or post-hoc `rails-guard`. The hook acceptance suite must include an intentional shell-bypass fixture and require `rails-guard` to catch it.
+4. **Ticket authoring schema needs examples.** `packages/core/lib/tickets.mjs` defines the schema, but Codex users need templates for atomic tickets, rails, scopes, edges, and allowed suppressions.
+5. **Model-router uses ADLC tiers, not Codex profile names.** The integration must document mapping from `cheap|mid|frontier` to current Codex models/config profiles without hardcoding stale model names into tool logic.
+6. **No installer smoke test yet.** This is now Wave 0 and blocks all plugin work. The fixture must install the local marketplace in an isolated temporary home, confirm the `adlc-codex` plugin id resolves, prove installed skill files and sentinels mechanically, and run a separate release-blocking `$adlc` discovery proof before docs claim the command works.
+7. **Git-backed sparse install needs payload proof.** The Git-backed marketplace command must fetch both `.agents/plugins` and `plugins/adlc-codex`; release docs must not publish any Git-backed install command until the sparse payload transcript proves it.
+8. **Branch mismatch.** The current checkout is on `main`; implementation should start by confirming or switching to `feat/codex-integration`.
+9. **Custom prompts are deprecated.** Any slash-command-like UX should be through skills/plugins, not `~/.codex/prompts`.
+
+## Gap Reduction Plan
+This section resolves the open strict-ADLC gaps in the safe order. It is separate from the Codex plugin packaging waves because strict ADLC correctness depends on deterministic contracts before ergonomic wrappers.
+
+### G0: Continuous Codex Install Proof
+- Run the isolated Codex marketplace/plugin smoke test from Wave 0 before and after every plugin-facing change, not only at the end.
+- Keep Git-backed install docs unpublished until sparse payload proof exists.
+- Acceptance: `.omo/evidence/adlc-codex-install-smoke.txt` proves isolated home, marketplace registration, plugin id resolution, skill file discovery, and no mutation of real `$HOME/.codex`.
+
+### G1: Minimal Ticket and Evidence Contracts
+- Add minimal examples before building P5:
+  - `.adlc/tickets.example.json`
+  - `docs/ticket-authoring.md`
+  - fixture tickets covering valid rails, missing rails, overlapping scopes, edges/contracts, and allowed suppressions.
+- Define the evidence records P5/P6 require:
+  - review pass started/completed
+  - raw finding
+  - verified finding
+  - killed/unverified finding
+  - dry pass
+  - two-dry-pass completion
+  - P6 acceptance packet generated from a manifest revision.
+- Acceptance: `gate-manifest` can record and verify each evidence shape from fixtures before any P5 orchestrator code is accepted.
+
+### G2: P5 Contract Pieces Before Orchestration
+- Define a stable finding schema before implementing `@adlc/prosecute`:
+  - `id`, `lens`, `severity`, `category`, `file`, `line_start`, `line_end`, `evidence`, `claim`, `recommendation`, `confidence`, `verified_status`.
+- Define verifier behavior:
+  - every finding must become `verified`, `killed`, or `needs-human`;
+  - unverified findings must not be sent to the builder as required fixes;
+  - verifier failures are operational errors, not dry passes.
+- Define dry-pass semantics:
+  - one dry pass means no verified findings in that pass;
+  - strict P5 completion requires two consecutive dry passes over the same target plus unchanged rail proof.
+- Acceptance: schema validation and dry-pass fixtures pass without invoking any model.
+
+### G3: Deterministic P5 Orchestrator CLI
+- Implement `@adlc/prosecute` only after G1-G2 are accepted.
+- Required behavior:
+  - run configured refute-chartered lenses;
+  - normalize findings into the finding schema;
+  - verify every finding before reporting it as actionable;
+  - loop until two consecutive dry passes or convergence budget exhausted;
+  - record all pass, finding, verifier, and dry-pass evidence through `gate-manifest`;
+  - exit `0` only on two verified dry passes, `2` on verified open findings or convergence failure, `1` on operational failure.
+- Acceptance: fixture review commands prove verified findings block, killed findings do not block, two dry passes pass, and missing manifest evidence fails.
+
+### G4: P6 Strict Evidence Packet
+- Keep `behavior-diff` and acceptance packet generation separate from P5.
+- P6 strict mode may run only when the manifest contains current-target P5 completion evidence.
+- Acceptance: P6 packet generation fails without verified P5 manifest evidence and succeeds with a fixture manifest containing two dry passes plus behavior diff references.
+
+### G5: Phase Runner With Artifact Assertions
+- Add `adlc run <phase>` only after the phase contracts exist.
+- The runner must assert artifacts, not only command execution:
+  - `p1` passes only with spec-lint/premortem evidence;
+  - `p2` passes only with valid ticket DAG/coldstart evidence;
+  - `p3` passes only with RED/hollow/frozen-rails evidence;
+  - `p4` passes only with green rails, no rail diff, and flail checks;
+  - `p5` passes only with deterministic P5 completion evidence;
+  - `p6` passes only with P5 evidence plus behavior acceptance packet;
+  - `p7` passes only with recorded lesson/mining/rot evidence or an explicit no-op record.
+- Acceptance: runner fixture tests fail when a command exits zero but the required manifest artifact is missing.
+
+### G6: Rails Hardening From One Source of Truth
+- Use `.adlc/tickets.json` as the canonical rail declaration source.
+- Use `ADLC_TICKET` as the CI/automation active-ticket selector and `.adlc/current-ticket.json` as local fallback with the precedence rules in Wave 3.
+- Add optional file-permission freeze only as a defense-in-depth layer; `rails-guard` remains the deterministic proof.
+- Acceptance: hook, runner, and CI fixtures all resolve the same active ticket and rails, and all detect the same shell-bypass mutation.
+
+### G7: Codex UX and Documentation
+- Keep `$adlc` as the single user entry point, but do not let skill text become the gate.
+- Skills may recommend commands; ADLC CLIs and manifest assertions decide pass/fail.
+- Model tier mapping must be config-driven and documented, not hardcoded.
+- Acceptance: Codex skills drive fixture commands and evidence checks; no skill claims a phase complete unless the corresponding deterministic gate passes.
+
+## Execution Strategy
+### Wave 0: Prove Codex marketplace install semantics
+- Create a temporary fixture outside the product paths with the candidate marketplace JSON and plugin manifest shape.
+- Treat Wave 0 as the schema source of truth: if Codex requires any different field, root, or path semantics, update the plan and use only the tested schema. Do not copy the candidate JSON into product paths until the isolated transcript proves it unchanged.
+- Run all commands with a temporary `HOME`, `CODEX_HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `XDG_DATA_HOME` so Codex cannot fall back to the developer's real home:
+  - `tmp_home="$(mktemp -d)"`
+  - `tmp_codex_home="$tmp_home/.codex"`
+  - `HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" XDG_CACHE_HOME="$tmp_home/.cache" XDG_DATA_HOME="$tmp_home/.local/share" CODEX_HOME="$tmp_codex_home" codex plugin marketplace add <fixture-root>`
+  - `HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" XDG_CACHE_HOME="$tmp_home/.cache" XDG_DATA_HOME="$tmp_home/.local/share" CODEX_HOME="$tmp_codex_home" codex plugin marketplace list`
+  - `HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" XDG_CACHE_HOME="$tmp_home/.cache" XDG_DATA_HOME="$tmp_home/.local/share" CODEX_HOME="$tmp_codex_home" codex plugin add adlc-codex --marketplace adlc`
+  - `HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" XDG_CACHE_HOME="$tmp_home/.cache" XDG_DATA_HOME="$tmp_home/.local/share" CODEX_HOME="$tmp_codex_home" codex plugin list`
+- Verify the installed plugin exposes a `$adlc` skill using deterministic offline checks:
+  - mechanically enumerate the installed plugin files under the isolated temporary home and XDG roots;
+  - assert exactly one installed `skills/adlc/SKILL.md` exists;
+  - assert that installed file contains `ADLC_CODEX_SENTINEL_PHASE_ROUTER_V1`, a sentinel phrase stored only in the `$adlc` skill and never in the smoke-test prompt;
+  - create `$tmp_codex_home`, `$tmp_xdg_config`, `$tmp_xdg_cache`, and `$tmp_xdg_data` before the first Codex invocation;
+  - do not use `codex exec`, `CODEX_API_KEY`, network, or live model behavior in the blocking marketplace-correctness smoke test.
+- Release-blocking `$adlc` discovery proof, required before docs claim the installed command works:
+  - prefer a Codex-native skill/plugin listing command if Codex exposes one that can prove the installed skill is registered without a model call;
+  - otherwise require explicit `CODEX_API_KEY` or pre-seeded isolated auth and run `codex exec` from a newly initialized temporary Git repository outside the ADLC repo so repo-local `.agents/skills` and AGENTS guidance cannot satisfy the prompt;
+  - capture behavioral stdout and require `ADLC_CODEX_SENTINEL_PHASE_ROUTER_V1`;
+  - if auth, network, or native discovery is unavailable, the release must stop before publishing "install and use `$adlc`" docs; only the offline marketplace-correctness result may be reported.
+- Capture a full tree manifest of the real `$HOME/.codex` before and after the fixture run including file type, path, symlink target, permissions, and regular-file content hashes; fail the smoke test if any entry changes. Prefer also making the real `$HOME/.codex` read-only in CI-style smoke tests when permissions allow it.
+- If any command differs from the target UX, update this plan and `docs/codex-integration.md` to the tested command. Do not preserve aspirational commands.
+- Acceptance: one captured transcript under `.omo/evidence/adlc-codex-install-smoke.txt` proves marketplace root, plugin id, skill discovery, and no mutation of the default `$HOME/.codex`.
+- Git-backed acceptance: only after local install passes, run the candidate release command with both sparse paths, `--sparse .agents/plugins --sparse plugins/adlc-codex`, in the same isolated-home harness and prove that `plugins/adlc-codex/.codex-plugin/plugin.json` and every `skills/*/SKILL.md` file exist in the resolved marketplace snapshot before `codex plugin add` runs. Publish the Git-backed install command only if this transcript exists and is linked from `docs/codex-integration.md`.
+
+### Wave 1: Plugin skeleton and marketplace
+- Create `plugins/adlc-codex/.codex-plugin/plugin.json`.
+- Create `.agents/plugins/marketplace.json`.
+- Add minimal `assets/` only if needed for Codex app presentation.
+- Acceptance: copy only the Wave 0-proven fixture shape into product paths and re-run the same isolated-home installer smoke test from the repository root. If Wave 0 changed the candidate schema, product paths must use the changed tested schema, not the earlier candidate block.
+
+### Wave 2: Skills
+- Add `$adlc` router skill.
+- Add the four phase skills.
+- Each skill must name:
+  - phase objective
+  - matching ADLC flaws defended
+  - commands to run
+  - evidence to record
+  - stop conditions
+  - when to ask the human
+  - an install sentinel phrase unique to that skill for fixture validation
+- Acceptance: `codex exec --ignore-user-config` with the local plugin can invoke each skill explicitly against fixtures and prove executable ADLC behavior:
+  - `$adlc` classifies at least one trivial, bounded, substantial, and architectural request and names the correct next gate.
+  - `$adlc-spec` invokes the local workspace `spec-lint` binary or pinned `npx @adlc/spec-lint@<SPEC_LINT_VERSION>` against a fixture spec, propagates exit `2` on unverifiable criteria, and records the expected prompt-only fallback when credentials are absent.
+  - `$adlc-rail-build` invokes `preflight`, `hollow-test`, `rails-guard`, and `flail-detector` fixture commands, propagates nonzero exits, and writes or references `.adlc/manifest.jsonl` only through the ADLC CLI.
+  - `$adlc-prosecute` runs a fixture skeptical-review command, distinguishes verified from unverified findings in output, and refuses to label P5 complete without dry-pass and manifest evidence. If no deterministic prosecution harness is implemented, it must label itself "manual review pilot" in every successful path.
+  - `$adlc-distill` invokes `lesson-foundry`, `rejection-mining`, and `skill-rot` in dry-run or prompt-only fixture mode and reports the generated `.adlc/lessons/` or prompt-only artifacts.
+  - Each skill has one malformed-state fixture that must stop before implementation work and surface the gate failure rather than printing a generic checklist.
+
+### Wave 3: Optional hooks
+- Add a conservative `PreToolUse` hook that blocks direct Codex edit/write attempts to active ticket rails during P4.
+- Define activation exactly: P4 enforcement is active only when `ADLC_P4_ENFORCEMENT=1`. Any other value, including unset, is inactive and must emit a visible "P4 rail hook inactive" notice rather than silently implying protection.
+- Resolve the active ticket with explicit precedence:
+  - `ADLC_TICKET` is the canonical CI/automation source and names a ticket id in `.adlc/tickets.json`.
+  - `.adlc/current-ticket.json` is the local interactive fallback and must contain the same ticket id shape.
+  - If both are present and agree, proceed.
+  - If both are present and disagree, block as a configuration conflict.
+  - If exactly one valid source is present, proceed with that source.
+  - If no valid source resolves a ticket with non-empty `rails`, block.
+- Treat hook failure as "fail closed" only when `ADLC_P4_ENFORCEMENT=1`, and document that this is an assistive guard rather than the ADLC gate proof.
+- In P4 enforcement mode, malformed ticket JSON, unknown ticket id, conflicting active-ticket sources, or an empty resolved `rails` set is a blocking hook error. Missing `.adlc/current-ticket.json` is acceptable when `ADLC_TICKET` resolves valid rails; unset `ADLC_TICKET` is acceptable when `.adlc/current-ticket.json` resolves valid rails. The hook must never interpret missing or invalid active-ticket state as "no rails."
+- Require `rails-guard --ticket <id> --tickets .adlc/tickets.json --record --json` after every P4 step that allowed shell execution or any other write-capable tool.
+- Acceptance:
+  - hook blocks a direct edit to a declared rail file in a fixture;
+  - hook allows non-rail edits;
+  - hook emits inactive notice and does not block when `ADLC_P4_ENFORCEMENT` is unset;
+  - hook emits inactive notice and does not block when `ADLC_P4_ENFORCEMENT=0`;
+  - hook fail-closes on configuration errors only when `ADLC_P4_ENFORCEMENT=1`;
+  - hook allows an env-only valid `ADLC_TICKET` fixture;
+  - hook allows a file-only valid `.adlc/current-ticket.json` fixture;
+  - hook allows a both-present matching fixture;
+  - hook blocks a both-present conflicting fixture;
+  - hook blocks when `ADLC_P4_ENFORCEMENT=1` and neither active-ticket source exists;
+  - hook blocks malformed ticket JSON;
+  - hook blocks an unknown ticket id;
+  - hook blocks a ticket with no resolved rail globs;
+  - shell-bypass fixture mutates a declared rail file and demonstrates that the hook alone does not catch it;
+  - the same shell-bypass fixture is caught by mandatory `rails-guard`.
+
+### Wave 4: Documentation and examples
+- Add `docs/codex-integration.md`.
+- Include local install commands, pinned per-package fallback `npx @adlc/<tool>@<PACKAGE_VERSION>` commands, phase map, adoption path, and state directory explanation.
+- Include Git-backed install commands only after the sparse payload smoke transcript exists and is linked.
+- Add sample `.adlc/tickets.example.json`.
+- Acceptance: a fresh user can follow the docs from local checkout to `$adlc` invocation without reading `ADLC.md`.
+
+### Wave 5: Verification
+- Run `npm test`.
+- Run installer smoke test in a temporary `CODEX_HOME`.
+- Run at least one dry/prompt-only command per LLM-backed package referenced by the skills.
+- Verify that docs never call P5 a completed ADLC gate unless the deterministic prosecution harness exists.
+- Run `npx adversarial-review --base main --include-files "focus on plugin install safety, hook overclaims, and supply-chain risk"` against the implementation branch before PR.
+
+## Success Criteria
+- Installation is two commands for local development. Git-backed install is two commands only after sparse payload evidence exists; otherwise it remains documented as planned, not supported.
+- `$adlc` is the only command users need to remember for the happy path.
+- Every ADLC phase P0-P7 has a Codex skill path; only phases with deterministic CLI enforcement are labeled complete.
+- P5 is either backed by a deterministic prosecution orchestrator or explicitly labeled incomplete/partially manual everywhere.
+- The docs explicitly teach the staged adoption path, not only the full lifecycle.
+- Hook docs and tests distinguish assistive enforcement from deterministic gate proof, including the shell-bypass case.
+- All plugin, skill, and docs tests pass in a temporary `CODEX_HOME`.
+- The final branch review includes `adversarial-review` output and resolves or documents every material concern.

--- a/README.md
+++ b/README.md
@@ -28,26 +28,29 @@ product.
 
 ## Install
 
-Each package publishes independently under the `@adlc` npm scope. Install only what you
-need, or run on demand with `npx`:
+Each package publishes independently under the `@adlc` npm scope. For normal use,
+install the dispatcher and run tools through the stable `adlc <tool>` surface:
 
 ```sh
-# one tool, global
-npm install -g @adlc/spec-lint
+npm install -g @adlc/cli
+adlc spec-lint <spec.md>
 
 # or run without installing
-npx @adlc/spec-lint <spec.md>
+npx @adlc/cli spec-lint <spec.md>
 ```
+
+Individual packages can still be installed for package development, but Codex skills,
+hooks, CI, and lifecycle docs should use the dispatcher.
 
 ## The toolkit
 
 | Phase | Packages |
 | --- | --- |
 | **Spec & ticket shaping** | [`parallax`](./packages/parallax) · [`spec-lint`](./packages/spec-lint) · [`premortem`](./packages/premortem) · [`coldstart`](./packages/coldstart) |
-| **Execution supervision & rails** | [`preflight`](./packages/preflight) · [`model-router`](./packages/model-router) · [`merge-forecast`](./packages/merge-forecast) · [`rails-guard`](./packages/rails-guard) · [`flail-detector`](./packages/flail-detector) · [`consensus-fix`](./packages/consensus-fix) |
-| **Review evidence & calibration** | [`behavior-diff`](./packages/behavior-diff) · [`gate-manifest`](./packages/gate-manifest) · [`hollow-test`](./packages/hollow-test) · [`review-calibration`](./packages/review-calibration) · [`model-ratchet`](./packages/model-ratchet) · [`gate-fuzzing`](./packages/gate-fuzzing) |
+| **Execution supervision & rails** | [`preflight`](./packages/preflight) · [`model-router`](./packages/model-router) · [`merge-forecast`](./packages/merge-forecast) · [`rails-guard`](./packages/rails-guard) · [`flail-detector`](./packages/flail-detector) · [`consensus-fix`](./packages/consensus-fix) · [`runner`](./packages/runner) |
+| **Review evidence & calibration** | [`behavior-diff`](./packages/behavior-diff) · [`gate-manifest`](./packages/gate-manifest) · [`hollow-test`](./packages/hollow-test) · [`prosecute`](./packages/prosecute) · [`review-calibration`](./packages/review-calibration) · [`model-ratchet`](./packages/model-ratchet) · [`gate-fuzzing`](./packages/gate-fuzzing) |
 | **Compounding defenses** | [`lesson-foundry`](./packages/lesson-foundry) · [`rejection-mining`](./packages/rejection-mining) · [`skill-rot`](./packages/skill-rot) |
-| **Shared foundation** | [`@adlc/core`](./packages/core) |
+| **Shared foundation** | [`@adlc/cli`](./packages/cli) · [`@adlc/core`](./packages/core) |
 
 See [docs/package-reference.md](./docs/package-reference.md) for binaries, command forms,
 and per-package detail, and [docs/toolkit.md](./docs/toolkit.md) for how the packages fit
@@ -79,7 +82,7 @@ Requires **Node.js 18 or newer**.
 ## Documentation
 
 - [ADLC.md](./ADLC.md) — the full lifecycle thesis and flaw inventory.
-- [docs/](./docs/README.md) — toolkit guide, package reference, and the narrative essays.
+- [docs/](./docs/README.md) — toolkit guide, package reference, ADRs, and narrative essays.
 - [CONVENTIONS.md](./CONVENTIONS.md) — the contract every package follows.
 
 ## Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ package READMEs.
 ## Start here
 
 - [Toolkit guide](./toolkit.md) explains how the packages fit into the ADLC flow.
+- [Codex integration](./codex-integration.md) explains installation, usage, and the
+  current gaps against the formal ADLC doctrine.
 - [Package reference](./package-reference.md) lists every package, binary, phase, and
   primary README source.
 - [ADR 0001](./adr/0001-codex-native-adlc-integration.md) records the Codex-native

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ package READMEs.
 - [Toolkit guide](./toolkit.md) explains how the packages fit into the ADLC flow.
 - [Package reference](./package-reference.md) lists every package, binary, phase, and
   primary README source.
+- [ADR 0001](./adr/0001-codex-native-adlc-integration.md) records the Codex-native
+  integration plan and dispatcher contract.
 
 ## Repository shape
 
@@ -31,4 +33,3 @@ package's `bin` field, and the root test script runs each package test suite wit
 ```sh
 npm test
 ```
-

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing the `@adlc` suite
 
-All 20 packages (`@adlc/core` + 19 CLIs) ship under the `@adlc` npm scope on a
+All 23 packages (`@adlc/core` + 22 CLIs) ship under the `@adlc` npm scope on a
 **single lockstep version** — one tag releases the whole suite.
 
 ## One-time setup
@@ -30,7 +30,7 @@ All 20 packages (`@adlc/core` + 19 CLIs) ship under the `@adlc` npm scope on a
      gh secret list --env npm-publish         # environment: MUST list NPM_TOKEN
      ```
 4. **First release** — see *Cutting a release* below. The workflow publishes all
-   20 packages using the environment-scoped `NPM_TOKEN`.
+   23 packages using the environment-scoped `NPM_TOKEN`.
 5. **Switch to OIDC.** On npmjs.com, configure each package's *Trusted Publisher*
    to this repo + the `Publish @adlc to npm` workflow, **and set the Environment
    field to `npm-publish`.** This binding is mandatory: if the environment field
@@ -52,7 +52,7 @@ All 20 packages (`@adlc/core` + 19 CLIs) ship under the `@adlc` npm scope on a
 Lockstep: bump every package to the same version, tag, push.
 
 ```bash
-# 1. set the version across all 20 manifests (also repins @adlc/core deps)
+# 1. set the version across all package manifests and repin internal @adlc/* deps
 node scripts/release.mjs 1.1.0
 
 # 2. commit + tag + push — the tag triggers the publish workflow
@@ -63,7 +63,8 @@ git push && git push --tags
 
 The `.github/workflows/publish.yml` workflow then installs, tests, and runs
 `scripts/release.mjs <version> --publish`, which publishes **`@adlc/core` first**
-(its consumers resolve it) followed by the 19 CLIs — each with
+(its consumers resolve it), then the routed tools, and **`@adlc/cli` last**
+because it depends on the dispatcher targets. Each package publishes with
 `--provenance` and `publishConfig.access=public`.
 
 There is no manual trigger: the workflow has no `workflow_dispatch`, so the only
@@ -73,9 +74,9 @@ approval on the `npm-publish` environment.
 
 ## How the wiring works
 
-- Every CLI declares `"@adlc/core": "<exact version>"`. `scripts/release.mjs`
-  repins this on each bump, so a published `@adlc/foo@1.1.0` always requires
-  `@adlc/core@1.1.0`.
+- Every internal dependency declared as `"@adlc/*": "<exact version>"` is
+  repinned by `scripts/release.mjs` on each bump, so a published
+  `@adlc/foo@1.1.0` always depends on the matching lockstep `@adlc` packages.
 - Inside the repo, npm **workspaces** symlink `@adlc/core` into `node_modules`,
   so source imports (`import { pass } from '@adlc/core'`) resolve in dev/test
   exactly as they will once published.

--- a/docs/adr/0001-codex-native-adlc-integration.md
+++ b/docs/adr/0001-codex-native-adlc-integration.md
@@ -1,0 +1,176 @@
+# ADR 0001: Codex-Native ADLC Integration
+
+Status: Accepted
+
+Date: 2026-06-18
+
+## Context
+
+ADLC is a toolkit of deterministic, gate-shaped CLIs plus doctrine for running
+agentic software development. The Claude Code integration in the sibling
+`../cc-integration` worktree is further along and proves useful lifecycle
+patterns, but Codex has different native surfaces: plugins, progressive
+disclosure skills, lifecycle hooks, app automations, and explicit subagent
+workflows.
+
+The Codex integration must implement the ADLC doctrine, not mechanically port
+Claude Code's command and agent file layout. The core doctrine is:
+
+- deterministic gates between phases;
+- exactly two mandatory human gates, P1 spec approval and P6 behavioral
+  acceptance;
+- rail freeze enforced at the tool layer and verified by deterministic gates;
+- fresh-context prosecution with verified findings;
+- `.adlc/manifest.jsonl` evidence as the source of phase truth;
+- P7 compounding through distillation, skill mining, and maintenance.
+
+An adversarial review of the first plan found material gaps: P0/P1/P6 were too
+prose-driven, manifest recording could be decoupled from gate execution, rail
+snapshots were not checked deeply enough, P5 fresh-context evidence was not
+machine-checkable enough, P7 automation was unproven, and plugin install proof
+could validate metadata without exercising behavior.
+
+## Decision
+
+Build a Codex-native peer integration with these hard requirements.
+
+### Distribution and command surface
+
+- Ship the Codex plugin from `plugins/adlc-codex/`.
+- Use Codex skills as the primary user-facing workflows. Do not build the
+  primary UX around deprecated Codex custom prompts.
+- Use one public dispatcher binary: `adlc <tool>`.
+- Add `@adlc/cli` as the package that owns the public `adlc` binary.
+- Move phase assertions under the dispatcher as `adlc run <phase>` and
+  `adlc accept ...`.
+- Stop publishing `@adlc/runner` as the owner of the top-level `adlc` binary.
+  It may keep an internal or explicit `adlc-runner` binary.
+- Resolve tools through package metadata from `@adlc/cli` dependencies, not the
+  user's `PATH`, so global stale binaries cannot silently satisfy gates.
+
+### Phase completion and evidence
+
+- Codex skills route work and execute commands; they cannot declare a phase
+  complete from narration.
+- A phase is complete only when `.adlc/manifest.jsonl` contains the required
+  evidence and `adlc run <phase> --json` passes.
+- Gate evidence must be recorded atomically with the checked operation wherever
+  possible. If a separate manifest recording step is unavoidable, it must bind
+  to a gate result artifact with ticket id, phase, command args, tool version,
+  input hashes, output hash, and resolved git-worktree revision.
+- Prompt-only LLM gates count only when the emitted prompt, Codex judgment, and
+  reviewed inputs are captured as evidence.
+
+### P0, P1, and P6 determinism
+
+- Ticket authoring must be deterministic in the initial integration, not a
+  future enhancement. It must lock `.adlc/tickets.json`, validate the proposed
+  ticket graph in memory, write atomically, and preserve rails as a trust root.
+- P1 human approval must be recorded as explicit evidence bound to the spec,
+  ticket set, and revision being approved.
+- P6 human acceptance must be an explicit attestation packet bound to ticket id,
+  behavior-diff packet hash, artifact hashes, and exact reviewed revision. It
+  must fail closed when the worktree, ticket definition, transcript, behavior
+  packet, or snapshots change after acceptance.
+
+### Skill topology
+
+Use a small phase-clustered skill set rather than one skill per gate:
+
+- `adlc`: doctrine router, work classifier, and phase map.
+- `adlc-spec`: P0-P2 ticket/spec shaping, P1 approval, coldstart, merge forecast,
+  and model routing.
+- `adlc-rail-build`: P3-P4 rails, hook posture, preflight, flail detection,
+  consensus-fix, and build supervision.
+- `adlc-prosecute`: P5-P6 prosecution evidence, behavior-diff, acceptance
+  packets, and revision binding.
+- `adlc-distill`: P7 and maintenance, including lesson-foundry,
+  rejection-mining, external skill-mining, skill-rot, model-ratchet,
+  review-calibration, and gate-fuzzing.
+
+Every skill must use the dispatcher form (`adlc <tool>`) and must describe the
+manifest-backed completion rule.
+
+### Rails
+
+- Ship plugin-bundled `hooks/hooks.json`; do not leave hook scripts orphaned.
+- Use an enforcing `PreToolUse` hook for structured file-editing tools that can
+  identify target paths and shell-capable tools whose command payload can mutate
+  files.
+- The hook blocks shell commands that target frozen rails and fails closed on
+  mutating shell payloads whose target paths cannot be identified or whose cwd
+  changes before mutation, and on shell expansion that prevents literal path
+  accounting.
+- The hook no-ops outside active P4 enforcement.
+- The hook fails closed when rails are declared and it cannot make a trustworthy
+  decision.
+- `adlc run <phase>` must verify frozen rail snapshots directly, so shell,
+  generator, formatter, or package-script mutations cannot advance the local
+  lifecycle merely because CI is not installed.
+- CI rail backstops remain required for pull requests and shell-capable writes.
+
+### P5 prosecution
+
+- Do not make first completion depend on plugin-bundled Codex custom subagents;
+  Codex subagents are explicit workflows and custom-agent plugin packaging is
+  less proven than skills/hooks.
+- The `adlc-prosecute` skill defines the process and may ask Codex to spawn
+  parallel reviewer subagents when explicitly requested and supported.
+- Deterministic P5 pass requires a machine-checkable evidence packet consumed by
+  `adlc prosecute` and asserted by `adlc run p5`.
+- The P5 schema must include ticket id, exact revision, clean worktree proof,
+  reviewer identity/session boundary, prompt/hash packet, required lenses,
+  finding dispositions, command evidence, and stale-revision rejection.
+
+### P7 automation
+
+- Treat scheduled P7 metabolism as first-class.
+- Use Codex app scheduled automations as the primary substrate because they can
+  invoke skills, run on schedules, and use project worktrees.
+- Run P7 automations in project worktree mode to avoid colliding with active
+  local work.
+- The automation invokes `$adlc-distill` and the external `$skill-mining` skill.
+  Skill-mining is an external prerequisite installable with
+  `npx skills add voodootikigod/skill-mining`.
+- LLM or write-producing automation must produce reviewable diffs or proposals;
+  it must not silently mutate protected rails or merge changes.
+- CI cron remains the deterministic fallback for keyless checks such as
+  `adlc skill-rot` and `adlc model-ratchet --dry-run`.
+- Completion must include a smoke proof that the automation prompt can resolve
+  the required skills, write P7 no-op evidence, and preserve rails.
+
+### Install and verification
+
+- Keep the offline marketplace/manifest/sentinel smoke test.
+- Add isolated `CODEX_HOME` install proof before declaring the plugin supported.
+- The isolated install smoke must verify usable behavior, not only metadata:
+  installed skill discovery, bundled hook registration, dispatcher help, at
+  least one routed tool, hook payload simulation from installed files, and no
+  mutation of real `~/.codex`.
+- Git-backed sparse marketplace proof is a separate deliverable.
+
+## Consequences
+
+- The first implementation is larger than a skill-only plugin because P0/P1/P6
+  must become executable contracts.
+- The unified dispatcher becomes the stable command prefix for docs, hooks,
+  skills, CI, and automations.
+- The plugin remains idiomatic Codex while preserving the lifecycle doctrine
+  proven in the Claude integration.
+- Evidence schemas become part of the product surface; tests must cover stale
+  revision, stale ticket, tampered artifact, rail mutation, and install behavior
+  failures.
+
+## Acceptance Criteria
+
+- `adlc --help`, unknown-tool handling, routed tool execution, `adlc run`, and
+  `adlc accept` pass tests.
+- `@adlc/runner` no longer publishes the `adlc` binary.
+- Codex skills and docs use `adlc <tool>` forms.
+- The plugin includes bundled hooks metadata and hook tests.
+- P0/P1/P5/P6/P7 evidence contracts are documented and covered by tests.
+- `node scripts/codex-install-smoke.mjs .` passes.
+- An isolated `CODEX_HOME` install smoke exercises installed plugin behavior.
+- The integration is driven through dispatcher commands, hook payload
+  simulations, plugin install smoke, and the P5/P6 fixture flow before it is
+  called complete.

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,91 +1,145 @@
 # Codex Integration
 
-This repository ships ADLC as deterministic CLIs first and a Codex plugin second.
-Codex skills should guide the workflow; ADLC CLIs and `.adlc/manifest.jsonl` decide
-whether a phase passes.
+This page is the landing doc for the Codex-native ADLC surface. It explains how to
+install it, how to use it, and where the current implementation still falls short of the
+formal ADLC doctrine.
 
-The Codex-native integration plan is recorded in
-[ADR 0001](./adr/0001-codex-native-adlc-integration.md).
+The integration is described in more detail in [ADR 0001](./adr/0001-codex-native-adlc-integration.md).
 
-## Local marketplace status
+## Install
 
-The offline smoke test validates the local marketplace entry, plugin manifest, skill
-sentinels, and standalone hook:
+Local verification:
 
 ```sh
 node scripts/codex-install-smoke.mjs .
 ```
 
-The actual Codex install commands are planned but unsupported until an isolated
-`CODEX_HOME` transcript proves Codex accepts the marketplace and plugin schema without
-mutating the real `~/.codex`:
+That smoke test validates the local marketplace entry, plugin manifest, bundled hooks,
+and skill sentinels. It does not run `codex` or exercise the rail hook.
+
+Maintainer-only install path:
+
+> Run this only in a disposable environment. It uses `ADLC_CODEX_LIVE_INSTALL=1` to
+> exercise the isolated install path and verify the plugin, hooks, and skills.
 
 ```sh
-codex plugin marketplace add .
-codex plugin add adlc-codex --marketplace adlc
+ADLC_CODEX_LIVE_INSTALL=1 node scripts/codex-install-smoke.mjs .
 ```
 
-Git-backed install is planned but unsupported until sparse payload proof is recorded.
+There is no published-package fallback in this checkout yet.
+Out-of-repo invocation is currently unsupported in this doc.
 
-## No-install CLI fallback
+Git-backed marketplace install is not yet supported.
 
-Use the dispatcher outside this repository:
+## Usage
+
+Use `adlc` as the stable public prefix. The dispatcher routes to the tool packages and
+keeps the command surface consistent across Codex skills, hooks, CI, and humans.
+
+In this checkout, bare `adlc` resolves to `node packages/cli/bin/adlc.mjs`. Outside this
+checkout, there is no supported invocation path documented yet.
+
+Example usage in this checkout:
 
 ```sh
-npx @adlc/cli@<ADLC_CLI_VERSION> spec-lint spec.md --json
-npx @adlc/cli@<ADLC_CLI_VERSION> rails-guard --ticket T1 --tickets .adlc/tickets.json --record --json
+node packages/cli/bin/adlc.mjs --help
+node packages/cli/bin/adlc.mjs spec-lint spec.md --json
+node packages/cli/bin/adlc.mjs run p5 --ticket T1 --dir .adlc --json
+node packages/cli/bin/adlc.mjs accept --ticket T1 --packet .adlc/packet.json --before .adlc/before.json --after .adlc/after.json --dir .adlc --json
+node packages/cli/bin/adlc.mjs rails-guard --ticket T1 --tickets .adlc/tickets.json --record --json
 ```
 
-Inside this repository, prefer the workspace-linked `adlc <tool>` dispatcher.
+These are templates. They require an existing `spec.md`, a populated `.adlc/` ticket set,
+and recorded evidence for the `T1` examples.
 
-## Strict ADLC status
+Typical flow:
 
-- P0-P4 and P7 have strong deterministic coverage.
-- P5 records reviewer-produced evidence; `adlc prosecute` does not run the reviewer.
-  Its transcript must name the ticket and reviewed revision that will be recorded, and
-  its review packet must hash the prompt and reviewed input artifacts.
-- P6 strict mode requires ticket- and revision-scoped P5 completion evidence plus a
-  behavior acceptance packet. `adlc accept` carries forward the recorded P5 revision by
-  default so behavior artifacts created after P5 do not change the reviewed target.
+1. Run `adlc preflight` before fan-out.
+2. Shape the work with `adlc spec-lint`, `adlc premortem`, and `adlc parallax`.
+3. Decompose with `adlc coldstart`, `adlc merge-forecast`, and `adlc model-router`.
+4. Build rails with `adlc hollow-test`, `adlc rails-guard`, and `adlc flail-detector`.
+5. Prosecute with `adlc prosecute`, then record behavior evidence with `adlc accept`.
+6. Distill repeated findings with `adlc lesson-foundry`, `adlc rejection-mining`, and
+   `adlc skill-rot`.
 
-## Core commands
-
-For normal git worktree use, do not pass `--revision`; P5 and P6 will use the current
-content fingerprint and fail closed if reviewed content changes before P6. The transcript
-referenced by the P5 input must include the ticket id and the resolved `git-worktree:<hash>`
-revision. `adlc prosecute` excludes that transcript path from the fingerprint so the
-binding is achievable for in-repo transcripts. The P5 input must also include
-`review_packet.prompt`, `review_packet.prompt_hash`, `review_packet.inputs`,
-`review_packet.inputs_hash`, and `review_packet.clean_worktree`.
-
-P3, P4, P5, and P6 phase assertions are ticket-scoped. Explicit `--revision` on P5/P6 is
-an offline selector for recorded manifest and artifact evidence; it does not compare
-against the live git worktree.
+Phase-scoped assertions that matter for the formal lifecycle:
 
 ```sh
-adlc prosecute --input .adlc/p5-passes.json --ticket T1 --dir .adlc --json
+adlc run p3 --ticket T1 --dir .adlc --json
+adlc run p4 --ticket T1 --dir .adlc --json
 adlc run p5 --ticket T1 --dir .adlc --json
-adlc accept --ticket T1 --packet .adlc/packet.json --before .adlc/before.json --after .adlc/after.json --dir .adlc --json
 adlc run p6 --ticket T1 --dir .adlc --json
 ```
 
-P6 packet and snapshot paths inside the worktree must live under `.adlc/` or
-`.omo/evidence/`, so they cannot be mistaken for reviewed source files.
+Notes:
 
-The bundled `docs/examples/p5-passes.json` fixture is pinned to
-`docs-example-revision`; use `--revision docs-example-revision` only when exercising that
-static fixture outside the git-worktree staleness check.
+- `p3`, `p4`, `p5`, and `p6` require `--ticket`.
+- `p5` and `p6` use the current git worktree fingerprint unless `--revision` is supplied.
+- Without `--revision`, `p5` and `p6` fail closed if reviewed content changes before
+  `p6` completes.
+- Explicit `--revision` is an offline selector for recorded evidence, not a live worktree
+  comparison.
+- `adlc prosecute` records reviewer-produced evidence; it does not run the reviewer.
+- `adlc accept` records the behavior-diff packet and snapshot evidence for P6.
 
-## P4 rail hook
+Bundled P5 fixture:
 
-The Codex hook is assistive only. It activates only when:
+- `docs/examples/p5-passes.json` is pinned to `docs-example-revision`.
+- When you use that fixture, keep `--revision docs-example-revision` on the prosecution
+  command so the recorded evidence matches the fixture's reviewed revision.
+- Requires a `.adlc/tickets.json` that defines ticket `T1`.
+- Example:
 
 ```sh
-ADLC_P4_ENFORCEMENT=1
+adlc prosecute --input docs/examples/p5-passes.json --ticket T1 --revision docs-example-revision --dir .adlc --json
 ```
 
-It resolves the active ticket from `ADLC_TICKET`, with `.adlc/current-ticket.json` as a
-local fallback. The bundled `PreToolUse` hook covers structured edit tools and common
-shell write forms; mutating shell payloads fail closed when target paths cannot be
-identified, when they change cwd, or when they rely on shell expansion. `adlc rails-guard`
-remains the deterministic proof after shell-capable steps.
+Evidence boundaries that stay part of the formal map:
+
+- P6 packet and snapshot artifacts must live under `.adlc/` or `.omo/evidence/`, so
+  they are not confused with reviewed source files.
+- `review_packet` requires `prompt`, `prompt_hash`, `inputs`, `inputs_hash`, and
+  `clean_worktree` fields when prosecution evidence is asserted.
+- The P4 rail hook fails closed on mutating shell payloads; it is an enforcement aid, not
+  a replacement for `rails-guard`.
+
+> Warning: The maintainer-only live path gated by `ADLC_CODEX_LIVE_INSTALL=1` runs in
+> throwaway `CODEX_HOME`, `HOME`, and XDG roots under `/tmp`. Use it as a maintainer
+> verification step in a disposable environment.
+
+There is no user-facing end-to-end install verification users can trust yet. The default
+`node scripts/codex-install-smoke.mjs .` path does not mutate `~/.codex` or exercise the
+rail hook. The same script has a maintainer-only live path gated by
+`ADLC_CODEX_LIVE_INSTALL=1`.
+
+## Formal ADLC Coverage
+
+| Phase | Status | Notes |
+| --- | --- | --- |
+| P0 | Strong | `adlc preflight` and the router skill provide the deterministic startup gate. |
+| P1 | Strong | `adlc spec-lint` and `adlc premortem` force executable acceptance criteria. |
+| P2 | Strong | `adlc coldstart`, `adlc merge-forecast`, and `adlc model-router` cover ticket shaping. |
+| P3 | Strong | `adlc rails-guard`, `adlc hollow-test`, and the rail hook protect frozen rails. |
+| P4 | Strong | Ticket-scoped rail assertions and the hook give deterministic build supervision. |
+| P5 | Partial | Review evidence is machine-checkable, but there is still no first-party deterministic prosecution orchestrator that fans out lenses and loops until dry automatically. |
+| P6 | Conditional | P6 is strong when backed by valid P5 evidence and a matching acceptance packet. |
+| P7 | Strong | `adlc lesson-foundry`, `adlc rejection-mining`, `adlc skill-rot`, and `adlc model-ratchet` support maintenance. |
+
+## Gaps
+
+Current gaps relative to the formal ADLC doctrine:
+
+1. P5 is still not fully automated. The repo can record and assert prosecution evidence, but
+   the formal orchestration loop for fan-out, finding verification, and dry-pass convergence
+   is not yet a single deterministic first-party gate.
+2. Git-backed sparse marketplace install remains unsupported until payload proof is
+   recorded.
+3. Codex hooks assist P4 rail protection, but they do not replace `rails-guard` or the
+   repository's other deterministic checks.
+
+## Boundary
+
+- `.adlc/` is the runtime state area for tickets, manifests, and gate evidence.
+- `.omo/` is for Codex planning and operator artifacts.
+- The docs in this directory are the canonical high-level map; package READMEs remain the
+  source of truth for exact flags, schemas, and exit codes.

--- a/docs/codex-integration.md
+++ b/docs/codex-integration.md
@@ -1,0 +1,91 @@
+# Codex Integration
+
+This repository ships ADLC as deterministic CLIs first and a Codex plugin second.
+Codex skills should guide the workflow; ADLC CLIs and `.adlc/manifest.jsonl` decide
+whether a phase passes.
+
+The Codex-native integration plan is recorded in
+[ADR 0001](./adr/0001-codex-native-adlc-integration.md).
+
+## Local marketplace status
+
+The offline smoke test validates the local marketplace entry, plugin manifest, skill
+sentinels, and standalone hook:
+
+```sh
+node scripts/codex-install-smoke.mjs .
+```
+
+The actual Codex install commands are planned but unsupported until an isolated
+`CODEX_HOME` transcript proves Codex accepts the marketplace and plugin schema without
+mutating the real `~/.codex`:
+
+```sh
+codex plugin marketplace add .
+codex plugin add adlc-codex --marketplace adlc
+```
+
+Git-backed install is planned but unsupported until sparse payload proof is recorded.
+
+## No-install CLI fallback
+
+Use the dispatcher outside this repository:
+
+```sh
+npx @adlc/cli@<ADLC_CLI_VERSION> spec-lint spec.md --json
+npx @adlc/cli@<ADLC_CLI_VERSION> rails-guard --ticket T1 --tickets .adlc/tickets.json --record --json
+```
+
+Inside this repository, prefer the workspace-linked `adlc <tool>` dispatcher.
+
+## Strict ADLC status
+
+- P0-P4 and P7 have strong deterministic coverage.
+- P5 records reviewer-produced evidence; `adlc prosecute` does not run the reviewer.
+  Its transcript must name the ticket and reviewed revision that will be recorded, and
+  its review packet must hash the prompt and reviewed input artifacts.
+- P6 strict mode requires ticket- and revision-scoped P5 completion evidence plus a
+  behavior acceptance packet. `adlc accept` carries forward the recorded P5 revision by
+  default so behavior artifacts created after P5 do not change the reviewed target.
+
+## Core commands
+
+For normal git worktree use, do not pass `--revision`; P5 and P6 will use the current
+content fingerprint and fail closed if reviewed content changes before P6. The transcript
+referenced by the P5 input must include the ticket id and the resolved `git-worktree:<hash>`
+revision. `adlc prosecute` excludes that transcript path from the fingerprint so the
+binding is achievable for in-repo transcripts. The P5 input must also include
+`review_packet.prompt`, `review_packet.prompt_hash`, `review_packet.inputs`,
+`review_packet.inputs_hash`, and `review_packet.clean_worktree`.
+
+P3, P4, P5, and P6 phase assertions are ticket-scoped. Explicit `--revision` on P5/P6 is
+an offline selector for recorded manifest and artifact evidence; it does not compare
+against the live git worktree.
+
+```sh
+adlc prosecute --input .adlc/p5-passes.json --ticket T1 --dir .adlc --json
+adlc run p5 --ticket T1 --dir .adlc --json
+adlc accept --ticket T1 --packet .adlc/packet.json --before .adlc/before.json --after .adlc/after.json --dir .adlc --json
+adlc run p6 --ticket T1 --dir .adlc --json
+```
+
+P6 packet and snapshot paths inside the worktree must live under `.adlc/` or
+`.omo/evidence/`, so they cannot be mistaken for reviewed source files.
+
+The bundled `docs/examples/p5-passes.json` fixture is pinned to
+`docs-example-revision`; use `--revision docs-example-revision` only when exercising that
+static fixture outside the git-worktree staleness check.
+
+## P4 rail hook
+
+The Codex hook is assistive only. It activates only when:
+
+```sh
+ADLC_P4_ENFORCEMENT=1
+```
+
+It resolves the active ticket from `ADLC_TICKET`, with `.adlc/current-ticket.json` as a
+local fallback. The bundled `PreToolUse` hook covers structured edit tools and common
+shell write forms; mutating shell payloads fail closed when target paths cannot be
+identified, when they change cwd, or when they rely on shell expansion. `adlc rails-guard`
+remains the deterministic proof after shell-capable steps.

--- a/docs/examples/p5-passes.json
+++ b/docs/examples/p5-passes.json
@@ -1,0 +1,61 @@
+{
+  "target": "feature branch",
+  "provenance": {
+    "reviewer": "local-reviewer",
+    "session": "docs-fixture-session",
+    "command": "npx adversarial-review --scope working-tree --include-files",
+    "transcript": ".omo/evidence/p5-review.txt"
+  },
+  "review_packet": {
+    "prompt": ".omo/evidence/p5-prompt.txt",
+    "prompt_hash": "086ada917eb0c8ba6905d617447bfe472c2dd36bbf4daf37746ac25d24818b2a",
+    "inputs": ".omo/evidence/p5-inputs.txt",
+    "inputs_hash": "9faa929a2253953619c4f281754b21859c8fef3135ec864ff450453fdfdcd26a",
+    "clean_worktree": "docs-example-revision"
+  },
+  "no_findings_attestation": {
+    "reason": "the reviewer found no verified findings after refutation",
+    "method": "manual transcript review",
+    "evidence": ".omo/evidence/p5-review.txt"
+  },
+  "passes": [
+    {
+      "lens": "security",
+      "findings": [
+        {
+          "id": "F1",
+          "severity": "medium",
+          "category": "security",
+          "file": "src/auth.mjs",
+          "line_start": 12,
+          "line_end": 12,
+          "evidence": "return true",
+          "claim": "authorization bypass",
+          "recommendation": "check the caller role before returning",
+          "confidence": 0.8,
+          "verified_status": "killed",
+          "verification": {
+            "reason": "the quoted code is inside a test fixture and is not reachable from production auth",
+            "method": "manual source trace plus test run",
+            "evidence": "npm test"
+          }
+        }
+      ]
+    },
+    {
+      "lens": "correctness",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified correctness findings"
+    },
+    {
+      "lens": "tests",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified test-integrity findings"
+    },
+    {
+      "lens": "behavior",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified behavior findings"
+    }
+  ]
+}

--- a/docs/package-reference.md
+++ b/docs/package-reference.md
@@ -8,6 +8,7 @@ Follow each README for full options, output schemas, examples, and implementatio
 | Package | Binary | Role | Source |
 | --- | --- | --- | --- |
 | `@adlc/behavior-diff` | `behavior-diff` | Captures and compares HTTP/API behavior snapshots for the P6 human gate. | [`packages/behavior-diff/README.md`](../packages/behavior-diff/README.md) |
+| `@adlc/cli` | `adlc` | Provides the stable dispatcher surface for all public ADLC tool execution. | [`packages/cli/README.md`](../packages/cli/README.md) |
 | `@adlc/coldstart` | `coldstart` | Checks whether tickets are executable without agent guesswork. | [`packages/coldstart/README.md`](../packages/coldstart/README.md) |
 | `@adlc/consensus-fix` | `consensus-fix` | Fans out candidate fixes and recommends, or optionally applies, the consensus winner that passes gates. | [`packages/consensus-fix/README.md`](../packages/consensus-fix/README.md) |
 | `@adlc/core` | none | Shared LLM, git, CLI, ledger, ticket, and mutation primitives. | [`packages/core/README.md`](../packages/core/README.md) |
@@ -22,40 +23,45 @@ Follow each README for full options, output schemas, examples, and implementatio
 | `@adlc/parallax` | `parallax` | Fans out readers to expose spec ambiguity, edge conflicts, or route conflicts. | [`packages/parallax/README.md`](../packages/parallax/README.md) |
 | `@adlc/preflight` | `preflight` | Checks baseline environment readiness before fan-out. | [`packages/preflight/README.md`](../packages/preflight/README.md) |
 | `@adlc/premortem` | `premortem` | Stress-tests an approved spec before implementation. | [`packages/premortem/README.md`](../packages/premortem/README.md) |
+| `@adlc/prosecute` | `adlc-prosecute` | Records ticket- and revision-scoped P5 review evidence and asserts distinct reviewer-produced dry lenses. Invoke as `adlc prosecute` in normal workflows. | [`packages/prosecute/README.md`](../packages/prosecute/README.md) |
 | `@adlc/rails-guard` | `rails-guard` | Enforces frozen rails, declared suppressions, and manifest recording. | [`packages/rails-guard/README.md`](../packages/rails-guard/README.md) |
 | `@adlc/rejection-mining` | `rejection-mining` | Mines review rejections into reusable review lenses. | [`packages/rejection-mining/README.md`](../packages/rejection-mining/README.md) |
 | `@adlc/review-calibration` | `review-calibration` | Measures reviewer recall by applying mutants and scoring whether review catches them. | [`packages/review-calibration/README.md`](../packages/review-calibration/README.md) |
+| `@adlc/runner` | `adlc-runner` | Asserts phase completion from manifest artifacts rather than command success alone. Normal workflows reach it through `adlc run` and `adlc accept`. | [`packages/runner/README.md`](../packages/runner/README.md) |
 | `@adlc/skill-rot` | `skill-rot` | Checks skill files for stale validation metadata and optional freshness stamping. | [`packages/skill-rot/README.md`](../packages/skill-rot/README.md) |
 | `@adlc/spec-lint` | `spec-lint` | Gates specs for wishes, unverifiable acceptance criteria, and LLM-only verification. | [`packages/spec-lint/README.md`](../packages/spec-lint/README.md) |
 
 ## Command forms
 
 ```sh
-behavior-diff capture --config behavior.json --out before.json
-behavior-diff compare before.json after.json [--json]
-coldstart <ticket-id> [options]
-coldstart --all [options]
-consensus-fix --test-cmd "..." --files a.mjs,b.mjs [options]
-flail-detector <log-file> [--scope <glob>...] [--max-repeat <n>] [--max-bytes <n>] [--json]
-gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid] [--json]
-gate-manifest record <gate-name> [--ticket id] [--data '{json}'] [--files a,b,c] [--dir path] [--json]
-gate-manifest verify [--json] [--dir path]
-gate-manifest show [--ticket id] [--json] [--dir path]
-gate-manifest attest [--ticket id] [--dir path]
-hollow-test --test-cmd "node --test test/" [options]
-lesson-foundry [options]
-merge-forecast [options]
-model-ratchet [--top <n>] [--review-cmd <cmd>] [--churn-limit <n>] [--dry-run] [--json]
-model-router [--tickets <path>] [--floor <number>] [--json]
-parallax --request "text"
-parallax --file req.md
-preflight [--test-cmd "..."] [--gh] [--llm] [--worktrees] [--json]
-premortem <spec.md> [--tier cheap|mid|frontier] [--out report.md] [--json] [--prompt-only]
-rails-guard [--base <ref>] [--ticket <id>] [--tickets <path>] [--rails <glob>...] [--record] [--json]
-rejection-mining [--limit N] [--min N] [--out-dir PATH] [--write] [--llm] [--prompt-only] [--json]
-review-calibration --review-cmd "cmd with {base} placeholder" [options]
-skill-rot [path ...] [--write] [--json]
-spec-lint <spec.md> [--llm] [--json] [--prompt-only]
+adlc behavior-diff capture --config behavior.json --out before.json
+adlc behavior-diff compare before.json after.json [--json]
+adlc coldstart <ticket-id> [options]
+adlc coldstart --all [options]
+adlc consensus-fix --test-cmd "..." --files a.mjs,b.mjs [options]
+adlc flail-detector <log-file> [--scope <glob>...] [--max-repeat <n>] [--max-bytes <n>] [--json]
+adlc gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid] [--json]
+adlc gate-manifest record <gate-name> [--ticket id] [--data '{json}'] [--files a,b,c] [--dir path] [--json]
+adlc gate-manifest verify [--json] [--dir path]
+adlc gate-manifest show [--ticket id] [--json] [--dir path]
+adlc gate-manifest attest [--ticket id] [--dir path]
+adlc hollow-test --test-cmd "node --test test/" [options]
+adlc lesson-foundry [options]
+adlc merge-forecast [options]
+adlc model-ratchet [--top <n>] [--review-cmd <cmd>] [--churn-limit <n>] [--dry-run] [--json]
+adlc model-router [--tickets <path>] [--floor <number>] [--json]
+adlc parallax --request "text"
+adlc parallax --file req.md
+adlc preflight [--test-cmd "..."] [--gh] [--llm] [--worktrees] [--json]
+adlc premortem <spec.md> [--tier cheap|mid|frontier] [--out report.md] [--json] [--prompt-only]
+adlc prosecute --input p5-passes.json --ticket id [--target label] [--revision rev] [--dir .adlc] [--json]
+adlc rails-guard [--base <ref>] [--ticket <id>] [--tickets <path>] [--rails <glob>...] [--record] [--json]
+adlc rejection-mining [--limit N] [--min N] [--out-dir PATH] [--write] [--llm] [--prompt-only] [--json]
+adlc review-calibration --review-cmd "cmd with {base} placeholder" [options]
+adlc run <p1|p2|p3|p4|p5|p6|p7> [--ticket id for p3-p6] [--revision rev for p5-p6] [--dir .adlc] [--json]
+adlc accept --ticket id --packet .adlc/packet.json [--before .adlc/before.json] [--after .adlc/after.json] [--revision rev] [--dir .adlc] [--json]
+adlc skill-rot [path ...] [--write] [--json]
+adlc spec-lint <spec.md> [--llm] [--json] [--prompt-only]
 ```
 
 ## Package groups
@@ -75,12 +81,15 @@ Execution supervision and rails:
 - `rails-guard`
 - `flail-detector`
 - `consensus-fix`
+- `runner`
+  - public phase assertions are `adlc run` and `adlc accept`
 
 Review evidence and calibration:
 
 - `behavior-diff`
 - `gate-manifest`
 - `hollow-test`
+- `prosecute`
 - `review-calibration`
 - `model-ratchet`
 - `gate-fuzzing`
@@ -94,3 +103,4 @@ Compounding defenses:
 Shared foundation:
 
 - `@adlc/core`
+- `@adlc/cli`

--- a/docs/ticket-authoring.md
+++ b/docs/ticket-authoring.md
@@ -1,0 +1,26 @@
+# ADLC Ticket Authoring
+
+Tickets are the executable contract between P2 decomposition, P3 rails, P4 build, and
+P5/P6 evidence. Keep them small enough for one fresh agent context.
+
+## Schema fields
+
+- `id`: stable ticket identifier.
+- `title`: concise human label.
+- `body`: self-contained task text with verification commands and any allowed suppressions.
+- `scope`: file globs this ticket may edit.
+- `rails`: frozen file globs the builder must not edit during P4.
+- `edges`: downstream ticket dependencies with explicit contracts.
+- `duration`: rough relative effort for merge forecasting.
+- `category`: task type such as `feature`, `bug`, `refactor`, or `docs`.
+- `budget`: ADLC tier hint such as `cheap`, `mid`, or `frontier`.
+
+## Rules
+
+- Every acceptance criterion in `body` needs a command, test file, or assertion method.
+- Rails must be behavior-bearing files: tests, schemas, contract types, or CI checks.
+- Suppressions are denied unless the ticket body declares the exact marker using
+  `allow-suppression: <marker>`.
+- Edges mean this ticket completes before `edge.to`; each edge must state the contract.
+
+See `.adlc/tickets.example.json` for a complete fixture.

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -3,40 +3,42 @@
 ADLC treats agentic development as a lifecycle with explicit gates. The tools in this
 repository are small CLIs that make those gates concrete: they inspect specs and tickets,
 route work to models, protect rails, compare behavior, record evidence, and convert
-review findings into reusable defenses.
+review findings into reusable defenses. User-facing workflows should invoke these tools
+through the stable `adlc <tool>` dispatcher.
 
 ## Lifecycle map
 
 | Phase | Question | Primary tools |
 | --- | --- | --- |
-| D2 Phase 0 | Is the workspace ready for fan-out? | `preflight` |
-| P1 / C1-C2 | Is the spec testable and stress-tested? | `spec-lint`, `premortem`, `parallax` |
-| P2 / C3 | Can an agent execute this ticket without guessing? | `coldstart`, `merge-forecast`, `model-router` |
-| P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | `rails-guard`, `flail-detector` |
-| P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | `consensus-fix` |
-| P5-P6 / C14 | Did behavior change, and can a human review the evidence? | `behavior-diff`, `gate-manifest`, `hollow-test` |
-| C12 / maintenance | What must be re-prosecuted after model or repo drift? | `model-ratchet`, `review-calibration`, `skill-rot` |
-| P7 | Which repeated findings should become deterministic defenses? | `lesson-foundry`, `rejection-mining` |
-| Continuous calibration | Can hostile candidates defeat the gates? | `gate-fuzzing` |
+| D2 Phase 0 | Is the workspace ready for fan-out? | `adlc preflight` |
+| P1 / C1-C2 | Is the spec testable and stress-tested? | `adlc spec-lint`, `adlc premortem`, `adlc parallax` |
+| P2 / C3 | Can an agent execute this ticket without guessing? | `adlc coldstart`, `adlc merge-forecast`, `adlc model-router` |
+| P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | `adlc rails-guard`, `adlc flail-detector` |
+| P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | `adlc consensus-fix` |
+| P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | `adlc prosecute`, `adlc behavior-diff`, `adlc gate-manifest`, `adlc hollow-test` |
+| C12 / maintenance | What must be re-prosecuted after model or repo drift? | `adlc model-ratchet`, `adlc review-calibration`, `adlc skill-rot` |
+| P7 | Which repeated findings should become deterministic defenses? | `adlc lesson-foundry`, `adlc rejection-mining` |
+| Continuous calibration | Can hostile candidates defeat the gates? | `adlc gate-fuzzing` |
 
 ## Typical flow
 
-1. Run `preflight` before spawning parallel agents so missing tools, dirty state, or
+1. Run `adlc preflight` before spawning parallel agents so missing tools, dirty state, or
    provider problems fail before work fans out.
-2. Run `spec-lint`, `premortem`, and optionally `parallax` while shaping the work so the
+2. Run `adlc spec-lint`, `adlc premortem`, and optionally `adlc parallax` while shaping the work so the
    accepted spec has verifiable criteria and known divergences.
-3. Use `coldstart` to check ticket executability, then `merge-forecast` and `model-router`
+3. Use `adlc coldstart` to check ticket executability, then `adlc merge-forecast` and `adlc model-router`
    to manage fan-out width and model assignment.
-4. During implementation, use `rails-guard` for frozen-test and suppression controls and
-   `flail-detector` to catch repeated error loops, scope drift, churn, or oversized logs.
-5. For hard failing tests, use `consensus-fix` to fan out independent candidate repairs
+4. During implementation, use `adlc rails-guard` for frozen-test and suppression controls and
+   `adlc flail-detector` to catch repeated error loops, scope drift, churn, or oversized logs.
+5. For hard failing tests, use `adlc consensus-fix` to fan out independent candidate repairs
    and select a gated consensus winner.
-6. Before review, use `hollow-test`, `behavior-diff`, and `gate-manifest` to prove that
-   tests are load-bearing, behavior changes are visible, and gate evidence is recorded.
-7. After review, use `lesson-foundry` and `rejection-mining` to convert repeated review
+6. Before review, use `adlc hollow-test`, `adlc prosecute`, `adlc behavior-diff`, and `adlc gate-manifest`
+   to prove that tests are load-bearing, prosecution reached two dry passes, behavior
+   changes are visible, and gate evidence is recorded.
+7. After review, use `adlc lesson-foundry` and `adlc rejection-mining` to convert repeated review
    findings into deterministic lint checks, skills, or spec-gap templates.
-8. On a schedule or after model changes, use `model-ratchet`, `review-calibration`,
-   `skill-rot`, and `gate-fuzzing` to re-check assumptions that can decay over time.
+8. On a schedule or after model changes, use `adlc model-ratchet`, `adlc review-calibration`,
+   `adlc skill-rot`, and `adlc gate-fuzzing` to re-check assumptions that can decay over time.
 
 ## Evidence conventions
 
@@ -45,7 +47,7 @@ Several tools use `.adlc/` as the shared workspace for machine-readable state:
 - `.adlc/tickets.json` stores ticket metadata consumed by routing, cold-start, rail, and
   merge-forecast tools.
 - `.adlc/manifest.jsonl` stores append-only gate evidence through `gate-manifest`.
-- `.adlc/lessons/` is the default output location for `lesson-foundry`.
+- `.adlc/lessons/` is the default output location for `adlc lesson-foundry`.
 
 The package READMEs define each tool's exact schema. Treat these docs as a routing map,
 then follow the linked README for command-specific details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adlc",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adlc",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -17,6 +17,10 @@
     },
     "node_modules/@adlc/behavior-diff": {
       "resolved": "packages/behavior-diff",
+      "link": true
+    },
+    "node_modules/@adlc/cli": {
+      "resolved": "packages/cli",
       "link": true
     },
     "node_modules/@adlc/coldstart": {
@@ -75,6 +79,10 @@
       "resolved": "packages/premortem",
       "link": true
     },
+    "node_modules/@adlc/prosecute": {
+      "resolved": "packages/prosecute",
+      "link": true
+    },
     "node_modules/@adlc/rails-guard": {
       "resolved": "packages/rails-guard",
       "link": true
@@ -87,6 +95,10 @@
       "resolved": "packages/review-calibration",
       "link": true
     },
+    "node_modules/@adlc/runner": {
+      "resolved": "packages/runner",
+      "link": true
+    },
     "node_modules/@adlc/skill-rot": {
       "resolved": "packages/skill-rot",
       "link": true
@@ -97,10 +109,10 @@
     },
     "packages/behavior-diff": {
       "name": "@adlc/behavior-diff",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "behavior-diff": "bin/behavior-diff.mjs"
@@ -109,12 +121,46 @@
         "node": ">=18"
       }
     },
-    "packages/coldstart": {
-      "name": "@adlc/coldstart",
-      "version": "1.0.0",
+    "packages/cli": {
+      "name": "@adlc/cli",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/behavior-diff": "1.0.2",
+        "@adlc/coldstart": "1.0.2",
+        "@adlc/consensus-fix": "1.0.2",
+        "@adlc/flail-detector": "1.0.2",
+        "@adlc/gate-fuzzing": "1.0.2",
+        "@adlc/gate-manifest": "1.0.2",
+        "@adlc/hollow-test": "1.0.2",
+        "@adlc/lesson-foundry": "1.0.2",
+        "@adlc/merge-forecast": "1.0.2",
+        "@adlc/model-ratchet": "1.0.2",
+        "@adlc/model-router": "1.0.2",
+        "@adlc/parallax": "1.0.2",
+        "@adlc/preflight": "1.0.2",
+        "@adlc/premortem": "1.0.2",
+        "@adlc/prosecute": "1.0.2",
+        "@adlc/rails-guard": "1.0.2",
+        "@adlc/rejection-mining": "1.0.2",
+        "@adlc/review-calibration": "1.0.2",
+        "@adlc/runner": "1.0.2",
+        "@adlc/skill-rot": "1.0.2",
+        "@adlc/spec-lint": "1.0.2"
+      },
+      "bin": {
+        "adlc": "bin/adlc.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/coldstart": {
+      "name": "@adlc/coldstart",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "coldstart": "bin/coldstart.mjs"
@@ -125,10 +171,10 @@
     },
     "packages/consensus-fix": {
       "name": "@adlc/consensus-fix",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "consensus-fix": "bin/consensus-fix.mjs"
@@ -139,7 +185,7 @@
     },
     "packages/core": {
       "name": "@adlc/core",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -147,10 +193,10 @@
     },
     "packages/flail-detector": {
       "name": "@adlc/flail-detector",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "flail-detector": "bin/flail-detector.mjs"
@@ -161,10 +207,10 @@
     },
     "packages/gate-fuzzing": {
       "name": "@adlc/gate-fuzzing",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "gate-fuzzing": "bin/gate-fuzzing.mjs"
@@ -175,10 +221,10 @@
     },
     "packages/gate-manifest": {
       "name": "@adlc/gate-manifest",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "gate-manifest": "bin/gate-manifest.mjs"
@@ -189,10 +235,10 @@
     },
     "packages/hollow-test": {
       "name": "@adlc/hollow-test",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "hollow-test": "bin/hollow-test.mjs"
@@ -203,10 +249,10 @@
     },
     "packages/lesson-foundry": {
       "name": "@adlc/lesson-foundry",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "lesson-foundry": "bin/lesson-foundry.mjs"
@@ -217,10 +263,10 @@
     },
     "packages/merge-forecast": {
       "name": "@adlc/merge-forecast",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "merge-forecast": "bin/merge-forecast.mjs"
@@ -231,10 +277,10 @@
     },
     "packages/model-ratchet": {
       "name": "@adlc/model-ratchet",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "model-ratchet": "bin/model-ratchet.mjs"
@@ -245,10 +291,10 @@
     },
     "packages/model-router": {
       "name": "@adlc/model-router",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "model-router": "bin/model-router.mjs"
@@ -259,10 +305,10 @@
     },
     "packages/parallax": {
       "name": "@adlc/parallax",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "parallax": "bin/parallax.mjs"
@@ -273,10 +319,10 @@
     },
     "packages/preflight": {
       "name": "@adlc/preflight",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "preflight": "bin/preflight.mjs"
@@ -287,10 +333,10 @@
     },
     "packages/premortem": {
       "name": "@adlc/premortem",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "premortem": "bin/premortem.mjs"
@@ -299,12 +345,26 @@
         "node": ">=18"
       }
     },
-    "packages/rails-guard": {
-      "name": "@adlc/rails-guard",
-      "version": "1.0.0",
+    "packages/prosecute": {
+      "name": "@adlc/prosecute",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
+      },
+      "bin": {
+        "adlc-prosecute": "bin/adlc-prosecute.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/rails-guard": {
+      "name": "@adlc/rails-guard",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "rails-guard": "bin/rails-guard.mjs"
@@ -315,10 +375,10 @@
     },
     "packages/rejection-mining": {
       "name": "@adlc/rejection-mining",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "rejection-mining": "bin/rejection-mining.mjs"
@@ -329,10 +389,10 @@
     },
     "packages/review-calibration": {
       "name": "@adlc/review-calibration",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "review-calibration": "bin/review-calibration.mjs"
@@ -341,12 +401,26 @@
         "node": ">=18"
       }
     },
-    "packages/skill-rot": {
-      "name": "@adlc/skill-rot",
-      "version": "1.0.0",
+    "packages/runner": {
+      "name": "@adlc/runner",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
+      },
+      "bin": {
+        "adlc-runner": "bin/adlc.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/skill-rot": {
+      "name": "@adlc/skill-rot",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "skill-rot": "bin/skill-rot.mjs"
@@ -357,10 +431,10 @@
     },
     "packages/spec-lint": {
       "name": "@adlc/spec-lint",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.0"
+        "@adlc/core": "1.0.2"
       },
       "bin": {
         "spec-lint": "bin/spec-lint.mjs"

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,52 @@
+# @adlc/cli
+
+The umbrella dispatcher for the ADLC suite. It provides one stable command
+surface for Codex skills, hooks, CI, and humans:
+
+```sh
+adlc <tool> [args...]
+adlc run <phase> [args...]
+adlc accept [args...]
+```
+
+The dispatcher is a router. It adds no behavior to a tool run: argv is forwarded
+verbatim and the child exit code is propagated unchanged.
+
+## Why this exists
+
+ADLC packages publish independently, but an agent harness needs a single stable
+prefix. A skill or hook that shells out to twenty different binaries is brittle,
+slower to document, and easier to route around. `@adlc/cli` installs the suite
+and makes every gate reachable through `adlc <tool>`.
+
+## Resolution model
+
+The dispatcher resolves package-local binaries from its own `@adlc/*`
+dependencies. It does not search the user's `PATH` for tool names, so stale
+global binaries cannot silently satisfy a gate.
+
+## Usage
+
+```sh
+adlc --help
+adlc --version
+adlc spec-lint spec.md --json
+adlc rails-guard --ticket T1 --record --json
+adlc run p5 --ticket T1 --dir .adlc --json
+adlc accept --ticket T1 --packet .adlc/packet.json --dir .adlc --json
+```
+
+## Exit codes
+
+Exit codes mirror the underlying tool:
+
+- `0`: gate passes or command succeeds.
+- `1`: operational error.
+- `2`: gate fails.
+
+Dispatcher-level failures, such as an unknown tool or missing package, exit `1`.
+
+## ADLC phase
+
+Cross-cutting. This is the delivery and invocation layer for the ADLC Codex
+integration.

--- a/packages/cli/bin/adlc.mjs
+++ b/packages/cli/bin/adlc.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dispatch, dispatchRunner } from '../lib/dispatch.mjs';
+import { renderHelp } from '../lib/help.mjs';
+import { isTool, suggest, TOOLS } from '../lib/registry.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function version() {
+  try {
+    const pkg = JSON.parse(readFileSync(join(HERE, '..', 'package.json'), 'utf8'));
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const argv = process.argv.slice(2);
+const first = argv[0];
+
+if (!first || first === '--help' || first === '-h' || first === 'help') {
+  console.log(renderHelp(version()));
+  process.exit(0);
+}
+
+if (first === '--version' || first === '-v') {
+  console.log(version());
+  process.exit(0);
+}
+
+if (first === 'run' || first === 'accept') {
+  const { code, error } = dispatchRunner(argv);
+  if (error) console.error(`error: ${error}`);
+  process.exit(code);
+}
+
+if (!isTool(first)) {
+  console.error(`error: unknown tool: ${first}`);
+  const hint = suggest(first);
+  if (hint) console.error(`did you mean "${hint}"?`);
+  console.error(`run "adlc --help" for the list of ${TOOLS.length} tools.`);
+  process.exit(1);
+}
+
+const { code, error } = dispatch(first, argv.slice(1));
+if (error) console.error(`error: ${error}`);
+process.exit(code);

--- a/packages/cli/lib/dispatch.mjs
+++ b/packages/cli/lib/dispatch.mjs
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { getTool } from './registry.mjs';
+
+const require = createRequire(import.meta.url);
+
+function packageJsonPath(packageName) {
+  try {
+    return require.resolve(`${packageName}/package.json`);
+  } catch {
+    return null;
+  }
+}
+
+function readPackage(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function binPathFromPackage(pkgJsonPath, pkg, preferredBinName) {
+  const bin = pkg?.bin;
+  if (!bin) return null;
+  if (typeof bin === 'string') return join(dirname(pkgJsonPath), bin);
+  const name = preferredBinName ?? Object.keys(bin)[0];
+  const relative = bin[name];
+  return relative ? join(dirname(pkgJsonPath), relative) : null;
+}
+
+export function resolveBin(toolName) {
+  const tool = getTool(toolName);
+  if (!tool) return null;
+  const pkgJsonPath = packageJsonPath(tool.packageName);
+  if (!pkgJsonPath) return null;
+  const pkg = readPackage(pkgJsonPath);
+  return binPathFromPackage(pkgJsonPath, pkg, tool.binName ?? tool.name);
+}
+
+export function resolveRunnerBin() {
+  const pkgJsonPath = packageJsonPath('@adlc/runner');
+  if (!pkgJsonPath) return null;
+  const pkg = readPackage(pkgJsonPath);
+  return binPathFromPackage(pkgJsonPath, pkg, 'adlc-runner') ?? binPathFromPackage(pkgJsonPath, pkg);
+}
+
+function runBin(label, bin, args) {
+  if (!bin) {
+    return {
+      code: 1,
+      error: `tool not installed: ${label} - run "npm i -g @adlc/cli" to install the suite`,
+    };
+  }
+
+  const result = spawnSync(process.execPath, [bin, ...args], { stdio: 'inherit' });
+  if (result.error) return { code: 1, error: `failed to run ${label}: ${result.error.message}` };
+  if (result.signal) return { code: 1, error: `${label} terminated by signal ${result.signal}` };
+  return { code: typeof result.status === 'number' ? result.status : 1 };
+}
+
+export function dispatch(toolName, args) {
+  return runBin(`@adlc/${toolName}`, resolveBin(toolName), args);
+}
+
+export function dispatchRunner(args) {
+  return runBin('@adlc/runner', resolveRunnerBin(), args);
+}

--- a/packages/cli/lib/help.mjs
+++ b/packages/cli/lib/help.mjs
@@ -1,0 +1,28 @@
+import { GROUPS, TOOLS } from './registry.mjs';
+
+export function renderHelp(version) {
+  const lines = [];
+  lines.push(`adlc ${version} - Agentic Development Lifecycle toolkit dispatcher`);
+  lines.push('');
+  lines.push('Usage:');
+  lines.push('  adlc <tool> [args...]       run an ADLC tool');
+  lines.push('  adlc run <phase> [args...]  assert phase evidence');
+  lines.push('  adlc accept [args...]       record P6 acceptance evidence');
+  lines.push('  adlc --help                 this help');
+  lines.push('  adlc --version              print the dispatcher version');
+  lines.push('');
+  lines.push('Exit codes mirror the routed tool: 0 = pass, 1 = operational error, 2 = gate fail.');
+  lines.push('');
+  lines.push(`Tools (${TOOLS.length}):`);
+
+  const width = Math.max(...TOOLS.map((tool) => tool.name.length));
+  for (const group of GROUPS) {
+    lines.push('');
+    lines.push(`  ${group.title}`);
+    for (const tool of group.tools) {
+      lines.push(`    ${tool.name.padEnd(width)}  ${tool.summary}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/cli/lib/registry.mjs
+++ b/packages/cli/lib/registry.mjs
@@ -1,0 +1,90 @@
+/**
+ * @typedef {{ name: string, packageName: string, binName?: string, summary: string }} Tool
+ * @typedef {{ title: string, tools: Tool[] }} Group
+ */
+
+/** @type {Group[]} */
+export const GROUPS = [
+  {
+    title: 'Spec and ticket shaping',
+    tools: [
+      { name: 'parallax', packageName: '@adlc/parallax', summary: 'Fan out readers to expose spec ambiguity and route conflicts.' },
+      { name: 'spec-lint', packageName: '@adlc/spec-lint', summary: 'Gate specs for acceptance criteria that lack a verification method.' },
+      { name: 'premortem', packageName: '@adlc/premortem', summary: 'Stress-test an approved spec before implementation.' },
+      { name: 'coldstart', packageName: '@adlc/coldstart', summary: 'Check whether tickets are executable without agent guesswork.' },
+    ],
+  },
+  {
+    title: 'Execution supervision and rails',
+    tools: [
+      { name: 'preflight', packageName: '@adlc/preflight', summary: 'Check baseline environment readiness before fan-out.' },
+      { name: 'model-router', packageName: '@adlc/model-router', summary: 'Assign tickets to frontier, direct, or ladder model strategies.' },
+      { name: 'merge-forecast', packageName: '@adlc/merge-forecast', summary: 'Estimate fan-out width, dependency pressure, and merge backpressure.' },
+      { name: 'rails-guard', packageName: '@adlc/rails-guard', summary: 'Enforce frozen rails, declared suppressions, and manifest recording.' },
+      { name: 'flail-detector', packageName: '@adlc/flail-detector', summary: 'Detect repeated errors, scope violations, edit churn, and oversized logs.' },
+      { name: 'consensus-fix', packageName: '@adlc/consensus-fix', summary: 'Fan out candidate fixes and select the gated consensus winner.' },
+    ],
+  },
+  {
+    title: 'Review evidence and calibration',
+    tools: [
+      { name: 'behavior-diff', packageName: '@adlc/behavior-diff', summary: 'Capture and compare HTTP/API behavior snapshots for the P6 human gate.' },
+      { name: 'gate-manifest', packageName: '@adlc/gate-manifest', summary: 'Record, verify, show, and attest append-only gate evidence.' },
+      { name: 'hollow-test', packageName: '@adlc/hollow-test', summary: 'Mutate changed code to find tests that pass without testing behavior.' },
+      { name: 'prosecute', packageName: '@adlc/prosecute', binName: 'adlc-prosecute', summary: 'Record ticket- and revision-bound P5 prosecution evidence.' },
+      { name: 'review-calibration', packageName: '@adlc/review-calibration', summary: 'Measure reviewer recall by scoring whether review catches mutants.' },
+      { name: 'model-ratchet', packageName: '@adlc/model-ratchet', summary: 'Identify hot files for re-prosecution after model or repo drift.' },
+      { name: 'gate-fuzzing', packageName: '@adlc/gate-fuzzing', summary: 'Run hostile candidates against gate suites to find defeats.' },
+    ],
+  },
+  {
+    title: 'Compounding defenses',
+    tools: [
+      { name: 'lesson-foundry', packageName: '@adlc/lesson-foundry', summary: 'Mine repeated findings into deterministic defenses.' },
+      { name: 'rejection-mining', packageName: '@adlc/rejection-mining', summary: 'Mine review rejections into reusable review lenses.' },
+      { name: 'skill-rot', packageName: '@adlc/skill-rot', summary: 'Check skill files for stale validation metadata and stamp freshness.' },
+    ],
+  },
+];
+
+/** @type {Tool[]} */
+export const TOOLS = GROUPS.flatMap((group) => group.tools);
+
+const TOOL_BY_NAME = new Map(TOOLS.map((tool) => [tool.name, tool]));
+
+export function getTool(name) {
+  return TOOL_BY_NAME.get(name) ?? null;
+}
+
+export function isTool(name) {
+  return TOOL_BY_NAME.has(name);
+}
+
+export function suggest(name) {
+  let best = null;
+  let bestDist = Infinity;
+  for (const tool of TOOLS) {
+    const dist = editDistance(name, tool.name);
+    if (dist < bestDist) {
+      best = tool.name;
+      bestDist = dist;
+    }
+  }
+  return bestDist <= Math.max(2, Math.floor(name.length / 3)) ? best : null;
+}
+
+function editDistance(a, b) {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  let current = new Array(b.length + 1);
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(current[j - 1] + 1, previous[j] + 1, previous[j - 1] + cost);
+    }
+    [previous, current] = [current, previous];
+  }
+  return previous[b.length];
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@adlc/cli",
+  "version": "1.0.2",
+  "description": "Umbrella dispatcher for the @adlc suite - one install, one `adlc <tool>` command surface.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Chris Williams (@voodootikigod)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voodootikigod/adlc.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/voodootikigod/adlc/tree/main/packages/cli#readme",
+  "bugs": "https://github.com/voodootikigod/adlc/issues",
+  "keywords": [
+    "adlc",
+    "agentic",
+    "ai",
+    "llm",
+    "cli",
+    "dispatcher",
+    "gate"
+  ],
+  "bin": {
+    "adlc": "./bin/adlc.mjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@adlc/behavior-diff": "1.0.2",
+    "@adlc/coldstart": "1.0.2",
+    "@adlc/consensus-fix": "1.0.2",
+    "@adlc/flail-detector": "1.0.2",
+    "@adlc/gate-fuzzing": "1.0.2",
+    "@adlc/gate-manifest": "1.0.2",
+    "@adlc/hollow-test": "1.0.2",
+    "@adlc/lesson-foundry": "1.0.2",
+    "@adlc/merge-forecast": "1.0.2",
+    "@adlc/model-ratchet": "1.0.2",
+    "@adlc/model-router": "1.0.2",
+    "@adlc/parallax": "1.0.2",
+    "@adlc/preflight": "1.0.2",
+    "@adlc/premortem": "1.0.2",
+    "@adlc/prosecute": "1.0.2",
+    "@adlc/rails-guard": "1.0.2",
+    "@adlc/rejection-mining": "1.0.2",
+    "@adlc/review-calibration": "1.0.2",
+    "@adlc/runner": "1.0.2",
+    "@adlc/skill-rot": "1.0.2",
+    "@adlc/spec-lint": "1.0.2"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/cli/test/dispatch.test.mjs
+++ b/packages/cli/test/dispatch.test.mjs
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveBin, resolveRunnerBin } from '../lib/dispatch.mjs';
+import { isTool, suggest, TOOLS } from '../lib/registry.mjs';
+import { renderHelp } from '../lib/help.mjs';
+
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'adlc.mjs');
+
+function runAdlc(args, options = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN, ...args], {
+      encoding: 'utf8',
+      cwd: options.cwd,
+      stderr: 'pipe',
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+    };
+  }
+}
+
+function withTempSpec(contents, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-cli-'));
+  try {
+    const path = join(dir, 'spec.md');
+    writeFileSync(path, contents);
+    return fn(path, dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('registry exposes the suite tools and omits internal packages', () => {
+  assert.equal(TOOLS.length, 20);
+  assert.equal(isTool('spec-lint'), true);
+  assert.equal(isTool('prosecute'), true);
+  assert.equal(isTool('core'), false);
+  assert.equal(isTool('runner'), false);
+});
+
+test('suggest returns near misses only', () => {
+  assert.equal(suggest('spec-lnt'), 'spec-lint');
+  assert.equal(suggest('railsguard'), 'rails-guard');
+  assert.equal(suggest('zzzzzzzz'), null);
+});
+
+test('resolves package-local tool bins without PATH lookup', () => {
+  assert.match(resolveBin('spec-lint') ?? '', /packages\/spec-lint\/bin\/spec-lint\.mjs$/);
+  assert.match(resolveBin('prosecute') ?? '', /packages\/prosecute\/bin\/adlc-prosecute\.mjs$/);
+  assert.equal(resolveBin('definitely-not-real'), null);
+});
+
+test('resolves runner bin for run and accept verbs', () => {
+  assert.match(resolveRunnerBin() ?? '', /packages\/runner\/bin\/adlc\.mjs$/);
+});
+
+test('help lists every routed tool and exits 0', () => {
+  const { code, stdout } = runAdlc(['--help']);
+  assert.equal(code, 0);
+  for (const tool of TOOLS) assert.match(stdout, new RegExp(`\\b${tool.name}\\b`));
+});
+
+test('renderHelp embeds version and tool count', () => {
+  const output = renderHelp('9.9.9');
+  assert.match(output, /adlc 9\.9\.9/);
+  assert.match(output, /Tools \(20\)/);
+});
+
+test('version prints a semver-shaped string', () => {
+  const { code, stdout } = runAdlc(['--version']);
+  assert.equal(code, 0);
+  assert.match(stdout.trim(), /^\d+\.\d+\.\d+/);
+});
+
+test('unknown tool exits 1 with suggestion', () => {
+  const { code, stderr } = runAdlc(['spec-lnt']);
+  assert.equal(code, 1);
+  assert.match(stderr, /unknown tool/);
+  assert.match(stderr, /did you mean "spec-lint"/);
+});
+
+test('routes to spec-lint and propagates exit 0', () => {
+  withTempSpec('## Acceptance Criteria\n- Returns 200, verified by `curl -sf localhost`\n', (path) => {
+    assert.equal(runAdlc(['spec-lint', path]).code, 0);
+  });
+});
+
+test('routes to spec-lint and propagates exit 2', () => {
+  withTempSpec('## Acceptance Criteria\n- It should feel fast and delightful\n', (path) => {
+    assert.equal(runAdlc(['spec-lint', path]).code, 2);
+  });
+});
+
+test('routes run verb to runner', () => {
+  const { code, stdout } = runAdlc(['run', 'p5', '--help']);
+  assert.equal(code, 0);
+  assert.match(stdout, /adlc run <phase>/);
+});
+
+test('routes accept verb to runner', () => {
+  const { code, stdout } = runAdlc(['accept', '--help']);
+  assert.equal(code, 0);
+  assert.match(stdout, /adlc accept --ticket id/);
+});

--- a/packages/cli/test/release-script.test.mjs
+++ b/packages/cli/test/release-script.test.mjs
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { packagePublishOrder, repinInternalDependencies } from '../../../scripts/release.mjs';
+
+test('release publish order keeps core first and cli last', () => {
+  assert.deepEqual(
+    packagePublishOrder(['spec-lint', 'cli', 'core', 'runner', 'behavior-diff']),
+    ['core', 'behavior-diff', 'runner', 'spec-lint', 'cli']
+  );
+});
+
+test('release repins every internal @adlc dependency kind', () => {
+  const original = {
+    name: '@adlc/cli',
+    version: '1.0.2',
+    dependencies: {
+      '@adlc/core': '1.0.2',
+      '@adlc/spec-lint': '1.0.2',
+      chalk: '^5.0.0',
+    },
+    devDependencies: {
+      '@adlc/runner': '1.0.2',
+    },
+    peerDependencies: {
+      '@adlc/prosecute': '1.0.2',
+    },
+    optionalDependencies: {
+      '@adlc/rails-guard': '1.0.2',
+    },
+  };
+
+  const next = repinInternalDependencies(original, '1.1.0');
+
+  assert.equal(next.version, '1.1.0');
+  assert.equal(next.dependencies['@adlc/core'], '1.1.0');
+  assert.equal(next.dependencies['@adlc/spec-lint'], '1.1.0');
+  assert.equal(next.devDependencies['@adlc/runner'], '1.1.0');
+  assert.equal(next.peerDependencies['@adlc/prosecute'], '1.1.0');
+  assert.equal(next.optionalDependencies['@adlc/rails-guard'], '1.1.0');
+  assert.equal(next.dependencies.chalk, '^5.0.0');
+  assert.equal(original.version, '1.0.2');
+});

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,110 @@
+import type { ParseArgsConfig } from 'node:util';
+
+export const ADLC_DIR: string;
+export const TICKETS_PATH: string;
+
+export type ParsedArgs = {
+  readonly values: Record<string, string | boolean | string[] | boolean[] | undefined>;
+  readonly positionals: string[];
+};
+export function parseArgs(config?: ParseArgsConfig): ParsedArgs;
+export function pass(message?: string): never;
+export function gateFail(message?: string, details?: unknown): never;
+export function opError(message?: string): never;
+export function printJson(value: unknown): void;
+export function readStdin(): Promise<string>;
+export function promptOnly(prompts: string | readonly string[]): never;
+
+export type ModelTier = 'cheap' | 'mid' | 'frontier';
+export type Provider = {
+  readonly name: string;
+  readonly apiKey?: string;
+  readonly models: Record<string, string>;
+  readonly send?: (options: CompletionRequest) => Promise<string>;
+};
+export type CompletionOptions = {
+  readonly tier?: ModelTier | string;
+  readonly model?: string;
+  readonly system?: string;
+  readonly prompt: string;
+  readonly maxTokens?: number;
+};
+export type CompletionRequest = CompletionOptions & {
+  readonly apiKey: string;
+  readonly model: string;
+};
+export type FanResult =
+  | { readonly ok: true; readonly value: string }
+  | { readonly ok: false; readonly error: string };
+
+export function isAgyTimeout(output: string): boolean;
+export function complete(options: CompletionOptions): Promise<string>;
+export function fan(options: CompletionOptions, count: number): Promise<FanResult[]>;
+export function extractJson(text: string): unknown;
+export function detectProvider(env?: Record<string, string | undefined>): Provider | null;
+export function resolveModel(
+  provider: Pick<Provider, 'models'>,
+  options?: { readonly tier?: ModelTier | string; readonly model?: string },
+  env?: Record<string, string | undefined>
+): string;
+
+export function git(args: readonly string[], opts?: {
+  cwd?: string;
+  stdio?: unknown;
+  encoding?: string;
+  maxBuffer?: number;
+  [key: string]: unknown;
+}): string;
+export function gitDiff(base?: string, cwd?: string): string;
+export function changedFiles(base?: string, cwd?: string): string[];
+export function isDirty(cwd?: string): boolean;
+export function isGitRepo(cwd?: string): boolean;
+export function refExists(ref: string, cwd?: string): boolean;
+export function resolveBase(cwd?: string, candidates?: string[]): string | null;
+export function coChange(limit?: number, cwd?: string): {
+  pairCounts: Record<string, number>;
+  fileCounts: Record<string, number>;
+};
+export function churn(limit?: number, cwd?: string): Record<string, number>;
+
+export function appendEntry<T = unknown>(name: string, entry: T, dir?: string): T;
+export function withLedgerLock<T>(target: string, fn: () => T): T;
+export function readEntries<T = unknown>(
+  name: string,
+  dir?: string
+): { entries: T[]; skipped: Array<{ line: number; error: string }> };
+export function ledgerPath(name: string, dir?: string): string;
+export function sha256(input: string | Uint8Array): string;
+export function canonicalJson(value: unknown): string;
+export function hashFiles(
+  files: readonly string[],
+  readFile?: (path: string) => string | Uint8Array
+): Record<string, string | null>;
+
+export function validateTicket(ticket: unknown): string[];
+export function loadTickets(path?: string): { tickets: unknown[]; errors: string[] };
+export function topoSort(tickets: Array<{ id: string; edges?: Array<{ to: string }> }>): {
+  order: string[];
+  cycle: string[] | null;
+};
+export function computeFloat(tickets: Array<{ id: string; duration?: number; edges?: Array<{ to: string }> }>): unknown;
+export function globMatch(pattern: string, path: string): boolean;
+export function scopesOverlap(left: unknown, right: unknown): boolean;
+export function inScope(ticket: unknown, path: string): boolean;
+export function pairKey(left: string, right: string): string;
+
+export function resolveRevision(options?: {
+  cwd?: string;
+  revision?: string | null;
+  ignorePaths?: string[];
+}): string | null;
+
+export namespace mutate {
+  export const OPERATORS: ReadonlyArray<{
+    readonly name: string;
+    readonly apply: (line: string) => string | null;
+  }>;
+  export function generateMutants(...args: unknown[]): unknown;
+  export function applyMutant(...args: unknown[]): unknown;
+  export function changedLinesFromDiff(...args: unknown[]): unknown;
+}

--- a/packages/core/index.mjs
+++ b/packages/core/index.mjs
@@ -4,4 +4,5 @@ export * from './lib/git.mjs';
 export * from './lib/cli.mjs';
 export * from './lib/ledger.mjs';
 export * from './lib/tickets.mjs';
+export * from './lib/revision.mjs';
 export * as mutate from './lib/mutate.mjs';

--- a/packages/core/lib/ledger.mjs
+++ b/packages/core/lib/ledger.mjs
@@ -94,6 +94,22 @@ export function sha256(content) {
   return createHash('sha256').update(content).digest('hex');
 }
 
+function canonicalizeJsonValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalizeJsonValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalizeJsonValue(value[key])])
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value) {
+  return JSON.stringify(canonicalizeJsonValue(value));
+}
+
 /** Hash a list of files → { path: sha256 }. Missing files hash to null. */
 export function hashFiles(paths, readFile = (p) => readFileSync(p)) {
   const out = {};

--- a/packages/core/lib/revision.mjs
+++ b/packages/core/lib/revision.mjs
@@ -1,0 +1,170 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const GIT_MAX_BUFFER = 64 * 1024 * 1024;
+
+function git(args, cwd) {
+  return execFileSync('git', args, {
+    cwd,
+    maxBuffer: GIT_MAX_BUFFER,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+function newHash() {
+  const hash = createHash('sha256');
+  return {
+    add(part) {
+      hash.update(part);
+      hash.update('\0');
+    },
+    digest() {
+      return hash.digest('hex');
+    },
+  };
+}
+
+function addWorkingTreeFile(hash, cwd, relative, object) {
+  const absolute = join(cwd, relative);
+  if (!existsSync(absolute)) {
+    return;
+  }
+  hash.add(Buffer.from(relative));
+  const stat = statSync(absolute);
+  if (!stat.isFile()) {
+    hash.add(Buffer.from(`non-file:${stat.mode}:${stat.size}`));
+    return;
+  }
+  const mode = (stat.mode & 0o111) ? '100755' : '100644';
+  hash.add(Buffer.from(`git-blob:${mode}:${object}`));
+}
+
+function splitNull(raw) {
+  return raw.toString('utf8').split('\0').filter(Boolean);
+}
+
+function trackedEntries(cwd) {
+  const entries = new Map();
+  for (const record of splitNull(git(['ls-files', '-s', '-z'], cwd))) {
+    const tab = record.indexOf('\t');
+    if (tab === -1) continue;
+    const metadata = record.slice(0, tab).trim().split(/\s+/);
+    const path = record.slice(tab + 1);
+    if (metadata.length >= 3 && path) entries.set(path, { mode: metadata[0], object: metadata[1] });
+  }
+  return entries;
+}
+
+function dirtyTrackedPaths(cwd) {
+  return new Set(splitNull(git(['diff', '--name-only', '-z'], cwd)));
+}
+
+function addGitBlob(hash, relative, entry) {
+  hash.add(Buffer.from(relative));
+  hash.add(Buffer.from(`git-blob:${entry.mode}:${entry.object}`));
+}
+
+function batchWorkingTreeBlobs(cwd, paths) {
+  if (paths.length === 0) return new Map();
+  const objects = new Map();
+  let chunk = [];
+  let chunkBytes = 0;
+  const flush = () => {
+    if (chunk.length === 0) return;
+    const output = git(['hash-object', '--', ...chunk], cwd).toString('utf8').split('\n').filter(Boolean);
+    for (const [index, path] of chunk.entries()) {
+      const object = output[index];
+      if (object) objects.set(path, object);
+    }
+    chunk = [];
+    chunkBytes = 0;
+  };
+
+  for (const path of paths) {
+    const pathBytes = Buffer.byteLength(path) + 1;
+    if (chunk.length > 0 && chunkBytes + pathBytes > 128 * 1024) flush();
+    chunk.push(path);
+    chunkBytes += pathBytes;
+  }
+  flush();
+  return objects;
+}
+
+const DEFAULT_IGNORED_PATHS = [
+  '.adlc/manifest.jsonl',
+  '.adlc/manifest.lock',
+  '.adlc/tickets.json',
+  '.adlc/current-ticket.json',
+];
+
+function normalizeRelativePath(cwd, path) {
+  const normalized = relative(cwd, resolve(cwd, path)).replaceAll('\\', '/');
+  if (!normalized || normalized.startsWith('../') || normalized === '..') return null;
+  return normalized;
+}
+
+function ignoredPathSet(cwd, paths) {
+  return new Set(
+    [...DEFAULT_IGNORED_PATHS, ...paths]
+      .map((path) => normalizeRelativePath(cwd, path))
+      .filter(Boolean)
+  );
+}
+
+function isIgnoredPath(relativePath, ignoredPaths) {
+  const normalized = relativePath.replaceAll('\\', '/');
+  return ignoredPaths.has(normalized);
+}
+
+export function resolveRevision({ cwd = process.cwd(), revision, ignorePaths = [] } = {}) {
+  if (revision !== undefined && revision !== null && String(revision).trim() !== '') {
+    return String(revision);
+  }
+
+  try {
+    git(['rev-parse', '--is-inside-work-tree'], cwd);
+    const tracked = trackedEntries(cwd);
+    const dirtyTracked = dirtyTrackedPaths(cwd);
+    const untracked = splitNull(git(['ls-files', '--others', '--exclude-standard', '-z'], cwd));
+    const hash = newHash();
+    const ignoredPaths = ignoredPathSet(cwd, ignorePaths);
+    const files = new Set([
+      ...tracked.keys(),
+      ...untracked,
+    ]);
+    const sortedFiles = Array.from(files).sort();
+    const workingTreeBlobIds = batchWorkingTreeBlobs(
+      cwd,
+      sortedFiles.filter((relative) => {
+        if (isIgnoredPath(relative, ignoredPaths)) return false;
+        const trackedEntry = tracked.get(relative);
+        if (trackedEntry && !dirtyTracked.has(relative)) return false;
+        try {
+          return statSync(join(cwd, relative)).isFile();
+        } catch {
+          return false;
+        }
+      })
+    );
+
+    for (const relative of sortedFiles) {
+      if (isIgnoredPath(relative, ignoredPaths)) continue;
+      try {
+        const trackedEntry = tracked.get(relative);
+        if (trackedEntry && !dirtyTracked.has(relative)) {
+          addGitBlob(hash, relative, trackedEntry);
+        } else {
+          addWorkingTreeFile(hash, cwd, relative, workingTreeBlobIds.get(relative));
+        }
+      } catch {
+        hash.add(Buffer.from(relative));
+        hash.add(Buffer.from('missing'));
+      }
+    }
+    return `git-worktree:${hash.digest()}`;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,17 +21,23 @@
     "core"
   ],
   "main": "index.mjs",
+  "types": "index.d.ts",
   "exports": {
-    ".": "./index.mjs",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    },
     "./llm": "./lib/llm.mjs",
     "./git": "./lib/git.mjs",
     "./cli": "./lib/cli.mjs",
     "./ledger": "./lib/ledger.mjs",
+    "./revision": "./lib/revision.mjs",
     "./tickets": "./lib/tickets.mjs",
     "./mutate": "./lib/mutate.mjs"
   },
   "files": [
     "index.mjs",
+    "index.d.ts",
     "lib/",
     "README.md",
     "LICENSE"

--- a/packages/core/test/core.test.mjs
+++ b/packages/core/test/core.test.mjs
@@ -1,18 +1,22 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { execFileSync } from 'node:child_process';
+import * as corePublic from '../index.mjs';
 import { extractJson } from '../lib/llm.mjs';
-import { appendEntry, readEntries, sha256, hashFiles } from '../lib/ledger.mjs';
+import { appendEntry, canonicalJson, readEntries, sha256, hashFiles } from '../lib/ledger.mjs';
 import { resolveBase, refExists } from '../lib/git.mjs';
 import {
   validateTicket, loadTickets, topoSort, computeFloat,
   globMatch, inScope, scopesOverlap,
 } from '../lib/tickets.mjs';
 import { generateMutants, applyMutant, changedLinesFromDiff } from '../lib/mutate.mjs';
+import { resolveRevision as resolveWorktreeRevision } from '../lib/revision.mjs';
+
+const repoRoot = new URL('../../../', import.meta.url).pathname;
 
 test('extractJson: plain object', () => {
   assert.deepEqual(extractJson('{"a": 1}'), { a: 1 });
@@ -50,6 +54,34 @@ test('sha256 + hashFiles: deterministic, missing file hashes null', () => {
   assert.equal(sha256('abc'), sha256('abc'));
   const hashes = hashFiles(['/definitely/not/a/file']);
   assert.equal(hashes['/definitely/not/a/file'], null);
+});
+
+test('canonicalJson: sorts object keys recursively while preserving array order', () => {
+  const left = { b: 2, a: { d: 4, c: 3 }, list: [{ y: 2, x: 1 }] };
+  const right = { list: [{ x: 1, y: 2 }], a: { c: 3, d: 4 }, b: 2 };
+  assert.equal(canonicalJson(left), canonicalJson(right));
+  assert.notEqual(canonicalJson({ list: [1, 2] }), canonicalJson({ list: [2, 1] }));
+});
+
+test('index.d.ts: public declarations match runtime signatures used by consumers', () => {
+  const types = readFileSync(join(repoRoot, 'packages/core/index.d.ts'), 'utf8');
+  const rootDeclarations = new Set(
+    [...types.matchAll(/^export (?:async )?function (\w+)|^export const (\w+)|^export namespace (\w+)/gm)]
+      .map((match) => match[1] ?? match[2] ?? match[3])
+  );
+  for (const exportName of Object.keys(corePublic).sort()) {
+    assert.ok(rootDeclarations.has(exportName), `missing declaration for root export ${exportName}`);
+  }
+
+  const mutateBlock = types.split('export namespace mutate {')[1]?.split('\n}')[0] ?? '';
+  for (const exportName of Object.keys(corePublic.mutate).sort()) {
+    assert.match(mutateBlock, new RegExp(`\\b${exportName}\\b`), `missing declaration for mutate.${exportName}`);
+  }
+
+  assert.match(types, /export function appendEntry<T = unknown>\(name: string, entry: T, dir\?: string\): T;/);
+  assert.match(types, /export function gateFail\(message\?: string, details\?: unknown\): never;/);
+  assert.match(types, /export function gitDiff\(base\?: string, cwd\?: string\): string;/);
+  assert.match(types, /export function promptOnly\(prompts: string \| readonly string\[\]\): never;/);
 });
 
 test('validateTicket: catches missing fields', () => {
@@ -206,6 +238,141 @@ test('resolveBase: returns null when no trunk candidate exists (callers must fai
     g('branch', '-m', 'main', 'work'); // rename away from main/master
     assert.equal(refExists('main', dir), false);
     assert.equal(resolveBase(dir), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: handles large tracked diffs without exec buffer failure', () => {
+  const { dir, g } = gitRepo();
+  try {
+    const file = join(dir, 'large.txt');
+    writeFileSync(file, 'a'.repeat(2 * 1024 * 1024));
+    g('add', '-A'); g('commit', '-qm', 'large');
+    writeFileSync(file, 'b'.repeat(2 * 1024 * 1024));
+    const revision = resolveWorktreeRevision({ cwd: dir });
+    assert.match(revision, /^git-worktree:/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: touching an untracked file without content change is stable', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const untracked = join(dir, 'review.txt');
+    writeFileSync(untracked, 'same content\n'.repeat(10));
+    const before = resolveWorktreeRevision({ cwd: dir });
+    const now = new Date();
+    utimesSync(untracked, now, new Date(now.getTime() + 10_000));
+    const after = resolveWorktreeRevision({ cwd: dir });
+    assert.equal(after, before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: untracked source content changes the fingerprint', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    writeFileSync(join(dir, 'feature.mjs'), 'export const value = 1;\n');
+    const after = resolveWorktreeRevision({ cwd: dir });
+    assert.notEqual(after, before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: handles dirty files whose paths contain newlines', () => {
+  const { dir, g } = gitRepo();
+  try {
+    const file = join(dir, 'multi\nline.txt');
+    writeFileSync(file, 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    writeFileSync(file, 'changed\n');
+    const after = resolveWorktreeRevision({ cwd: dir });
+    assert.match(after, /^git-worktree:/);
+    assert.notEqual(after, before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: explicitly ignored review artifacts do not change the fingerprint', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    writeFileSync(join(dir, 'acceptance.json'), '{"accepted":true}\n');
+    const after = resolveWorktreeRevision({ cwd: dir, ignorePaths: ['acceptance.json'] });
+    assert.equal(after, before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: root files with artifact basenames are fingerprinted unless explicitly ignored', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    writeFileSync(join(dir, 'after.json'), '{"unreviewed":true}\n');
+    assert.notEqual(resolveWorktreeRevision({ cwd: dir }), before);
+    assert.equal(resolveWorktreeRevision({ cwd: dir, ignorePaths: ['after.json'] }), before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: nested files with artifact basenames still change the fingerprint', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    mkdirSync(join(dir, 'test/fixtures'), { recursive: true });
+    writeFileSync(join(dir, 'test/fixtures/after.json'), '{"unreviewed":true}\n');
+    const after = resolveWorktreeRevision({ cwd: dir });
+    assert.notEqual(after, before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: .adlc runtime and ticket files are ignored by the generic worktree hash', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc/manifest.jsonl'), '{"type":"runtime"}\n');
+    assert.equal(resolveWorktreeRevision({ cwd: dir }), before);
+    writeFileSync(join(dir, '.adlc/tickets.json'), '{"tickets":[]}\n');
+    assert.equal(resolveWorktreeRevision({ cwd: dir }), before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveRevision: ignored .adlc tickets stay out of the generic worktree hash', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, '.gitignore'), '.adlc/*\n!.adlc/tickets.example.json\n');
+    writeFileSync(join(dir, 'tracked.txt'), 'base\n');
+    g('add', '-A'); g('commit', '-qm', 'base');
+    const before = resolveWorktreeRevision({ cwd: dir });
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc/tickets.json'), '{"tickets":[]}\n');
+    assert.equal(resolveWorktreeRevision({ cwd: dir }), before);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/prosecute/LICENSE
+++ b/packages/prosecute/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Chris Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prosecute/README.md
+++ b/packages/prosecute/README.md
@@ -1,0 +1,94 @@
+# @adlc/prosecute
+
+P5 review-evidence recorder. It does not run a model review by itself. It consumes
+normalized reviewer-produced pass evidence, records ticket- and revision-scoped P5
+evidence to `.adlc/manifest.jsonl`, and passes only after two consecutive dry passes
+with at least three distinct dry lenses.
+
+## Usage
+
+```sh
+adlc-prosecute --input p5-passes.json --ticket T1 --dir .adlc --json
+```
+
+## Input shape
+
+```json
+{
+  "target": "feature branch",
+  "provenance": {
+      "reviewer": "local-reviewer",
+      "session": "codex-session-123",
+      "command": "npx adversarial-review --scope working-tree --include-files",
+      "transcript": ".omo/evidence/p5-review.txt"
+  },
+  "review_packet": {
+      "prompt": ".omo/evidence/p5-prompt.txt",
+      "prompt_hash": "sha256-of-prompt-file",
+      "inputs": ".omo/evidence/p5-inputs.txt",
+      "inputs_hash": "sha256-of-reviewed-input-packet",
+      "clean_worktree": "git-worktree:..."
+  },
+  "passes": [
+    {
+      "lens": "security",
+      "findings": [
+        {
+          "id": "F1",
+          "severity": "high",
+          "category": "security",
+          "file": "src/auth.js",
+          "line_start": 10,
+          "line_end": 12,
+          "evidence": "quoted changed code",
+          "claim": "token bypass",
+          "recommendation": "validate issuer",
+          "confidence": 0.8,
+          "verified_status": "verified"
+        }
+      ]
+    },
+    {
+      "lens": "security",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified security findings"
+    },
+    {
+      "lens": "correctness",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified correctness findings"
+    }
+  ]
+}
+```
+
+`verified_status` must be `verified`, `killed`, or `needs-human`. Killed findings must
+include `verification.reason`, `verification.method`, and `verification.evidence`.
+Inputs must use the built-in lens names: `security`, `correctness`, `tests`, `behavior`,
+`integration`, or `docs`. Clean reviews with zero finding candidates are accepted when the
+dry passes include evidence. If no finding is marked `verified`, the input must include
+`no_findings_attestation` with
+`reason`, `method`, and `evidence`. Only passes with zero findings count as dry; killed
+findings are recorded but do not advance dry-pass convergence.
+
+The transcript is not treated as a generic attachment. It must be readable, at least 64
+bytes, and it must reference both the `--ticket` value and the resolved reviewed revision
+string (`git-worktree:<hash>` unless `--revision` is supplied). This binds the recorded
+P5 evidence to the ticket and revision that P6 later checks, but it still does not prove
+that an external reviewer ran. Use the named `provenance.command` and transcript from the
+actual skeptical review run, not a hand-written placeholder.
+
+The review packet binds the reviewer prompt and reviewed input packet to P5 evidence.
+`prompt` and `inputs` are file paths, their hashes must match the supplied SHA-256 values,
+and `clean_worktree` must equal the exact reviewed revision.
+
+## Exit codes
+
+- `0`: two consecutive dry passes were recorded
+- `1`: operational error
+- `2`: verified/needs-human findings remain or the convergence budget ended before two dry passes
+
+## ADLC phase
+
+P5 Prosecute. This tool makes the review-evidence and dry-pass record executable, but
+the reviewer command named in `provenance.command` remains the source of the review.

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { parseArgs, printJson, opError } from '@adlc/core';
+import { runProsecution } from '../lib/run.mjs';
+
+const { values } = parseArgs({
+  options: {
+    input: { type: 'string' },
+    ticket: { type: 'string' },
+    target: { type: 'string' },
+    revision: { type: 'string' },
+    dir: { type: 'string', default: '.adlc' },
+    json: { type: 'boolean', default: false },
+    help: { type: 'boolean', default: false },
+  },
+});
+
+if (values.help) {
+  console.log(`adlc-prosecute --input <passes.json> --ticket id [--target label] [--revision rev] [--dir .adlc] [--json]
+
+ADLC P5 review-evidence recorder.
+
+Exit codes:
+  0  two consecutive dry passes recorded
+  1  operational error
+  2  verified findings remain or dry-pass convergence failed
+`);
+  process.exit(0);
+}
+
+if (!values.input) opError('usage: adlc-prosecute --input <passes.json> --ticket id');
+if (!values.ticket) opError('usage: adlc-prosecute --input <passes.json> --ticket id');
+
+let input;
+try {
+  input = JSON.parse(readFileSync(values.input, 'utf8'));
+} catch (err) {
+  opError(`could not read input: ${err.message}`);
+}
+
+const result = runProsecution(input, {
+  ticket: values.ticket,
+  target: values.target,
+  revision: values.revision,
+  inputPath: values.input,
+  dir: values.dir,
+});
+
+if (values.json) {
+  printJson(result);
+} else if (result.exitCode === 0) {
+  console.log(result.message);
+} else {
+  console.error(result.message);
+  if (result.errors) console.error(result.errors.join('\n'));
+}
+
+process.exit(result.exitCode);

--- a/packages/prosecute/lib/run.mjs
+++ b/packages/prosecute/lib/run.mjs
@@ -1,0 +1,335 @@
+import { appendEntry, ADLC_DIR, canonicalJson, readEntries, resolveRevision, sha256 } from '@adlc/core';
+import { readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { validateInput } from './schema.mjs';
+
+function now() {
+  return new Date().toISOString();
+}
+
+function writeEvidence(type, data, dir) {
+  return appendEntry('manifest', { ts: now(), type, ...data }, dir);
+}
+
+function manifestArtifactPaths(cwd, dir) {
+  const root = resolve(cwd, dir);
+  return [join(root, 'manifest.jsonl'), join(root, 'manifest.lock'), join(root, 'tickets.json')];
+}
+
+function isInsideCwd(cwd, absolute) {
+  const rel = relative(cwd, absolute).replaceAll('\\', '/');
+  return rel !== '' && !rel.startsWith('../') && rel !== '..';
+}
+
+function isEvidencePath(cwd, absolute) {
+  const rel = relative(cwd, absolute).replaceAll('\\', '/');
+  return rel.startsWith('.adlc/') || rel.startsWith('.omo/evidence/');
+}
+
+function revisionIgnorePaths(cwd, dir, input, inputPath) {
+  return [
+    ...manifestArtifactPaths(cwd, dir),
+    inputPath ? resolve(cwd, inputPath) : null,
+    input?.provenance?.transcript ? resolve(cwd, input.provenance.transcript) : null,
+    input?.review_packet?.prompt ? resolve(cwd, input.review_packet.prompt) : null,
+    input?.review_packet?.inputs ? resolve(cwd, input.review_packet.inputs) : null,
+  ].filter(Boolean);
+}
+
+function ticketDefinitionHash(cwd, ticket, dir) {
+  const paths = [resolve(cwd, dir, 'tickets.json'), resolve(cwd, '.adlc/tickets.json')];
+  for (const path of paths) {
+    try {
+      const raw = readFileSync(path, 'utf8');
+      const parsed = JSON.parse(raw);
+      const tickets = Array.isArray(parsed?.tickets) ? parsed.tickets : [];
+      const definition = tickets.find((candidate) => candidate?.id === ticket);
+      if (definition) return sha256(canonicalJson(definition));
+    } catch {
+      // Try the next supported ticket location.
+    }
+  }
+  return null;
+}
+
+function transcriptReferencesTicket(text, ticket) {
+  return text
+    .split(/\r?\n/)
+    .some((line) => {
+      const match = line.match(/^\s*ticket\s*:\s*(.+?)\s*$/i);
+      return match?.[1] === ticket;
+    });
+}
+
+function transcriptProof(transcript, cwd, { ticket, revision }) {
+  try {
+    const absolute = resolve(cwd, transcript);
+    const stat = statSync(absolute);
+    if (!stat.isFile()) return `provenance.transcript is not a file: ${transcript}`;
+    if (isInsideCwd(cwd, absolute) && !isEvidencePath(cwd, absolute)) {
+      return `provenance.transcript inside the worktree must live under .adlc/ or .omo/evidence/: ${transcript}`;
+    }
+    if (stat.size < 64) return `provenance.transcript is too small to serve as review evidence: ${transcript}`;
+    const content = readFileSync(absolute);
+    const text = content.toString('utf8');
+    if (!transcriptReferencesTicket(text, ticket)) {
+      return `provenance.transcript must reference ticket ${ticket}: ${transcript}`;
+    }
+    if (!text.includes(revision)) {
+      return `provenance.transcript must reference reviewed revision ${revision}: ${transcript}`;
+    }
+    return { path: absolute, hash: sha256(content) };
+  } catch (err) {
+    return `provenance.transcript cannot be read: ${transcript}: ${err.message}`;
+  }
+}
+
+function artifactProof(path, expectedHash, cwd, label) {
+  try {
+    const absolute = resolve(cwd, path);
+    const stat = statSync(absolute);
+    if (!stat.isFile()) return `${label} is not a file: ${path}`;
+    if (isInsideCwd(cwd, absolute) && !isEvidencePath(cwd, absolute)) {
+      return `${label} inside the worktree must live under .adlc/ or .omo/evidence/: ${path}`;
+    }
+    const content = readFileSync(absolute);
+    const actualHash = sha256(content);
+    if (actualHash !== expectedHash) {
+      return `${label} hash mismatch: ${path}`;
+    }
+    return { path: absolute, hash: actualHash };
+  } catch (err) {
+    return `${label} cannot be read: ${path}: ${err.message}`;
+  }
+}
+
+function reviewPacketProof(packet, cwd, revision) {
+  const errors = [];
+  const prompt = artifactProof(packet.prompt, packet.prompt_hash, cwd, 'review_packet.prompt');
+  const inputs = artifactProof(packet.inputs, packet.inputs_hash, cwd, 'review_packet.inputs');
+  if (typeof prompt === 'string') errors.push(prompt);
+  if (typeof inputs === 'string') errors.push(inputs);
+  if (packet.clean_worktree !== revision) {
+    errors.push(`review_packet.clean_worktree must equal reviewed revision ${revision}`);
+  }
+  if (errors.length > 0) return errors;
+  return {
+    prompt,
+    inputs,
+    cleanWorktree: packet.clean_worktree,
+  };
+}
+
+function finalDryLenses(passResults) {
+  const lenses = new Set();
+  for (let index = passResults.length - 1; index >= 0; index -= 1) {
+    const pass = passResults[index];
+    if (!pass.dry) break;
+    lenses.add(pass.lens);
+  }
+  return lenses;
+}
+
+function classifyPass(pass) {
+  const verified = pass.findings.filter((f) => f.verified_status === 'verified');
+  const needsHuman = pass.findings.filter((f) => f.verified_status === 'needs-human');
+  const killed = pass.findings.filter((f) => f.verified_status === 'killed');
+  const dry = pass.findings.length === 0;
+  return { verified, needsHuman, killed, dry };
+}
+
+function findingIdentity(finding) {
+  return sha256(canonicalJson({
+    id: finding.id ?? null,
+    file: finding.file ?? null,
+    line_start: finding.line_start ?? null,
+    line_end: finding.line_end ?? null,
+    category: finding.category ?? null,
+    claim: finding.claim ?? null,
+    evidence: finding.evidence ?? null,
+  }));
+}
+
+function seedOpenFindingsFromManifest(dir, ticket, revision) {
+  const openFindings = new Map();
+  const { entries } = readEntries('manifest', dir);
+  for (const entry of entries) {
+    if (entry.ticket !== ticket || entry.revision !== revision || !entry.finding) continue;
+    const type = entry.type ?? entry.gate;
+    const identity = findingIdentity(entry.finding);
+    if (type === 'p5-finding-verified' || type === 'p5-finding-needs-human') {
+      openFindings.set(identity, entry.finding);
+    }
+    if (type === 'p5-finding-killed') {
+      openFindings.delete(identity);
+    }
+  }
+  return openFindings;
+}
+
+export function runProsecution(input, {
+  ticket,
+  dir = ADLC_DIR,
+  target = input?.target ?? 'working tree',
+  revision,
+  inputPath,
+  cwd = process.cwd(),
+} = {}) {
+  const errors = validateInput(input);
+  if (!ticket) errors.push('ticket is required for P5 evidence');
+  const resolvedRevision = resolveRevision({
+    cwd,
+    revision,
+    ignorePaths: revisionIgnorePaths(cwd, dir, input, inputPath),
+  });
+  const ticketHash = ticket ? ticketDefinitionHash(cwd, ticket, dir) : null;
+  if (ticket && !ticketHash) errors.push(`ticket definition not found for ${ticket}; define it in .adlc/tickets.json`);
+  if (!resolvedRevision) errors.push('revision could not be resolved; pass --revision or run inside a git worktree');
+  let transcript;
+  let reviewPacket;
+  if (input?.provenance?.transcript) {
+    transcript = transcriptProof(input.provenance.transcript, cwd, {
+      ticket: ticket ?? '',
+      revision: resolvedRevision ?? '',
+    });
+    if (typeof transcript === 'string') errors.push(transcript);
+  }
+  if (input?.review_packet && resolvedRevision) {
+    reviewPacket = reviewPacketProof(input.review_packet, cwd, resolvedRevision);
+    if (Array.isArray(reviewPacket)) errors.push(...reviewPacket);
+  }
+  if (errors.length > 0) {
+    return { status: 'op-error', exitCode: 1, errors };
+  }
+  const inputEvidencePath = inputPath ? resolve(cwd, inputPath) : null;
+
+  let consecutiveDry = 0;
+  const passResults = [];
+  const openFindings = seedOpenFindingsFromManifest(dir, ticket, resolvedRevision);
+
+  for (const [index, pass] of input.passes.entries()) {
+    const passNo = index + 1;
+    writeEvidence('p5-pass-started', {
+      ticket,
+      target,
+      revision: resolvedRevision,
+      pass: passNo,
+      lens: pass.lens,
+      provenance: input.provenance,
+      transcript,
+      reviewPacket,
+      inputPath: inputEvidencePath,
+      ticketHash,
+    }, dir);
+
+    for (const finding of pass.findings) {
+      writeEvidence('p5-finding-raw', {
+        ticket,
+        target,
+        revision: resolvedRevision,
+        pass: passNo,
+        lens: pass.lens,
+        finding,
+      }, dir);
+      writeEvidence(`p5-finding-${finding.verified_status}`, {
+        ticket,
+        target,
+        revision: resolvedRevision,
+        pass: passNo,
+        lens: pass.lens,
+        finding,
+      }, dir);
+    }
+
+    const result = classifyPass(pass);
+    if (result.dry) {
+      consecutiveDry += 1;
+      writeEvidence('p5-dry-pass', {
+        ticket,
+        target,
+        revision: resolvedRevision,
+        pass: passNo,
+        lens: pass.lens,
+        consecutiveDry,
+        dryEvidence: pass.dry_evidence ?? null,
+      }, dir);
+    } else {
+      consecutiveDry = 0;
+      for (const finding of pass.findings) {
+        const identity = findingIdentity(finding);
+        if (finding.verified_status === 'verified' || finding.verified_status === 'needs-human') {
+          openFindings.set(identity, finding);
+        }
+        if (finding.verified_status === 'killed') {
+          openFindings.delete(identity);
+        }
+      }
+    }
+
+    writeEvidence('p5-pass-completed', {
+      ticket,
+      target,
+      revision: resolvedRevision,
+      pass: passNo,
+      lens: pass.lens,
+      dry: result.dry,
+      verified: result.verified.length,
+      killed: result.killed.length,
+      needsHuman: result.needsHuman.length,
+      consecutiveDry,
+    }, dir);
+
+    passResults.push({
+      pass: passNo,
+      lens: pass.lens,
+      dry: result.dry,
+      verified: result.verified.length,
+      killed: result.killed.length,
+      needsHuman: result.needsHuman.length,
+      consecutiveDry,
+    });
+
+  }
+
+  const dryLenses = finalDryLenses(passResults);
+  if (consecutiveDry >= 2 && openFindings.size === 0 && dryLenses.size >= 3) {
+    writeEvidence('p5-complete', {
+      ticket,
+      target,
+      revision: resolvedRevision,
+      pass: passResults.length,
+      consecutiveDry,
+      provenance: input.provenance,
+      transcript,
+      reviewPacket,
+      inputPath: inputEvidencePath,
+      dryLenses: Array.from(dryLenses).sort(),
+      ticketHash,
+    }, dir);
+    return {
+      status: 'pass',
+      exitCode: 0,
+      target,
+      ticket,
+      revision: resolvedRevision,
+      passes: passResults,
+      openFindings: [],
+      message: 'P5 review evidence complete: two consecutive dry passes and three distinct dry lenses recorded',
+    };
+  }
+
+  return {
+    status: 'gate-fail',
+    exitCode: 2,
+    target,
+    ticket,
+    revision: resolvedRevision,
+    passes: passResults,
+    openFindings: Array.from(openFindings.values()),
+    message: openFindings.size > 0
+      ? 'P5 incomplete: verified or needs-human findings were seen at this revision'
+      : consecutiveDry >= 2
+        ? 'P5 incomplete: fewer than three distinct dry lenses were recorded'
+        : 'P5 incomplete: convergence budget ended before two consecutive dry passes',
+  };
+}

--- a/packages/prosecute/lib/schema.mjs
+++ b/packages/prosecute/lib/schema.mjs
@@ -1,0 +1,100 @@
+const STATUSES = new Set(['verified', 'killed', 'needs-human']);
+const SEVERITIES = new Set(['critical', 'high', 'medium', 'low']);
+const LENSES = new Set(['security', 'correctness', 'tests', 'behavior', 'integration', 'docs']);
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isLine(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isConfidence(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+function validateProof(value, prefix, fields) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return [`${prefix} must be an object`];
+  }
+  const errors = [];
+  for (const field of fields) {
+    if (!isNonEmptyString(value[field])) errors.push(`${prefix}.${field} must be a non-empty string`);
+  }
+  return errors;
+}
+
+export function validateFinding(finding, passIndex, findingIndex) {
+  const prefix = `pass ${passIndex + 1} finding ${findingIndex + 1}`;
+  if (!finding || typeof finding !== 'object' || Array.isArray(finding)) {
+    return [`${prefix}: finding must be an object`];
+  }
+
+  const errors = [];
+  for (const field of ['id', 'category', 'file', 'evidence', 'claim', 'recommendation']) {
+    if (!isNonEmptyString(finding[field])) errors.push(`${prefix}: ${field} must be a non-empty string`);
+  }
+  if (!SEVERITIES.has(finding.severity)) {
+    errors.push(`${prefix}: severity must be one of ${Array.from(SEVERITIES).join(', ')}`);
+  }
+  if (!isLine(finding.line_start)) errors.push(`${prefix}: line_start must be an integer >= 0`);
+  if (!isLine(finding.line_end)) errors.push(`${prefix}: line_end must be an integer >= 0`);
+  if (isLine(finding.line_start) && isLine(finding.line_end) && finding.line_end < finding.line_start) {
+    errors.push(`${prefix}: line_end must be >= line_start`);
+  }
+  if (!isConfidence(finding.confidence)) errors.push(`${prefix}: confidence must be a number from 0 to 1`);
+  if (!STATUSES.has(finding.verified_status)) {
+    errors.push(`${prefix}: verified_status must be one of ${Array.from(STATUSES).join(', ')}`);
+  }
+  if (finding.verified_status === 'killed') {
+    errors.push(...validateProof(finding.verification, `${prefix}: verification`, ['reason', 'method', 'evidence']));
+  }
+  return errors;
+}
+
+export function validateInput(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return ['input must be a JSON object'];
+  }
+  if (!Array.isArray(input.passes)) return ['passes must be an array'];
+  if (input.passes.length === 0) return ['passes must contain at least one pass'];
+
+  const errors = [];
+  errors.push(...validateProof(input.provenance, 'provenance', ['reviewer', 'session', 'command', 'transcript']));
+  errors.push(...validateProof(input.review_packet, 'review_packet', [
+    'prompt',
+    'prompt_hash',
+    'inputs',
+    'inputs_hash',
+    'clean_worktree',
+  ]));
+  const findings = input.passes.flatMap((pass) => (Array.isArray(pass?.findings) ? pass.findings : []));
+  if (!findings.some((finding) => finding?.verified_status === 'verified')) {
+    errors.push(...validateProof(input.no_findings_attestation, 'no_findings_attestation', [
+      'reason',
+      'method',
+      'evidence',
+    ]));
+  }
+  for (const [passIndex, pass] of input.passes.entries()) {
+    if (!pass || typeof pass !== 'object' || Array.isArray(pass)) {
+      errors.push(`pass ${passIndex + 1}: pass must be an object`);
+      continue;
+    }
+    if (!LENSES.has(pass.lens)) {
+      errors.push(`pass ${passIndex + 1}: lens must be one of ${Array.from(LENSES).join(', ')}`);
+    }
+    if (!Array.isArray(pass.findings)) {
+      errors.push(`pass ${passIndex + 1}: findings must be an array`);
+      continue;
+    }
+    if (pass.findings.length === 0 && !isNonEmptyString(pass.dry_evidence)) {
+      errors.push(`pass ${passIndex + 1}: dry_evidence must be a non-empty string when findings is empty`);
+    }
+    for (const [findingIndex, finding] of pass.findings.entries()) {
+      errors.push(...validateFinding(finding, passIndex, findingIndex));
+    }
+  }
+  return errors;
+}

--- a/packages/prosecute/package.json
+++ b/packages/prosecute/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@adlc/prosecute",
+  "version": "1.0.2",
+  "description": "P5 review-evidence recorder for ticket- and revision-bound findings and dry-pass completion.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Chris Williams (@voodootikigod)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voodootikigod/adlc.git",
+    "directory": "packages/prosecute"
+  },
+  "homepage": "https://github.com/voodootikigod/adlc/tree/main/packages/prosecute#readme",
+  "bugs": "https://github.com/voodootikigod/adlc/issues",
+  "keywords": [
+    "adlc",
+    "agentic",
+    "ai",
+    "llm",
+    "cli",
+    "prosecute",
+    "gate"
+  ],
+  "bin": {
+    "adlc-prosecute": "./bin/adlc-prosecute.mjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@adlc/core": "1.0.2"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/prosecute/test/prosecute.test.mjs
+++ b/packages/prosecute/test/prosecute.test.mjs
@@ -1,0 +1,745 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { runProsecution } from '../lib/run.mjs';
+import { canonicalJson, resolveRevision, sha256 } from '@adlc/core';
+
+const FIXTURE_REVISION = 'fixture-revision';
+const repoRoot = resolve(new URL('../../../', import.meta.url).pathname);
+
+function tmpAdlc() {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-prosecute-'));
+  writeFileSync(join(dir, 'tickets.json'), JSON.stringify({
+    tickets: [
+      { id: 'T1', title: 'Fixture ticket', scope: ['src/**'], rails: ['test/**'], edges: [] },
+      { id: 'T10', title: 'Substring guard ticket', scope: ['src/**'], rails: ['test/**'], edges: [] },
+    ],
+  }));
+  return dir;
+}
+
+function gitRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-prosecute-git-'));
+  const g = (...args) => execFileSync('git', args, {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  g('init', '-q', '-b', 'main');
+  g('config', 'user.email', 't@t.co');
+  g('config', 'user.name', 'tester');
+  g('config', 'commit.gpgsign', 'false');
+  return { dir, g };
+}
+
+function transcript(dir, { ticket = 'T1', revision = FIXTURE_REVISION } = {}) {
+  const path = join(dir, 'review.txt');
+  writeFileSync(path, [
+    `ticket: ${ticket}`,
+    `reviewed revision: ${revision}`,
+    'review transcript fixture with enough detail to be accepted as evidence',
+    'review transcript fixture with enough detail to be accepted as evidence',
+  ].join('\n'));
+  return path;
+}
+
+function reviewPacket(dir, { revision = FIXTURE_REVISION, prefix = 'review' } = {}) {
+  const prompt = join(dir, `${prefix}-prompt.txt`);
+  const inputs = join(dir, `${prefix}-inputs.txt`);
+  writeFileSync(prompt, `review prompt for ${revision}\n`);
+  writeFileSync(inputs, `reviewed input packet for ${revision}\n`);
+  return {
+    prompt,
+    prompt_hash: sha256(readFileSync(prompt)),
+    inputs,
+    inputs_hash: sha256(readFileSync(inputs)),
+    clean_worktree: revision,
+  };
+}
+
+function finding(overrides = {}) {
+  return {
+    id: 'F1',
+    severity: 'high',
+    category: 'correctness',
+    file: 'src/app.mjs',
+    line_start: 1,
+    line_end: 1,
+    evidence: 'return false',
+    claim: 'wrong result',
+    recommendation: 'return true',
+    confidence: 0.9,
+    verified_status: 'verified',
+    ...overrides,
+  };
+}
+
+function input(dir, overrides = {}) {
+  return {
+    provenance: {
+      reviewer: 'fixture-reviewer',
+      session: 'fixture-session',
+      command: 'fixture review command',
+      transcript: transcript(dir),
+    },
+    review_packet: reviewPacket(dir),
+    no_findings_attestation: {
+      reason: 'fixture reviewer found no candidates',
+      method: 'review transcript audit',
+      evidence: 'review.txt',
+    },
+    ...overrides,
+  };
+}
+
+describe('runProsecution', () => {
+  it('passes after two consecutive dry passes and records p5-complete', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      target: 'fixture',
+      passes: [
+        {
+          lens: 'security',
+          findings: [finding({
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'correctness', findings: [], dry_evidence: 'review transcript found no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'review transcript found no test findings' },
+        { lens: 'behavior', findings: [], dry_evidence: 'review transcript found no behavior findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.revision, FIXTURE_REVISION);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.match(manifest, /"type":"p5-complete"/);
+    assert.match(manifest, /"revision":"fixture-revision"/);
+    assert.match(manifest, /"type":"p5-dry-pass"/);
+  });
+
+  it('passes a clean review with only dry passes and no finding candidates', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      target: 'fixture',
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.openFindings, []);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.match(manifest, /"type":"p5-complete"/);
+  });
+
+  it('fails when verified findings remain without two dry passes', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [{ lens: 'security', findings: [finding()] }],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 2);
+    assert.equal(result.openFindings.length, 1);
+  });
+
+  it('passes when a later killed disposition resolves an earlier verified finding', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [finding()] },
+        {
+          lens: 'security',
+          findings: [finding({
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+        { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.openFindings, []);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.match(manifest, /"type":"p5-finding-verified"/);
+    assert.match(manifest, /"type":"p5-finding-killed"/);
+    assert.match(manifest, /"type":"p5-complete"/);
+  });
+
+  it('does not count dry lenses from before a later finding toward final convergence', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings before later review work' },
+        { lens: 'correctness', findings: [finding()] },
+        {
+          lens: 'correctness',
+          findings: [finding({
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings after refutation' },
+        { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings after refutation' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 2);
+    assert.deepEqual(result.openFindings, []);
+    assert.match(result.message, /fewer than three distinct dry lenses/);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.doesNotMatch(manifest, /"type":"p5-complete"/);
+  });
+
+  it('keeps a verified finding open when a killed disposition only shares the id', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [finding({ id: 'F1', claim: 'auth bypass' })] },
+        {
+          lens: 'security',
+          findings: [finding({
+            id: 'F1',
+            claim: 'different claim',
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+        { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 2);
+    assert.equal(result.openFindings.length, 1);
+  });
+
+  it('does not complete dry-only prosecution when a previous manifest finding is unresolved', () => {
+    const dir = tmpAdlc();
+    const first = runProsecution(input(dir, {
+      passes: [{ lens: 'security', findings: [finding()] }],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+    assert.equal(first.exitCode, 2);
+
+    const second = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(second.exitCode, 2);
+    assert.equal(second.openFindings.length, 1);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.doesNotMatch(manifest, /"type":"p5-complete"/);
+  });
+
+  it('completes later prosecution when it kills a previous manifest finding before dry passes', () => {
+    const dir = tmpAdlc();
+    const first = runProsecution(input(dir, {
+      passes: [{ lens: 'security', findings: [finding()] }],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+    assert.equal(first.exitCode, 2);
+
+    const second = runProsecution(input(dir, {
+      passes: [
+        {
+          lens: 'security',
+          findings: [finding({
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+        { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(second.exitCode, 0);
+    assert.deepEqual(second.openFindings, []);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.match(manifest, /"type":"p5-complete"/);
+  });
+
+  it('returns op-error for invalid schema', () => {
+    const result = runProsecution({ passes: [{ lens: 'x', findings: [{ id: 'bad' }] }] });
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.length > 0);
+  });
+
+  it('requires ticketed evidence', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [{ lens: 'security', findings: [], dry_evidence: 'none found' }],
+    }));
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.some((error) => error.includes('ticket is required')));
+  });
+
+  it('requires the ticket to be defined before recording P5 evidence', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'adlc-prosecute-no-ticket-'));
+    try {
+      const result = runProsecution(input(dir, {
+        passes: [
+          { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+          { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+          { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+        ],
+      }), { dir, ticket: 'T404', revision: FIXTURE_REVISION });
+      assert.equal(result.exitCode, 1);
+      assert.ok(result.errors.some((error) => error.includes('ticket definition not found for T404')));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not complete when verified findings were seen before dry passes at the same revision', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [finding()] },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 2);
+    assert.equal(result.openFindings.length, 1);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.doesNotMatch(manifest, /"type":"p5-complete"/);
+  });
+
+  it('does not complete when verified findings appear after two dry passes', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [finding({ id: 'F2', category: 'test-integrity' })] },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 2);
+    assert.equal(result.openFindings.length, 1);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.doesNotMatch(manifest, /"type":"p5-complete"/);
+  });
+
+  it('does not count killed-only passes as dry', () => {
+    const dir = tmpAdlc();
+    const killed = {
+      verified_status: 'killed',
+      verification: {
+        reason: 'fixture refuted',
+        method: 'unit test',
+        evidence: 'test passes',
+      },
+    };
+    const result = runProsecution(input(dir, {
+      passes: [
+        { lens: 'security', findings: [finding({ ...killed, id: 'F1' })] },
+        { lens: 'correctness', findings: [finding({ ...killed, id: 'F2', category: 'correctness' })] },
+        { lens: 'tests', findings: [finding({ ...killed, id: 'F3', category: 'test-integrity' })] },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 2);
+    assert.equal(result.passes.every((pass) => pass.dry === false), true);
+  });
+
+
+  it('requires a readable review transcript', () => {
+    const dir = tmpAdlc();
+    const result = runProsecution({
+      provenance: {
+        reviewer: 'fixture-reviewer',
+        session: 'fixture-session',
+        command: 'fixture review command',
+        transcript: join(dir, 'missing.txt'),
+      },
+      review_packet: reviewPacket(dir),
+      passes: [{ lens: 'security', findings: [], dry_evidence: 'none found' }],
+    }, { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.some((error) => error.includes('provenance.transcript cannot be read')));
+  });
+
+  it('requires the transcript to name the ticket and reviewed revision', () => {
+    const dir = tmpAdlc();
+    const reviewTranscript = join(dir, 'review.txt');
+    writeFileSync(reviewTranscript, 'generic review transcript with enough bytes but no binding markers\n'.repeat(2));
+    const result = runProsecution({
+      provenance: {
+        reviewer: 'fixture-reviewer',
+        session: 'fixture-session',
+        command: 'fixture review command',
+        transcript: reviewTranscript,
+      },
+      review_packet: reviewPacket(dir),
+      no_findings_attestation: {
+        reason: 'fixture reviewer found no candidates',
+        method: 'review transcript audit',
+        evidence: 'review.txt',
+      },
+      passes: [
+        {
+          lens: 'security',
+          findings: [finding({
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+        { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings' },
+      ],
+    }, { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.some((error) => error.includes('provenance.transcript must reference ticket T1')));
+  });
+
+  it('does not bind a transcript to a ticket by substring', () => {
+    const dir = tmpAdlc();
+    const reviewTranscript = transcript(dir, { ticket: 'T10' });
+    const result = runProsecution({
+      provenance: {
+        reviewer: 'fixture-reviewer',
+        session: 'fixture-session',
+        command: 'fixture review command',
+        transcript: reviewTranscript,
+      },
+      review_packet: reviewPacket(dir),
+      no_findings_attestation: {
+        reason: 'fixture reviewer found no candidates',
+        method: 'review transcript audit',
+        evidence: 'review.txt',
+      },
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+      ],
+    }, { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.some((error) => error.includes('provenance.transcript must reference ticket T1')));
+  });
+
+  it('requires review packet hashes to match the reviewed prompt and input artifacts', () => {
+    const dir = tmpAdlc();
+    const badPacket = reviewPacket(dir);
+    badPacket.inputs_hash = '0'.repeat(64);
+    const result = runProsecution(input(dir, {
+      review_packet: badPacket,
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+        { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+      ],
+    }), { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.some((error) => error.includes('review_packet.inputs hash mismatch')));
+  });
+
+  it('allows default revision binding when the transcript is inside the worktree', () => {
+    const repo = gitRepo();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'base\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{ id: 'T1', title: 'Fixture ticket', scope: ['src/**'], rails: ['test/**'], edges: [] }],
+      }));
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      mkdirSync(join(repo.dir, '.omo/evidence'), { recursive: true });
+      const reviewTranscript = join(repo.dir, '.omo/evidence/p5-review.txt');
+      const revision = resolveRevision({ cwd: repo.dir, ignorePaths: [reviewTranscript] });
+      writeFileSync(reviewTranscript, [
+        'ticket: T1',
+        `reviewed revision: ${revision}`,
+        'review transcript fixture with enough detail to be accepted as evidence',
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+
+      const result = runProsecution({
+        provenance: {
+          reviewer: 'fixture-reviewer',
+          session: 'fixture-session',
+          command: 'fixture review command',
+          transcript: '.omo/evidence/p5-review.txt',
+        },
+        review_packet: reviewPacket(join(repo.dir, '.omo/evidence'), { revision }),
+        no_findings_attestation: {
+          reason: 'fixture reviewer found no candidates',
+          method: 'review transcript audit',
+          evidence: '.omo/evidence/p5-review.txt',
+        },
+        passes: [
+          {
+            lens: 'security',
+            findings: [finding({
+              verified_status: 'killed',
+              verification: {
+                reason: 'fixture refuted',
+                method: 'unit test',
+                evidence: 'test passes',
+              },
+            })],
+          },
+          { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+          { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+          { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings' },
+        ],
+      }, { dir: join(repo.dir, '.adlc'), ticket: 'T1', cwd: repo.dir });
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.revision, revision);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('binds non-default prosecution evidence to the manifest-dir ticket file before root .adlc tickets', () => {
+    const repo = gitRepo();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'base\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{ id: 'T1', title: 'root ticket', scope: ['root/**'], rails: ['root-test/**'], edges: [] }],
+      }));
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const dir = join(repo.dir, '.review');
+      mkdirSync(dir, { recursive: true });
+      const activeTicket = { id: 'T1', title: 'active ticket', scope: ['src/**'], rails: ['test/**'], edges: [] };
+      writeFileSync(join(dir, 'tickets.json'), JSON.stringify({ tickets: [activeTicket] }));
+      mkdirSync(join(repo.dir, '.omo/evidence'), { recursive: true });
+      const reviewTranscript = join(repo.dir, '.omo/evidence/p5-review.txt');
+      const revision = resolveRevision({ cwd: repo.dir, ignorePaths: [reviewTranscript, join(dir, 'tickets.json')] });
+      writeFileSync(reviewTranscript, [
+        'ticket: T1',
+        `reviewed revision: ${revision}`,
+        'review transcript fixture with enough detail to be accepted as evidence',
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+
+      const result = runProsecution({
+        provenance: {
+          reviewer: 'fixture-reviewer',
+          session: 'fixture-session',
+          command: 'fixture review command',
+          transcript: '.omo/evidence/p5-review.txt',
+        },
+        review_packet: reviewPacket(join(repo.dir, '.omo/evidence'), { revision }),
+        no_findings_attestation: {
+          reason: 'fixture reviewer found no candidates',
+          method: 'review transcript audit',
+          evidence: '.omo/evidence/p5-review.txt',
+        },
+        passes: [
+          { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+          { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+          { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+        ],
+      }, { dir, ticket: 'T1', cwd: repo.dir });
+
+      assert.equal(result.exitCode, 0);
+      const complete = readFileSync(join(dir, 'manifest.jsonl'), 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+        .find((entry) => entry.type === 'p5-complete');
+      assert.equal(complete.ticketHash, sha256(canonicalJson(activeTicket)));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an in-worktree transcript path outside evidence directories', () => {
+    const repo = gitRepo();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'base\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{ id: 'T1', title: 'Fixture ticket', scope: ['src/**'], rails: ['test/**'], edges: [] }],
+      }));
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const sourceTranscript = join(repo.dir, 'src.txt');
+      const revision = resolveRevision({ cwd: repo.dir, ignorePaths: [sourceTranscript] });
+      writeFileSync(sourceTranscript, [
+        'base',
+        `ticket: T1 reviewed revision: ${revision}`,
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+
+      const result = runProsecution({
+        provenance: {
+          reviewer: 'fixture-reviewer',
+          session: 'fixture-session',
+          command: 'fixture review command',
+          transcript: 'src.txt',
+        },
+        review_packet: reviewPacket(join(repo.dir, '.adlc'), { revision }),
+        no_findings_attestation: {
+          reason: 'fixture reviewer found no candidates',
+          method: 'review transcript audit',
+          evidence: 'src.txt',
+        },
+        passes: [
+          {
+            lens: 'security',
+            findings: [finding({
+              verified_status: 'killed',
+              verification: {
+                reason: 'fixture refuted',
+                method: 'unit test',
+                evidence: 'test passes',
+              },
+            })],
+          },
+          { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+          { lens: 'tests', findings: [], dry_evidence: 'no test findings' },
+          { lens: 'behavior', findings: [], dry_evidence: 'no behavior findings' },
+        ],
+      }, { dir: join(repo.dir, '.adlc'), ticket: 'T1', cwd: repo.dir });
+
+      assert.equal(result.exitCode, 1);
+      assert.ok(result.errors.some((error) => error.includes('must live under .adlc/ or .omo/evidence/')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('requires an attestation when all passes are empty', () => {
+    const dir = tmpAdlc();
+    const reviewTranscript = transcript(dir);
+    const result = runProsecution({
+      provenance: {
+        reviewer: 'fixture-reviewer',
+        session: 'fixture-session',
+        command: 'fixture review command',
+        transcript: reviewTranscript,
+      },
+      review_packet: reviewPacket(dir),
+      passes: [
+        { lens: 'security', findings: [], dry_evidence: 'no security findings' },
+        { lens: 'correctness', findings: [], dry_evidence: 'no correctness findings' },
+      ],
+    }, { dir, ticket: 'T1', revision: FIXTURE_REVISION });
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.errors.some((error) => error.includes('no_findings_attestation')));
+  });
+});
+
+describe('adlc-prosecute cli', () => {
+  it('exits 0 for two dry passes', () => {
+    const dir = tmpAdlc();
+    const input = join(dir, 'passes.json');
+    const reviewTranscript = transcript(dir);
+    writeFileSync(input, JSON.stringify({
+      provenance: {
+        reviewer: 'fixture-reviewer',
+        session: 'fixture-session',
+        command: 'fixture review command',
+        transcript: reviewTranscript,
+      },
+      review_packet: reviewPacket(dir),
+      no_findings_attestation: {
+        reason: 'fixture reviewer found no candidates',
+        method: 'review transcript audit',
+        evidence: 'review.txt',
+      },
+      passes: [
+        {
+          lens: 'security',
+          findings: [finding({
+            verified_status: 'killed',
+            verification: {
+              reason: 'fixture refuted',
+              method: 'unit test',
+              evidence: 'test passes',
+            },
+          })],
+        },
+        { lens: 'correctness', findings: [], dry_evidence: 'no findings in correctness pass' },
+        { lens: 'tests', findings: [], dry_evidence: 'no findings in tests pass' },
+        { lens: 'behavior', findings: [], dry_evidence: 'no findings in behavior pass' },
+      ],
+    }));
+    const bin = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
+    const out = execFileSync(process.execPath, [
+      bin,
+      '--input',
+      input,
+      '--ticket',
+      'T1',
+      '--revision',
+      FIXTURE_REVISION,
+      '--dir',
+      dir,
+      '--json',
+    ], { encoding: 'utf8' });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.exitCode, 0);
+  });
+
+  it('accepts the bundled docs fixture from the repository root', () => {
+    const dir = tmpAdlc();
+    const bin = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
+    const out = execFileSync(process.execPath, [
+      bin,
+      '--input',
+      'docs/examples/p5-passes.json',
+      '--ticket',
+      'T1',
+      '--revision',
+      'docs-example-revision',
+      '--dir',
+      dir,
+      '--json',
+    ], { cwd: repoRoot, encoding: 'utf8' });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.exitCode, 0);
+  });
+});

--- a/packages/runner/LICENSE
+++ b/packages/runner/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Chris Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -1,0 +1,45 @@
+# @adlc/runner
+
+Artifact-asserting phase runner for ADLC.
+
+## Usage
+
+```sh
+adlc run p5 --ticket T1 --dir .adlc --json
+adlc run p6 --ticket T1 --dir .adlc
+```
+
+The runner does not treat "a command ran" as a gate. It checks `.adlc/manifest.jsonl`
+for the evidence each phase requires. P3, P4, P5, and P6 evidence must be scoped to a
+ticket; `adlc run p3`, `adlc run p4`, `adlc run p5`, and `adlc run p6` fail operationally
+without `--ticket`.
+
+For normal git worktree use, omit `--revision`. P5 and P6 use the current content
+fingerprint and fail closed if reviewed content changes. Committing the exact content
+reviewed at P5 does not move the fingerprint; changing tracked content, ignored ADLC
+control files such as `.adlc/tickets.json`, or untracked non-artifact files after P5 makes
+P6 fail closed until P5 is re-run.
+
+Explicit `--revision` is an offline selector for recorded manifest and artifact evidence.
+When supplied, the runner verifies the matching manifest entries, transcript hashes, review
+packet hashes, ticket hash when available, and P6 packet/snapshot hashes without comparing
+against the live git worktree.
+
+Standard generated artifacts such as the active manifest/lock files, the exact packet path
+passed to `adlc accept --packet ...`, and any exact snapshot paths passed with
+`--before`/`--after` do not move the P6 fingerprint. In-worktree P6 packet and snapshot
+paths must live under `.adlc/` or `.omo/evidence/`; source paths are rejected before they
+can become fingerprint exclusions. The runner records hashes for the packet and snapshots
+and re-verifies them at `adlc run p6`, so accepted behavior evidence is tamper-evident even
+though its paths are excluded from the worktree fingerprint.
+
+## Exit codes
+
+- `0`: required phase artifacts are present
+- `1`: operational error
+- `2`: required phase artifacts are missing
+
+## ADLC phase
+
+Cross-phase. This package gives CI and Codex skills one stable command for asserting
+phase completion.

--- a/packages/runner/bin/adlc.mjs
+++ b/packages/runner/bin/adlc.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import { parseArgs, printJson, opError } from '@adlc/core';
+import { assertPhase, requirementsForPhase } from '../lib/assertions.mjs';
+import { recordAcceptancePacket } from '../lib/acceptance.mjs';
+
+const { values, positionals } = parseArgs({
+  options: {
+    dir: { type: 'string', default: '.adlc' },
+    ticket: { type: 'string' },
+    revision: { type: 'string' },
+    packet: { type: 'string' },
+    before: { type: 'string' },
+    after: { type: 'string' },
+    json: { type: 'boolean', default: false },
+    help: { type: 'boolean', default: false },
+  },
+});
+
+function help() {
+  console.log(`adlc run <phase> [--dir .adlc] [--ticket id] [--revision rev] [--json]
+adlc accept --ticket id --packet .adlc/packet.json [--before .adlc/before.json] [--after .adlc/after.json] [--dir .adlc] [--revision rev] [--json]
+
+Artifact-asserting ADLC phase runner.
+
+Phases: p1 p2 p3 p4 p5 p6 p7
+Ticket required: p3 p4 p5 p6
+Revision required: p5 p6 use the current git worktree fingerprint unless --revision is supplied.
+Explicit --revision selects recorded manifest/artifact evidence without live worktree comparison.
+
+Exit codes:
+  0  required phase evidence exists
+  1  operational error
+  2  required phase evidence is missing
+`);
+}
+
+if (values.help) {
+  help();
+  process.exit(0);
+}
+
+const verb = positionals[0];
+const phase = positionals[1];
+if (verb === 'accept') {
+  const result = recordAcceptancePacket({
+    dir: values.dir,
+    ticket: values.ticket,
+    packet: values.packet,
+    before: values.before,
+    after: values.after,
+    revision: values.revision,
+  });
+  if (values.json) {
+    printJson(result);
+  } else if (result.ok) {
+    console.log(`adlc accept: recorded P6 acceptance packet for ${result.ticket}`);
+  } else {
+    opError(result.errors.join('; '));
+  }
+  process.exit(result.exitCode);
+}
+
+if (verb !== 'run' || !phase) {
+  opError('usage: adlc run <phase> [--dir .adlc] [--ticket id] [--json]');
+}
+
+if (requirementsForPhase(phase) === null) {
+  opError(`unknown phase: ${phase}`);
+}
+
+const result = assertPhase(phase, { dir: values.dir, ticket: values.ticket, revision: values.revision });
+if (result.operational) opError(result.errors.join('; '));
+
+if (values.json) {
+  printJson(result);
+} else if (result.ok) {
+  console.log(`adlc ${phase}: required evidence present`);
+} else {
+  console.error(`adlc ${phase}: missing evidence: ${result.missing.join(', ') || 'none'}`);
+  if (result.skipped.length > 0) console.error(`malformed manifest lines: ${result.skipped.length}`);
+}
+
+process.exit(result.ok ? 0 : 2);

--- a/packages/runner/lib/acceptance.mjs
+++ b/packages/runner/lib/acceptance.mjs
@@ -1,0 +1,236 @@
+import { appendEntry, canonicalJson, readEntries, resolveRevision, sha256 } from '@adlc/core';
+import { readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+function now() {
+  return new Date().toISOString();
+}
+
+function latestP5Revision(entries, ticket) {
+  return latestP5Entry(entries, ticket)?.revision;
+}
+
+function latestP5Entry(entries, ticket, revision) {
+  return entries
+    .filter((entry) => entry.type === 'p5-complete' && entry.ticket === ticket)
+    .filter((entry) => revision === undefined || entry.revision === revision)
+    .at(-1);
+}
+
+function p5TranscriptPaths(entry, cwd) {
+  const path = entry?.transcript?.path;
+  if (!path || !isEvidencePath(cwd, path)) return [];
+  return [path];
+}
+
+function p5ReviewPacketPaths(entry, cwd) {
+  return [
+    entry?.inputPath,
+    entry?.reviewPacket?.prompt?.path,
+    entry?.reviewPacket?.inputs?.path,
+  ].filter((path) => path && isEvidencePath(cwd, path));
+}
+
+function isInsideCwd(cwd, absolute) {
+  const rel = relative(cwd, absolute).replaceAll('\\', '/');
+  return rel !== '' && !rel.startsWith('../') && rel !== '..';
+}
+
+function transcriptIntegrityErrors(entry) {
+  const transcript = entry?.transcript;
+  if (!transcript?.path || !transcript?.hash) return [];
+  try {
+    const content = readFileSync(transcript.path);
+    if (sha256(content) === transcript.hash) return [];
+    return [`P5 evidence is stale: transcript hash changed after prosecution: ${transcript.path}`];
+  } catch (err) {
+    return [`P5 evidence is stale: transcript cannot be read: ${transcript.path}: ${err.message}`];
+  }
+}
+
+function p5ArtifactIntegrityError(label, artifact) {
+  if (!artifact?.path || !artifact?.hash) {
+    return `P5 evidence is incomplete: ${label} missing path/hash`;
+  }
+  try {
+    const content = readFileSync(artifact.path);
+    if (sha256(content) === artifact.hash) return null;
+    return `P5 evidence is stale: ${label} hash changed after prosecution: ${artifact.path}`;
+  } catch (err) {
+    return `P5 evidence is stale: ${label} cannot be read: ${artifact.path}: ${err.message}`;
+  }
+}
+
+function reviewPacketIntegrityErrors(entry) {
+  if (!entry?.reviewPacket || typeof entry.reviewPacket !== 'object') {
+    return ['P5 evidence is incomplete: p5-complete missing reviewPacket'];
+  }
+  const errors = [];
+  if (entry.reviewPacket.cleanWorktree !== entry.revision) {
+    errors.push(`P5 evidence is incomplete: reviewPacket cleanWorktree does not match ${entry.revision}`);
+  }
+  const promptError = p5ArtifactIntegrityError('reviewPacket.prompt', entry.reviewPacket.prompt);
+  if (promptError) errors.push(promptError);
+  const inputsError = p5ArtifactIntegrityError('reviewPacket.inputs', entry.reviewPacket.inputs);
+  if (inputsError) errors.push(inputsError);
+  return errors;
+}
+
+function historicalTranscriptIntegrityErrors(entries, ticket, assertedEntry, cwd) {
+  if (!assertedEntry?.transcript?.path) return [];
+  const assertedPath = resolve(cwd, assertedEntry.transcript.path);
+  return entries
+    .filter((entry) => entry !== assertedEntry)
+    .filter((entry) => entry.type === 'p5-complete' && entry.ticket === ticket)
+    .filter((entry) => entry.transcript?.path && resolve(cwd, entry.transcript.path) !== assertedPath)
+    .flatMap((entry) => transcriptIntegrityErrors(entry));
+}
+
+function isEvidencePath(cwd, path) {
+  const rel = relative(cwd, resolve(cwd, path)).replaceAll('\\', '/');
+  return rel.startsWith('.adlc/') || rel.startsWith('.omo/evidence/');
+}
+
+function validateInWorktreeEvidencePath(cwd, label, path) {
+  const absolute = resolve(cwd, path);
+  if (isInsideCwd(cwd, absolute) && !isEvidencePath(cwd, absolute)) {
+    return `${label} inside the worktree must live under .adlc/ or .omo/evidence/: ${path}`;
+  }
+  return null;
+}
+
+function ticketDefinitionHash(cwd, ticket, dir) {
+  const paths = [resolve(cwd, dir, 'tickets.json'), resolve(cwd, '.adlc/tickets.json')];
+  for (const path of paths) {
+    try {
+      const raw = readFileSync(path, 'utf8');
+      const parsed = JSON.parse(raw);
+      const tickets = Array.isArray(parsed?.tickets) ? parsed.tickets : [];
+      const definition = tickets.find((candidate) => candidate?.id === ticket);
+      if (definition) return sha256(canonicalJson(definition));
+    } catch {
+      // Try the next supported ticket location.
+    }
+  }
+  return null;
+}
+
+function staleTicketDefinitionError(recordedHash, currentHash) {
+  if (recordedHash === null) {
+    return 'P5 evidence is stale: ticket definition was not bound during prosecution';
+  }
+  if (recordedHash === currentHash) return null;
+  if (currentHash === null) {
+    return 'P5 evidence is stale: ticket definition disappeared after prosecution';
+  }
+  return 'P5 evidence is stale: ticket definition changed after prosecution';
+}
+
+function manifestArtifactPaths(cwd, dir) {
+  const root = resolve(cwd, dir);
+  return [join(root, 'manifest.jsonl'), join(root, 'manifest.lock'), join(root, 'tickets.json')];
+}
+
+export function recordAcceptancePacket({
+  dir = '.adlc',
+  ticket,
+  packet,
+  before,
+  after,
+  revision,
+  cwd = process.cwd(),
+} = {}) {
+  const errors = [];
+  if (!ticket) errors.push('ticket is required for P6 acceptance evidence');
+  if (!packet) errors.push('packet is required for P6 acceptance evidence');
+
+  let packetPath;
+  let packetHash;
+  const artifactPaths = [];
+  const artifactHashes = [];
+  for (const artifact of [before, after].filter(Boolean)) {
+    const error = validateInWorktreeEvidencePath(cwd, 'artifact', artifact);
+    if (error) errors.push(error);
+    const artifactPath = resolve(cwd, artifact);
+    try {
+      const stat = statSync(artifactPath);
+      if (!stat.isFile()) errors.push(`artifact is not a file: ${artifact}`);
+      artifactHashes.push({ path: artifactPath, hash: sha256(readFileSync(artifactPath)) });
+    } catch (err) {
+      errors.push(`artifact cannot be read: ${artifact}: ${err.message}`);
+    }
+    artifactPaths.push(artifactPath);
+  }
+  if (packet) {
+    const pathError = validateInWorktreeEvidencePath(cwd, 'packet', packet);
+    if (pathError) errors.push(pathError);
+    try {
+      packetPath = resolve(cwd, packet);
+      const stat = statSync(packetPath);
+      if (!stat.isFile()) errors.push(`packet is not a file: ${packet}`);
+      const content = readFileSync(packetPath);
+      if (content.length === 0) errors.push(`packet is empty: ${packet}`);
+      packetHash = sha256(content);
+    } catch (err) {
+      errors.push(`packet cannot be read: ${packet}: ${err.message}`);
+    }
+  }
+
+  const { entries } = readEntries('manifest', dir);
+  const p5Revision = latestP5Revision(entries, ticket);
+  const assertedP5Entry = latestP5Entry(entries, ticket, revision ?? p5Revision);
+  if (ticket && !assertedP5Entry) {
+    errors.push(revision
+      ? `P5 evidence is missing: no p5-complete for ticket ${ticket} at ${revision}`
+      : `P5 evidence is missing: no p5-complete for ticket ${ticket}`);
+  }
+  const transcriptPaths = p5TranscriptPaths(assertedP5Entry, cwd);
+  const reviewPacketPaths = p5ReviewPacketPaths(assertedP5Entry, cwd);
+  const p5TicketHash = assertedP5Entry?.ticketHash ?? null;
+  const currentTicketHash = assertedP5Entry ? ticketDefinitionHash(cwd, ticket, dir) : null;
+  const ticketStaleError = assertedP5Entry
+    ? staleTicketDefinitionError(p5TicketHash, currentTicketHash)
+    : null;
+  errors.push(...transcriptIntegrityErrors(assertedP5Entry));
+  errors.push(...reviewPacketIntegrityErrors(assertedP5Entry));
+  errors.push(...historicalTranscriptIntegrityErrors(entries, ticket, assertedP5Entry, cwd));
+  const ignorePaths = packetPath
+    ? [...manifestArtifactPaths(cwd, dir), ...transcriptPaths, ...reviewPacketPaths, ...artifactPaths, packetPath]
+    : [...manifestArtifactPaths(cwd, dir), ...transcriptPaths, ...reviewPacketPaths, ...artifactPaths];
+  const liveWorktreeRevision = revision ? null : resolveRevision({ cwd, ignorePaths });
+  const assertedRevision = revision ?? p5Revision;
+  if (!revision && assertedRevision && !liveWorktreeRevision) {
+    errors.push(`current worktree revision could not be resolved while P5 evidence exists at ${assertedRevision}`);
+  }
+  if (!revision && assertedRevision && liveWorktreeRevision && assertedRevision !== liveWorktreeRevision) {
+    errors.push(`P5 evidence is stale: recorded ${assertedRevision}, current worktree is ${liveWorktreeRevision}`);
+  }
+  if (ticketStaleError) {
+    errors.push(ticketStaleError);
+  }
+  const resolvedRevision = assertedRevision ?? liveWorktreeRevision;
+  if (!resolvedRevision) errors.push('revision could not be resolved; pass --revision or run inside a git worktree');
+  if (errors.length > 0) return { ok: false, exitCode: 1, errors };
+
+  appendEntry('manifest', {
+    ts: now(),
+    type: 'p6-acceptance-packet',
+    ticket,
+    revision: resolvedRevision,
+    packet: packetPath,
+    packetHash,
+    artifactPaths,
+    artifactHashes,
+  }, dir);
+
+  return {
+    ok: true,
+    exitCode: 0,
+    ticket,
+    revision: resolvedRevision,
+    packet: packetPath,
+    packetHash,
+    artifactPaths,
+    artifactHashes,
+  };
+}

--- a/packages/runner/lib/assertions.mjs
+++ b/packages/runner/lib/assertions.mjs
@@ -1,0 +1,523 @@
+import { readEntries, ADLC_DIR, canonicalJson, hashFiles, resolveRevision, sha256 } from '@adlc/core';
+import { readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const PHASE_REQUIREMENTS = {
+  p1: ['spec-lint', 'premortem'],
+  p2: ['coldstart', 'merge-forecast'],
+  p3: ['rails-red', 'hollow-test', 'rails-frozen'],
+  p4: ['rails-green', 'rails-check', 'flail-check'],
+  p5: ['p5-complete'],
+  p6: ['p5-complete', 'p6-acceptance-packet'],
+  p7: ['lesson-foundry', 'rejection-mining', 'skill-rot'],
+};
+
+function entryType(entry) {
+  return entry.type ?? entry.gate;
+}
+
+function matchesTicket(entry, ticket) {
+  return ticket === undefined || entry.ticket === ticket;
+}
+
+function requiresTicket(phase) {
+  return phase === 'p3' || phase === 'p4' || phase === 'p5' || phase === 'p6';
+}
+
+function requiresRevision(phase) {
+  return phase === 'p5' || phase === 'p6';
+}
+
+function matchesRevision(entry, revision) {
+  return revision === undefined || entry.revision === revision;
+}
+
+function latestP5Revision(entries, ticket) {
+  return latestP5Entry(entries, ticket)?.revision;
+}
+
+function latestP5Entry(entries, ticket, revision) {
+  return entries
+    .filter((entry) => entryType(entry) === 'p5-complete' && matchesTicket(entry, ticket) && entry.revision)
+    .filter((entry) => revision === undefined || entry.revision === revision)
+    .at(-1);
+}
+
+function p5TranscriptPaths(entry, cwd) {
+  const path = entry?.transcript?.path;
+  if (!path || !isEvidencePath(cwd, path)) return [];
+  return [path];
+}
+
+function p5ReviewPacketPaths(entry, cwd) {
+  return [
+    entry?.inputPath,
+    entry?.reviewPacket?.prompt?.path,
+    entry?.reviewPacket?.inputs?.path,
+  ].filter((path) => path && isEvidencePath(cwd, path));
+}
+
+function transcriptIntegrityErrors(entry) {
+  const transcript = entry?.transcript;
+  if (!transcript?.path || !transcript?.hash) return [];
+  try {
+    const content = readFileSync(transcript.path);
+    if (sha256(content) === transcript.hash) return [];
+    return [`P5 evidence is stale: transcript hash changed after prosecution: ${transcript.path}`];
+  } catch (err) {
+    return [`P5 evidence is stale: transcript cannot be read: ${transcript.path}: ${err.message}`];
+  }
+}
+
+function p5ArtifactIntegrityError(label, artifact) {
+  if (!artifact?.path || !artifact?.hash) {
+    return `P5 evidence is incomplete: ${label} missing path/hash`;
+  }
+  try {
+    const content = readFileSync(artifact.path);
+    if (sha256(content) === artifact.hash) return null;
+    return `P5 evidence is stale: ${label} hash changed after prosecution: ${artifact.path}`;
+  } catch (err) {
+    return `P5 evidence is stale: ${label} cannot be read: ${artifact.path}: ${err.message}`;
+  }
+}
+
+function historicalTranscriptIntegrityErrors(entries, assertedEntry, ticket, cwd) {
+  if (!assertedEntry?.transcript?.path) return [];
+  const assertedPath = resolve(cwd, assertedEntry.transcript.path);
+  return entries
+    .filter((entry) => entry !== assertedEntry)
+    .filter((entry) => entryType(entry) === 'p5-complete' && matchesTicket(entry, ticket))
+    .filter((entry) => entry.transcript?.path && resolve(cwd, entry.transcript.path) !== assertedPath)
+    .flatMap((entry) => transcriptIntegrityErrors(entry));
+}
+
+function isEvidencePath(cwd, path) {
+  const rel = relative(cwd, resolve(cwd, path)).replaceAll('\\', '/');
+  return rel.startsWith('.adlc/') || rel.startsWith('.omo/evidence/');
+}
+
+function ticketDefinitionHash(cwd, ticket, dir) {
+  const paths = [resolve(cwd, dir, 'tickets.json'), resolve(cwd, '.adlc/tickets.json')];
+  for (const path of paths) {
+    try {
+      const raw = readFileSync(path, 'utf8');
+      const parsed = JSON.parse(raw);
+      const tickets = Array.isArray(parsed?.tickets) ? parsed.tickets : [];
+      const definition = tickets.find((candidate) => candidate?.id === ticket);
+      if (definition) return sha256(canonicalJson(definition));
+    } catch {
+      // Try the next supported ticket location.
+    }
+  }
+  return null;
+}
+
+function staleTicketDefinitionError(recordedHash, currentHash) {
+  if (recordedHash === null) {
+    return 'P5 evidence is stale: ticket definition was not bound during prosecution';
+  }
+  if (recordedHash === currentHash) return null;
+  if (currentHash === null) {
+    return 'P5 evidence is stale: ticket definition disappeared after prosecution';
+  }
+  return 'P5 evidence is stale: ticket definition changed after prosecution';
+}
+
+function p5CompletionIntegrityErrors(entries, entry, ticket, revision) {
+  if (!entry) return [];
+  const errors = [];
+  const dryLenses = Array.isArray(entry.dryLenses) ? new Set(entry.dryLenses.filter((lens) => typeof lens === 'string' && lens)) : new Set();
+  if (!entry.provenance || typeof entry.provenance !== 'object') {
+    errors.push('P5 evidence is incomplete: p5-complete missing provenance');
+  } else {
+    if (typeof entry.provenance.reviewer !== 'string' || entry.provenance.reviewer.length === 0) {
+      errors.push('P5 evidence is incomplete: p5-complete missing provenance.reviewer');
+    }
+    if (typeof entry.provenance.command !== 'string' || entry.provenance.command.length === 0) {
+      errors.push('P5 evidence is incomplete: p5-complete missing provenance.command');
+    }
+  }
+  if (!entry.transcript?.path || !entry.transcript?.hash) {
+    errors.push('P5 evidence is incomplete: p5-complete missing transcript path/hash');
+  }
+  if (!entry.reviewPacket || typeof entry.reviewPacket !== 'object') {
+    errors.push('P5 evidence is incomplete: p5-complete missing reviewPacket');
+  } else {
+    if (entry.reviewPacket.cleanWorktree !== revision) {
+      errors.push(`P5 evidence is incomplete: reviewPacket cleanWorktree does not match ${revision}`);
+    }
+    const promptError = p5ArtifactIntegrityError('reviewPacket.prompt', entry.reviewPacket.prompt);
+    if (promptError) errors.push(promptError);
+    const inputsError = p5ArtifactIntegrityError('reviewPacket.inputs', entry.reviewPacket.inputs);
+    if (inputsError) errors.push(inputsError);
+  }
+  if (!Number.isInteger(entry.consecutiveDry) || entry.consecutiveDry < 2) {
+    errors.push('P5 evidence is incomplete: p5-complete requires consecutiveDry >= 2');
+  }
+  if (dryLenses.size < 3) {
+    errors.push('P5 evidence is incomplete: p5-complete requires at least three distinct dry lenses');
+  }
+
+  const dryPasses = entries.filter((candidate) =>
+    entryType(candidate) === 'p5-dry-pass' &&
+    matchesTicket(candidate, ticket) &&
+    matchesRevision(candidate, revision)
+  );
+  const completedDryPasses = entries.filter((candidate) =>
+    entryType(candidate) === 'p5-pass-completed' &&
+    matchesTicket(candidate, ticket) &&
+    matchesRevision(candidate, revision) &&
+    candidate.dry === true
+  );
+  for (const lens of dryLenses) {
+    if (!dryPasses.some((pass) => pass.lens === lens)) {
+      errors.push(`P5 evidence is incomplete: missing p5-dry-pass for lens ${lens}`);
+    }
+    if (!completedDryPasses.some((pass) => pass.lens === lens)) {
+      errors.push(`P5 evidence is incomplete: missing dry p5-pass-completed for lens ${lens}`);
+    }
+  }
+  if (!dryPasses.some((pass) => Number.isInteger(pass.consecutiveDry) && pass.consecutiveDry >= 2)) {
+    errors.push('P5 evidence is incomplete: no supporting p5-dry-pass has consecutiveDry >= 2');
+  }
+  const completedBeforeEntry = entries.slice(0, entries.indexOf(entry)).filter((candidate) =>
+    entryType(candidate) === 'p5-pass-completed' &&
+    matchesTicket(candidate, ticket) &&
+    matchesRevision(candidate, revision)
+  );
+  const finalDryLenses = new Set();
+  for (let index = completedBeforeEntry.length - 1; index >= 0; index -= 1) {
+    const candidate = completedBeforeEntry[index];
+    if (candidate.dry !== true) break;
+    if (typeof candidate.lens === 'string' && candidate.lens) finalDryLenses.add(candidate.lens);
+  }
+  for (const lens of dryLenses) {
+    if (!finalDryLenses.has(lens)) {
+      errors.push(`P5 evidence is incomplete: dry lens ${lens} is not in the final dry streak`);
+    }
+  }
+  if (finalDryLenses.size < 3) {
+    errors.push('P5 evidence is incomplete: final dry streak requires at least three distinct dry lenses');
+  }
+  errors.push(...openP5FindingErrors(entries, ticket, revision, entries.indexOf(entry)));
+  return errors;
+}
+
+function findingId(entry) {
+  return typeof entry.finding?.id === 'string' && entry.finding.id.length > 0
+    ? entry.finding.id
+    : null;
+}
+
+function findingIdentity(entry) {
+  const finding = entry.finding;
+  if (!finding || typeof finding !== 'object') return null;
+  return sha256(canonicalJson({
+    id: finding.id ?? null,
+    file: finding.file ?? null,
+    line_start: finding.line_start ?? null,
+    line_end: finding.line_end ?? null,
+    category: finding.category ?? null,
+    claim: finding.claim ?? null,
+    evidence: finding.evidence ?? null,
+  }));
+}
+
+function openP5FindingErrors(entries, ticket, revision, completionIndex) {
+  const openTypes = new Set(['p5-finding-verified', 'p5-finding-needs-human']);
+  const errors = [];
+  entries.forEach((entry, index) => {
+    const type = entryType(entry);
+    if (!openTypes.has(type) || !matchesTicket(entry, ticket) || !matchesRevision(entry, revision)) return;
+    const id = findingId(entry);
+    if (!id) {
+      errors.push(`P5 evidence is contradictory: unresolved ${type} without finding.id`);
+      return;
+    }
+    const identity = findingIdentity(entry);
+    const killedBeforeCompletion = entries.slice(index + 1, completionIndex).some((candidate) =>
+      entryType(candidate) === 'p5-finding-killed' &&
+      matchesTicket(candidate, ticket) &&
+      matchesRevision(candidate, revision) &&
+      findingIdentity(candidate) === identity
+    );
+    if (!killedBeforeCompletion) {
+      errors.push(`P5 evidence is contradictory: unresolved ${type} ${id}`);
+    }
+  });
+  return errors;
+}
+
+function p6ArtifactPaths(entries, ticket, cwd) {
+  return [
+    ...entries
+      .filter((entry) => entryType(entry) === 'p6-acceptance-packet' && matchesTicket(entry, ticket))
+      .map((entry) => entry.packet)
+      .filter(Boolean)
+      .filter((path) => isEvidencePath(cwd, path)),
+    ...entries
+      .filter((entry) => entryType(entry) === 'p6-acceptance-packet' && matchesTicket(entry, ticket))
+      .flatMap((entry) => Array.isArray(entry.artifactPaths) ? entry.artifactPaths : [])
+      .filter(Boolean)
+      .filter((path) => isEvidencePath(cwd, path)),
+  ];
+}
+
+function manifestArtifactPaths(cwd, dir) {
+  const root = resolve(cwd, dir);
+  return [join(root, 'manifest.jsonl'), join(root, 'manifest.lock'), join(root, 'tickets.json')];
+}
+
+function latestP6Entry(entries, ticket, revision) {
+  return entries
+    .filter((entry) => entryType(entry) === 'p6-acceptance-packet' && matchesTicket(entry, ticket))
+    .filter((entry) => revision === undefined || entry.revision === revision)
+    .at(-1);
+}
+
+function hashIntegrityError(label, path, expectedHash) {
+  try {
+    const content = readFileSync(path);
+    if (sha256(content) === expectedHash) return null;
+    return `P6 evidence is stale: ${label} hash changed after acceptance: ${path}`;
+  } catch (err) {
+    return `P6 evidence is stale: ${label} cannot be read: ${path}: ${err.message}`;
+  }
+}
+
+function p6IntegrityErrors(entry) {
+  if (!entry) return [];
+  const errors = [];
+  if (!entry.packet || typeof entry.packet !== 'string') {
+    errors.push('P6 evidence is incomplete: acceptance packet missing packet path');
+  }
+  if (!entry.packetHash || typeof entry.packetHash !== 'string') {
+    errors.push('P6 evidence is incomplete: acceptance packet missing packetHash');
+  }
+  if (entry.packet && entry.packetHash) {
+    const error = hashIntegrityError('packet', entry.packet, entry.packetHash);
+    if (error) errors.push(error);
+  }
+  const artifactPaths = Array.isArray(entry.artifactPaths) ? entry.artifactPaths : [];
+  const artifactHashes = Array.isArray(entry.artifactHashes) ? entry.artifactHashes : [];
+  if (artifactPaths.length !== artifactHashes.length) {
+    errors.push('P6 evidence is incomplete: artifact paths and hashes differ');
+  }
+  for (const artifact of artifactHashes) {
+    if (!artifact?.path || typeof artifact.path !== 'string') {
+      errors.push('P6 evidence is incomplete: artifact hash entry missing path');
+      continue;
+    }
+    if (!artifact.hash || typeof artifact.hash !== 'string') {
+      errors.push(`P6 evidence is incomplete: artifact hash entry missing hash: ${artifact.path}`);
+      continue;
+    }
+    const error = hashIntegrityError('artifact', artifact.path, artifact.hash);
+    if (error) errors.push(error);
+  }
+  return errors;
+}
+
+function latestRailCheckEntry(entries, ticket, revision) {
+  return entries
+    .filter((entry) => entryType(entry) === 'rails-check' && matchesTicket(entry, ticket))
+    .filter((entry) => matchesRevision(entry, revision))
+    .at(-1);
+}
+
+function p4IntegrityErrors(entries, ticket, revision, cwd) {
+  const entry = latestRailCheckEntry(entries, ticket, revision);
+  if (!entry) return [];
+  const errors = [];
+  if (entry.railsDiffEmpty !== true) {
+    errors.push('P4 evidence is incomplete: rails-check missing railsDiffEmpty=true');
+  }
+  if (entry.suppressionsClean !== true) {
+    errors.push('P4 evidence is incomplete: rails-check missing suppressionsClean=true');
+  }
+  if (!entry.railFiles || typeof entry.railFiles !== 'object' || Array.isArray(entry.railFiles)) {
+    errors.push('P4 evidence is incomplete: rails-check missing railFiles hash snapshot');
+    return errors;
+  }
+  const railPaths = Object.keys(entry.railFiles);
+  if (railPaths.length === 0) {
+    errors.push('P4 evidence is incomplete: rails-check railFiles snapshot is empty');
+    return errors;
+  }
+  const currentHashes = hashFiles(railPaths, (path) => readFileSync(resolve(cwd, path)));
+  for (const path of railPaths) {
+    if (typeof entry.railFiles[path] !== 'string') {
+      errors.push(`P4 evidence is incomplete: rails-check missing hash for ${path}`);
+      continue;
+    }
+    if (currentHashes[path] !== entry.railFiles[path]) {
+      errors.push(`P4 evidence is stale: rail file hash changed after rails-check: ${path}`);
+    }
+  }
+  return errors;
+}
+
+export function requirementsForPhase(phase) {
+  return PHASE_REQUIREMENTS[phase] ?? null;
+}
+
+export function assertPhase(phase, { dir = ADLC_DIR, ticket, revision, cwd = process.cwd() } = {}) {
+  const requirements = requirementsForPhase(phase);
+  if (requirements === null) {
+    return { ok: false, operational: true, phase, errors: [`unknown phase: ${phase}`] };
+  }
+  if (requiresTicket(phase) && !ticket) {
+    return { ok: false, operational: true, phase, errors: [`${phase} requires --ticket`] };
+  }
+
+  const { entries, skipped } = readEntries('manifest', dir);
+  const hasExplicitRevision = revision !== undefined && revision !== null && String(revision).trim() !== '';
+  const explicitRevision = hasExplicitRevision ? String(revision) : undefined;
+  const latestScopedP5Revision = requiresRevision(phase) ? latestP5Revision(entries, ticket) : null;
+  const p5Revision = phase === 'p6' && !explicitRevision ? latestScopedP5Revision : null;
+  const assertedP5Entry = requiresRevision(phase)
+    ? latestP5Entry(entries, ticket, explicitRevision ?? latestScopedP5Revision ?? undefined)
+    : null;
+  const p5TranscriptEvidencePaths = p5TranscriptPaths(assertedP5Entry, cwd);
+  const p5ReviewPacketEvidencePaths = p5ReviewPacketPaths(assertedP5Entry, cwd);
+  const ignoredEvidencePaths = phase === 'p6'
+    ? [...manifestArtifactPaths(cwd, dir), ...p5TranscriptEvidencePaths, ...p5ReviewPacketEvidencePaths, ...p6ArtifactPaths(entries, ticket, cwd)]
+    : [...manifestArtifactPaths(cwd, dir), ...p5TranscriptEvidencePaths, ...p5ReviewPacketEvidencePaths];
+  const liveWorktreeRevision = requiresRevision(phase) && !explicitRevision
+    ? resolveRevision({ cwd, ignorePaths: ignoredEvidencePaths })
+    : null;
+  const currentRevision = requiresRevision(phase)
+    ? explicitRevision ?? liveWorktreeRevision
+    : revision;
+  const p5TicketHash = assertedP5Entry?.ticketHash ?? null;
+  const currentTicketHash = assertedP5Entry ? ticketDefinitionHash(cwd, ticket, dir) : null;
+  const ticketStaleError = assertedP5Entry
+    ? staleTicketDefinitionError(p5TicketHash, currentTicketHash)
+    : null;
+  const transcriptErrors = [
+    ...transcriptIntegrityErrors(assertedP5Entry),
+    ...historicalTranscriptIntegrityErrors(entries, assertedP5Entry, ticket, cwd),
+  ];
+  const p5CompletionErrors = p5CompletionIntegrityErrors(entries, assertedP5Entry, ticket, assertedP5Entry?.revision);
+  const assertedRevisionForLiveCheck = requiresRevision(phase) && !explicitRevision
+    ? latestScopedP5Revision
+    : null;
+  if (requiresRevision(phase) && assertedRevisionForLiveCheck && !liveWorktreeRevision) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: assertedRevisionForLiveCheck,
+      currentRevision: liveWorktreeRevision,
+      errors: [`current worktree revision could not be resolved while P5 evidence exists at ${assertedRevisionForLiveCheck}`],
+    };
+  }
+  if (requiresRevision(phase) && assertedRevisionForLiveCheck && liveWorktreeRevision && assertedRevisionForLiveCheck !== liveWorktreeRevision) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: assertedRevisionForLiveCheck,
+      currentRevision: liveWorktreeRevision,
+      errors: [`P5 evidence is stale: recorded ${assertedRevisionForLiveCheck}, current worktree is ${liveWorktreeRevision}`],
+    };
+  }
+  if (requiresRevision(phase) && ticketStaleError) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: p5Revision ?? currentRevision,
+      currentRevision,
+      errors: [ticketStaleError],
+    };
+  }
+  if (requiresRevision(phase) && transcriptErrors.length > 0) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: p5Revision ?? currentRevision,
+      currentRevision,
+      errors: transcriptErrors,
+    };
+  }
+  if (requiresRevision(phase) && p5CompletionErrors.length > 0) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: p5Revision ?? currentRevision,
+      currentRevision,
+      errors: p5CompletionErrors,
+    };
+  }
+  const resolvedRevision = phase === 'p6' && !revision
+    ? p5Revision ?? currentRevision
+    : requiresRevision(phase)
+      ? currentRevision
+      : revision;
+  const p6Errors = phase === 'p6' && assertedP5Entry
+    ? p6IntegrityErrors(latestP6Entry(entries, ticket, resolvedRevision))
+    : [];
+  const p4Errors = phase === 'p4'
+    ? p4IntegrityErrors(entries, ticket, resolvedRevision, cwd)
+    : [];
+  if (p6Errors.length > 0) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: resolvedRevision,
+      currentRevision,
+      errors: p6Errors,
+    };
+  }
+  if (p4Errors.length > 0) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      revision: resolvedRevision,
+      errors: p4Errors,
+    };
+  }
+  if (requiresRevision(phase) && !resolvedRevision) {
+    return {
+      ok: false,
+      operational: true,
+      phase,
+      ticket,
+      errors: [`${phase} requires a git worktree revision or --revision`],
+    };
+  }
+
+  const present = new Set(
+    entries
+      .filter((entry) => matchesTicket(entry, ticket))
+      .filter((entry) => matchesRevision(entry, resolvedRevision))
+      .map((entry) => entryType(entry))
+      .filter(Boolean)
+  );
+  const missing = requirements.filter((type) => !present.has(type));
+
+  return {
+    ok: missing.length === 0 && skipped.length === 0,
+    operational: false,
+    phase,
+    ticket,
+    revision: resolvedRevision,
+    required: requirements,
+    present: Array.from(present).sort(),
+    missing,
+    skipped,
+  };
+}

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@adlc/runner",
+  "version": "1.0.2",
+  "description": "Artifact-asserting ADLC phase runner for deterministic gate completion checks.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Chris Williams (@voodootikigod)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voodootikigod/adlc.git",
+    "directory": "packages/runner"
+  },
+  "homepage": "https://github.com/voodootikigod/adlc/tree/main/packages/runner#readme",
+  "bugs": "https://github.com/voodootikigod/adlc/issues",
+  "keywords": [
+    "adlc",
+    "agentic",
+    "ai",
+    "llm",
+    "cli",
+    "runner",
+    "gate"
+  ],
+  "bin": {
+    "adlc-runner": "./bin/adlc.mjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@adlc/core": "1.0.2"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/runner/test/codex-integration.test.mjs
+++ b/packages/runner/test/codex-integration.test.mjs
@@ -1,0 +1,566 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveRevision, sha256 } from '@adlc/core';
+
+const repoRoot = resolve(new URL('../../../', import.meta.url).pathname);
+
+describe('codex plugin smoke script', () => {
+  it('validates marketplace, manifest, and skill sentinels offline', () => {
+    const out = execFileSync(process.execPath, [join(repoRoot, 'scripts/codex-install-smoke.mjs'), repoRoot], {
+      encoding: 'utf8',
+    });
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.skills, 5);
+  });
+
+  it('fails if isolated install mutates real Codex plugin data', () => {
+    const home = mkdtempSync(join(tmpdir(), 'adlc-real-home-'));
+    try {
+      mkdirSync(join(home, '.codex/plugins/data'), { recursive: true });
+      const result = spawnSync(process.execPath, [join(repoRoot, 'scripts/codex-install-smoke.mjs'), repoRoot], {
+        env: { ...process.env, HOME: home, ADLC_CODEX_SMOKE_MUTATE_REAL_PLUGIN_DATA: '1' },
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, 2);
+      assert.match(result.stderr, /mutated the caller real HOME\/XDG Codex state/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('codex integration docs flow', () => {
+  it('runs the documented P5 to P6 auto-revision commands', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'adlc-docs-flow-'));
+    try {
+      const g = (...args) => execFileSync('git', args, {
+        cwd: dir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      g('init', '-q', '-b', 'main');
+      g('config', 'user.email', 't@t.co');
+      g('config', 'user.name', 'tester');
+      g('config', 'commit.gpgsign', 'false');
+      writeFileSync(join(dir, 'src.txt'), 'base\n');
+      g('add', '-A');
+      g('commit', '-qm', 'base');
+
+      mkdirSync(join(dir, '.adlc'), { recursive: true });
+      writeFileSync(join(dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{ id: 'T1', title: 'Docs flow ticket', scope: ['src/**'], rails: ['test/**'], edges: [] }],
+      }));
+      const transcriptPath = join(dir, '.adlc/p5-review.txt');
+      const passes = JSON.parse(readFileSync(join(repoRoot, 'docs/examples/p5-passes.json'), 'utf8'));
+      passes.provenance.transcript = '.adlc/p5-review.txt';
+      const revision = resolveRevision({ cwd: dir, ignorePaths: [transcriptPath] });
+      writeFileSync(transcriptPath, [
+        'ticket: T1',
+        `reviewed revision: ${revision}`,
+        'security finding killed; correctness dry; tests dry; behavior dry',
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+      const promptPath = join(dir, '.adlc/p5-prompt.txt');
+      const inputsPath = join(dir, '.adlc/p5-inputs.txt');
+      writeFileSync(promptPath, `review prompt for ${revision}\n`);
+      writeFileSync(inputsPath, `reviewed input packet for ${revision}\n`);
+      passes.review_packet = {
+        prompt: '.adlc/p5-prompt.txt',
+        prompt_hash: sha256(readFileSync(promptPath)),
+        inputs: '.adlc/p5-inputs.txt',
+        inputs_hash: sha256(readFileSync(inputsPath)),
+        clean_worktree: revision,
+      };
+      writeFileSync(join(dir, '.adlc/p5-passes.json'), JSON.stringify(passes));
+
+      const prosecute = join(repoRoot, 'packages/prosecute/bin/adlc-prosecute.mjs');
+      const runner = join(repoRoot, 'packages/runner/bin/adlc.mjs');
+      const common = { cwd: dir, encoding: 'utf8' };
+
+      const p5Record = execFileSync(process.execPath, [
+        prosecute,
+        '--input',
+        '.adlc/p5-passes.json',
+        '--ticket',
+        'T1',
+        '--dir',
+        '.adlc',
+        '--json',
+      ], common);
+      assert.equal(JSON.parse(p5Record).exitCode, 0);
+
+      const p5Run = execFileSync(process.execPath, [
+        runner,
+        'run',
+        'p5',
+        '--ticket',
+        'T1',
+        '--dir',
+        '.adlc',
+        '--json',
+      ], common);
+      assert.equal(JSON.parse(p5Run).ok, true);
+
+      writeFileSync(join(dir, '.adlc/before.json'), '{"before":true}\n');
+      writeFileSync(join(dir, '.adlc/after.json'), '{"after":true}\n');
+      writeFileSync(join(dir, '.adlc/packet.json'), JSON.stringify({ behaviorDiff: 'accepted' }));
+      const accepted = execFileSync(process.execPath, [
+        runner,
+        'accept',
+        '--ticket',
+        'T1',
+        '--packet',
+        '.adlc/packet.json',
+        '--before',
+        '.adlc/before.json',
+        '--after',
+        '.adlc/after.json',
+        '--dir',
+        '.adlc',
+        '--json',
+      ], common);
+      assert.equal(JSON.parse(accepted).ok, true);
+
+      const p6Run = execFileSync(process.execPath, [
+        runner,
+        'run',
+        'p6',
+        '--ticket',
+        'T1',
+        '--dir',
+        '.adlc',
+        '--json',
+      ], common);
+      assert.equal(JSON.parse(p6Run).ok, true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('adlc rails hook', () => {
+  function fixture() {
+    const dir = mkdtempSync(join(tmpdir(), 'adlc-hook-'));
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc/tickets.json'), JSON.stringify({
+      tickets: [
+        { id: 'T1', title: 't', rails: ['test/**'], scope: ['src/**'], edges: [] },
+      ],
+    }));
+    return dir;
+  }
+
+  it('is inactive unless ADLC_P4_ENFORCEMENT=1', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      input: JSON.stringify({ path: 'test/a.test.mjs' }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.stderr, /inactive/);
+  });
+
+  it('blocks rail edits when active', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({ path: 'test/a.test.mjs' }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks absolute rail paths after project-relative normalization', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({ path: join(dir, 'test/a.test.mjs') }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks dot-prefixed rail paths after normalization', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({ path: './test/./a.test.mjs' }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('allows non-rail edits from Codex apply_patch hook payloads', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: src/a.mjs',
+      '@@',
+      '+export const value = 1;',
+      '*** End Patch',
+    ].join('\n');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'apply_patch',
+        tool_input: { command: patch },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
+  });
+
+  it('blocks rail edits from Codex apply_patch hook payloads', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: test/a.test.mjs',
+      '@@',
+      '+test("rail", () => {});',
+      '*** End Patch',
+    ].join('\n');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'apply_patch',
+        tool_input: { command: patch },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks rail edits from fully-qualified Codex apply_patch hook payloads', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: test/a.test.mjs',
+      '@@',
+      '+test("rail", () => {});',
+      '*** End Patch',
+    ].join('\n');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'functions.apply_patch',
+        tool_input: { command: patch },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks shell-based writes to rail paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'cat > test/a.test.mjs <<EOF\nchanged\nEOF' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks Python interpreter writes to rail paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'python3 -c "open(\'test/a.test.mjs\', \'w\').write(\'x\')"' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks Node interpreter writes to rail paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'node -e "require(\'fs\').writeFileSync(\'test/a.test.mjs\', \'x\')"' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks Ruby interpreter writes to rail paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'ruby -e "File.write(\'test/a.test.mjs\', \'x\')"' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('fails closed on cwd-changing shell writes', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'cd test && cat > a.test.mjs <<EOF\nchanged\nEOF' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /changes cwd/);
+  });
+
+  it('fails closed on variable-expanded shell writes', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'p=test/a.test.mjs; cat > "$p" <<EOF\nchanged\nEOF' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /shell expansion/);
+  });
+
+  it('fails closed on variable-expanded tee writes', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'p=test/a.test.mjs; printf changed | tee "$p"' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /shell expansion/);
+  });
+
+  it('blocks dd key-value shell writes to rails', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'dd if=/dev/null of=test/a.test.mjs count=0' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks unlisted shell writers with literal rail targets', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    for (const command of [
+      'truncate -s 0 test/a.test.mjs',
+      'rsync src/a.mjs test/a.test.mjs',
+      'awk -i inplace \'{ print }\' test/a.test.mjs',
+    ]) {
+      const result = spawnSync(process.execPath, [hook], {
+        cwd: dir,
+        env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+        input: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command },
+        }),
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, 2, command);
+      assert.match(result.stderr, /blocked rail edit/, command);
+    }
+  });
+
+  it('fails closed on destructive find commands without literal file targets', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'find test -type f -delete' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /known read-only command/);
+  });
+
+  it('blocks sed write scripts to rail paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: "sed -n 'w test/a.test.mjs' src/a.mjs" },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('fails closed on unknown pathless shell commands', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'make generated' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /known read-only command/);
+  });
+
+  it('allows read-only shell commands with no editable paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'git status --short' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
+  });
+
+  it('allows required P4 gate and test commands with no editable paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    for (const command of [
+      'npm test',
+      'node --test packages/runner/test/runner.test.mjs',
+      'adlc hollow-test --test-cmd "npm test"',
+      'adlc rails-guard --ticket T1 --record --json',
+      'adlc flail-detector build.log --json',
+      'adlc run p4 --ticket T1 --dir .adlc --json',
+    ]) {
+      const result = spawnSync(process.execPath, [hook], {
+        cwd: dir,
+        env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+        input: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command },
+        }),
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, 0, command);
+    }
+  });
+
+  it('fails closed on malformed active hook payloads', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: '{bad',
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /malformed hook payload JSON/);
+  });
+
+  it('fails closed when active payload contains no editable paths', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({ tool: 'edit' }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /did not include any editable paths/);
+  });
+
+  it('allows non-rail edits when active from current-ticket.json', () => {
+    const dir = fixture();
+    writeFileSync(join(dir, '.adlc/current-ticket.json'), JSON.stringify({ id: 'T1' }));
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1' },
+      input: JSON.stringify({ path: 'src/a.mjs' }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
+  });
+
+  it('fails closed on conflicting active ticket sources', () => {
+    const dir = fixture();
+    writeFileSync(join(dir, '.adlc/current-ticket.json'), JSON.stringify({ id: 'T2' }));
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({ path: 'src/a.mjs' }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /conflicts/);
+  });
+});

--- a/packages/runner/test/runner.test.mjs
+++ b/packages/runner/test/runner.test.mjs
@@ -1,0 +1,1145 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, appendFileSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { assertPhase } from '../lib/assertions.mjs';
+import { canonicalJson, resolveRevision, sha256 } from '@adlc/core';
+import { recordAcceptancePacket } from '../lib/acceptance.mjs';
+
+const repoRoot = resolve(new URL('../../../', import.meta.url).pathname);
+
+function tmpAdlc() {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-runner-'));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeManifest(dir, entries) {
+  for (const entry of entries) appendFileSync(join(dir, 'manifest.jsonl'), JSON.stringify(entry) + '\n');
+}
+
+function ticketHash(ticket) {
+  return sha256(canonicalJson(ticket));
+}
+
+function ticketDefinition(ticket) {
+  return { id: ticket, title: `${ticket} fixture`, scope: ['src/**'], rails: ['test/**'], edges: [] };
+}
+
+function writeTicketDefinition(dir, ticket = 'T1') {
+  writeFileSync(join(dir, 'tickets.json'), JSON.stringify({ tickets: [ticketDefinition(ticket)] }));
+}
+
+function writeP5Evidence(dir, {
+  ticket = 'T1',
+  revision = resolveRevision(),
+  hash,
+  transcriptPath = join(dir, `${ticket}-p5-review.txt`),
+  dryLenses = ['security', 'correctness', 'tests'],
+} = {}) {
+  if (hash === undefined) writeTicketDefinition(dir, ticket);
+  const ticketHashValue = hash === undefined ? ticketHash(ticketDefinition(ticket)) : hash;
+  const transcriptText = [
+    `ticket: ${ticket}`,
+    `reviewed revision: ${revision}`,
+    'review transcript fixture with enough detail to be accepted as evidence',
+    'review transcript fixture with enough detail to be accepted as evidence',
+  ].join('\n');
+  writeFileSync(transcriptPath, transcriptText);
+  const transcript = { path: transcriptPath, hash: sha256(readFileSync(transcriptPath)) };
+  const evidenceDir = dirname(transcriptPath);
+  const promptPath = join(evidenceDir, `${ticket}-p5-prompt.txt`);
+  const inputsPath = join(evidenceDir, `${ticket}-p5-inputs.txt`);
+  writeFileSync(promptPath, `review prompt for ${ticket} at ${revision}\n`);
+  writeFileSync(inputsPath, `reviewed inputs for ${ticket} at ${revision}\n`);
+  const reviewPacket = {
+    prompt: { path: promptPath, hash: sha256(readFileSync(promptPath)) },
+    inputs: { path: inputsPath, hash: sha256(readFileSync(inputsPath)) },
+    cleanWorktree: revision,
+  };
+  const entries = [];
+  dryLenses.forEach((lens, index) => {
+    const pass = index + 1;
+    entries.push({
+      type: 'p5-dry-pass',
+      ticket,
+      revision,
+      pass,
+      lens,
+      consecutiveDry: pass,
+    });
+    entries.push({
+      type: 'p5-pass-completed',
+      ticket,
+      revision,
+      pass,
+      lens,
+      dry: true,
+      verified: 0,
+      killed: 0,
+      needsHuman: 0,
+      consecutiveDry: pass,
+    });
+  });
+  entries.push({
+    type: 'p5-complete',
+    ticket,
+    revision,
+    pass: dryLenses.length,
+    consecutiveDry: dryLenses.length,
+    provenance: {
+      reviewer: 'fixture-reviewer',
+      command: 'fixture review command',
+      transcript: transcriptPath,
+    },
+    transcript,
+    reviewPacket,
+    dryLenses,
+    ticketHash: ticketHashValue,
+  });
+  writeManifest(dir, entries);
+}
+
+function writeP5Finding(dir, {
+  type = 'p5-finding-verified',
+  ticket = 'T1',
+  revision = resolveRevision(),
+  id = 'F1',
+  pass = 1,
+  lens = 'security',
+  file = 'src/auth.mjs',
+  claim = 'verified claim',
+  evidence = 'verified finding evidence',
+} = {}) {
+  writeManifest(dir, [{
+    type,
+    ticket,
+    revision,
+    pass,
+    lens,
+    finding: {
+      id,
+      category: lens,
+      severity: 'high',
+      file,
+      line_start: 1,
+      line_end: 1,
+      evidence,
+      claim,
+      recommendation: 'fix it',
+      confidence: 0.9,
+      verified_status: type === 'p5-finding-killed' ? 'killed' : type.replace('p5-finding-', ''),
+    },
+  }]);
+}
+
+function gitRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-runner-git-'));
+  const g = (...args) => execFileSync('git', args, {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  g('init', '-q', '-b', 'main');
+  g('config', 'user.email', 't@t.co');
+  g('config', 'user.name', 'tester');
+  g('config', 'commit.gpgsign', 'false');
+  return { dir, g };
+}
+
+function p4Fixture() {
+  const cwd = mkdtempSync(join(tmpdir(), 'adlc-runner-p4-'));
+  const dir = join(cwd, '.adlc');
+  mkdirSync(join(cwd, 'test'), { recursive: true });
+  mkdirSync(dir, { recursive: true });
+  const railPath = join(cwd, 'test/a.test.mjs');
+  writeFileSync(railPath, 'test("rail", () => {});\n');
+  return { cwd, dir, railPath };
+}
+
+function writeP4Evidence(dir, content) {
+  writeManifest(dir, [
+    { type: 'rails-green', ticket: 'T1' },
+    {
+      type: 'rails-check',
+      ticket: 'T1',
+      railsDiffEmpty: true,
+      suppressionsClean: true,
+      railFiles: { 'test/a.test.mjs': sha256(content) },
+    },
+    { type: 'flail-check', ticket: 'T1' },
+  ]);
+}
+
+function writeP4EvidenceForTicket(dir, ticket, content) {
+  writeManifest(dir, [
+    { type: 'rails-green', ticket },
+    {
+      type: 'rails-check',
+      ticket,
+      railsDiffEmpty: true,
+      suppressionsClean: true,
+      railFiles: { 'test/a.test.mjs': sha256(content) },
+    },
+    { type: 'flail-check', ticket },
+  ]);
+}
+
+describe('assertPhase', () => {
+  it('passes p4 when rails-check rail hashes match current rail files', () => {
+    const { cwd, dir, railPath } = p4Fixture();
+    try {
+      writeP4Evidence(dir, readFileSync(railPath));
+      const result = assertPhase('p4', { dir, ticket: 'T1', cwd });
+      assert.equal(result.ok, true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('requires ticket-scoped evidence for p3 and p4', () => {
+    const { cwd, dir, railPath } = p4Fixture();
+    try {
+      writeP4EvidenceForTicket(dir, 'T2', readFileSync(railPath));
+
+      const p3 = assertPhase('p3', { dir, cwd });
+      assert.equal(p3.ok, false);
+      assert.equal(p3.operational, true);
+      assert.match(p3.errors[0], /p3 requires --ticket/);
+
+      const p4 = assertPhase('p4', { dir, cwd });
+      assert.equal(p4.ok, false);
+      assert.equal(p4.operational, true);
+      assert.match(p4.errors[0], /p4 requires --ticket/);
+
+      const t1 = assertPhase('p4', { dir, ticket: 'T1', cwd });
+      assert.equal(t1.ok, false);
+      assert.deepEqual(t1.missing, ['rails-green', 'rails-check', 'flail-check']);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects p4 when rails-check lacks rail file hashes', () => {
+    const { cwd, dir } = p4Fixture();
+    try {
+      writeManifest(dir, [
+        { type: 'rails-green', ticket: 'T1' },
+        { type: 'rails-check', ticket: 'T1', railsDiffEmpty: true, suppressionsClean: true },
+        { type: 'flail-check', ticket: 'T1' },
+      ]);
+      const result = assertPhase('p4', { dir, ticket: 'T1', cwd });
+      assert.equal(result.ok, false);
+      assert.equal(result.operational, true);
+      assert.ok(result.errors.some((error) => error.includes('missing railFiles hash snapshot')));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects p4 when rail files change after rails-check evidence is recorded', () => {
+    const { cwd, dir, railPath } = p4Fixture();
+    try {
+      writeP4Evidence(dir, readFileSync(railPath));
+      writeFileSync(railPath, 'test("rail", () => { throw new Error("changed"); });\n');
+      const result = assertPhase('p4', { dir, ticket: 'T1', cwd });
+      assert.equal(result.ok, false);
+      assert.equal(result.operational, true);
+      assert.ok(result.errors.some((error) => error.includes('rail file hash changed')));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('passes p5 only when p5-complete exists', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Evidence(dir, { revision });
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, true);
+  });
+
+  it('uses explicit p5 revision as an offline manifest and artifact selector', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'adlc-runner-offline-'));
+    const dir = join(cwd, '.adlc');
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeP5Evidence(dir, { revision: 'fixture-revision' });
+      const result = assertPhase('p5', {
+        dir,
+        ticket: 'T1',
+        revision: 'fixture-revision',
+        cwd,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, 'fixture-revision');
+      assert.equal(result.currentRevision, undefined);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a forged bare p5-complete manifest entry', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeTicketDefinition(dir);
+    writeManifest(dir, [{
+      type: 'p5-complete',
+      ticket: 'T1',
+      revision,
+      ticketHash: ticketHash(ticketDefinition('T1')),
+    }]);
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, true);
+    assert.ok(result.errors.some((error) => error.includes('missing provenance')));
+    assert.ok(result.errors.some((error) => error.includes('missing transcript')));
+    assert.ok(result.errors.some((error) => error.includes('missing reviewPacket')));
+  });
+
+  it('rejects p5-complete when a verified finding remains unresolved at the same revision', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Finding(dir, { revision, id: 'F1' });
+    writeP5Evidence(dir, { revision });
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, true);
+    assert.ok(result.errors.some((error) => error.includes('unresolved p5-finding-verified F1')));
+  });
+
+  it('accepts p5-complete after a later killed disposition resolves a verified finding', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Finding(dir, { revision, id: 'F1' });
+    writeP5Finding(dir, { type: 'p5-finding-killed', revision, id: 'F1' });
+    writeP5Evidence(dir, { revision });
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, true);
+  });
+
+  it('accepts p5-complete when a killed disposition resolves a verified finding from an earlier pass', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Finding(dir, { revision, id: 'F1', pass: 1 });
+    writeP5Finding(dir, { type: 'p5-finding-killed', revision, id: 'F1', pass: 2 });
+    writeP5Evidence(dir, { revision });
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, true);
+  });
+
+  it('does not resolve a verified finding with a killed finding that only shares the id', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Finding(dir, { revision, id: 'F1', lens: 'security', file: 'src/auth.mjs', claim: 'auth bypass' });
+    writeP5Finding(dir, {
+      type: 'p5-finding-killed',
+      revision,
+      id: 'F1',
+      lens: 'docs',
+      file: 'docs/auth.md',
+      claim: 'stale docs wording',
+      evidence: 'different finding evidence',
+    });
+    writeP5Evidence(dir, { revision });
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, true);
+    assert.ok(result.errors.some((error) => error.includes('unresolved p5-finding-verified F1')));
+  });
+
+  it('rejects p5-complete when a killed disposition is appended after completion', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Finding(dir, { revision, id: 'F1' });
+    writeP5Evidence(dir, { revision });
+    writeP5Finding(dir, { type: 'p5-finding-killed', revision, id: 'F1' });
+    const result = assertPhase('p5', { dir, ticket: 'T1' });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, true);
+    assert.ok(result.errors.some((error) => error.includes('unresolved p5-finding-verified F1')));
+  });
+
+  it('fails p6 without p5 evidence and acceptance packet', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeManifest(dir, [{ type: 'p6-acceptance-packet', ticket: 'T1', revision }]);
+    const result = assertPhase('p6', { dir, ticket: 'T1' });
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.missing, ['p5-complete']);
+  });
+
+  it('rejects p6 acceptance packets before matching p5 evidence exists', () => {
+    const dir = tmpAdlc();
+    writeTicketDefinition(dir);
+    const packet = join(dir, 'acceptance.json');
+    writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+    const result = recordAcceptancePacket({ dir, ticket: 'T1', packet });
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((error) => error.includes('no p5-complete for ticket T1')));
+  });
+
+  it('rejects explicit-revision p6 acceptance before matching p5 evidence exists', () => {
+    const dir = tmpAdlc();
+    writeTicketDefinition(dir);
+    const packet = join(dir, 'acceptance.json');
+    writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+    const result = recordAcceptancePacket({ dir, ticket: 'T1', packet, revision: 'fixture-revision' });
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((error) => error.includes('no p5-complete for ticket T1 at fixture-revision')));
+  });
+
+  it('passes p6 with revision-scoped p5 evidence and acceptance packet', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    const packet = join(dir, 'acceptance.json');
+    writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+    writeP5Evidence(dir, { revision });
+
+    const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet });
+    assert.equal(recorded.ok, true);
+
+    const result = assertPhase('p6', { dir, ticket: 'T1' });
+    assert.equal(result.ok, true);
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8');
+    assert.match(manifest, /"type":"p6-acceptance-packet"/);
+    assert.match(manifest, /"packetHash":/);
+  });
+
+  it('uses explicit p6 revision as an offline manifest and artifact selector', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'adlc-runner-offline-'));
+    const dir = join(cwd, '.adlc');
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeP5Evidence(dir, { revision: 'fixture-revision' });
+      const packet = join(dir, 'acceptance.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({
+        dir,
+        ticket: 'T1',
+        packet,
+        revision: 'fixture-revision',
+        cwd,
+      });
+      assert.equal(recorded.ok, true);
+      assert.equal(recorded.revision, 'fixture-revision');
+
+      const result = assertPhase('p6', {
+        dir,
+        ticket: 'T1',
+        revision: 'fixture-revision',
+        cwd,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, 'fixture-revision');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a forged bare p6 acceptance packet manifest entry', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    writeP5Evidence(dir, { revision });
+    writeManifest(dir, [{ type: 'p6-acceptance-packet', ticket: 'T1', revision }]);
+
+    const result = assertPhase('p6', { dir, ticket: 'T1', revision });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, true);
+    assert.ok(result.errors.some((error) => error.includes('missing packet path')));
+    assert.ok(result.errors.some((error) => error.includes('missing packetHash')));
+  });
+
+  it('passes p6 when the acceptance packet is created inside an evidence root after p5', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    const packet = join(repoRoot, '.adlc/acceptance.json');
+    try {
+      mkdirSync(join(repoRoot, '.adlc'), { recursive: true });
+      writeP5Evidence(dir, { revision });
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet });
+      assert.equal(recorded.ok, true);
+      assert.equal(recorded.revision, revision);
+
+      const result = assertPhase('p6', { dir, ticket: 'T1' });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, revision);
+    } finally {
+      rmSync(packet, { force: true });
+    }
+  });
+
+  it('passes p6 when the documented packet and snapshots are created inside an evidence root after p5', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/before.json'), '{"before":true}\n');
+      writeFileSync(join(repo.dir, '.adlc/after.json'), '{"after":true}\n');
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({
+        dir,
+        ticket: 'T1',
+        packet,
+        before: '.adlc/before.json',
+        after: '.adlc/after.json',
+        cwd: repo.dir,
+      });
+      assert.equal(recorded.ok, true);
+      assert.equal(recorded.revision, revision);
+
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, revision);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects in-worktree P6 artifacts outside evidence roots', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      writeFileSync(join(repo.dir, 'packet.json'), JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({
+        dir,
+        ticket: 'T1',
+        packet: 'packet.json',
+        before: 'src.txt',
+        cwd: repo.dir,
+      });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('packet inside the worktree must live')));
+      assert.ok(recorded.errors.some((error) => error.includes('artifact inside the worktree must live')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stales p6 when recorded acceptance packet or snapshot evidence changes', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/before.json'), '{"before":true}\n');
+      writeFileSync(join(repo.dir, '.adlc/after.json'), '{"after":true}\n');
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+      const recorded = recordAcceptancePacket({
+        dir,
+        ticket: 'T1',
+        packet,
+        before: '.adlc/before.json',
+        after: '.adlc/after.json',
+        cwd: repo.dir,
+      });
+      assert.equal(recorded.ok, true);
+      assert.equal(assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir }).ok, true);
+
+      writeFileSync(join(repo.dir, '.adlc/after.json'), '{"after":"tampered"}\n');
+      const afterTamper = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(afterTamper.ok, false);
+      assert.ok(afterTamper.errors.some((error) => error.includes('artifact hash changed')));
+
+      writeFileSync(join(repo.dir, '.adlc/after.json'), '{"after":true}\n');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'tampered' }));
+      const packetTamper = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(packetTamper.ok, false);
+      assert.ok(packetTamper.errors.some((error) => error.includes('packet hash changed')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes p6 with a non-default manifest dir inside the worktree', () => {
+    const repo = gitRepo();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const dir = join(repo.dir, '.review');
+      mkdirSync(dir, { recursive: true });
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision, transcriptPath: join(repo.dir, '.adlc/p5-review.txt') });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, revision);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('binds non-default manifest evidence to the manifest-dir ticket file before root .adlc tickets', () => {
+    const repo = gitRepo();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{ id: 'T1', title: 'root ticket', scope: ['root/**'], rails: ['root-test/**'], edges: [] }],
+      }));
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const dir = join(repo.dir, '.review');
+      mkdirSync(dir, { recursive: true });
+      const activeTicket = { id: 'T1', title: 'active ticket', scope: ['src/**'], rails: ['test/**'], edges: [] };
+      writeFileSync(join(dir, 'tickets.json'), JSON.stringify({ tickets: [activeTicket] }));
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const revision = resolveRevision({ cwd: repo.dir, ignorePaths: [join(dir, 'tickets.json')] });
+      writeP5Evidence(dir, {
+        revision,
+        hash: ticketHash(activeTicket),
+        transcriptPath: join(repo.dir, '.adlc/p5-review.txt'),
+      });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+      assert.equal(assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir }).ok, true);
+
+      writeFileSync(join(dir, 'tickets.json'), JSON.stringify({
+        tickets: [{ ...activeTicket, scope: ['changed/**'] }],
+      }));
+      const staleRecorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(staleRecorded.ok, false);
+      assert.ok(staleRecorded.errors.some((error) => error.includes('ticket definition changed')));
+      const stalePhase = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(stalePhase.ok, false);
+      assert.ok(stalePhase.errors.some((error) => error.includes('ticket definition changed')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes p6 after a reviewed dirty tree is committed without content changes', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'base\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed change\n');
+      writeFileSync(join(repo.dir, 'feature.mjs'), 'export const reviewed = true;\n');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'reviewed change');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+      assert.equal(recorded.revision, revision);
+
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, revision);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not stale one ticket when an unrelated ticket is added', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      const ticket = { id: 'T1', title: 'one', scope: ['src/**'], edges: [] };
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({ tickets: [ticket] }));
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision, hash: ticketHash(ticket) });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [ticket, { id: 'T2', title: 'two', scope: ['other/**'], edges: [] }],
+      }));
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, true);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not stale p6 when the active ticket definition is key-reordered only', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      const ticket = {
+        id: 'T1',
+        title: 'one',
+        scope: ['src/**'],
+        edges: [],
+        metadata: { priority: 'high', owner: 'codex' },
+      };
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({ tickets: [ticket] }));
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision, hash: ticketHash(ticket) });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{
+          metadata: { owner: 'codex', priority: 'high' },
+          edges: [],
+          scope: ['src/**'],
+          title: 'one',
+          id: 'T1',
+        }],
+      }));
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, true);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stales p6 when the active ticket definition changes after p5', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      const ticket = { id: 'T1', title: 'one', scope: ['src/**'], edges: [] };
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({ tickets: [ticket] }));
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision, hash: ticketHash(ticket) });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+      const recordedBeforeChange = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recordedBeforeChange.ok, true);
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({
+        tickets: [{ ...ticket, scope: ['changed/**'] }],
+      }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('ticket definition changed')));
+      const pinnedRecorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, revision, cwd: repo.dir });
+      assert.equal(pinnedRecorded.ok, false);
+      assert.ok(pinnedRecorded.errors.some((error) => error.includes('ticket definition changed')));
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, false);
+      assert.equal(result.operational, true);
+      assert.ok(result.errors.some((error) => error.includes('ticket definition changed')));
+      const pinned = assertPhase('p6', { dir, ticket: 'T1', revision, cwd: repo.dir });
+      assert.equal(pinned.ok, false);
+      assert.equal(pinned.operational, true);
+      assert.ok(pinned.errors.some((error) => error.includes('ticket definition changed')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stales p5 and p6 when P5 did not bind a ticket definition that now exists', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      const ticket = { id: 'T1', title: 'one', scope: ['src/**'], edges: [] };
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision, hash: null });
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(join(repo.dir, '.adlc/tickets.json'), JSON.stringify({ tickets: [ticket] }));
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('ticket definition was not bound')));
+      rmSync(packet, { force: true });
+      const p5 = assertPhase('p5', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(p5.ok, false);
+      assert.equal(p5.operational, true);
+      assert.ok(p5.errors.some((error) => error.includes('ticket definition was not bound')));
+      const p6 = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(p6.ok, false);
+      assert.equal(p6.operational, true);
+      assert.ok(p6.errors.some((error) => error.includes('ticket definition was not bound')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stales p6 when recorded P5 transcript evidence changes after prosecution', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, '.gitignore'), '.adlc/*\n');
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const transcript = join(repo.dir, '.adlc/p5-review.txt');
+      writeFileSync(transcript, [
+        'ticket: T1',
+        'reviewed revision: pending',
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision, transcriptPath: transcript });
+      writeManifest(dir, [{ type: 'p6-acceptance-packet', ticket: 'T1', revision }]);
+      writeFileSync(transcript, [
+        'ticket: T1',
+        'reviewed revision: pending',
+        'mutated review transcript after P5',
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('transcript hash changed')));
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, false);
+      assert.equal(result.operational, true);
+      assert.ok(result.errors.some((error) => error.includes('transcript hash changed')));
+      const pinned = assertPhase('p6', { dir, ticket: 'T1', revision, cwd: repo.dir });
+      assert.equal(pinned.ok, false);
+      assert.equal(pinned.operational, true);
+      assert.ok(pinned.errors.some((error) => error.includes('transcript hash changed')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stales p5 and p6 when recorded P5 reviewed input evidence changes after prosecution', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'base\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      const complete = readFileSync(join(dir, 'manifest.jsonl'), 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+        .find((entry) => entry.type === 'p5-complete');
+      writeFileSync(complete.reviewPacket.inputs.path, 'tampered reviewed input packet\n');
+      const p5 = assertPhase('p5', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(p5.ok, false);
+      assert.ok(p5.errors.some((error) => error.includes('reviewPacket.inputs hash changed')));
+      const packet = join(repo.dir, '.adlc/packet.json');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('reviewPacket.inputs hash changed')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows re-prosecution to supersede an older P5 transcript at the same path', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, '.gitignore'), '.adlc/*\n');
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed A\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base A');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const transcript = join(repo.dir, '.adlc/p5-review.txt');
+      writeFileSync(transcript, [
+        'ticket: T1',
+        'reviewed revision: A',
+        'review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+      const revisionA = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision: revisionA, transcriptPath: transcript });
+
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed B\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base B');
+      writeFileSync(transcript, [
+        'ticket: T1',
+        'reviewed revision: B',
+        'new review transcript fixture with enough detail to be accepted as evidence',
+      ].join('\n'));
+      const revisionB = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision: revisionB, transcriptPath: transcript });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+      assert.equal(recorded.revision, revisionB);
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, true);
+      assert.equal(result.revision, revisionB);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('stales p6 when an older distinct P5 transcript evidence file changes after re-prosecution', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, '.gitignore'), '.adlc/*\n');
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed A\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base A');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const transcriptA = join(repo.dir, '.adlc/p5-review-A.txt');
+      const revisionA = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision: revisionA, transcriptPath: transcriptA });
+
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed B\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base B');
+      const transcriptB = join(repo.dir, '.adlc/p5-review-B.txt');
+      const revisionB = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision: revisionB, transcriptPath: transcriptB });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, true);
+      assert.equal(recorded.revision, revisionB);
+      assert.equal(assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir }).ok, true);
+
+      writeFileSync(transcriptA, 'mutated older transcript after P6 acceptance\n');
+      const staleRecorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(staleRecorded.ok, false);
+      assert.ok(staleRecorded.errors.some((error) => error.includes('transcript hash changed')));
+      const stalePhase = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(stalePhase.ok, false);
+      assert.equal(stalePhase.operational, true);
+      assert.ok(stalePhase.errors.some((error) => error.includes('transcript hash changed')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not ignore root after.json unless it is recorded as a p6 artifact', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'after.json'), '{"reviewed":true}\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      writeFileSync(join(repo.dir, 'after.json'), '{"reviewed":false}\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const packet = join(repo.dir, '.adlc/packet.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('P5 evidence is stale')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails implicit p6 acceptance when tracked source changes after p5', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed change\n');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      writeFileSync(join(repo.dir, 'src.txt'), 'unreviewed change\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const packet = join(repo.dir, '.adlc/acceptance.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('P5 evidence is stale')));
+      const pinnedRecorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, revision, cwd: repo.dir });
+      assert.equal(pinnedRecorded.ok, true);
+
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(result.ok, false);
+      assert.equal(result.operational, true);
+      assert.ok(result.errors.some((error) => error.includes('P5 evidence is stale')));
+      const pinned = assertPhase('p6', { dir, ticket: 'T1', revision, cwd: repo.dir });
+      assert.equal(pinned.ok, true);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses explicit p5 revision as a selector when tracked source changes after p5', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      writeFileSync(join(repo.dir, 'src.txt'), 'unreviewed change\n');
+
+      const implicit = assertPhase('p5', { dir, ticket: 'T1', cwd: repo.dir });
+      assert.equal(implicit.ok, false);
+      assert.equal(implicit.operational, true);
+      assert.ok(implicit.errors.some((error) => error.includes('P5 evidence is stale')));
+
+      const pinned = assertPhase('p5', { dir, ticket: 'T1', revision, cwd: repo.dir });
+      assert.equal(pinned.ok, true);
+      assert.equal(pinned.revision, revision);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails p6 acceptance when untracked source appears after p5', () => {
+    const repo = gitRepo();
+    const dir = tmpAdlc();
+    try {
+      writeFileSync(join(repo.dir, 'src.txt'), 'reviewed\n');
+      repo.g('add', '-A');
+      repo.g('commit', '-qm', 'base');
+      const revision = resolveRevision({ cwd: repo.dir });
+      writeP5Evidence(dir, { revision });
+      writeFileSync(join(repo.dir, 'feature.mjs'), 'export const unreviewed = true;\n');
+      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
+      const packet = join(repo.dir, '.adlc/acceptance.json');
+      writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+
+      const recorded = recordAcceptancePacket({ dir, ticket: 'T1', packet, cwd: repo.dir });
+      assert.equal(recorded.ok, false);
+      assert.ok(recorded.errors.some((error) => error.includes('P5 evidence is stale')));
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails p6 when current revision cannot be resolved', () => {
+    const dir = tmpAdlc();
+    const cwd = mkdtempSync(join(tmpdir(), 'adlc-not-git-'));
+    try {
+      writeP5Evidence(dir, { revision: 'git-worktree:old' });
+      writeManifest(dir, [{ type: 'p6-acceptance-packet', ticket: 'T1', revision: 'git-worktree:old' }]);
+      const result = assertPhase('p6', { dir, ticket: 'T1', cwd });
+      assert.equal(result.ok, false);
+      assert.equal(result.operational, true);
+      assert.ok(result.errors.some((error) => error.includes('current worktree revision could not be resolved')));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('requires a ticket for p5 and p6', () => {
+    const dir = tmpAdlc();
+    const result = assertPhase('p5', { dir });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, true);
+    assert.match(result.errors[0], /requires --ticket/);
+  });
+
+  it('does not accept unmatched explicit revision evidence', () => {
+    const dir = tmpAdlc();
+    writeManifest(dir, [{ type: 'p5-complete', ticket: 'T1', revision: 'git-worktree:old' }]);
+    const result = assertPhase('p5', { dir, ticket: 'T1', revision: 'git-worktree:new' });
+    assert.equal(result.ok, false);
+    assert.equal(result.operational, false);
+    assert.deepEqual(result.missing, ['p5-complete']);
+  });
+
+  it('fails when manifest has malformed lines', () => {
+    const dir = tmpAdlc();
+    const revision = resolveRevision();
+    appendFileSync(join(dir, 'manifest.jsonl'), '{bad\n');
+    const result = assertPhase('p5', { dir, ticket: 'T1', revision });
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped.length, 1);
+  });
+});
+
+describe('adlc cli', () => {
+  it('exits 1 when scoped evidence omits ticket', () => {
+    const dir = tmpAdlc();
+    const bin = new URL('../bin/adlc.mjs', import.meta.url).pathname;
+    let code = 0;
+    try {
+      execFileSync(process.execPath, [bin, 'run', 'p5', '--dir', dir], { encoding: 'utf8' });
+    } catch (err) {
+      code = err.status;
+    }
+    assert.equal(code, 1);
+  });
+
+  it('rejects p6 acceptance without prior p5 evidence', () => {
+    const dir = tmpAdlc();
+    writeTicketDefinition(dir);
+    const packet = join(dir, 'acceptance.json');
+    writeFileSync(packet, JSON.stringify({ behaviorDiff: 'accepted' }));
+    const bin = new URL('../bin/adlc.mjs', import.meta.url).pathname;
+    let code = 0;
+    try {
+      execFileSync(process.execPath, [
+        bin,
+        'accept',
+        '--ticket',
+        'T1',
+        '--packet',
+        packet,
+        '--dir',
+        dir,
+        '--json',
+      ], { encoding: 'utf8' });
+    } catch (err) {
+      code = err.status;
+      assert.match(err.stdout, /no p5-complete for ticket T1/);
+    }
+    assert.equal(code, 1);
+  });
+});

--- a/plugins/adlc-codex/.codex-plugin/plugin.json
+++ b/plugins/adlc-codex/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "adlc-codex",
+  "version": "1.0.2",
+  "description": "Codex workflows for operating the Agentic Development Lifecycle with the ADLC toolkit.",
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+function fail(message) {
+  console.error(`adlc-rails-guard: ${message}`);
+  process.exit(2);
+}
+
+function notice(message) {
+  console.error(`adlc-rails-guard: ${message}`);
+}
+
+function parseJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    if (err?.code === 'ENOENT') throw err;
+    fail(`malformed JSON in ${path}: ${err.message}`);
+  }
+}
+
+function readRequiredJson(path) {
+  try {
+    return parseJson(path);
+  } catch (err) {
+    if (err?.code === 'ENOENT') fail(`file not found: ${path}`);
+    throw err;
+  }
+}
+
+function readOptionalJson(path) {
+  try {
+    return parseJson(path);
+  } catch (err) {
+    if (err?.code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
+function globMatch(pattern, path) {
+  const regex = new RegExp(
+    '^' +
+      pattern
+        .split(/(\*\*\/|\*\*|\*)/)
+        .map((part) => {
+          if (part === '**/') return '(?:.*/)?';
+          if (part === '**') return '.*';
+          if (part === '*') return '[^/]*';
+          return part.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+        })
+        .join('') +
+      '$'
+  );
+  return regex.test(path);
+}
+
+function loadTickets(path) {
+  const data = readRequiredJson(path);
+  if (!Array.isArray(data.tickets)) fail(`${path} must contain a tickets array`);
+  const ids = new Set();
+  const errors = [];
+  for (const ticket of data.tickets) {
+    if (!ticket || typeof ticket !== 'object') {
+      errors.push('ticket is not an object');
+      continue;
+    }
+    if (!ticket.id || typeof ticket.id !== 'string') errors.push('ticket missing string id');
+    if (!ticket.title || typeof ticket.title !== 'string') errors.push(`${ticket.id ?? '?'}: missing string title`);
+    if (ticket.rails !== undefined && !Array.isArray(ticket.rails)) errors.push(`${ticket.id}: rails must be an array`);
+    if (ticket.id) {
+      if (ids.has(ticket.id)) errors.push(`duplicate ticket id: ${ticket.id}`);
+      ids.add(ticket.id);
+    }
+  }
+  if (errors.length > 0) fail(`ticket file errors: ${errors.join('; ')}`);
+  return data.tickets;
+}
+
+function collectPaths(value, out = new Set()) {
+  if (typeof value === 'string') {
+    collectPatchPaths(value, out);
+    return out;
+  }
+  if (!value || typeof value !== 'object') return out;
+  if (Array.isArray(value)) {
+    for (const item of value) collectPaths(item, out);
+    return out;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (['path', 'filePath', 'file_path', 'target', 'targetPath', 'target_path'].includes(key) && typeof child === 'string') {
+      out.add(child);
+    } else if (['paths', 'filePaths', 'file_paths'].includes(key) && Array.isArray(child)) {
+      for (const item of child) {
+        if (typeof item === 'string') out.add(item);
+        else collectPaths(item, out);
+      }
+    } else if (['command', 'cmd', 'patch', 'input'].includes(key) && typeof child === 'string') {
+      collectPatchPaths(child, out);
+    } else {
+      collectPaths(child, out);
+    }
+  }
+  return out;
+}
+
+function collectCommandText(value, out = []) {
+  if (!value || typeof value !== 'object') return out;
+  if (Array.isArray(value)) {
+    for (const item of value) collectCommandText(item, out);
+    return out;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (['command', 'cmd', 'input', 'script'].includes(key) && typeof child === 'string') {
+      out.push(child);
+    } else {
+      collectCommandText(child, out);
+    }
+  }
+  return out;
+}
+
+function collectPatchPaths(text, out) {
+  for (const line of text.split(/\r?\n/)) {
+    for (const prefix of ['*** Add File: ', '*** Update File: ', '*** Delete File: ', '*** Move to: ']) {
+      if (line.startsWith(prefix)) {
+        const path = line.slice(prefix.length).trim();
+        if (path) out.add(path);
+      }
+    }
+  }
+}
+
+function shellTokens(text) {
+  const tokens = [];
+  const pattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^']*)'|([^\s;&|<>]+)/g;
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    tokens.push(match[1] ?? match[2] ?? match[3]);
+  }
+  return tokens;
+}
+
+function looksPathLike(value) {
+  return (
+    !value.startsWith('-') &&
+    !value.includes('=') &&
+    /^[A-Za-z0-9_./@+-]+$/.test(value) &&
+    (/[/\\]/.test(value) || /\.[A-Za-z0-9]+$/.test(value))
+  );
+}
+
+function keyValuePath(value) {
+  const match = value.match(/^(?:--?[A-Za-z0-9_-]+|[A-Za-z_][A-Za-z0-9_-]*)=(.+)$/);
+  if (!match) return null;
+  const path = match[1].replace(/^["']|["']$/g, '');
+  return looksPathLike(path) ? path : null;
+}
+
+function shellHasMutation(text) {
+  return (
+    /(^|[\s;&|])(?:>>?|[0-9]>>?|[0-9]>)\s*\S+/.test(text) ||
+    /\b(?:tee|touch|rm|mv|cp|install|dd|truncate|rsync)\b/.test(text) ||
+    /\bfind\b[^;&|]*(?:-delete|-exec(?:dir)?\b|-ok(?:dir)?\b)/.test(text) ||
+    /\b(?:sed|perl)\s+[^;&|]*-(?:i|p?i)\b/.test(text) ||
+    /\bsed\b[^;&|]*(?:"[^"\n]*\bw\s+\S+[^"\n]*"|'[^'\n]*\bw\s+\S+[^'\n]*')/.test(text) ||
+    /\bawk\s+[^;&|]*\s-i(?:\s|=)/.test(text) ||
+    /\b(?:node|python3?|ruby)\b[^;&|]*(?:writeFile|appendFile|rmSync|renameSync|copyFile|truncateSync|mkdirSync|write_text|write_bytes)/.test(text) ||
+    /\bopen\s*\([^)]*,\s*['"][^'"]*[wax+][^'"]*['"]/.test(text) ||
+    /\bFile\.(?:write|open)\b/.test(text)
+  );
+}
+
+function shellIsPositivelyReadOnly(text) {
+  const normalized = text.trim();
+  return (
+    normalized === '' ||
+    /^(?:git\s+(?:status|diff|show|log|rev-parse|branch|ls-files)\b|pwd\b|ls\b|rg\b|grep\b|cat\b|sed\s+-n\b|head\b|tail\b|wc\b|nl\b|node\s+(?:--check|--test)\b|npm\s+(?:test|run\s+test)\b|adlc\s+(?:hollow-test|rails-guard|flail-detector|preflight|run\s+p[34])\b)/.test(normalized)
+  );
+}
+
+function shellChangesCwd(text) {
+  return /(^|[\s;&|()])(?:cd|pushd|popd)\b/.test(text);
+}
+
+function shellHasExpansion(text) {
+  return /(?:\$\{?[A-Za-z_][A-Za-z0-9_]*\}?|\$\(|`|[*?]|\[[^\]\n]+\])/.test(text);
+}
+
+function collectShellPaths(text, out) {
+  const redirectPattern = /(?:^|[\s])(?:>>?|[0-9]>>?|[0-9]>)\s*(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/g;
+  let redirect;
+  while ((redirect = redirectPattern.exec(text)) !== null) {
+    out.add(redirect[1] ?? redirect[2] ?? redirect[3]);
+  }
+
+  const quotedPathPattern = /["'`]([^"'`\n]*[/\\][^"'`\n]*)["'`]/g;
+  let quoted;
+  while ((quoted = quotedPathPattern.exec(text)) !== null) {
+    const value = quoted[1];
+    if (looksPathLike(value)) out.add(value);
+  }
+
+  const sedWritePattern = /\bsed\b[^;&|]*(?:"[^"\n]*\bw\s+([A-Za-z0-9_./@+-]+)[^"\n]*"|'[^'\n]*\bw\s+([A-Za-z0-9_./@+-]+)[^'\n]*')/g;
+  let sedWrite;
+  while ((sedWrite = sedWritePattern.exec(text)) !== null) {
+    const value = sedWrite[1] ?? sedWrite[2];
+    if (value && looksPathLike(value)) out.add(value);
+  }
+
+  for (const token of shellTokens(text)) {
+    const path = keyValuePath(token);
+    if (path) out.add(path);
+    else if (looksPathLike(token)) out.add(token);
+  }
+}
+
+function toolName(payload) {
+  return payload.tool_name ?? payload.toolName ?? payload.tool ?? payload.name ?? '';
+}
+
+function isShellToolName(name) {
+  return /(^|\.)(bash|shell|exec|exec_command|run_command)$/i.test(String(name));
+}
+
+async function stdinText() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function resolveActiveTicketId() {
+  const envTicket = process.env.ADLC_TICKET;
+  let fileTicket;
+  const current = readOptionalJson('.adlc/current-ticket.json');
+  if (current) {
+    fileTicket = current.id ?? current.ticket ?? current.ticketId;
+  }
+
+  if (envTicket && fileTicket && envTicket !== fileTicket) {
+    fail(`ADLC_TICKET (${envTicket}) conflicts with .adlc/current-ticket.json (${fileTicket})`);
+  }
+  return envTicket ?? fileTicket;
+}
+
+if (process.env.ADLC_P4_ENFORCEMENT !== '1') {
+  notice('P4 rail hook inactive');
+  process.exit(0);
+}
+
+const ticketId = resolveActiveTicketId();
+if (!ticketId) fail('ADLC_P4_ENFORCEMENT=1 but no active ticket source resolved');
+
+const tickets = loadTickets(process.env.ADLC_TICKETS ?? '.adlc/tickets.json');
+
+const ticket = tickets.find((t) => t.id === ticketId);
+if (!ticket) fail(`unknown active ticket: ${ticketId}`);
+const rails = ticket.rails ?? [];
+if (rails.length === 0) fail(`ticket ${ticketId} has no rails`);
+
+let payload = {};
+const raw = await stdinText();
+if (raw.trim()) {
+  try {
+    payload = JSON.parse(raw);
+  } catch (err) {
+    fail(`malformed hook payload JSON: ${err.message}`);
+  }
+}
+
+function normalizePath(path) {
+  const normalized = path.replaceAll('\\', '/');
+  const absolute = isAbsolute(normalized) ? normalized : resolve(process.cwd(), normalized);
+  const projectRelative = relative(process.cwd(), absolute).replaceAll('\\', '/');
+  return projectRelative.startsWith('..') ? normalized : projectRelative;
+}
+
+const rawPaths = collectPaths(payload);
+const shellTool = isShellToolName(toolName(payload));
+let shellMutating = false;
+let cwdChangingShellMutation = false;
+let expandingShellMutation = false;
+const commandTexts = shellTool ? collectCommandText(payload) : [];
+if (shellTool) {
+  for (const commandText of commandTexts) {
+    if (shellHasMutation(commandText)) shellMutating = true;
+    if (shellHasMutation(commandText) && shellChangesCwd(commandText)) cwdChangingShellMutation = true;
+    if (shellHasMutation(commandText) && shellHasExpansion(commandText)) expandingShellMutation = true;
+    collectShellPaths(commandText, rawPaths);
+  }
+}
+
+if (cwdChangingShellMutation) {
+  fail('mutating shell payload changes cwd; use a structured edit tool or project-relative shell target paths');
+}
+if (expandingShellMutation) {
+  fail('mutating shell payload uses shell expansion; use a structured edit tool or literal project-relative shell target paths');
+}
+
+const paths = Array.from(rawPaths).map(normalizePath);
+if (paths.length === 0) {
+  if (shellTool && !shellMutating && commandTexts.length > 0 && commandTexts.every(shellIsPositivelyReadOnly)) {
+    notice('shell command has no editable rail targets');
+    process.exit(0);
+  }
+  fail(shellTool ? 'shell payload did not include literal editable paths or a known read-only command' : 'active hook payload did not include any editable paths');
+}
+const blocked = paths.filter((path) => rails.some((rail) => globMatch(rail, path)));
+if (blocked.length > 0) fail(`blocked rail edit for ${ticketId}: ${blocked.join(', ')}`);
+
+process.exit(0);

--- a/plugins/adlc-codex/hooks/hooks.json
+++ b/plugins/adlc-codex/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(apply_patch|functions\\.apply_patch|write|Write|edit|Edit|multi_edit|multiedit|MultiEdit|Bash|bash|Shell|shell|exec|exec_command|run_command|functions\\.exec_command)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks/adlc-rails-guard.mjs\"",
+            "timeout": 10,
+            "statusMessage": "ADLC: Checking frozen rails"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/adlc-codex/skills/adlc-distill/SKILL.md
+++ b/plugins/adlc-codex/skills/adlc-distill/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: adlc-distill
+description: Run ADLC P7 distillation and maintenance workflows in Codex, including lesson-foundry, rejection-mining, skill-mining, scheduled maintenance, skill-rot, model-ratchet, review-calibration, and gate-fuzzing.
+---
+
+ADLC_CODEX_SENTINEL_DISTILL_V1
+
+# ADLC Distill
+
+P7 converts repeated findings into deterministic defenses and keeps cached guidance fresh.
+
+Commands:
+
+```sh
+adlc lesson-foundry --json
+adlc rejection-mining --json
+adlc skill-rot .agents/skills plugins/adlc-codex/skills --json
+adlc model-ratchet --json
+adlc review-calibration --review-cmd "npx adversarial-review --base {base}" --json
+adlc gate-fuzzing --json
+```
+
+Scheduled or automated P7 maintenance should invoke this skill and the external
+`$skill-mining` workflow when available, with CI cron as the deterministic fallback.
+Record a no-op manifest entry when there is nothing to distill so the runner can distinguish
+"checked and empty" from "skipped."

--- a/plugins/adlc-codex/skills/adlc-prosecute/SKILL.md
+++ b/plugins/adlc-codex/skills/adlc-prosecute/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: adlc-prosecute
+description: Record ADLC P5 review evidence and P6 acceptance packet workflows in Codex. Use after skeptical review to record verified findings, dry-pass evidence, and behavior acceptance evidence.
+---
+
+ADLC_CODEX_SENTINEL_PROSECUTE_V1
+
+# ADLC Prosecute
+
+This skill does not run the reviewer by itself. Run the skeptical review first, capture the
+transcript, then record the reviewer-produced evidence with `adlc prosecute`.
+The transcript must name the ticket and reviewed `git-worktree:<hash>` revision that P5
+records. Do not pass `--revision` in normal git worktrees; auto-resolved revisions keep
+P6 staleness protection active.
+The P5 input must also include `review_packet` with prompt path/hash, reviewed-input
+path/hash, and `clean_worktree` equal to the reviewed revision.
+
+For scoped P5 evidence:
+
+```sh
+adlc prosecute --input .adlc/p5-passes.json --ticket <ticket-id> --dir .adlc --json
+adlc run p5 --ticket <ticket-id> --dir .adlc --json
+```
+
+P6 strict mode requires P5 evidence:
+
+```sh
+adlc behavior-diff capture --config behavior.json --out .adlc/before.json
+adlc behavior-diff compare .adlc/before.json .adlc/after.json --json
+adlc accept --ticket <ticket-id> --packet .adlc/packet.json --before .adlc/before.json --after .adlc/after.json --dir .adlc --json
+adlc run p6 --ticket <ticket-id> --dir .adlc --json
+```
+
+The bundled docs fixture is static. Use it only with its fixture revision:
+
+```sh
+adlc prosecute --input docs/examples/p5-passes.json --ticket T1 --revision docs-example-revision --dir .adlc --json
+```

--- a/plugins/adlc-codex/skills/adlc-rail-build/SKILL.md
+++ b/plugins/adlc-codex/skills/adlc-rail-build/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: adlc-rail-build
+description: Run ADLC P3-P4 rail and build workflows in Codex, including frozen rails, hollow-test, rails-guard, preflight, and flail detection.
+---
+
+ADLC_CODEX_SENTINEL_RAIL_BUILD_V1
+
+# ADLC Rail And Build
+
+P3 rails are authored before P4 build and are frozen during P4.
+
+Set P4 hook enforcement explicitly:
+
+```sh
+export ADLC_P4_ENFORCEMENT=1
+export ADLC_TICKET=<ticket-id>
+```
+
+Required gates:
+
+```sh
+adlc hollow-test --test-cmd "npm test"
+adlc preflight --test-cmd "npm test" --json
+adlc rails-guard --ticket "$ADLC_TICKET" --tickets .adlc/tickets.json --record --json
+adlc flail-detector session.log --json
+```
+
+Hooks are assistive. `adlc rails-guard` is the deterministic rail-freeze proof.

--- a/plugins/adlc-codex/skills/adlc-spec/SKILL.md
+++ b/plugins/adlc-codex/skills/adlc-spec/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: adlc-spec
+description: Run ADLC P0-P2 specification, interrogation, ticket decomposition, cold-start, merge forecast, and model routing workflows in Codex.
+---
+
+ADLC_CODEX_SENTINEL_SPEC_V1
+
+# ADLC Spec
+
+Drive P0-P2 with executable acceptance criteria.
+
+Commands:
+
+```sh
+adlc parallax --request "<request>"
+adlc spec-lint spec.md --json
+adlc premortem spec.md --json
+adlc coldstart --all --tickets .adlc/tickets.json --json
+adlc merge-forecast --tickets .adlc/tickets.json --json
+adlc model-router --tickets .adlc/tickets.json --json
+```
+
+Stop for human approval after P1 spec approval. Do not mark P2 complete until the ticket
+DAG and cold-start checks pass.

--- a/plugins/adlc-codex/skills/adlc/SKILL.md
+++ b/plugins/adlc-codex/skills/adlc/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: adlc
+description: Route software work through the Agentic Development Lifecycle in Codex. Use when the user asks to apply ADLC, operate in ADLC, triage work, or choose the next ADLC gate.
+---
+
+ADLC_CODEX_SENTINEL_PHASE_ROUTER_V1
+
+# ADLC Router
+
+Classify the work before acting:
+
+- Trivial: direct edit, existing rails, one prosecution pass.
+- Bounded: write or identify rails, build, prosecute-lite.
+- Substantial: P1-P7 full lifecycle.
+- Architectural: P1 design alternatives, then full lifecycle.
+
+Use deterministic ADLC CLIs for pass/fail. Skills may recommend commands; they do not
+declare gates complete unless the relevant CLI and `.adlc/manifest.jsonl` evidence pass.
+
+Start with:
+
+```sh
+adlc preflight --json
+```
+
+For strict phase assertions, use:
+
+```sh
+adlc run <p1|p2|p3|p4|p5|p6|p7> --dir .adlc --json
+```
+
+P3, P4, P5, and P6 assertions are ticket-scoped; include `--ticket <ticket-id>` for
+those phases.

--- a/scripts/codex-install-smoke.mjs
+++ b/scripts/codex-install-smoke.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+function fail(message) {
+  console.error(`codex-install-smoke: ${message}`);
+  process.exit(2);
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    fail(`could not read ${path}: ${err.message}`);
+  }
+}
+
+function realCodexPaths() {
+  const home = process.env.HOME;
+  if (!home) return [];
+  return [
+    join(home, '.codex'),
+    join(process.env.XDG_CONFIG_HOME ?? join(home, '.config'), 'codex'),
+    join(process.env.XDG_CACHE_HOME ?? join(home, '.cache'), 'codex'),
+    join(process.env.XDG_DATA_HOME ?? join(home, '.local/share'), 'codex'),
+  ];
+}
+
+function sha256File(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function isVolatileRuntimeEntry(root, relativePath) {
+  if (!root.endsWith('/.codex')) return false;
+  return (
+    /^logs_\d+\.sqlite(?:-(?:shm|wal))?$/.test(relativePath) ||
+    /^state_\d+\.sqlite(?:-(?:shm|wal))?$/.test(relativePath) ||
+    /^goals_\d+\.sqlite(?:-(?:shm|wal))?$/.test(relativePath) ||
+    /^memories_\d+\.sqlite(?:-(?:shm|wal))?$/.test(relativePath) ||
+    relativePath === 'models_cache.json' ||
+    relativePath === 'history.jsonl' ||
+    relativePath === 'session_index.jsonl' ||
+    relativePath === 'sessions' ||
+    relativePath.startsWith('sessions/') ||
+    relativePath === 'shell_snapshots' ||
+    relativePath.startsWith('shell_snapshots/') ||
+    relativePath === 'plugins/data/omo-sisyphuslabs/sessions' ||
+    relativePath.startsWith('plugins/data/omo-sisyphuslabs/sessions/')
+  );
+}
+
+function snapshotPath(root) {
+  if (!existsSync(root)) return { root, exists: false, entries: [] };
+  const entries = [];
+  const visit = (path, relativePath) => {
+    if (relativePath && isVolatileRuntimeEntry(root, relativePath)) return;
+    const stat = lstatSync(path);
+    const entry = {
+      path: relativePath,
+      type: stat.isDirectory() ? 'dir' : stat.isSymbolicLink() ? 'symlink' : 'file',
+      mode: stat.mode,
+    };
+    if (stat.isFile()) {
+      entry.size = stat.size;
+      entry.hash = sha256File(path);
+    }
+    if (stat.isSymbolicLink()) {
+      entry.size = stat.size;
+      entry.target = readlinkSync(path);
+    }
+    entries.push(entry);
+    if (!stat.isDirectory()) return;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      visit(join(path, entry.name), relativePath ? `${relativePath}/${entry.name}` : entry.name);
+    }
+  };
+  visit(root, '');
+  entries.sort((a, b) => a.path.localeCompare(b.path));
+  return { root, exists: true, entries };
+}
+
+function snapshotRealCodexHomes() {
+  return realCodexPaths().map(snapshotPath);
+}
+
+function assertUnchangedSnapshots(before, after) {
+  const beforeText = JSON.stringify(before);
+  const afterText = JSON.stringify(after);
+  if (beforeText !== afterText) {
+    const changed = before.map((snapshot, index) => changedSnapshotEntries(snapshot, after[index])).flat();
+    fail(`isolated Codex install mutated the caller real HOME/XDG Codex state: ${changed}`);
+  }
+}
+
+function changedSnapshotEntries(before, after) {
+  if (!after) return [`${before.root}:missing-after-snapshot`];
+  if (before.exists !== after.exists) return [`${before.root}:existence`];
+  const beforeEntries = new Map(before.entries.map((entry) => [entry.path, entry]));
+  const afterEntries = new Map(after.entries.map((entry) => [entry.path, entry]));
+  const changed = [];
+  for (const [path, entry] of beforeEntries) {
+    if (!afterEntries.has(path)) changed.push(`${before.root}/${path}:removed`);
+    else if (JSON.stringify(entry) !== JSON.stringify(afterEntries.get(path))) changed.push(`${before.root}/${path}:changed`);
+  }
+  for (const path of afterEntries.keys()) {
+    if (!beforeEntries.has(path)) changed.push(`${before.root}/${path}:added`);
+  }
+  return changed.slice(0, 10);
+}
+
+const repo = resolve(process.argv[2] ?? '.');
+const marketplacePath = join(repo, '.agents/plugins/marketplace.json');
+const marketplace = readJson(marketplacePath);
+if (marketplace.name !== 'adlc') fail('marketplace name must be adlc');
+
+const entry = marketplace.plugins?.find((plugin) => plugin.name === 'adlc-codex');
+if (!entry) fail('missing adlc-codex marketplace entry');
+if (entry.source?.source !== 'local') fail('adlc-codex source must be local');
+
+const pluginRoot = resolve(repo, entry.source.path);
+const manifestPath = join(pluginRoot, '.codex-plugin/plugin.json');
+const manifest = readJson(manifestPath);
+if (manifest.name !== 'adlc-codex') fail('plugin manifest name must be adlc-codex');
+if (manifest.skills !== './skills/') fail('plugin manifest skills must be ./skills/');
+if (manifest.hooks !== './hooks/hooks.json') fail('plugin manifest hooks must be ./hooks/hooks.json');
+
+const sentinels = {
+  'skills/adlc/SKILL.md': 'ADLC_CODEX_SENTINEL_PHASE_ROUTER_V1',
+  'skills/adlc-spec/SKILL.md': 'ADLC_CODEX_SENTINEL_SPEC_V1',
+  'skills/adlc-rail-build/SKILL.md': 'ADLC_CODEX_SENTINEL_RAIL_BUILD_V1',
+  'skills/adlc-prosecute/SKILL.md': 'ADLC_CODEX_SENTINEL_PROSECUTE_V1',
+  'skills/adlc-distill/SKILL.md': 'ADLC_CODEX_SENTINEL_DISTILL_V1',
+};
+
+for (const [relative, sentinel] of Object.entries(sentinels)) {
+  const path = join(pluginRoot, relative);
+  if (!existsSync(path)) fail(`missing skill file: ${relative}`);
+  if (!readFileSync(path, 'utf8').includes(sentinel)) fail(`missing sentinel ${sentinel} in ${relative}`);
+}
+
+const hookPath = join(pluginRoot, 'hooks/adlc-rails-guard.mjs');
+if (!existsSync(hookPath)) fail('missing hooks/adlc-rails-guard.mjs');
+const hookSource = readFileSync(hookPath, 'utf8');
+if (hookSource.includes('from \'@adlc/') || hookSource.includes('from "@adlc/')) {
+  fail('rails guard hook must not depend on workspace package imports');
+}
+
+const hooksConfigPath = join(pluginRoot, 'hooks/hooks.json');
+const hooksConfig = readJson(hooksConfigPath);
+const preToolUse = hooksConfig.hooks?.PreToolUse;
+if (!Array.isArray(preToolUse)) fail('hooks/hooks.json must register PreToolUse hooks');
+const railsHookRegistration = preToolUse.find((entry) =>
+  typeof entry.matcher === 'string' &&
+  entry.matcher.includes('apply_patch') &&
+  entry.matcher.includes('functions\\.apply_patch') &&
+  Array.isArray(entry.hooks) &&
+  entry.hooks.some((hook) => hook.command?.includes('${PLUGIN_ROOT}/hooks/adlc-rails-guard.mjs'))
+);
+if (!railsHookRegistration) fail('hooks/hooks.json must register adlc-rails-guard.mjs for edit tools');
+
+function runCodexJson(codexEnv, args) {
+  const result = spawnSync('codex', args, {
+    cwd: repo,
+    env: {
+      PATH: process.env.PATH,
+      TERM: process.env.TERM,
+      NO_COLOR: process.env.NO_COLOR,
+      CI: '1',
+      ...codexEnv,
+    },
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    fail(`codex ${args.join(' ')} failed: status=${result.status} stderr=${result.stderr}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch (err) {
+    fail(`codex ${args.join(' ')} did not return JSON: ${err.message}: ${result.stdout}`);
+  }
+}
+
+const codexHome = mkdtempSync(join(tmpdir(), 'adlc-codex-home-'));
+const isolatedHome = mkdtempSync(join(tmpdir(), 'adlc-codex-user-'));
+const isolatedConfigHome = join(isolatedHome, '.config');
+const isolatedCacheHome = join(isolatedHome, '.cache');
+const isolatedDataHome = join(isolatedHome, '.local/share');
+mkdirSync(isolatedConfigHome, { recursive: true });
+mkdirSync(isolatedCacheHome, { recursive: true });
+mkdirSync(isolatedDataHome, { recursive: true });
+const codexEnv = {
+  CODEX_HOME: codexHome,
+  HOME: isolatedHome,
+  XDG_CONFIG_HOME: isolatedConfigHome,
+  XDG_CACHE_HOME: isolatedCacheHome,
+  XDG_DATA_HOME: isolatedDataHome,
+};
+const realHomeBefore = snapshotRealCodexHomes();
+if (process.env.ADLC_CODEX_SMOKE_MUTATE_REAL_PLUGIN_DATA === '1' && process.env.HOME) {
+  const mutationDir = join(process.env.HOME, '.codex/plugins/data/adlc-smoke-mutation-test');
+  mkdirSync(mutationDir, { recursive: true });
+  writeFileSync(join(mutationDir, 'mutation.json'), '{"mutated":true}\n');
+}
+
+if (process.env.ADLC_CODEX_LIVE_INSTALL !== '1') {
+  assertUnchangedSnapshots(realHomeBefore, snapshotRealCodexHomes());
+  console.log(JSON.stringify({
+    ok: true,
+    marketplace: marketplacePath,
+    pluginRoot,
+    isolatedHomeVerified: false,
+    realHomeUnchanged: true,
+    liveInstall: false,
+    skills: Object.keys(sentinels).length,
+    hooks: 1,
+    hookRegistrations: 1,
+  }, null, 2));
+  process.exit(0);
+}
+
+let installedPluginRoot;
+try {
+  const marketplaceAdd = runCodexJson(codexEnv, ['plugin', 'marketplace', 'add', repo, '--json']);
+  if (marketplaceAdd.marketplaceName !== 'adlc') fail('isolated Codex marketplace add did not register adlc');
+  const pluginAdd = runCodexJson(codexEnv, ['plugin', 'add', 'adlc-codex', '--marketplace', 'adlc', '--json']);
+  if (pluginAdd.pluginId !== 'adlc-codex@adlc') fail('isolated Codex plugin add returned wrong plugin id');
+  installedPluginRoot = pluginAdd.installedPath;
+  if (!installedPluginRoot?.startsWith(codexHome)) {
+    fail(`isolated Codex install path escaped CODEX_HOME: ${installedPluginRoot}`);
+  }
+  const list = runCodexJson(codexEnv, ['plugin', 'list', '--json', '--available']);
+  const installed = list.installed?.find((plugin) => plugin.pluginId === 'adlc-codex@adlc');
+  if (!installed?.enabled) fail('isolated Codex plugin list does not show adlc-codex enabled');
+  if (!existsSync(join(installedPluginRoot, 'hooks/hooks.json'))) {
+    fail('isolated Codex install did not include hooks/hooks.json');
+  }
+  const installedManifest = readJson(join(installedPluginRoot, '.codex-plugin/plugin.json'));
+  if (installedManifest.hooks !== './hooks/hooks.json') {
+    fail('isolated Codex install manifest does not expose hooks/hooks.json');
+  }
+  if (!existsSync(join(installedPluginRoot, 'skills/adlc/SKILL.md'))) {
+    fail('isolated Codex install did not include skills/adlc/SKILL.md');
+  }
+  assertUnchangedSnapshots(realHomeBefore, snapshotRealCodexHomes());
+} finally {
+  if (!installedPluginRoot) {
+    rmSync(codexHome, { recursive: true, force: true });
+    rmSync(isolatedHome, { recursive: true, force: true });
+  }
+}
+
+const fixture = mkdtempSync(join(tmpdir(), 'adlc-codex-smoke-'));
+try {
+  mkdirSync(join(fixture, '.adlc'), { recursive: true });
+  writeFileSync(join(fixture, '.adlc/tickets.json'), JSON.stringify({
+    tickets: [
+      { id: 'T1', title: 'Smoke ticket', rails: ['test/**'], scope: ['src/**'], edges: [] },
+    ],
+  }));
+  const installedHooksConfig = readJson(join(installedPluginRoot, 'hooks/hooks.json'));
+  const installedRegistration = installedHooksConfig.hooks.PreToolUse.find((entry) =>
+    entry.hooks?.some((hook) => hook.command?.includes('${PLUGIN_ROOT}/hooks/adlc-rails-guard.mjs'))
+  );
+  if (!installedRegistration) fail('isolated Codex install lacks registered rails hook command');
+  const command = installedRegistration.hooks
+    .find((hook) => hook.command?.includes('${PLUGIN_ROOT}/hooks/adlc-rails-guard.mjs'))
+    .command.replaceAll('${PLUGIN_ROOT}', installedPluginRoot);
+  const blocked = spawnSync(command, {
+    shell: true,
+    cwd: fixture,
+    env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+    input: JSON.stringify({ path: 'test/smoke.test.mjs' }),
+    encoding: 'utf8',
+  });
+  if (blocked.status !== 2 || !blocked.stderr.includes('blocked rail edit')) {
+    fail(`registered rails hook did not block simulated rail edit: status=${blocked.status} stderr=${blocked.stderr}`);
+  }
+} finally {
+  rmSync(fixture, { recursive: true, force: true });
+  rmSync(codexHome, { recursive: true, force: true });
+  rmSync(isolatedHome, { recursive: true, force: true });
+}
+assertUnchangedSnapshots(realHomeBefore, snapshotRealCodexHomes());
+
+console.log(JSON.stringify({
+  ok: true,
+  marketplace: marketplacePath,
+  pluginRoot,
+  isolatedHomeVerified: true,
+  realHomeUnchanged: true,
+  liveInstall: true,
+  skills: Object.keys(sentinels).length,
+  hooks: 1,
+  hookRegistrations: 1,
+}, null, 2));

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -8,55 +8,90 @@
 // temporary NPM_TOKEN for the bootstrap run. Every package carries
 // publishConfig.access=public, so no per-call --access is required.
 
-import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { execFileSync } from 'node:child_process';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PKGS = join(ROOT, 'packages');
 
-const version = process.argv[2];
-const publish = process.argv.includes('--publish');
-
-if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
-  console.error('usage: release.mjs <semver> [--publish]');
-  process.exit(1);
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
 }
 
-// core publishes first because every CLI depends on it.
-const names = readdirSync(PKGS).filter((n) => n !== 'core');
-const order = ['core', ...names];
+function writeJson(path, value) {
+  writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+}
 
-// 1. Set version everywhere; repin the @adlc/core dependency to match (lockstep).
-for (const name of order) {
-  const pj = join(PKGS, name, 'package.json');
-  const pkg = JSON.parse(readFileSync(pj, 'utf8'));
-  pkg.version = version;
-  if (pkg.dependencies?.['@adlc/core']) {
-    pkg.dependencies['@adlc/core'] = version;
+export function packagePublishOrder(names) {
+  const unique = Array.from(new Set(names)).sort();
+  return [
+    ...unique.filter((name) => name === 'core'),
+    ...unique.filter((name) => name !== 'core' && name !== 'cli'),
+    ...unique.filter((name) => name === 'cli'),
+  ];
+}
+
+export function repinInternalDependencies(pkg, version) {
+  const next = structuredClone(pkg);
+  for (const dependencyKind of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    if (!next[dependencyKind]) continue;
+    for (const name of Object.keys(next[dependencyKind])) {
+      if (name.startsWith('@adlc/')) next[dependencyKind][name] = version;
+    }
   }
-  writeFileSync(pj, JSON.stringify(pkg, null, 2) + '\n');
-  console.log(`set ${pkg.name}@${version}`);
+  next.version = version;
+  return next;
 }
 
-// Keep the (private) root version in lockstep too.
-const rootPj = join(ROOT, 'package.json');
-const root = JSON.parse(readFileSync(rootPj, 'utf8'));
-root.version = version;
-writeFileSync(rootPj, JSON.stringify(root, null, 2) + '\n');
-console.log(`set ${root.name}@${version} (root)`);
-
-if (!publish) {
-  console.log(`\nversions set to ${version} (no publish). Commit, tag v${version}, push.`);
-  process.exit(0);
+function workspacePackageNames(packagesDir) {
+  return readdirSync(packagesDir).filter((name) => existsSync(join(packagesDir, name, 'package.json')));
 }
 
-// 2. Publish in dependency order. core must land before its consumers resolve it.
-for (const name of order) {
-  const dir = join(PKGS, name);
-  const { name: pkgName } = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
-  console.log(`\npublishing ${pkgName}@${version} ...`);
-  execFileSync('npm', ['publish', '--provenance'], { cwd: dir, stdio: 'inherit' });
+export function releaseMain(argv = process.argv.slice(2), { root = ROOT, packagesDir = PKGS } = {}) {
+  const version = argv[0];
+  const publish = argv.includes('--publish');
+
+  if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
+    console.error('usage: release.mjs <semver> [--publish]');
+    return 1;
+  }
+
+  // core publishes first; cli publishes last because it depends on every routed tool.
+  const order = packagePublishOrder(workspacePackageNames(packagesDir));
+
+  // 1. Set version everywhere and repin every internal @adlc/* dependency to match.
+  for (const name of order) {
+    const pj = join(packagesDir, name, 'package.json');
+    const pkg = repinInternalDependencies(readJson(pj), version);
+    writeJson(pj, pkg);
+    console.log(`set ${pkg.name}@${version}`);
+  }
+
+  // Keep the (private) root version in lockstep too.
+  const rootPj = join(root, 'package.json');
+  const rootPkg = readJson(rootPj);
+  rootPkg.version = version;
+  writeJson(rootPj, rootPkg);
+  console.log(`set ${rootPkg.name}@${version} (root)`);
+
+  if (!publish) {
+    console.log(`\nversions set to ${version} (no publish). Commit, tag v${version}, push.`);
+    return 0;
+  }
+
+  // 2. Publish in dependency order.
+  for (const name of order) {
+    const dir = join(packagesDir, name);
+    const { name: pkgName } = readJson(join(dir, 'package.json'));
+    console.log(`\npublishing ${pkgName}@${version} ...`);
+    execFileSync('npm', ['publish', '--provenance'], { cwd: dir, stdio: 'inherit' });
+  }
+  console.log(`\npublished @adlc suite @ ${version}`);
+  return 0;
 }
-console.log(`\npublished @adlc suite @ ${version}`);
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(releaseMain());
+}


### PR DESCRIPTION
Implements the Codex-native ADLC integration from ADR 0001.

Adds the dispatcher, runner/prosecute evidence contracts, plugin bundle, smoke tests, and release wiring.

Verified with npm test, isolated Codex smoke tests, npm audit, and local npm pack dry-runs.