### PR TITLE
docs: Build out individual tool docs with lifecycle visualizations

### DIFF
--- a/docs/package-reference.md
+++ b/docs/package-reference.md
@@ -7,29 +7,29 @@ Follow each README for full options, output schemas, examples, and implementatio
 
 | Package | Binary | Role | Source |
 | --- | --- | --- | --- |
-| `@adlc/behavior-diff` | `behavior-diff` | Captures and compares HTTP/API behavior snapshots for the P6 human gate. | [`packages/behavior-diff/README.md`](../packages/behavior-diff/README.md) |
-| `@adlc/cli` | `adlc` | Provides the stable dispatcher surface for all public ADLC tool execution. | [`packages/cli/README.md`](../packages/cli/README.md) |
-| `@adlc/coldstart` | `coldstart` | Checks whether tickets are executable without agent guesswork. | [`packages/coldstart/README.md`](../packages/coldstart/README.md) |
-| `@adlc/consensus-fix` | `consensus-fix` | Fans out candidate fixes and recommends, or optionally applies, the consensus winner that passes gates. | [`packages/consensus-fix/README.md`](../packages/consensus-fix/README.md) |
-| `@adlc/core` | none | Shared LLM, git, CLI, ledger, ticket, and mutation primitives. | [`packages/core/README.md`](../packages/core/README.md) |
-| `@adlc/flail-detector` | `flail-detector` | Detects repeated errors, scope violations, edit churn, and oversized session logs. | [`packages/flail-detector/README.md`](../packages/flail-detector/README.md) |
-| `@adlc/gate-fuzzing` | `gate-fuzzing` | Runs hostile candidates against gate suites to find defeats and calibration gaps. | [`packages/gate-fuzzing/README.md`](../packages/gate-fuzzing/README.md) |
-| `@adlc/gate-manifest` | `gate-manifest` | Records, verifies, shows, and attests append-only gate evidence. | [`packages/gate-manifest/README.md`](../packages/gate-manifest/README.md) |
-| `@adlc/hollow-test` | `hollow-test` | Mutates changed code to find tests that pass without testing the intended behavior. | [`packages/hollow-test/README.md`](../packages/hollow-test/README.md) |
-| `@adlc/lesson-foundry` | `lesson-foundry` | Mines repeated findings into deterministic defenses such as lint checks or skills. | [`packages/lesson-foundry/README.md`](../packages/lesson-foundry/README.md) |
-| `@adlc/merge-forecast` | `merge-forecast` | Estimates fan-out width, dependency pressure, and merge backpressure. | [`packages/merge-forecast/README.md`](../packages/merge-forecast/README.md) |
-| `@adlc/model-ratchet` | `model-ratchet` | Identifies hot files for re-prosecution after model or repository drift. | [`packages/model-ratchet/README.md`](../packages/model-ratchet/README.md) |
-| `@adlc/model-router` | `model-router` | Assigns tickets to frontier, direct, or ladder model strategies. | [`packages/model-router/README.md`](../packages/model-router/README.md) |
-| `@adlc/parallax` | `parallax` | Fans out readers to expose spec ambiguity, edge conflicts, or route conflicts. | [`packages/parallax/README.md`](../packages/parallax/README.md) |
-| `@adlc/preflight` | `preflight` | Checks baseline environment readiness before fan-out. | [`packages/preflight/README.md`](../packages/preflight/README.md) |
-| `@adlc/premortem` | `premortem` | Stress-tests an approved spec before implementation. | [`packages/premortem/README.md`](../packages/premortem/README.md) |
-| `@adlc/prosecute` | `adlc-prosecute` | Records ticket- and revision-scoped P5 review evidence and asserts distinct reviewer-produced dry lenses. Invoke as `adlc prosecute` in normal workflows. | [`packages/prosecute/README.md`](../packages/prosecute/README.md) |
-| `@adlc/rails-guard` | `rails-guard` | Enforces frozen rails, declared suppressions, and manifest recording. | [`packages/rails-guard/README.md`](../packages/rails-guard/README.md) |
-| `@adlc/rejection-mining` | `rejection-mining` | Mines review rejections into reusable review lenses. | [`packages/rejection-mining/README.md`](../packages/rejection-mining/README.md) |
-| `@adlc/review-calibration` | `review-calibration` | Measures reviewer recall by applying mutants and scoring whether review catches them. | [`packages/review-calibration/README.md`](../packages/review-calibration/README.md) |
-| `@adlc/runner` | `adlc-runner` | Asserts phase completion from manifest artifacts rather than command success alone. Normal workflows reach it through `adlc run` and `adlc accept`. | [`packages/runner/README.md`](../packages/runner/README.md) |
-| `@adlc/skill-rot` | `skill-rot` | Checks skill files for stale validation metadata and optional freshness stamping. | [`packages/skill-rot/README.md`](../packages/skill-rot/README.md) |
-| `@adlc/spec-lint` | `spec-lint` | Gates specs for wishes, unverifiable acceptance criteria, and LLM-only verification. | [`packages/spec-lint/README.md`](../packages/spec-lint/README.md) |
+| `@adlc/behavior-diff` | `behavior-diff` | Captures and compares HTTP/API behavior snapshots for the P6 human gate. | [`docs/tools/behavior-diff.md`](./tools/behavior-diff.md) |
+| `@adlc/cli` | `adlc` | Provides the stable dispatcher surface for all public ADLC tool execution. | [`docs/tools/cli.md`](./tools/cli.md) |
+| `@adlc/coldstart` | `coldstart` | Checks whether tickets are executable without agent guesswork. | [`docs/tools/coldstart.md`](./tools/coldstart.md) |
+| `@adlc/consensus-fix` | `consensus-fix` | Fans out candidate fixes and recommends, or optionally applies, the consensus winner that passes gates. | [`docs/tools/consensus-fix.md`](./tools/consensus-fix.md) |
+| `@adlc/core` | none | Shared LLM, git, CLI, ledger, ticket, and mutation primitives. | [`docs/tools/core.md`](./tools/core.md) |
+| `@adlc/flail-detector` | `flail-detector` | Detects repeated errors, scope violations, edit churn, and oversized session logs. | [`docs/tools/flail-detector.md`](./tools/flail-detector.md) |
+| `@adlc/gate-fuzzing` | `gate-fuzzing` | Runs hostile candidates against gate suites to find defeats and calibration gaps. | [`docs/tools/gate-fuzzing.md`](./tools/gate-fuzzing.md) |
+| `@adlc/gate-manifest` | `gate-manifest` | Records, verifies, shows, and attests append-only gate evidence. | [`docs/tools/gate-manifest.md`](./tools/gate-manifest.md) |
+| `@adlc/hollow-test` | `hollow-test` | Mutates changed code to find tests that pass without testing the intended behavior. | [`docs/tools/hollow-test.md`](./tools/hollow-test.md) |
+| `@adlc/lesson-foundry` | `lesson-foundry` | Mines repeated findings into deterministic defenses such as lint checks or skills. | [`docs/tools/lesson-foundry.md`](./tools/lesson-foundry.md) |
+| `@adlc/merge-forecast` | `merge-forecast` | Estimates fan-out width, dependency pressure, and merge backpressure. | [`docs/tools/merge-forecast.md`](./tools/merge-forecast.md) |
+| `@adlc/model-ratchet` | `model-ratchet` | Identifies hot files for re-prosecution after model or repository drift. | [`docs/tools/model-ratchet.md`](./tools/model-ratchet.md) |
+| `@adlc/model-router` | `model-router` | Assigns tickets to frontier, direct, or ladder model strategies. | [`docs/tools/model-router.md`](./tools/model-router.md) |
+| `@adlc/parallax` | `parallax` | Fans out readers to expose spec ambiguity, edge conflicts, or route conflicts. | [`docs/tools/parallax.md`](./tools/parallax.md) |
+| `@adlc/preflight` | `preflight` | Checks baseline environment readiness before fan-out. | [`docs/tools/preflight.md`](./tools/preflight.md) |
+| `@adlc/premortem` | `premortem` | Stress-tests an approved spec before implementation. | [`docs/tools/premortem.md`](./tools/premortem.md) |
+| `@adlc/prosecute` | `adlc-prosecute` | Records ticket- and revision-scoped P5 review evidence and asserts distinct reviewer-produced dry lenses. Invoke as `adlc prosecute` in normal workflows. | [`docs/tools/prosecute.md`](./tools/prosecute.md) |
+| `@adlc/rails-guard` | `rails-guard` | Enforces frozen rails, declared suppressions, and manifest recording. | [`docs/tools/rails-guard.md`](./tools/rails-guard.md) |
+| `@adlc/rejection-mining` | `rejection-mining` | Mines review rejections into reusable review lenses. | [`docs/tools/rejection-mining.md`](./tools/rejection-mining.md) |
+| `@adlc/review-calibration` | `review-calibration` | Measures reviewer recall by applying mutants and scoring whether review catches them. | [`docs/tools/review-calibration.md`](./tools/review-calibration.md) |
+| `@adlc/runner` | `adlc-runner` | Asserts phase completion from manifest artifacts rather than command success alone. Normal workflows reach it through `adlc run` and `adlc accept`. | [`docs/tools/runner.md`](./tools/runner.md) |
+| `@adlc/skill-rot` | `skill-rot` | Checks skill files for stale validation metadata and optional freshness stamping. | [`docs/tools/skill-rot.md`](./tools/skill-rot.md) |
+| `@adlc/spec-lint` | `spec-lint` | Gates specs for wishes, unverifiable acceptance criteria, and LLM-only verification. | [`docs/tools/spec-lint.md`](./tools/spec-lint.md) |
 
 ## Command forms
 

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -10,35 +10,35 @@ through the stable `adlc <tool>` dispatcher.
 
 | Phase | Question | Primary tools |
 | --- | --- | --- |
-| D2 Phase 0 | Is the workspace ready for fan-out? | `adlc preflight` |
-| P1 / C1-C2 | Is the spec testable and stress-tested? | `adlc spec-lint`, `adlc premortem`, `adlc parallax` |
-| P2 / C3 | Can an agent execute this ticket without guessing? | `adlc coldstart`, `adlc merge-forecast`, `adlc model-router` |
-| P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | `adlc rails-guard`, `adlc flail-detector` |
-| P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | `adlc consensus-fix` |
-| P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | `adlc prosecute`, `adlc behavior-diff`, `adlc gate-manifest`, `adlc hollow-test` |
-| C12 / maintenance | What must be re-prosecuted after model or repo drift? | `adlc model-ratchet`, `adlc review-calibration`, `adlc skill-rot` |
-| P7 | Which repeated findings should become deterministic defenses? | `adlc lesson-foundry`, `adlc rejection-mining` |
-| Continuous calibration | Can hostile candidates defeat the gates? | `adlc gate-fuzzing` |
+| D2 Phase 0 | Is the workspace ready for fan-out? | [`adlc preflight`](./tools/preflight.md) |
+| P1 / C1-C2 | Is the spec testable and stress-tested? | [`adlc spec-lint`](./tools/spec-lint.md), [`adlc premortem`](./tools/premortem.md), [`adlc parallax`](./tools/parallax.md) |
+| P2 / C3 | Can an agent execute this ticket without guessing? | [`adlc coldstart`](./tools/coldstart.md), [`adlc merge-forecast`](./tools/merge-forecast.md), [`adlc model-router`](./tools/model-router.md) |
+| P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | [`adlc rails-guard`](./tools/rails-guard.md), [`adlc flail-detector`](./tools/flail-detector.md) |
+| P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | [`adlc consensus-fix`](./tools/consensus-fix.md) |
+| P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | [`adlc prosecute`](./tools/prosecute.md), [`adlc behavior-diff`](./tools/behavior-diff.md), [`adlc gate-manifest`](./tools/gate-manifest.md), [`adlc hollow-test`](./tools/hollow-test.md) |
+| C12 / maintenance | What must be re-prosecuted after model or repo drift? | [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md), [`adlc skill-rot`](./tools/skill-rot.md) |
+| P7 | Which repeated findings should become deterministic defenses? | [`adlc lesson-foundry`](./tools/lesson-foundry.md), [`adlc rejection-mining`](./tools/rejection-mining.md) |
+| Continuous calibration | Can hostile candidates defeat the gates? | [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) |
 
 ## Typical flow
 
-1. Run `adlc preflight` before spawning parallel agents so missing tools, dirty state, or
+1. Run [`adlc preflight`](./tools/preflight.md) before spawning parallel agents so missing tools, dirty state, or
    provider problems fail before work fans out.
-2. Run `adlc spec-lint`, `adlc premortem`, and optionally `adlc parallax` while shaping the work so the
+2. Run [`adlc spec-lint`](./tools/spec-lint.md), [`adlc premortem`](./tools/premortem.md), and optionally [`adlc parallax`](./tools/parallax.md) while shaping the work so the
    accepted spec has verifiable criteria and known divergences.
-3. Use `adlc coldstart` to check ticket executability, then `adlc merge-forecast` and `adlc model-router`
+3. Use [`adlc coldstart`](./tools/coldstart.md) to check ticket executability, then [`adlc merge-forecast`](./tools/merge-forecast.md) and [`adlc model-router`](./tools/model-router.md)
    to manage fan-out width and model assignment.
-4. During implementation, use `adlc rails-guard` for frozen-test and suppression controls and
-   `adlc flail-detector` to catch repeated error loops, scope drift, churn, or oversized logs.
-5. For hard failing tests, use `adlc consensus-fix` to fan out independent candidate repairs
+4. During implementation, use [`adlc rails-guard`](./tools/rails-guard.md) for frozen-test and suppression controls and
+   [`adlc flail-detector`](./tools/flail-detector.md) to catch repeated error loops, scope drift, churn, or oversized logs.
+5. For hard failing tests, use [`adlc consensus-fix`](./tools/consensus-fix.md) to fan out independent candidate repairs
    and select a gated consensus winner.
-6. Before review, use `adlc hollow-test`, `adlc prosecute`, `adlc behavior-diff`, and `adlc gate-manifest`
+6. Before review, use [`adlc hollow-test`](./tools/hollow-test.md), [`adlc prosecute`](./tools/prosecute.md), [`adlc behavior-diff`](./tools/behavior-diff.md), and [`adlc gate-manifest`](./tools/gate-manifest.md)
    to prove that tests are load-bearing, prosecution reached two dry passes, behavior
    changes are visible, and gate evidence is recorded.
-7. After review, use `adlc lesson-foundry` and `adlc rejection-mining` to convert repeated review
+7. After review, use [`adlc lesson-foundry`](./tools/lesson-foundry.md) and [`adlc rejection-mining`](./tools/rejection-mining.md) to convert repeated review
    findings into deterministic lint checks, skills, or spec-gap templates.
-8. On a schedule or after model changes, use `adlc model-ratchet`, `adlc review-calibration`,
-   `adlc skill-rot`, and `adlc gate-fuzzing` to re-check assumptions that can decay over time.
+8. On a schedule or after model changes, use [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md),
+   [`adlc skill-rot`](./tools/skill-rot.md), and [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) to re-check assumptions that can decay over time.
 
 ## Evidence conventions
 
@@ -47,7 +47,7 @@ Several tools use `.adlc/` as the shared workspace for machine-readable state:
 - `.adlc/tickets.json` stores ticket metadata consumed by routing, cold-start, rail, and
   merge-forecast tools.
 - `.adlc/manifest.jsonl` stores append-only gate evidence through `gate-manifest`.
-- `.adlc/lessons/` is the default output location for `adlc lesson-foundry`.
+- `.adlc/lessons/` is the default output location for [`adlc lesson-foundry`](./tools/lesson-foundry.md).
 
 The package READMEs define each tool's exact schema. Treat these docs as a routing map,
 then follow the linked README for command-specific details.

--- a/docs/tools/behavior-diff.md
+++ b/docs/tools/behavior-diff.md
@@ -1,0 +1,204 @@
+---
+title: behavior-diff
+description: Documentation for the behavior-diff tool in the ADLC toolkit.
+---
+
+# behavior-diff — ADLC C14
+
+**ADLC Phase:** P6 Integrate
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G5{{"GATE: Zero Findings"}} --> P6["P6 Integrate"]
+    P6 --> G6{{"GATE: Human Acceptance"}}
+    G6 --> P7["P7 Distill"]
+    style P6 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Behavior-space diff for the **P6 human gate**. Review *what changed* in behavior,
+not 5,000-line diffs. Captures observable HTTP surface (status, content-type, body
+structure) before and after a change, then diffs in behavior-space: "3 endpoints
+changed shape, 1 removed, everything else identical."
+
+The code diff is 5,000 lines; the behavior diff is six items. The human reviews
+**intent vs behavior** — the one judgment machines cannot make — while the manifest
+(C11) proves the machines already did the rest.
+
+---
+
+## ADLC phase
+
+**P6 — Human Gate**. Consumed directly by the human reviewer during the gate step.
+Pairs with `gate-manifest` (C11): manifest proves machine checks passed; behavior-diff
+proves observable behavior is within expected bounds.
+
+---
+
+## Verbs
+
+### `capture`
+
+Hit each route in a config file and record the observable HTTP behavior to a JSON
+snapshot.
+
+```
+behavior-diff capture --config behavior.json --out before.json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--config <path>` | yes | Path to the behavior config JSON file |
+| `--out <path>` | yes | Output path for the snapshot JSON |
+| `--json` | no | Print machine-readable result summary to stdout |
+
+**Config format** (`behavior.json`):
+
+```json
+{
+  "baseUrl": "http://localhost:3000",
+  "routes": [
+    { "method": "GET", "path": "/health" },
+    { "method": "GET", "path": "/api/users" },
+    { "method": "POST", "path": "/api/items", "body": { "name": "test" } },
+    { "method": "GET", "path": "/api/data", "headers": { "Accept": "application/json" } }
+  ]
+}
+```
+
+Each route: `{ method, path, body?, headers? }`. `body` is serialized as JSON with
+`Content-Type: application/json` automatically added.
+
+**Per-route errors are recorded** (as `{ method, path, error }`) without aborting
+the run. The snapshot always contains an entry for every route in the config.
+
+**Exit codes for capture:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | All routes attempted, snapshot written (even if some routes errored) |
+| `1` | Operational error: config file unreadable, invalid config, cannot write output |
+
+---
+
+### `compare`
+
+Compare two snapshots and produce a human-readable behavior report.
+
+```
+behavior-diff compare before.json after.json [--json]
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--json` | no | Print machine-readable diff result to stdout |
+
+**Output (human-readable):**
+
+```
+2 routes identical, 2 changed, 0 errored
+
+  + GET /metrics: route added (absent in before, present in after)
+  ~ GET /health:
+      body (json): 2 changes:
+        ~ version: "1.0.0" → "2.0.0"
+        + newField: "added"
+  ~ GET /users:
+      status: 200 → 503
+      body (json): 2 changes:
+        - users: [...]
+        + error: "Service Unavailable"
+```
+
+**Diff rules:**
+
+- Routes matched by `METHOD path`.
+- Status change: reported directly.
+- Content-type change: reported (parameters like `; charset=utf-8` stripped for comparison).
+- JSON bodies: structural recursive diff. Paths use dot notation (`body.items[3].price`).
+  Arrays: length change reported + first divergent index drilled. Capped at 50 paths.
+- Text/binary bodies: compared by SHA-256 hash.
+- Route only in before → "removed". Route only in after → "added".
+
+**Exit codes for compare:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — all routes identical |
+| `1` | Operational error: snapshot file unreadable or invalid JSON |
+| `2` | Gate fails — one or more routes changed, removed, or added |
+
+---
+
+## Typical workflow
+
+```bash
+# Before the change: capture baseline
+behavior-diff capture --config behavior.json --out before.json
+
+# Make your code change, restart the service, then:
+behavior-diff capture --config behavior.json --out after.json
+
+# Review behavior diff (exits 0 if clean, 2 if changes found)
+behavior-diff compare before.json after.json
+```
+
+---
+
+## Snapshot format
+
+```json
+{
+  "baseUrl": "http://localhost:3000",
+  "capturedAt": "2024-01-15T10:30:00.000Z",
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/health",
+      "status": 200,
+      "contentType": "application/json",
+      "body": { "status": "ok" }
+    },
+    {
+      "method": "GET",
+      "path": "/large-html",
+      "status": 200,
+      "contentType": "text/html",
+      "body": { "textHash": "sha256hex...", "bytes": 4096 }
+    },
+    {
+      "method": "GET",
+      "path": "/broken",
+      "error": "timeout after 10000ms"
+    }
+  ]
+}
+```
+
+- JSON responses: body is parsed and stored as a JSON value.
+- Non-JSON responses: body stored as `{ textHash, bytes }`.
+- Errors: route stored as `{ method, path, error }` (no status/body).
+
+---
+
+## Future work (noted in spec)
+
+**Browser/headless mode** — render routes via headless browser and diff rendered DOM
+or screenshots. Documented as future work; not yet implemented. HTTP fixture mode
+(this tool) is the current supported mode.
+
+---
+
+## Core gaps
+
+None. This tool is self-contained and uses only `parseArgs`, `pass`, `gateFail`,
+`opError`, and `printJson` from `@adlc/core`. Hashing is done locally via
+`node:crypto` rather than the core `sha256` helper to avoid coupling the capture
+serialization format to a shared library.

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -1,0 +1,75 @@
+---
+title: cli
+description: Documentation for the cli tool in the ADLC toolkit.
+---
+
+# @adlc/cli
+
+**ADLC Phase:** Shared foundation
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    Found["Shared Foundation (Core/CLI)"] -.-> P1["P1 Interrogate"]
+    Found -.-> P2["P2 Decompose"]
+    Found -.-> P3["P3 Rail"]
+    Found -.-> P4["P4 Build"]
+    Found -.-> P5["P5 Prosecute"]
+    Found -.-> P6["P6 Integrate"]
+    Found -.-> P7["P7 Distill"]
+    style Found fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+The umbrella dispatcher for the ADLC suite. It provides one stable command
+surface for Codex skills, hooks, CI, and humans:
+
+```sh
+adlc <tool> [args...]
+adlc run <phase> [args...]
+adlc accept [args...]
+```
+
+The dispatcher is a router. It adds no behavior to a tool run: argv is forwarded
+verbatim and the child exit code is propagated unchanged.
+
+## Why this exists
+
+ADLC packages publish independently, but an agent harness needs a single stable
+prefix. A skill or hook that shells out to twenty different binaries is brittle,
+slower to document, and easier to route around. `@adlc/cli` installs the suite
+and makes every gate reachable through `adlc <tool>`.
+
+## Resolution model
+
+The dispatcher resolves package-local binaries from its own `@adlc/*`
+dependencies. It does not search the user's `PATH` for tool names, so stale
+global binaries cannot silently satisfy a gate.
+
+## Usage
+
+```sh
+adlc --help
+adlc --version
+adlc spec-lint spec.md --json
+adlc rails-guard --ticket T1 --record --json
+adlc run p5 --ticket T1 --dir .adlc --json
+adlc accept --ticket T1 --packet .adlc/packet.json --dir .adlc --json
+```
+
+## Exit codes
+
+Exit codes mirror the underlying tool:
+
+- `0`: gate passes or command succeeds.
+- `1`: operational error.
+- `2`: gate fails.
+
+Dispatcher-level failures, such as an unknown tool or missing package, exit `1`.
+
+## ADLC phase
+
+Cross-cutting. This is the delivery and invocation layer for the ADLC Codex
+integration.

--- a/docs/tools/coldstart.md
+++ b/docs/tools/coldstart.md
@@ -1,0 +1,139 @@
+---
+title: coldstart
+description: Documentation for the coldstart tool in the ADLC toolkit.
+---
+
+# coldstart — ADLC P2 Ticket Executability Gate
+
+**ADLC Phase:** P2 Decompose
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G1{{"GATE: Spec Approved"}} --> P2["P2 Decompose"]
+    P2 --> G2{{"GATE: Coldstart Pass"}}
+    G2 --> P3["P3 Rail"]
+    style P2 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Checks whether a ticket is fully self-contained before a build agent touches it.
+A cheap-tier LLM plays the role of a fresh agent with no prior context and lists
+every question it would have to ask a *human* before it could start executing.
+Empty gap list → gate passes (exit 0). Non-empty → exit 2 with gaps per ticket.
+
+This is **ADLC phase C3 / P2** — the last check before a ticket enters the build
+queue. Pennies per ticket; catches the #1 cause of build-phase flailing.
+
+---
+
+## Usage
+
+```
+coldstart <ticket-id> [options]
+coldstart --all     [options]
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file |
+| `--all` | off | Run the gate on every ticket in the file |
+| `--prompt-only` | off | Print the exact prompt(s) and exit 0 — no LLM call made |
+| `--json` | off | Machine-readable JSON output for orchestrators |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — ticket(s) are fully executable |
+| `1` | Operational error — bad input, unknown ticket id, missing file, no provider |
+| `2` | Gate fails — one or more tickets have gaps |
+
+---
+
+## Examples
+
+```sh
+# Check a single ticket
+coldstart T1
+
+# Check all tickets, output JSON
+coldstart --all --json
+
+# Print the exact prompt without calling an LLM (paste into any harness)
+coldstart T1 --prompt-only
+
+# Use a custom tickets file
+coldstart T3 --tickets path/to/tickets.json
+```
+
+---
+
+## What counts as a gap?
+
+The model is instructed that **information derivable from the repo does not count
+as missing**. Only genuine human-only questions are gaps:
+
+- Data shapes referenced but not embedded (e.g. "use the UserSchema" with no schema)
+- Contracts named but absent (edge points to a missing type file)
+- Acceptance criteria that cannot be mechanically verified
+- Vague scope ("improve", "clean up", "fix")
+- Unstated target files when they cannot be inferred from context
+
+---
+
+## JSON output schema
+
+```json
+{
+  "ok": true,
+  "results": [
+    {
+      "id": "T1",
+      "pass": true,
+      "gaps": []
+    },
+    {
+      "id": "T2",
+      "pass": false,
+      "gaps": [
+        { "what": "UserSchema", "why_blocking": "Shape referenced in body but not defined." }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Provider configuration
+
+The tool auto-detects the first available provider in order:
+`ANTHROPIC_API_KEY` → `OPENAI_API_KEY` → `GEMINI_API_KEY`.
+
+Force a provider: `ADLC_PROVIDER=openai`.
+Override the cheap-tier model: `ADLC_MODEL_CHEAP=claude-haiku-4-5`.
+
+Without a provider, the tool exits 1 unless `--prompt-only` is passed.
+
+---
+
+## ADLC phase served
+
+**C3 / P2** — ticket executability gate. Runs after `spec-lint` (C1) and before
+the ticket enters the build queue. Part of the Cheap Wins cluster alongside C1
+and C5 (`rails-guard`).
+
+---
+
+## Core gaps
+
+None. All required functionality is available in `@adlc/core`:
+`loadTickets`, `complete`, `extractJson`, `parseArgs`, `pass`, `gateFail`,
+`opError`, `printJson`, `promptOnly`, `detectProvider`.

--- a/docs/tools/consensus-fix.md
+++ b/docs/tools/consensus-fix.md
@@ -1,0 +1,180 @@
+---
+title: consensus-fix
+description: Documentation for the consensus-fix tool in the ADLC toolkit.
+---
+
+# @adlc/consensus-fix
+
+**ADLC Phase:** P4 Build
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G3{{"GATE: Rails Frozen"}} --> P4["P4 Build"]
+    P4 --> G4{{"GATE: Build Pass"}}
+    G4 --> P5["P5 Prosecute"]
+    style P4 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+N-version programming for failing tests. Fan N independent LLM completions at the same broken test, evaluate each candidate, group survivors by agreement, and recommend the smallest fix from the largest consensus group.
+
+**ADLC phase served: C7 / P4** — hard bugs that single-shot fixes can't crack, exploiting sampling diversity (E1).
+
+---
+
+## Usage
+
+```
+consensus-fix --test-cmd "..." --files a.mjs,b.mjs [options]
+```
+
+### Required flags
+
+| Flag | Description |
+|------|-------------|
+| `--test-cmd <cmd>` | Shell command to run the failing test. Must exit non-zero when the bug is present. |
+| `--files <paths>` | Comma-separated list of source files the LLM is allowed to modify. |
+
+### Optional flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--rails <cmd>` | _(none)_ | The **regression gate**: a command that runs the FULL frozen rail suite (all tests + types). A candidate survives only if BOTH `--test-cmd` and `--rails` exit 0. A candidate that fixes the repro but reddens the rails is **rejected**, not ranked. If omitted, candidates are checked only against `--test-cmd` and a **WARNING** is printed (no silent caps). |
+| `--n <int>` | `3` | Number of independent fix candidates to generate. |
+| `--tier cheap\|mid\|frontier` | `mid` | LLM tier to use for completions. |
+| `--apply` | off | Write the winning fix. Default is dry-run (report only). |
+| `--allow-dirty` | off | Skip dirty-tree check. Useful in CI with staged-only changes. |
+| `--json` | off | Machine-readable output (JSON to stdout). |
+| `--prompt-only` | off | Print the prompt(s) that would be sent and exit 0. Works with zero API keys. |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes: at least one candidate survived and there is a consensus group with 2+ members (or `--n < 3`). |
+| `1` | Operational error: bad arguments, unreadable files, dirty tree (without `--allow-dirty`), no LLM provider. |
+| `2` | Gate fails: no candidates survived OR all survivors are singletons and `--n >= 3` (all-divergent, spec ambiguity). |
+
+---
+
+## How it works
+
+1. **Pre-flight**: run `--test-cmd` once. If it exits 0, the test already passes — `opError`.
+2. **Snapshot**: capture the full content of every `--files` path.
+3. **Fan**: send N independent, stateless LLM completions in parallel with the prompt: failing command + last 4000 chars of test output + all source file contents. Request JSON `{changes: [{file, content}]}`.
+4. **Evaluate sequentially**: for each candidate:
+   - Parse and validate JSON. Discard if invalid or if any `file` is not in `--files`.
+   - Apply changes, run `--test-cmd` (the **repro gate**). If it passes and `--rails` was supplied, run `--rails` (the **regression gate**) against the same applied changes. A candidate survives only if BOTH exit 0. A candidate that passes the repro but reddens the rails is rejected (lands in `failed`, not `survivors`).
+   - Record pass/fail and changed-line count.
+   - Restore snapshot (`finally`) regardless of outcome.
+5. **Agreement grouping**: normalize each surviving changeset (collapse whitespace per line) and group identical sets.
+6. **Winner selection**: among candidates that passed BOTH gates, pick the member of the largest agreement group with the fewest changed lines (ties broken by candidate index). The smallest-diff tiebreaker never sees a candidate that failed the rails, so it cannot reward a gaming fix.
+7. **Output**: dry-run report by default; `--apply` writes the winner.
+
+### All-divergent detection
+
+When `--n >= 3` and every survivor is in its own singleton group, the tool exits 2 with the message `all-divergent: spec ambiguity — escalate`. This is a signal that the test specification is ambiguous about something load-bearing — divergence is evidence, not noise.
+
+---
+
+## Examples
+
+```bash
+# Dry-run: see what the winning fix would be without writing it
+consensus-fix --test-cmd "node --test test/math.test.mjs" \
+              --files src/math.mjs \
+              --n 5
+
+# Repro gate + full rails regression gate (recommended).
+# A candidate that fixes the one test but breaks any other test is rejected.
+consensus-fix --test-cmd "node --test test/math.test.mjs" \
+              --rails    "node --test test/*.test.mjs" \
+              --files src/math.mjs \
+              --n 5
+
+# Apply the winner
+consensus-fix --test-cmd "npm test -- --grep 'add function'" \
+              --rails    "npm test" \
+              --files src/add.mjs,src/utils.mjs \
+              --apply
+
+# Preview prompts without any API key
+consensus-fix --test-cmd "cargo test test_parse" \
+              --files src/parser.mjs \
+              --n 3 \
+              --prompt-only
+
+# Machine-readable output for orchestrators
+consensus-fix --test-cmd "pytest tests/test_core.py::test_sum" \
+              --files lib/core.mjs \
+              --json
+
+# Allow running against an uncommitted working tree
+consensus-fix --test-cmd "node --test test/*.test.mjs" \
+              --files lib/broken.mjs \
+              --allow-dirty --n 3
+```
+
+---
+
+## JSON output shape (`--json`)
+
+```json
+{
+  "summary": {
+    "total": 3,
+    "passed": 2,
+    "failed": 1,
+    "discarded": 0,
+    "groups": 1,
+    "allDivergent": false,
+    "railsChecked": true
+  },
+  "groups": [
+    { "groupIndex": 0, "size": 2, "candidateIndices": [0, 2] }
+  ],
+  "winner": {
+    "index": 0,
+    "changedLines": 1,
+    "largestGroupSize": 2,
+    "changes": [{ "file": "src/math.mjs", "content": "..." }],
+    "applied": false
+  },
+  "discardedDetails": []
+}
+```
+
+---
+
+## Safety guarantees
+
+- **Dirty-tree guard**: refuses to run against a dirty git tree unless `--allow-dirty`. Prevents accidental loss of unstaged work.
+- **Snapshot + restore in `finally`**: every candidate evaluation restores all `--files` to their original content, even if the test crashes or the LLM returns garbage.
+- **SIGINT restore**: if interrupted (Ctrl-C), the snapshot is restored before exit.
+- **File-list enforcement**: any candidate that references a file outside `--files` is discarded with a diagnostic message, never written.
+
+---
+
+## LLM provider detection
+
+Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`. Force a provider with `ADLC_PROVIDER`. Override the model per tier via `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, `ADLC_MODEL_FRONTIER`.
+
+---
+
+## Relationship to sibling tools
+
+- **flail-detector (C6)**: detects when a single agent is spinning. `consensus-fix` is the escalation path — run it when flail-detector fires on a hard bug.
+- **premortem (C2)**: identifies failure modes before building. `consensus-fix` fixes failure modes discovered during test runs.
+- **rails-guard (C5)**: enforces read-only rails. `consensus-fix` respects the `--files` list as its own rails boundary.
+- **hollow-test (C4)**: finds tests that don't actually test anything. A test that `consensus-fix` keeps failing on might be hollow — run `hollow-test` to check.
+
+---
+
+## Core gaps
+
+None. `fan`, `complete`, `extractJson`, `detectProvider`, `resolveModel`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`, `promptOnly`, and `isDirty` are all provided by `@adlc/core`.

--- a/docs/tools/core.md
+++ b/docs/tools/core.md
@@ -1,0 +1,89 @@
+---
+title: core
+description: Documentation for the core tool in the ADLC toolkit.
+---
+
+# @adlc/core — FROZEN CONTRACT
+
+**ADLC Phase:** Shared foundation
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    Found["Shared Foundation (Core/CLI)"] -.-> P1["P1 Interrogate"]
+    Found -.-> P2["P2 Decompose"]
+    Found -.-> P3["P3 Rail"]
+    Found -.-> P4["P4 Build"]
+    Found -.-> P5["P5 Prosecute"]
+    Found -.-> P6["P6 Integrate"]
+    Found -.-> P7["P7 Distill"]
+    style Found fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Shared library for all ADLC tools. **This package is frozen during tool
+builds (rails).** Tools import from it; tools never modify it. If the API is
+insufficient for your tool, work around it inside your own package and note
+the gap in your README — do not edit core.
+
+Import surface (from a tool at `packages/<name>/`):
+
+```js
+import { complete, fan, extractJson, detectProvider, resolveModel } from '../../core/index.mjs';
+import { git, gitDiff, changedFiles, isDirty, isGitRepo, coChange, pairKey, churn } from '../../core/index.mjs';
+import { parseArgs, pass, gateFail, opError, printJson, readStdin, promptOnly } from '../../core/index.mjs';
+import { ADLC_DIR, appendEntry, readEntries, ledgerPath, sha256, hashFiles } from '../../core/index.mjs';
+import { TICKETS_PATH, loadTickets, validateTicket, topoSort, computeFloat, globMatch, inScope, scopesOverlap } from '../../core/index.mjs';
+import { mutate } from '../../core/index.mjs'; // mutate.generateMutants / applyMutant / changedLinesFromDiff / OPERATORS
+```
+
+## llm
+
+- `detectProvider(env?)` → `{ name, apiKey, models } | null`. Order: anthropic, openai, gemini. Force with `ADLC_PROVIDER`.
+- `resolveModel(provider, { tier, model }, env?)` → model id. Tiers: `cheap | mid | frontier`. Override via `ADLC_MODEL_CHEAP/MID/FRONTIER`.
+- `complete({ tier, model, system, prompt, maxTokens })` → `Promise<string>`. Throws if no provider (tools must catch and offer `--prompt-only`).
+- `fan(opts, n)` → `Promise<[{ ok, value | error }]>` — n independent stateless completions.
+- `extractJson(text)` → parsed JSON value from messy model output. Throws if none.
+
+## git
+
+- `git(args[], opts?)` → stdout string (execFileSync; throws on non-zero).
+- `isGitRepo(cwd?)`, `gitDiff(base?, cwd?)`, `changedFiles(base?, cwd?)`, `isDirty(cwd?)`.
+- `coChange(limit?, cwd?)` → `{ pairCounts: {'a b': n}, fileCounts }` (logical coupling; commits touching >50 files skipped). Pair keys via `pairKey(a, b)` (sorted).
+- `churn(limit?, cwd?)` → `{ file: commitCount }`.
+
+## cli
+
+- `parseArgs(config)` — node:util parseArgs with `allowPositionals: true` default.
+- `pass(msg?)` exit 0 · `gateFail(msg, details?)` exit 2 · `opError(msg)` exit 1.
+- `printJson(obj)`, `readStdin()`, `promptOnly(promptOrArray)` (print prompt(s), exit 0).
+
+**Exit codes are the contract: 0 = gate passes, 1 = operational error, 2 = gate fails.**
+
+## ledger (persistence at `.adlc/`)
+
+- `appendEntry(name, entry, dir?)` → appends to `.adlc/<name>.jsonl`.
+- `readEntries(name, dir?)` → `{ entries, skipped }` — malformed lines reported, never swallowed.
+- `sha256(content)`, `hashFiles(paths)` → `{ path: hash | null }`.
+
+Well-known ledger names: `manifest` (gate-manifest entries), `findings`
+(prosecution findings: `{ ts, tool, file, line, category, severity, desc, verdict }`).
+
+## tickets (`.adlc/tickets.json`)
+
+Schema (see lib/tickets.mjs header): `{ id, title, body, scope[], rails[], edges[{to, contract}], duration, category, budget }`.
+
+- `loadTickets(path?)` → `{ tickets, errors }` (validates ids, duplicate ids, unknown edges).
+- `validateTicket(t)` → `errors[]`.
+- `topoSort(tickets)` → `{ order, cycle | null }`. Edges mean "completes before edge.to".
+- `computeFloat(tickets)` → `{ floats: {id: n}, criticalPath: [ids], makespan }` (CPM; duration default 1) or `{ error }` on cycle.
+- `globMatch(pattern, path)` (`*`, `**`), `inScope(ticket, path)`, `scopesOverlap(a, b)` (conservative).
+
+## mutate
+
+- `mutate.OPERATORS` — invert-comparison, bool-flip, null-return, off-by-one, logic-swap.
+- `mutate.generateMutants(content, { targetLines?, maxMutants? })` → `[{ line, operator, original, mutated }]` (skips comments/imports/console lines).
+- `mutate.applyMutant(content, mutant)` → mutated content (throws if line content drifted).
+- `mutate.changedLinesFromDiff(diffText)` → `{ file: Set<newSideLineNo> }`.

--- a/docs/tools/flail-detector.md
+++ b/docs/tools/flail-detector.md
@@ -1,0 +1,173 @@
+---
+title: flail-detector
+description: Documentation for the flail-detector tool in the ADLC toolkit.
+---
+
+# flail-detector
+
+**ADLC Phase:** P4 Build
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G3{{"GATE: Rails Frozen"}} --> P4["P4 Build"]
+    P4 --> G4{{"GATE: Build Pass"}}
+    G4 --> P5["P5 Prosecute"]
+    style P4 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Session-log flail analysis — mechanical two-strike rule. ADLC phase **C6 / P4 supervisor**.
+
+Watches a build session log for flail signatures. On trigger: emits verdict
+`flail`, prints a recommendation block, and exits 2 so CI can gate. Fully
+deterministic; no LLM calls.
+
+## Usage
+
+```
+flail-detector <log-file> [--scope <glob>...] [--max-repeat <n>] [--max-bytes <n>] [--json]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `<log-file>` | Path to the session log file to analyze (required) |
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--scope <glob>` | _(none)_ | Declared-scope glob pattern (repeatable). When given, file paths found in tool-log lines that fall outside ALL supplied globs are flagged as **scope violations**. |
+| `--max-repeat <n>` | `2` | Trigger the **repeated-error** signal when a normalized error signature appears >= n times. |
+| `--max-bytes <n>` | _(no limit)_ | Trigger the **size** signal when the log file exceeds n bytes. |
+| `--json` | off | Machine-readable JSON output for orchestrators. |
+| `--help` | — | Print help and exit 0. |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — no flail signals detected (clean) |
+| `1` | Operational error — file not found, bad argument |
+| `2` | Gate fails — one or more flail signals triggered |
+
+## Signals
+
+### 1. repeated-error
+
+Lines matching `/error|exception|failed|cannot|ENOENT/i` are normalized
+(lowercase; strip digits, hex literals, quoted strings, and absolute paths),
+then counted per unique signature. Any signature occurring >= `--max-repeat`
+times triggers this signal.
+
+**Normalization** ensures that `Error: cannot find module "lodash" at line 42`
+and `Error: cannot find module "express" at line 99` collapse to the same
+signature — the error kind is what matters, not the varying operands.
+
+### 2. scope-violation
+
+Only active when `--scope` is given. File paths extracted from common
+tool-log patterns:
+
+- `Writing <path>`
+- `Editing <path>`
+- `Created <path>`
+- `"file_path":"<path>"` (JSON tool-log format)
+
+Any path that does not match at least one `--scope` glob is a violation.
+
+### 3. edit-churn
+
+The same file path appearing in >= 3 write/edit log lines (regardless of
+which verb — Writing, Editing, or Created). Indicates the agent is cycling
+back to the same file repeatedly.
+
+### 4. size
+
+When `--max-bytes` is given, triggers if the log file byte count exceeds the
+threshold.
+
+## Input Handling
+
+If more than half the non-empty lines of the log parse as JSON objects, the
+file is treated as **JSONL**: string values of the keys `content`, `text`, and
+`message` are recursively extracted and fed into the signal detectors. All
+other files are treated as **plain text**, one line at a time.
+
+## Output
+
+Human-readable (default):
+
+```
+flail-detector: FLAIL
+  bytes: 361
+  signals:
+    repeated-error (1 signature(s)):
+      [2x] error: cannot resolve module at line in
+    scope-violation (1 path(s) outside scope):
+      /etc/hosts
+    edit-churn (1 file(s) edited >= 3 times):
+      [3x] src/index.ts
+
+  recommendation:
+    Kill the session. Append these dead-ends to the ticket: error: cannot resolve module at line in
+```
+
+Machine-readable (`--json`):
+
+```json
+{
+  "verdict": "flail",
+  "signals": [...],
+  "bytes": 361,
+  "recommendation": "Kill the session. Append these dead-ends to the ticket: ..."
+}
+```
+
+## Examples
+
+```bash
+# Analyze a plain-text session log
+flail-detector session.log
+
+# Enforce scope (write/edit must stay inside src/ or test/)
+flail-detector session.log --scope 'src/**' --scope 'test/**'
+
+# Raise the error-repeat threshold to 3
+flail-detector session.log --max-repeat 3
+
+# Flag oversized logs (e.g. > 1 MB context)
+flail-detector session.log --max-bytes 1048576
+
+# JSON for orchestrators
+flail-detector session.log --json
+```
+
+## ADLC Phase
+
+**C6 / P4 supervisor.** Encodes the two-strike regeneration rule mechanically.
+See ADLC.md §C6 for the design rationale.
+
+Intended to be invoked by a P4 supervisor after each build attempt. On `flail`
+(exit 2): kill the session, append the dead-end signatures to the ticket, and
+regenerate fresh. On second trigger: escalate to P2 — the ticket is wrong, not
+the agent.
+
+## Relationship to Sibling Tools
+
+- **rails-guard (C5)**: enforces frozen rails on git diffs; flail-detector
+  watches live session logs for behavioral drift.
+- **consensus-fix (C7)**: fan-out fix strategy invoked after flail is
+  confirmed; flail-detector is the upstream gate that triggers it.
+- **premortem (C2)**: upstream risk analysis; flail-detector catches the
+  risk materializing at runtime.
+
+## Core Gaps
+
+None. This tool uses only `parseArgs`, `opError`, `printJson`, `pass`,
+`gateFail`, and `globMatch` from `@adlc/core`. No LLM, no git, no ledger
+writes.

--- a/docs/tools/gate-fuzzing.md
+++ b/docs/tools/gate-fuzzing.md
@@ -1,0 +1,165 @@
+---
+title: gate-fuzzing
+description: Documentation for the gate-fuzzing tool in the ADLC toolkit.
+---
+
+# gate-fuzzing
+
+**ADLC Phase:** Continuous calibration
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P7["P7 Distill"] --> Calib["Continuous Calibration"]
+    Calib -.-> P5["P5 Prosecute (Update Reviewers)"]
+    style Calib fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Standing red-team / gate calibration for the ADLC toolkit (C-tool).
+
+A generator-adversary fans N cheap/mid model instances to produce candidate diffs
+designed to **pass every configured gate while being genuinely wrong**. Each gate
+a wrong-but-passing diff defeats is a calibration finding that hardens that gate.
+
+This turns "we found 11 bypasses once" into "finding bypasses is a CI gate."
+
+## Usage
+
+```
+gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid]
+             [--max-rounds <int>] [--dry-rounds <int>] [--token-budget <int>]
+             [--witness-trials <int>] [--max-fail-rate <float>] [--canary-budget <int>]
+             [--behavioral-witness] [--allow-cmd <name>...] [--unsafe-no-sandbox]
+             [--strict-budget] [--fail-on-behavioral]
+             [--record] [--triage] [--json] [--prompt-only] [--help]
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Earned clean: potency canary beaten, no defeats found, dry streak reached |
+| `1` | Operational error: dirty tree, no sandbox binary, control self-test failed, all-inconclusive (strict), canary not beaten (strict) |
+| `2` | A gate was defeated: wrong-but-passing, surface-and-claim-bound, independently-witnessed |
+
+## Flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--suite <path>` | `.adlc/gate-suite.json` | Gate suite descriptor (refuses if absent) |
+| `--n <int>` | `6` | Fan width per round |
+| `--tier cheap\|mid` | `mid` | Adversary tier (frontier rejected) |
+| `--max-rounds <int>` | `10` | Hard round ceiling |
+| `--dry-rounds <int>` | `3` | K consecutive dry rounds to stop |
+| `--token-budget <int>` | `200000` | Estimated token ceiling (chars/4) |
+| `--witness-trials <int>` | `3` | N witness runs per side (unanimous) |
+| `--max-fail-rate <float>` | `0.5` | Fan-failure fraction → inconclusive round |
+| `--canary-budget <int>` | `2` | Rounds to beat potency canary |
+| `--behavioral-witness` | off | Use independent-context lens for behavioral gates |
+| `--allow-cmd <name>` | node,git,npm,npx | Extend interpreter allowlist |
+| `--unsafe-no-sandbox` | off | Skip OS sandbox (ONLY inside disposable VM) |
+| `--strict-budget` | off | Any inconclusive stop → exit 1 (CI recommended) |
+| `--fail-on-behavioral` | off | Behavioral defeats → exit 2 (default: REPORT only) |
+| `--record` | off | Write repro artifacts + cluster findings |
+| `--triage` | off | Cheap-model root-cause annotation (never affects verdict) |
+| `--json` | off | Machine-readable JSON report |
+| `--prompt-only` | off | Print adversary prompts and exit 0 (zero API keys) |
+
+## Isolation & sandbox requirement
+
+gate-fuzzing executes adversary-generated diffs, setup commands, gates, and
+witnesses. Every candidate runs in a **fresh disposable git clone** of your repo
+(`git clone --local --no-hardlinks`), never in your real working tree, and the
+clone is always destroyed afterward. All harness git calls are hardened with
+`-c core.hooksPath=/dev/null -c core.fsmonitor=false` so a candidate cannot plant
+a hook that runs at gate-time. The run refuses against a non-git or dirty tree.
+
+On top of the clone, it **requires an OS sandbox** to confine execution:
+
+- **Linux:** `bwrap` (bubblewrap) — unshares all namespaces, denies network
+- **macOS:** `sandbox-exec` — SBPL profile that denies network, confines writes
+  to the clone directory
+
+Without a sandbox binary, pass `--unsafe-no-sandbox` ONLY inside a disposable
+VM or container. Running without sandbox protection against adversary-generated
+code is a security risk.
+
+**Recommended:** always run gate-fuzzing inside a disposable VM/container.
+
+## Gate suite format
+
+Create `.adlc/gate-suite.json`:
+
+```json
+{
+  "baseline": "auto",
+  "validityGates": ["build", "lint", "typecheck"],
+  "gates": [
+    {
+      "name": "rails-guard",
+      "run": ["node", "{{clone}}/packages/rails-guard/bin/rails-guard.mjs",
+              "--rails", "test/**", "--base", "{{baseline}}"],
+      "cwd": "{{clone}}",
+      "surface": ["test/**"],
+      "claims": ["freeze-integrity"],
+      "docs": ["packages/rails-guard/README.md"]
+    },
+    {
+      "name": "build",
+      "run": ["npm", "run", "build"],
+      "cwd": "{{clone}}",
+      "validity": true
+    }
+  ]
+}
+```
+
+- `surface`: glob patterns of paths the gate guards (clause 3 in defeat definition)
+- `claims`: property kinds the gate asserts (e.g. `freeze-integrity`, `test-adequacy`)
+- `validity: true`: marks build/lint/typecheck gates (anti-gaming)
+- `{{clone}}`, `{{baseline}}`: substituted by harness at runtime
+
+## What is a "defeat"?
+
+A candidate diff defeats a gate G iff ALL of:
+1. Valid (applies cleanly, passes build/lint/typecheck)
+2. Passes ALL configured gates (every gate exits 0)
+3. Candidate touches G's declared surface
+4. Candidate violates a property G claims to protect (claimKind match)
+5. An independent, unanimously-discriminating, held-out witness proves it wrong
+
+Independence sources (§1.1):
+- **(a) Contract-derived** — mechanically derived from G's declared contract
+- **(b) Independent-context approval** — fresh-context lens confirms genuine defect
+
+Source (c) suite-minus-G corroboration removed (Fix 3 — logically vacuous).
+
+## A defeat → a committed gate-fix
+
+gate-fuzzing emits repro artifacts to `.adlc/gate-defeats/<id>.json` containing
+the diff, setup, witness, and a RED test scaffold. The real defense is committing
+that RED test into the defeated gate's `test/` directory and fixing the gate
+until the test passes. This is the compounding ratchet.
+
+## ADLC phase
+
+C-tool (continuous calibration). Scheduled / nightly, not per-commit.
+See ADLC.md §C and Post 8 for the doctrine.
+
+## Core gaps
+
+- `fan()` / `complete()` return raw text; no `usage` block is exposed. Budget is
+  estimated as `≈chars/4` (labeled `tokensEstimated` in JSON output, not provider-reported).
+  The clean fix threads usage out of `provider.send` — out of scope for this package
+  (core is frozen). See §3.2 of DESIGN.md.
+
+## Siblings
+
+- `review-calibration` — `runWitness` exit-0 convention is re-implemented locally
+  (each tool stands alone; §13.1 of DESIGN.md)
+- `lesson-foundry` — gate-bypass findings route to SPEC-GAP (cluster/visibility only;
+  §4.4 of DESIGN.md)
+- `rails-guard`, `gate-manifest`, `hollow-test` — example gates in the suite

--- a/docs/tools/gate-manifest.md
+++ b/docs/tools/gate-manifest.md
@@ -1,0 +1,168 @@
+---
+title: gate-manifest
+description: Documentation for the gate-manifest tool in the ADLC toolkit.
+---
+
+# gate-manifest
+
+**ADLC Phase:** P5/P6 Prosecute/Integrate
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P4["P4 Build"] --> P5["P5 Prosecute"]
+    P5 --> P6["P6 Integrate"]
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+    style P6 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+**ADLC C11 — cross-cutting provenance.** A hash-chained evidence ledger that records what each ADLC gate verified, proving to auditors (and CI) that agentic code was checked before it shipped. Set `ADLC_MANIFEST_KEY` to add HMAC-SHA256 signatures so the chain attests *authorship*, not just internal consistency (see [Signing & provenance](#signing--provenance)).
+
+## ADLC phase
+
+Serves **C11** (cross-cutting provenance / agentic SLSA). Consumed by **P6 human-gate** reviewers who need `attest` output as a PR comment, and by **CI** which runs `verify` as a blocking gate.
+
+## Usage
+
+```
+gate-manifest record <gate-name> [--ticket id] [--data '{json}'] [--files a,b,c] [--dir path] [--json]
+gate-manifest verify [--json] [--dir path]
+gate-manifest show   [--ticket id] [--json] [--dir path]
+gate-manifest attest [--ticket id] [--dir path]
+```
+
+### record
+
+Append one entry to `.adlc/manifest.jsonl`.
+
+```sh
+gate-manifest record spec-lint --ticket T-42 --data '{"model":"haiku","pass":true}' --files src/foo.mjs,src/bar.mjs
+```
+
+The entry stored:
+
+```json
+{
+  "seq": 3,
+  "gate": "spec-lint",
+  "ticket": "T-42",
+  "ts": "2024-01-01T00:00:00.000Z",
+  "data": { "model": "haiku", "pass": true },
+  "files": { "src/foo.mjs": "<sha256>", "src/bar.mjs": "<sha256>" },
+  "prev": "<sha256 of the previous raw JSONL line, or null>",
+  "sig": "<HMAC-SHA256 over the canonical entry bytes — present only when ADLC_MANIFEST_KEY is set>"
+}
+```
+
+When `ADLC_MANIFEST_KEY` is set, `record` appends a `sig` (the human output prints `(signed)` / `(unsigned)`). See **Signing & provenance** below.
+
+| Flag | Description |
+|------|-------------|
+| `--ticket id` | Associate this entry with a ticket id (optional) |
+| `--data '{json}'` | Arbitrary JSON payload (must be valid JSON; malformed → exit 1) |
+| `--files a,b,c` | Comma-separated paths; each is SHA-256 hashed (missing files hash to null) |
+| `--dir path` | Override ledger directory (default `.adlc`) |
+| `--json` | Print the recorded entry as JSON |
+
+### verify
+
+Walk the raw ledger lines and validate the hash chain. Every entry's `prev` must equal `sha256` of the exact raw bytes of the previous line; sequence numbers must be strictly monotonically increasing.
+
+```sh
+gate-manifest verify          # human-readable
+gate-manifest verify --json   # machine-readable
+```
+
+**Exit 0** when valid (or empty manifest). **Exit 2** when the chain is broken — reports the seq and line number of the first break.
+
+When `ADLC_MANIFEST_KEY` is set, `verify` additionally checks every entry's HMAC signature. A missing sig (`unsigned entry`) or a wrong sig (`signature invalid`) breaks the chain. The JSON result includes `signed: true` only when a key was present and every entry verified cryptographically; otherwise `signed: false`.
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit `{ valid, message, count, signed, break }` |
+| `--dir path` | Override ledger directory |
+
+### show
+
+Print entries from the ledger, optionally filtered by ticket.
+
+```sh
+gate-manifest show
+gate-manifest show --ticket T-42
+gate-manifest show --ticket T-42 --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--ticket id` | Filter to entries with this ticket id |
+| `--json` | Emit `{ entries, skipped }` |
+| `--dir path` | Override ledger directory |
+
+### attest
+
+Generate a Markdown summary suitable for a PR comment.
+
+```sh
+gate-manifest attest --ticket T-42
+```
+
+Output example:
+
+```markdown
+## Gate evidence for T-42
+
+| seq | gate | ts | files | data |
+|-----|------|-----|-------|------|
+| 1 | spec-lint | 2024-01-01T… | 0 | — |
+| 2 | hollow-test | 2024-01-01T… | 3 | model=haiku |
+
+Chain status: **valid** (2 entries)
+```
+
+| Flag | Description |
+|------|-------------|
+| `--ticket id` | Filter entries and use ticket id in heading |
+| `--dir path` | Override ledger directory |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Gate passes (record, show, attest always; verify when chain is valid) |
+| 1 | Operational error (bad input, unreadable file, malformed `--data` JSON) |
+| 2 | Gate fails (verify detects chain break) |
+
+## Chain integrity
+
+`record` reads the ledger file via `readFileSync` (raw bytes) — never via `readEntries` which re-serialises and would lose byte-exact fidelity. The `prev` field is `sha256(previous raw JSONL line)` (null for the first entry). Tampering any middle line breaks all subsequent `prev` hashes, detected by `verify`.
+
+## Signing & provenance
+
+The hash chain alone proves **internal consistency**, not **authorship**. `sha256` is a public, keyless function: anyone who can write `manifest.jsonl` can recompute every `prev` and forge a clean chain from scratch. On its own the chain is therefore *not* cryptographic provenance — do not represent a hash-chain-only pass as in-toto/SLSA attestation.
+
+To get real provenance, set a secret signing key:
+
+```sh
+export ADLC_MANIFEST_KEY="$(openssl rand -hex 32)"   # store in your CI secret manager, never in the repo
+gate-manifest record spec-lint --ticket T-42
+gate-manifest verify --json    # → { ..., "signed": true }
+```
+
+- **record** computes `sig = HMAC-SHA256(key, canonicalEntryBytes)`. The signed bytes are the deterministic JSON of `{ seq, gate, ts, ticket?, data?, files, prev }` in that fixed key order (optional `ticket`/`data` included only when present), **excluding** `sig` itself. `sig` is appended last.
+- **verify** (run with the key) requires every entry to carry a valid sig — comparison is constant-time (`crypto.timingSafeEqual`). A missing sig → `unsigned entry`; a wrong sig → `signature invalid`. Either breaks the chain (exit 2). This defeats the forge-from-scratch attack: without the key, an attacker cannot produce valid signatures.
+- **verify** without a key still checks the hash chain but reports `signed: false`, so callers cannot claim cryptographic provenance.
+
+Zero-dependency: HMAC comes from Node's built-in `node:crypto`. Key management (rotation, distribution) is out of scope for this tool — supply the key via the environment.
+
+## Sibling tools
+
+- `rails-guard` (C5) — appends its own proof here after verifying diff is rails-clean.
+- `hollow-test` (C4) — appends coverage and mutation results.
+- `review-calibration` (C8) — appends prosecution verdicts and calibration score.
+
+## Core gaps
+
+None for ledger/CLI primitives — `sha256`, `hashFiles`, `appendEntry`, `readEntries`, `ledgerPath`, `ADLC_DIR`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson` from `@adlc/core` cover them. Core exposes `sha256` but no keyed-MAC primitive, so HMAC signing uses Node's built-in `node:crypto` (`createHmac`, `timingSafeEqual`) directly in `lib/sign.mjs` — still zero runtime dependencies.

--- a/docs/tools/hollow-test.md
+++ b/docs/tools/hollow-test.md
@@ -1,0 +1,151 @@
+---
+title: hollow-test
+description: Documentation for the hollow-test tool in the ADLC toolkit.
+---
+
+# hollow-test
+
+**ADLC phase: P3/P5 Rail/Prosecute**
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P3["P3 Rail"] --> P4["P4 Build"]
+    P4 --> P5["P5 Prosecute"]
+    style P3 fill:#f9f,stroke:#333,stroke-width:2px
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Diff-scoped mutation gate — the honest coverage check. Mutates only the lines
+changed in your diff, runs your test suite against each mutant, and fails if
+any mutation survives. A surviving mutant proves hollow coverage: lines are
+executed but their behavior is unconstrained by any assertion.
+
+Diff-scoping keeps the run at seconds-to-minutes rather than the hours that
+kill whole-codebase mutation testing.
+
+## Usage
+
+```
+hollow-test --test-cmd "node --test test/" [options]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--test-cmd <cmd>` | *(required)* | Shell command to run the test suite. Must exit non-zero on failure. |
+| `--base <ref>` | `HEAD` | Git base ref for the diff (e.g. `HEAD~1`, `main`, a SHA). |
+| `--max <n>` | `20` | Maximum total mutants across all files. Budget is spread round-robin. |
+| `--timeout-ms <n>` | `120000` | Per-mutant test-command timeout in milliseconds. |
+| `--json` | *(off)* | Machine-readable JSON output (for orchestrators). |
+| `--help` | *(off)* | Show usage and exit 0. |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — all mutants were killed (or no mutable lines in diff). |
+| `1` | Operational error — dirty working tree, not a git repo, bad arguments. |
+| `2` | Gate fails — one or more mutants survived (hollow coverage). |
+
+## Examples
+
+```bash
+# Check the last commit
+hollow-test --test-cmd "node --test test/" --base HEAD~1
+
+# Check staged changes vs main
+hollow-test --test-cmd "npm test" --base main --max 30
+
+# Machine-readable output for CI
+hollow-test --test-cmd "node --test test/*.test.mjs" --json
+```
+
+## Safety guarantees
+
+1. **Dirty-tree check**: refuses to run if `git status --porcelain` is non-empty.
+   This prevents accidentally leaving a corrupted file if the process is
+   interrupted. Commit or stash your changes first.
+
+2. **File restoration**: every mutated file is restored via a `try/finally`
+   block — even if the test command crashes or the process is interrupted via
+   SIGINT. The SIGINT handler performs an emergency restore before exiting.
+
+3. **Sequential execution**: mutants are applied and tested one at a time
+   (never in parallel) to avoid concurrent writes to the same file.
+
+## What is mutated (and what is skipped)
+
+Files are **excluded** from mutation if their path contains `test` or `spec`,
+or if they have extensions `.md`, `.json`, `.yml`, `.yaml`, `.lock`, `.txt`,
+`.toml`, or `.snap`.
+
+Within eligible files, only lines changed in the diff are targeted. Lines that
+are blank, comments, imports, `export {`, or `console.*` calls are skipped.
+
+### Mutation operators (from `@adlc/core`)
+
+| Operator | Example |
+|----------|---------|
+| `invert-comparison` | `===` → `!==`, `<=` → `>` |
+| `bool-flip` | `true` → `false` |
+| `null-return` | `return expr` → `return null` |
+| `off-by-one` | literal `n` → `n+1` |
+| `logic-swap` | `&&` → `\|\|` |
+
+## JSON output schema
+
+```json
+{
+  "tool": "hollow-test",
+  "summary": {
+    "total": 5,
+    "killed": 4,
+    "survived": 1
+  },
+  "mutants": [
+    {
+      "file": "src/calc.mjs",
+      "line": 7,
+      "operator": "null-return",
+      "status": "survived",
+      "timedOut": false,
+      "original": "  return a + b;",
+      "mutated": "  return null;"
+    }
+  ]
+}
+```
+
+## Relationship to sibling tools
+
+- **rails-guard (C5)**: enforces that test files are not modified during build
+  (they are the measuring instrument). hollow-test verifies that those tests
+  actually constrain behavior.
+- **review-calibration (C8)**: uses the same `mutate` operators to plant bugs
+  and measure reviewer recall. hollow-test and review-calibration share core
+  mutation machinery.
+- **flail-detector (C6)**: hollow-test is a P3 gate; flail-detector watches
+  the P4 build session. They serve complementary phases.
+
+## Core gaps
+
+None. All required functionality (`gitDiff`, `isDirty`, `isGitRepo`,
+`mutate.generateMutants`, `mutate.applyMutant`, `mutate.changedLinesFromDiff`,
+`parseArgs`, `pass`, `gateFail`, `opError`, `printJson`) is available in
+`@adlc/core`.
+
+## Implementation notes
+
+### NODE_TEST_CONTEXT stripping
+
+Node.js v22 sets `NODE_TEST_CONTEXT` in child process environments when
+running under `node --test`. If a child process inherits this variable and
+itself calls `node --test`, it silently skips all test files (exits 0).
+hollow-test strips `NODE_TEST_CONTEXT` from the child environment before
+running each mutant's test command. This ensures mutation trials work
+correctly even when hollow-test is itself running inside a test harness.

--- a/docs/tools/lesson-foundry.md
+++ b/docs/tools/lesson-foundry.md
@@ -1,0 +1,135 @@
+---
+title: lesson-foundry
+description: Documentation for the lesson-foundry tool in the ADLC toolkit.
+---
+
+# lesson-foundry
+
+**ADLC Phase:** P7 Distill
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G6{{"GATE: Human Acceptance"}} --> P7["P7 Distill"]
+    P7 -.-> P1["P1 Interrogate (Feedback)"]
+    style P7 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+**ADLC Phase: P7 (compounding closer)**
+
+Converts prosecution findings into permanent defenses. Every recurring finding is paid for exactly once.
+
+> C9 in the ADLC component inventory. Without this tool the lifecycle does not get cheaper — lessons are re-bought on every run.
+
+## What it does
+
+1. Reads prosecution findings from a JSONL ledger (default: `.adlc/findings.jsonl`)
+2. Skips entries with `verdict === 'killed'`; surfaces malformed lines
+3. Clusters findings by semantic similarity (token-set Jaccard >= 0.5)
+4. Routes each cluster of size >= `--min` to its **cheapest permanent defense**:
+   - **LINT** — any member desc contains a quoted literal or recognizable marker (TODO, FIXME, eslint-disable, etc.) → emits a grep-gate JSON descriptor + a runnable `check-<name>.mjs` script
+   - **SKILL** — category is `convention`, `pattern`, `architecture`, or `style` → emits a `SKILL.md` stub with frontmatter and evidence quotes
+   - **SPEC-GAP** — otherwise → appends a question to `interrogation-template.md` for P1 to address
+5. By default: dry-run (prints what would be written). Add `--write` to emit files.
+6. With `--gate`: exits 2 if any cluster has no existing defense file in `--out-dir`
+
+## Usage
+
+```
+lesson-foundry [options]
+
+Options:
+  --ledger <name>    Ledger name to read findings from (default: findings)
+  --min <n>          Minimum cluster size to surface (default: 2)
+  --out-dir <path>   Output directory for defense files (default: .adlc/lessons)
+  --write            Emit files (default: dry-run — prints what WOULD be written)
+  --gate             Exit 2 if any cluster >= --min has no defense file in --out-dir
+  --llm              Refine cluster wording via one mid-tier LLM call per cluster
+  --prompt-only      Print LLM prompts and exit 0 (works with zero API keys)
+  --json             Machine-readable output (stdout JSON, errors to stderr)
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Gate passes — no recurring unbanked lessons (or --gate not set) |
+| 1 | Operational error — bad input, unreadable ledger, write failure |
+| 2 | Gate fails — one or more clusters have no defense file in --out-dir |
+
+## Emitted file shapes
+
+### LINT: `<name>.lint.json`
+
+```json
+{
+  "name": "cluster-name",
+  "pattern": "ESCAPED_LITERAL_OR_MARKER",
+  "paths": ["**"],
+  "message": "lesson-foundry: recurring finding — <desc>"
+}
+```
+
+### LINT: `check-<name>.mjs`
+
+A runnable Node.js script that greps the repo for the pattern and exits 2 on match, 0 when clean. Run it as a CI gate.
+
+### SKILL: `<name>.SKILL.md`
+
+Markdown with YAML frontmatter (`name`, `description`, `category`, `triggers`) and a body containing the rule, evidence quotes, and provenance count. Ready to load into any skill-mining pipeline.
+
+### SPEC-GAP: `interrogation-template.md`
+
+Appended-to file with checkbox questions for each spec-gap cluster. Answer these in the P1 spec to prevent recurring findings.
+
+## Examples
+
+**Dry-run to see what would be produced:**
+```bash
+lesson-foundry --ledger findings --min 2
+```
+
+**Write defense files:**
+```bash
+lesson-foundry --ledger findings --min 2 --write --out-dir .adlc/lessons
+```
+
+**Gate in CI (fail if any recurring lesson is unbanked):**
+```bash
+lesson-foundry --ledger findings --min 2 --gate
+```
+
+**Machine-readable output:**
+```bash
+lesson-foundry --min 2 --gate --json
+```
+
+**Refine wording via LLM:**
+```bash
+lesson-foundry --min 2 --write --llm
+```
+
+**Print LLM prompts without calling any API:**
+```bash
+lesson-foundry --min 2 --prompt-only
+```
+
+## Relationship to sibling tools
+
+| Tool | Relationship |
+|------|-------------|
+| `adversarial-review` | Primary source of findings — its JSONL output feeds the ledger lesson-foundry reads |
+| `skill-mining` | lesson-foundry emits SKILL.md stubs; skill-mining manages the full skill registry |
+| `spec-lint` | lesson-foundry appends to `interrogation-template.md`; spec-lint gates on spec quality |
+| `rails-guard` | Defense files emitted by lesson-foundry should be PR'd like rails — read-only to other tools |
+
+## ADLC phase
+
+P7 — the compounding closer. Runs after prosecution findings accumulate across multiple ADLC cycles. The effect is a ratchet: each lesson is paid for exactly once, and recurring findings are demoted from probabilistic detection (LLM review, ~dollars per catch) to deterministic detection (lint/grep, ~free forever).
+
+## Core gaps
+
+None. All required functionality is available in `@adlc/core`.

--- a/docs/tools/merge-forecast.md
+++ b/docs/tools/merge-forecast.md
@@ -1,0 +1,101 @@
+---
+title: merge-forecast
+description: Documentation for the merge-forecast tool in the ADLC toolkit.
+---
+
+# @adlc/merge-forecast
+
+**ADLC phase: P2 Decompose**
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G1{{"GATE: Spec Approved"}} --> P2["P2 Decompose"]
+    P2 --> G2{{"GATE: Coldstart Pass"}}
+    G2 --> P3["P3 Rail"]
+    style P2 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Conflict forecast + dispatch schedule for parallel ticket execution. Predicts merge conflicts before any agent runs, certifies the safe fan-out width, and emits a foundation-first merge schedule.
+
+## Usage
+
+```
+merge-forecast [options]
+
+Options:
+  --tickets <path>           Path to tickets JSON (default: .adlc/tickets.json)
+  --width <N>                Desired fan-out width; gate fails (exit 2) if > certifiedWidth
+  --build-min <X>            Mean ticket build time in minutes (for backpressure width)
+  --merge-min <Y>            Mean merge-rebase-regreen time in minutes
+  --co-change-limit <N>      Git log depth for co-change mining (default: 500)
+  --conflict-threshold <F>   Score >= this triggers SEQUENCE verdict (default: 0.5)
+  --json                     Machine-readable JSON output
+  --help                     Show this help
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | Gate passes — schedule is safe at the recommended width |
+| 1    | Operational error — bad tickets file, unresolvable input |
+| 2    | Gate fails — `--width` exceeds certifiedWidth, or vetoed/high-risk pair scheduled concurrently |
+
+## Signals
+
+Each parallel-eligible ticket pair (neither is an ancestor of the other in the DAG) is scored by four signals. **Combined score = max of individual signals.**
+
+| Score | Signal | Description |
+|-------|--------|-------------|
+| 1.0   | `scope-overlap` | **HARD VETO** — tickets' declared scope globs overlap. These must serialize. |
+| 0.8   | `namespace-collision` | Dynamic route segments conflict (`[pk]` vs `[voteKey]` at same path depth) or migration prefix collision (`drizzle/0005_*` vs `migrations/0005_*`). |
+| 0.6   | `import-radius` | Files matching ticket A's scope import from ticket B's scope or vice versa. |
+| 0–0.5 | `co-change` | Historical co-commit coupling: `pairCount / min(fileCountA, fileCountB) × 0.5`. |
+
+Pairs at or above `--conflict-threshold` get a `SEQUENCE` verdict. Below threshold: `PARALLEL`.
+
+## Width Analysis
+
+- **certifiedWidth** — greedy largest independent set among wave-1 tickets (tickets where all pairs are below threshold).
+- **backpressureWidth** — `round(buildMin / mergeMin)` when both flags are given. Derived from integrator-lane throughput: if builds complete faster than merges absorb them, queue depth compounds.
+- **recommendedWidth** — `min(certifiedWidth, backpressureWidth?, --width?)`.
+
+## Schedule
+
+The schedule is derived from the ticket DAG via Kahn topological waves. All tickets in the same wave are ready to build concurrently (their dependencies completed in earlier waves). The merge order is **foundation-first** (ticket dependencies merge before their dependants; within a tier, first-done-first-merged).
+
+## Examples
+
+```sh
+# Basic forecast (auto-detect .adlc/tickets.json)
+merge-forecast
+
+# Gate against fan-out width
+merge-forecast --width 4
+
+# With backpressure — 20-min builds, 4-min merges
+merge-forecast --width 5 --build-min 20 --merge-min 4
+
+# JSON output for orchestrators
+merge-forecast --json
+
+# Custom tickets path + looser threshold
+merge-forecast --tickets plan/tickets.json --conflict-threshold 0.7
+
+# Deep co-change history
+merge-forecast --co-change-limit 1000
+```
+
+## Relation to Sibling Tools
+
+- **Upstream**: Tickets are produced by `model-router` (P2 phase). This tool validates the partition quality before agents run.
+- **Downstream**: `rails-guard` enforces the contract rails that `merge-forecast` identifies as conflict surfaces.
+- **Complement**: After completing parallel branches, `merge-forecast` can be re-run against the updated main to confirm rebase safety.
+
+## Core Gaps
+
+None. All required functionality is available in `@adlc/core` (`coChange`, `pairKey`, `isGitRepo`, `topoSort`, `globMatch`, `scopesOverlap`, `loadTickets`).

--- a/docs/tools/model-ratchet.md
+++ b/docs/tools/model-ratchet.md
@@ -1,0 +1,219 @@
+---
+title: model-ratchet
+description: Documentation for the model-ratchet tool in the ADLC toolkit.
+---
+
+# @adlc/model-ratchet
+
+**ADLC Phase:** Continuous calibration
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P7["P7 Distill"] --> Calib["Continuous Calibration"]
+    Calib -.-> P5["P5 Prosecute (Update Reviewers)"]
+    style Calib fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Scheduled re-prosecution of hot paths — **ADLC C12**.
+
+Every frontier model release is a free re-audit of the existing codebase: new
+models find what old ones missed. `model-ratchet` identifies the most valuable
+files to re-prosecute (high churn × high criticality), then either prints a
+prosecution plan or drives your review command over them, appending verified
+findings to the shared `.adlc/findings` ledger.
+
+Run on every model release (or monthly) to ratchet codebase quality
+monotonically upward for the cost of a scheduled job.
+
+## ADLC Phase
+
+**C12 / D1–D3 maintenance ratchet.** Pairs with:
+- **C8 review-calibration** — calibrate the new model's recall first, then aim it at hot paths.
+- **C9 lesson-foundry** — verified findings become lessons that compound into skills.
+
+## Installation
+
+```bash
+npm install -g @adlc/model-ratchet   # or use npx
+```
+
+## Usage
+
+```
+model-ratchet [--top <n>] [--review-cmd <cmd>] [--churn-limit <n>] [--dry-run] [--json]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--top <n>` | `10` | Number of hotspot files to select |
+| `--review-cmd <cmd>` | — | Shell command to run per file. Use `{file}` as placeholder. |
+| `--churn-limit <n>` | `1000` | Commit history depth for churn computation |
+| `--dry-run` | `false` | Print prosecution plan only; do not run review-cmd |
+| `--json` | `false` | Machine-readable JSON output |
+| `--help` | — | Show help |
+
+## Hot Score Formula
+
+```
+SCORE = churn(limit)[file] × (1 + inDegree)
+```
+
+- **churn(limit)[file]** — number of distinct commits touching the file in the
+  last `--churn-limit` commits (via `git log`).
+- **inDegree** — number of repo source files (`.mjs/.js/.ts/.tsx/.py`, walk
+  skips `node_modules/`, `.git/`, `dist/`) whose `import`/`require`/`from`
+  specifiers resolve (relative resolution, try extensions) to this file.
+
+Test/spec files (`.test.*`, `.spec.*`, `test/`, `__tests__/`) and non-source
+files (`.md`, `.json`, lock files) are excluded from both the candidate set
+and the import graph.
+
+## Default Mode (no `--review-cmd`, or with `--dry-run`)
+
+Prints the prosecution plan table and suggested charter lines per file:
+
+```
+model-ratchet — Prosecution Plan
+====================================================================
+FILE                        CHURN  IN-DEGREE  SCORE
+--------------------------  -----  ---------  -----
+src/auth.mjs                   42          3    168
+src/db/query.mjs               31          5    186
+src/utils.mjs                  25          1     50
+
+Suggested charter lines:
+  Refute correctness of src/auth.mjs — hotspot: changed 42 times, imported by 3 files
+  ...
+```
+
+## Review Mode (`--review-cmd`)
+
+Runs the command for each selected file with `{file}` substituted. Captures
+stdout and parses findings:
+
+- Lines matching `/\S+:\d+/` (e.g. `src/foo.js:42: missing null check`)
+- Lines starting with `- ` (bullet items)
+
+Each finding is appended to `.adlc/findings.jsonl`:
+
+```json
+{
+  "ts": "2026-01-01T00:00:00.000Z",
+  "tool": "model-ratchet",
+  "file": "src/auth.mjs",
+  "line": 42,
+  "category": "ratchet",
+  "severity": "unknown",
+  "desc": "src/auth.mjs:42: missing null check"
+}
+```
+
+Exit code 2 from `review-cmd` is treated as "findings present" (not an error).
+Exit codes other than 0 or 2 cause an operational error (tool exits 1).
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success — plan printed or review run complete |
+| `1` | Operational error — not a git repo, bad `--review-cmd` exit code, bad args |
+| `2` | Not used by `model-ratchet` itself (reserved for gate-fail; review-cmd findings go to ledger) |
+
+## Examples
+
+```bash
+# Print prosecution plan for top 10 hot files
+model-ratchet
+
+# Top 5 files, last 500 commits
+model-ratchet --top 5 --churn-limit 500
+
+# Dry-run plan even if review-cmd is provided
+model-ratchet --top 10 --review-cmd "adversarial-review {file}" --dry-run
+
+# Run adversarial review and append findings
+model-ratchet --review-cmd "adversarial-review --file {file}"
+
+# Machine-readable output for orchestrators
+model-ratchet --top 5 --json
+
+# Run a custom linter as the reviewer
+model-ratchet --review-cmd "eslint {file} --format compact"
+```
+
+## Cron and CI Examples
+
+### GitHub Actions — on every model release
+
+```yaml
+# .github/workflows/model-ratchet.yml
+name: model-ratchet
+
+on:
+  # Manually trigger when a new model is released
+  workflow_dispatch:
+  # Or run monthly
+  schedule:
+    - cron: '0 9 1 * *'
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for full churn history
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run model-ratchet
+        run: |
+          npx @adlc/model-ratchet \
+            --top 10 \
+            --review-cmd "npx @adlc/adversarial-review --file {file}" \
+            --json > ratchet-results.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ratchet-findings
+          path: .adlc/findings.jsonl
+```
+
+### Cron (shell)
+
+```bash
+# Run on every model release — add to crontab or a release script
+# crontab entry: run on the 1st of every month at 09:00
+# 0 9 1 * * cd /path/to/repo && model-ratchet --top 10 --review-cmd "adversarial-review {file}" --json >> .adlc/ratchet-runs.log 2>&1
+
+# Or run manually after a model upgrade:
+model-ratchet --top 20 --review-cmd "adversarial-review --file {file}" --json
+```
+
+### CI gate (plan-only, no API key required)
+
+```yaml
+- name: Print hot paths prosecution plan
+  run: npx @adlc/model-ratchet --top 10 --json
+```
+
+## Core Gaps
+
+None. Uses `churn()`, `isGitRepo()`, `appendEntry()`, `parseArgs()`, `opError()`,
+`pass()`, `printJson()` from `@adlc/core`. All hot-score logic, import-graph
+walking, and finding parsing live in `lib/`.
+
+## Relationship to Sibling Tools
+
+- **adversarial-review** — natural choice for `--review-cmd`; `model-ratchet`
+  aims it at the highest-value files.
+- **review-calibration (C8)** — calibrate first, then ratchet.
+- **lesson-foundry (C9)** — consume the `.adlc/findings` ledger entries that
+  `model-ratchet` appends.
+- **gate-manifest (C11)** — findings from ratchet runs appear in the shared
+  findings ledger that manifests track.

--- a/docs/tools/model-router.md
+++ b/docs/tools/model-router.md
@@ -1,0 +1,147 @@
+---
+title: model-router
+description: Documentation for the model-router tool in the ADLC toolkit.
+---
+
+# @adlc/model-router
+
+**ADLC Phase:** P2 Decompose
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G1{{"GATE: Spec Approved"}} --> P2["P2 Decompose"]
+    P2 --> G2{{"GATE: Coldstart Pass"}}
+    G2 --> P3["P3 Rail"]
+    style P2 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Deterministic per-ticket model assignment (ADLC phase D1). No LLM calls.
+Reads the ticket DAG and manifest ledger history, then emits tier + mode
+for every ticket so the dispatcher knows which model to invoke and whether
+to ladder.
+
+## Usage
+
+```
+model-router [--tickets <path>] [--floor <number>] [--json]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file |
+| `--floor <0-1>` | `0.2` | Minimum rail density for cheap-tier assignment |
+| `--json` | off | Machine-readable JSON output (for orchestrators) |
+
+## Output
+
+### Human table (default)
+
+Columns: `id`, `tier`, `mode`, `railDensity`, `float`, `reason`
+
+```
+id            tier        mode      railDensity  float   reason
+---------------------------------------------------------------
+AUTH-1        cheap       ladder    1.000        3       float=3 → ladder starting at 'cheap' (railDensity=1.000)
+AUTH-2        frontier    direct    0.000        0       category 'spec' requires frontier model
+```
+
+### JSON (--json)
+
+```json
+{
+  "assignments": [
+    {
+      "id": "AUTH-1",
+      "tier": "cheap",
+      "mode": "ladder",
+      "railDensity": 1.0,
+      "float": 3,
+      "reason": "..."
+    }
+  ],
+  "p3Findings": []
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All tickets assigned; gate passes |
+| `1` | Operational error (bad tickets file, JSON parse error, cycle in DAG) |
+| `2` | Gate fails: one or more non-frontier-category tickets have `railDensity < floor` |
+
+## Assignment rules (ADLC D1)
+
+### Rule 1: Frontier / Direct
+
+Applies when:
+- `ticket.category` is one of `contract`, `spec`, `architecture`
+- OR `railDensity < floor` (regardless of category — this also triggers exit 2)
+
+Result: `tier=frontier`, `mode=direct`
+
+Rationale: These tickets produce outputs that are hard to verify deterministically (contracts, specs) or where an escaped error is expensive to find. Only the frontier model is appropriate. Tickets below the rail-density floor are also sent here because the gates are insufficient to catch regeneration failures cheaply — this is surfaced as a P3 finding (the ticket is not railed enough to build cheaply).
+
+### Rule 2: Direct (critical path)
+
+Applies when: `float === 0` (ticket is on the critical path)
+
+Result: `mode=direct`, `tier` = best-performing tier from prior data with >= 3 samples, else `mid`
+
+Rationale: A failed attempt on a critical-path ticket delays the entire delivery. Skip the escalation ladder; go straight to the highest first-pass-rate tier.
+
+### Rule 3: Ladder (has slack)
+
+Applies when: `float > 0`
+
+Result: `mode=ladder`, `tier` = `cheap` if `railDensity >= 0.5` else `mid`
+
+Rationale: Retries on tickets with DAG float are absorbed by schedule slack with no wall-clock penalty. Start cheap; the escalation harness regenerates one tier up on gate failure, appending the known-dead-ends to the ticket context.
+
+## Concepts
+
+### Rail density
+
+```
+railDensity = min(1, rails.length / max(1, scope.length))
+```
+
+`rails` is the list of frozen paths that provide deterministic checks (test files, contract files). `scope` is the set of paths the ticket may touch. High density means most outputs are covered by fast, deterministic gates; errors are caught cheaply and regeneration is inexpensive.
+
+Density of `0` (no rails) means there are no automated gates — any error escapes to humans. Such tickets are routed to `frontier` regardless of category and trigger a P3 gate-fail finding.
+
+### DAG float (CPM)
+
+Classic critical-path-method float from `computeFloat()` in `@adlc/core`. Float is the amount of time a ticket can slip without delaying the overall delivery (`makespan`). Tickets on the critical path have `float === 0`.
+
+### Priors from the manifest ledger
+
+Every `build`-type entry in `.adlc/manifest.jsonl` with shape `{ model, category, firstPass: boolean }` is counted. Success rate per model (and per model + category when >= 3 samples exist) is computed with Laplace smoothing:
+
+```
+rate = (passes + 1) / (n + 2)
+```
+
+For critical-path tickets (Rule 2), the model name in the ledger is matched against the tier names `cheap`, `mid`, `frontier` to produce a tier recommendation. If no tier-named model has enough data, defaults to `mid`.
+
+## ADLC phase
+
+D1 — The cost dial: model routing.
+
+model-router is the first decision in the D-series (Dispatch). It runs before fan-out (D2) and merge-forecast. Its output drives the dispatcher's `--tier` and `--mode` arguments.
+
+Sibling tools:
+- `fan-out` (D2) — uses the tier assignments to set parallelism budgets
+- `flail-detector` — triggers escalation when a running job exceeds the failure threshold, consuming the `mode=ladder` assignments
+- `rails-guard` — enforces that `rails` paths exist before allowing the build to start
+
+## Core gaps
+
+None. All required APIs (`loadTickets`, `computeFloat`, `readEntries`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`) are available in `@adlc/core`.

--- a/docs/tools/parallax.md
+++ b/docs/tools/parallax.md
@@ -1,0 +1,173 @@
+---
+title: parallax
+description: Documentation for the parallax tool in the ADLC toolkit.
+---
+
+# @adlc/parallax
+
+Measured-ambiguity interrogation for feature requests, ticket edge contracts, and mid-build routing questions. Replaces single-model introspection with **sampling diversity as an instrument**: fan N independent cheap-tier completions, diff the readings, surface only the divergences as multiple-choice questions.
+
+**ADLC phase:** P1/D3 Spec shaping
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P0["P0 Triage"] --> P1["P1 Interrogate / Parallax"]
+    P1 --> G1{{"GATE: Spec Approved"}}
+    G1 --> P2["P2 Decompose"]
+    style P1 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+ D3 — Measured Ambiguity
+
+---
+
+## Modes
+
+### SPEC MODE (default)
+
+Fan N independent readers over a raw feature request. Each commits to one reading and outputs a structured spec. A mid-tier completion diffs the readings into an **agreement set** (draft spec) and **divergences** (questions only humans can answer). An ambiguity score gates the output.
+
+```
+parallax --request "text"
+parallax --file req.md
+echo "feature request" | parallax
+```
+
+### EDGE MODE
+
+Fan N agents over two adjacent tickets in the development DAG. Each independently authors the interface/contract implied between them. Same divergence analysis gates whether the edge contract is safe to speculate on.
+
+```
+parallax --edge T1 T2
+parallax --edge T1 T2 --tickets path/to/tickets.json
+```
+
+### ROUTE MODE (ambiguity router)
+
+Fan N agents to answer a question given optional context files. A judge completion decides whether the answers are semantically equivalent. If yes, print the answer and exit 0. If no, print multiple-choice divergences and exit 2.
+
+```
+parallax --route "question"
+parallax --route "question" --context spec.md --context arch.md
+```
+
+---
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--request <text>` | — | Spec mode: feature request inline |
+| `--file <path>` | — | Spec mode: feature request from file |
+| `--edge` | false | Edge mode: follow with two ticket IDs as positionals |
+| `--route <text>` | — | Route mode: question to route |
+| `--context <file>` | — | Route mode: context file (repeatable) |
+| `--tickets <path>` | `.adlc/tickets.json` | Tickets file for edge mode |
+| `--n <int>` | 3 | Fan width (number of independent readings) |
+| `--threshold <0-1>` | 0.25 | Ambiguity score gate threshold |
+| `--tier cheap\|mid\|frontier` | cheap for fan, mid for divergence | Override LLM tier |
+| `--json` | false | Machine-readable output (score + divergences) |
+| `--prompt-only` | false | Print exact prompts, exit 0 — no API key needed |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Gate passes — ambiguity score ≤ threshold (spec/edge), or answers equivalent (route) |
+| 1 | Operational error — bad input, missing file, network failure, insufficient readings |
+| 2 | Gate fails — ambiguity score > threshold (spec/edge), or answers diverge (route) |
+
+---
+
+## Report format
+
+**SPEC / EDGE mode output:**
+```markdown
+## Agreement set (draft spec)
+- <thing all readings agreed on>
+- ...
+
+## Divergences — answer these
+**Q1: <ambiguous point>**
+  A) <reading 1's choice>
+  B) <reading 2's choice>
+
+---
+**Ambiguity score:** 0.33 (threshold 0.25) — gate FAILS ✗
+```
+
+**ROUTE mode output (equivalent):**
+```
+<The single consensus answer, printed directly>
+```
+
+**ROUTE mode output (divergent):**
+```markdown
+## Route conflict — answer required
+
+**Question:** <question>
+
+**Interpretations:**
+  A) <variant 1>
+  B) <variant 2>
+```
+
+---
+
+## JSON output (`--json`)
+
+Spec/edge:
+```json
+{
+  "mode": "spec",
+  "agreements": ["..."],
+  "divergences": [{"point": "...", "options": [{"label": "A", "reading": "..."}]}],
+  "score": 0.33,
+  "threshold": 0.25,
+  "gate": false,
+  "warnings": []
+}
+```
+
+Route:
+```json
+{
+  "mode": "route",
+  "question": "...",
+  "equivalent": false,
+  "answer": "",
+  "variants": ["option A", "option B"],
+  "warnings": []
+}
+```
+
+---
+
+## Ambiguity score
+
+`score = divergences / (divergences + agreements)`, rounded to 2 decimal places.
+
+- 0.00 = perfect convergence (nothing to ask)
+- 1.00 = total divergence (no agreement at all)
+- Default gate threshold: 0.25
+
+The score is the key output: a spec that converged at N=5 with score 0.00 is a measurably safer artifact than any single-model pronouncement of completeness.
+
+---
+
+## Relationship to sibling tools
+
+- **grill-me** — predecessor; interrogation by introspection (single context, sequential). `parallax` replaces it with measurement.
+- **spec-lint (C1)** — can gate on the ambiguity score that `parallax` emits.
+- **model-router (D2)** — uses edge contracts that `parallax --edge` validates before speculative execution.
+- **flail-detector** — triggers `parallax --route` mid-build to route builder questions through the machine before escalating to humans.
+
+---
+
+## Core gaps
+
+None. All required functions (`fan`, `complete`, `extractJson`, `loadTickets`, `promptOnly`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`, `readStdin`) are present in `@adlc/core`.

--- a/docs/tools/preflight.md
+++ b/docs/tools/preflight.md
@@ -1,0 +1,150 @@
+---
+title: preflight
+description: Documentation for the preflight tool in the ADLC toolkit.
+---
+
+# @adlc/preflight
+
+**ADLC Phase:** P0 Triage / Preflight
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    Req([Request]) --> P0{"P0 Triage"}
+    P0 --> P1["P1 Interrogate"]
+    P0 -.-> Preflight["Preflight (Baseline check)"]
+    style Preflight fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Permissions and environment preflight check before fan-out (ADLC D2 Phase 0).
+
+Runs isolated checks to verify that every operation class the agent fleet needs
+actually works in the current environment — so permission prompts and
+configuration failures front-load into one batch instead of stalling mid-flight.
+
+From the ADLC D2 field notes:
+
+> A permission prompt mid-flight is a hidden serialization point: one blocked
+> agent × N teammates = N stalls, racing siblings, and half-started state.
+> Environment determinism is a precondition of parallel wall-clock math.
+
+## Usage
+
+```
+preflight [--test-cmd "..."] [--gh] [--llm] [--worktrees] [--json]
+```
+
+### No flags — required checks only
+
+```
+preflight
+```
+
+Runs the four required checks (bash, git, write, branch) and prints a table plus
+a verdict line. Exit 0 if all pass; exit 2 if any fail.
+
+### With optional checks
+
+```
+preflight --test-cmd "npm test" --gh --llm --worktrees
+```
+
+## Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--test-cmd "CMD"` | string | Run CMD via `sh -c`, expect exit 0. Tail of output shown on failure. |
+| `--gh` | boolean | Run `gh auth status`; expect exit 0. |
+| `--llm` | boolean | Call `detectProvider()` and assert it is non-null. No API call made. Reports which provider was found. |
+| `--worktrees` | boolean | `git worktree add --detach .worktrees/preflight-test HEAD` then remove. |
+| `--json` | boolean | Machine-readable output: `{ checks, verdict, failedNames }`. |
+
+## Checks
+
+### Required (always run)
+
+| Name | What it tests |
+|------|---------------|
+| `bash` | `echo preflight-ok` succeeds |
+| `git` | `git status` in cwd succeeds (cwd must be a git repo) |
+| `write` | Write + delete `.adlc/tmp/preflight-test` (mkdir -p as needed) |
+| `branch` | Create and delete `preflight-test-branch`; always cleans up in finally |
+
+### Optional (run only when flag given)
+
+| Name | Flag | What it tests |
+|------|------|---------------|
+| `worktrees` | `--worktrees` | `git worktree add/remove` cycle; always cleans up in finally |
+| `test-cmd` | `--test-cmd "CMD"` | Runs CMD via sh, expects exit 0 |
+| `gh` | `--gh` | `gh auth status` exits 0 |
+| `llm` | `--llm` | `detectProvider()` returns non-null (no API call) |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Gate passes — all checks (required + explicitly requested optional) passed |
+| 1 | Operational / internal error |
+| 2 | Gate fails — one or more required or explicitly requested checks failed |
+
+Note: optional checks that are NOT requested are not run and cannot fail.
+When a flag like `--gh` is passed, that check becomes required for this run.
+
+## Output
+
+### Human-readable (default)
+
+```
+──────────────────────
+check      status  detail
+──────────────────────
+bash       ✓ PASS    echo preflight-ok succeeded
+git        ✓ PASS    git status succeeded
+write      ✓ PASS    .adlc/tmp/preflight-test written and removed
+branch     ✓ PASS    branch 'preflight-test-branch' created and removed
+worktrees  ✓ PASS    worktree add/remove succeeded
+test-cmd   ✓ PASS    exited 0
+──────────────────────
+
+verdict: ALL CHECKS PASSED — environment is ready.
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "checks": [
+    { "name": "bash",   "status": "pass", "detail": "echo preflight-ok succeeded", "required": true },
+    { "name": "git",    "status": "pass", "detail": "git status succeeded",          "required": true },
+    { "name": "write",  "status": "pass", "detail": ".adlc/tmp/preflight-test written and removed", "required": true },
+    { "name": "branch", "status": "pass", "detail": "branch 'preflight-test-branch' created and removed", "required": true }
+  ],
+  "verdict": "pass",
+  "failedNames": []
+}
+```
+
+## ADLC phase served
+
+**D2 Phase 0** (pre-fan-out environment gate). Run once before spawning the
+parallel agent fleet to ensure every operation class succeeds. Integrates with
+`team-develop` as Phase 0 of the parallel build pipeline.
+
+## Cleanup guarantees
+
+Every check that creates a side effect (branch, worktree, tmp file) performs
+cleanup in a `finally` block — residue is removed whether the check passes or
+fails.
+
+## Relationship to sibling tools
+
+- `merge-forecast` — uses after preflight confirms the environment is ready; validates the ticket DAG and forecasts conflict probability before the fan-out.
+- `gate-manifest` — records gate passage events into the ADLC manifest ledger; preflight should record its passage there in orchestrated flows.
+
+## Core gaps
+
+None. All required core APIs (`detectProvider`, `git`, `parseArgs`, `printJson`)
+are available in `@adlc/core`.

--- a/docs/tools/premortem.md
+++ b/docs/tools/premortem.md
@@ -1,0 +1,128 @@
+---
+title: premortem
+description: Documentation for the premortem tool in the ADLC toolkit.
+---
+
+# @adlc/premortem
+
+**ADLC Phase:** P1 Interrogate
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P0["P0 Triage"] --> P1["P1 Interrogate"]
+    P1 --> G1{{"GATE: Spec Approved"}}
+    G1 --> P2["P2 Decompose"]
+    style P1 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Failure-first spec stress test — **ADLC phase C2 / P1 gate**.
+
+Inverts sycophancy: instead of asking "any problems with this plan?", it tells a
+frontier model the project already failed and asks it to write the postmortem.
+The model generates concrete, checkable risks anchored to the actual spec
+content. Output feeds back as interrogation questions for the next P1 review.
+
+Runs once per spec. Cheap. No bespoke judgement needed.
+
+---
+
+## Usage
+
+```
+premortem <spec.md> [--tier cheap|mid|frontier] [--out report.md] [--json] [--prompt-only]
+```
+
+### Arguments
+
+| Argument / Flag | Description | Default |
+|---|---|---|
+| `<spec.md>` | Path to the spec file to analyse **(required)** | — |
+| `--tier` | Model tier: `cheap`, `mid`, or `frontier` | `frontier` |
+| `--out <path>` | Write markdown report to this file instead of stdout | stdout |
+| `--json` | Emit machine-readable JSON `{ causes: [...] }` | false |
+| `--prompt-only` | Print the exact system + user prompt, then exit 0 — **no API key needed** | false |
+| `--help` | Print usage and exit 0 | false |
+
+### Examples
+
+```bash
+# Run against a spec, print to stdout
+premortem specs/checkout-v2.md
+
+# Write the report to a file
+premortem specs/checkout-v2.md --out reports/premortem-checkout.md
+
+# Machine-readable output for orchestrators
+premortem specs/checkout-v2.md --json
+
+# Inspect the prompt without spending tokens
+premortem specs/checkout-v2.md --prompt-only
+
+# Use a cheaper model for quick iteration
+premortem specs/checkout-v2.md --tier mid
+```
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Report produced successfully (or `--prompt-only` / `--help`) |
+| `1` | Operational error — missing spec file, no LLM provider configured, malformed model response |
+| `2` | *(reserved for future gate-fail use; not currently emitted)* |
+
+---
+
+## Output format
+
+The default markdown report contains:
+
+1. **Failure Causes table** — cause, earliest observable signal, and prevention per item.
+2. **Questions to fold into interrogation** — numbered list of interrogation questions, one per cause, ready to paste into the next P1 spec review.
+
+---
+
+## ADLC phase served
+
+**C2 — P1 stress test.**  Sits at the end of the P1 (spec approval) phase.  After
+a spec has passed `speccheck` (C1), `premortem` runs one frontier-model
+completion with the adversarial postmortem charter.  The resulting questions are
+appended to the spec review checklist before the spec is locked.
+
+---
+
+## LLM configuration
+
+The tool requires exactly one of:
+
+```
+ANTHROPIC_API_KEY   → uses claude-opus-4-8 at frontier tier
+OPENAI_API_KEY      → uses gpt-5.1 at frontier tier
+GEMINI_API_KEY      → uses gemini-2.5-pro at frontier tier
+```
+
+Force a provider: `ADLC_PROVIDER=anthropic`
+Override model by tier: `ADLC_MODEL_FRONTIER=claude-opus-4-8`
+
+Use `--prompt-only` to get the exact prompt for pasting into any harness when no
+key is available.
+
+---
+
+## Core gaps
+
+None.  All required functionality (`complete`, `extractJson`, `detectProvider`,
+`promptOnly`, `opError`, `parseArgs`, `printJson`) is available in `@adlc/core`.
+
+---
+
+## Relationship to sibling tools
+
+- **speccheck (C1)** — runs before `premortem`; ensures every acceptance criterion has a verification method.
+- **coldstart (C3)** — runs after `premortem`; stress-tests individual tickets for missing information.
+- **premortem** is advisory (`exit 0` on success) because it produces questions, not binary pass/fail.  A future integration could promote flagged questions to tickets and gate on them via `coldstart`.

--- a/docs/tools/prosecute.md
+++ b/docs/tools/prosecute.md
@@ -1,0 +1,113 @@
+---
+title: prosecute
+description: Documentation for the prosecute tool in the ADLC toolkit.
+---
+
+# @adlc/prosecute
+
+**ADLC Phase:** P5 Prosecute
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G4{{"GATE: Build Pass"}} --> P5["P5 Prosecute"]
+    P5 --> G5{{"GATE: Zero Findings"}}
+    G5 --> P6["P6 Integrate"]
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+P5 review-evidence recorder. It does not run a model review by itself. It consumes
+normalized reviewer-produced pass evidence, records ticket- and revision-scoped P5
+evidence to `.adlc/manifest.jsonl`, and passes only after two consecutive dry passes
+with at least three distinct dry lenses.
+
+## Usage
+
+```sh
+adlc-prosecute --input p5-passes.json --ticket T1 --dir .adlc --json
+```
+
+## Input shape
+
+```json
+{
+  "target": "feature branch",
+  "provenance": {
+      "reviewer": "local-reviewer",
+      "session": "codex-session-123",
+      "command": "npx adversarial-review --scope working-tree --include-files",
+      "transcript": ".omo/evidence/p5-review.txt"
+  },
+  "review_packet": {
+      "prompt": ".omo/evidence/p5-prompt.txt",
+      "prompt_hash": "sha256-of-prompt-file",
+      "inputs": ".omo/evidence/p5-inputs.txt",
+      "inputs_hash": "sha256-of-reviewed-input-packet",
+      "clean_worktree": "git-worktree:..."
+  },
+  "passes": [
+    {
+      "lens": "security",
+      "findings": [
+        {
+          "id": "F1",
+          "severity": "high",
+          "category": "security",
+          "file": "src/auth.js",
+          "line_start": 10,
+          "line_end": 12,
+          "evidence": "quoted changed code",
+          "claim": "token bypass",
+          "recommendation": "validate issuer",
+          "confidence": 0.8,
+          "verified_status": "verified"
+        }
+      ]
+    },
+    {
+      "lens": "security",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified security findings"
+    },
+    {
+      "lens": "correctness",
+      "findings": [],
+      "dry_evidence": "review transcript reports no verified correctness findings"
+    }
+  ]
+}
+```
+
+`verified_status` must be `verified`, `killed`, or `needs-human`. Killed findings must
+include `verification.reason`, `verification.method`, and `verification.evidence`.
+Inputs must use the built-in lens names: `security`, `correctness`, `tests`, `behavior`,
+`integration`, or `docs`. Clean reviews with zero finding candidates are accepted when the
+dry passes include evidence. If no finding is marked `verified`, the input must include
+`no_findings_attestation` with
+`reason`, `method`, and `evidence`. Only passes with zero findings count as dry; killed
+findings are recorded but do not advance dry-pass convergence.
+
+The transcript is not treated as a generic attachment. It must be readable, at least 64
+bytes, and it must reference both the `--ticket` value and the resolved reviewed revision
+string (`git-worktree:<hash>` unless `--revision` is supplied). This binds the recorded
+P5 evidence to the ticket and revision that P6 later checks, but it still does not prove
+that an external reviewer ran. Use the named `provenance.command` and transcript from the
+actual skeptical review run, not a hand-written placeholder.
+
+The review packet binds the reviewer prompt and reviewed input packet to P5 evidence.
+`prompt` and `inputs` are file paths, their hashes must match the supplied SHA-256 values,
+and `clean_worktree` must equal the exact reviewed revision.
+
+## Exit codes
+
+- `0`: two consecutive dry passes were recorded
+- `1`: operational error
+- `2`: verified/needs-human findings remain or the convergence budget ended before two dry passes
+
+## ADLC phase
+
+P5 Prosecute. This tool makes the review-evidence and dry-pass record executable, but
+the reviewer command named in `provenance.command` remains the source of the review.

--- a/docs/tools/rails-guard.md
+++ b/docs/tools/rails-guard.md
@@ -1,0 +1,182 @@
+---
+title: rails-guard
+description: Documentation for the rails-guard tool in the ADLC toolkit.
+---
+
+# rails-guard
+
+**ADLC Phase:** P3 Rail
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G2{{"GATE: Coldstart Pass"}} --> P3["P3 Rail"]
+    P3 --> G3{{"GATE: Rails Frozen"}}
+    G3 --> P4["P4 Build"]
+    style P3 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Rail-freeze enforcement and suppression-marker gate (ADLC C5).
+
+Blocks builder edits to declared frozen rail paths during P4, and greps added
+diff lines for suppression markers that escape test/lint coverage. On a clean
+pass it can record a **rails-diff-empty proof** in the gate manifest.
+
+## ADLC Phase
+
+**C5 — P3/P4 enforcement.** Sits in the CI gate between P3 (charter /
+planning) and P4 (builder execution). Guards two invariants simultaneously:
+
+1. **Rail-freeze**: declared rail paths (test files, contract types, CI config)
+   must not be touched by the builder during P4.
+2. **Suppression-marker gate**: newly added `.skip(`, `.only(`, `xfail`,
+   `@ts-ignore`, `@ts-expect-error`, `eslint-disable`, `# noqa`, `#[ignore]`
+   lines are blocked unless the active ticket's `body` contains an explicit
+   `allow-suppression: <marker>` declaration.
+
+## Usage
+
+```
+rails-guard [--base <ref>] [--ticket <id>] [--tickets <path>] \
+            [--rails <glob>...] [--record] [--json]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--base <ref>` | `HEAD` | Git ref to diff against |
+| `--ticket <id>` | — | Load rails and `allow-suppression` declarations from this ticket |
+| `--tickets <path>` | `.adlc/tickets.json` | Path to tickets file |
+| `--rails <glob>` | — | One or more frozen-path globs (repeatable; overrides `ticket.rails`) |
+| `--record` | off | On a clean pass, append a manifest entry to `.adlc/manifest.jsonl` |
+| `--json` | off | Emit machine-readable JSON result |
+| `--help` | — | Print this help and exit 0 |
+
+### Rail source resolution
+
+1. If `--rails` globs are supplied they are used directly.
+2. Otherwise `--ticket` must be provided; rails come from `ticket.rails`.
+3. If neither is available the tool exits 1 (operational error).
+
+### allow-suppression declarations
+
+To permit a specific suppression marker, add this exact text to the ticket body:
+
+```
+allow-suppression: @ts-ignore
+allow-suppression: .skip(
+```
+
+One declaration per line; case-sensitive; marker text must match exactly.
+
+## Examples
+
+```bash
+# Check that no frozen test files were touched, fail on any suppression
+rails-guard --rails "test/**" --rails "schema/**"
+
+# Use rails declared in ticket T42; allow .skip( for known broken test
+rails-guard --ticket T42 --tickets .adlc/tickets.json
+
+# Diff against a feature branch base commit
+rails-guard --rails "test/**" --base origin/main
+
+# CI gate with machine-readable output + manifest record on clean pass
+rails-guard --rails "test/**" --json --record
+```
+
+## Output
+
+### Human-readable (default)
+
+Clean:
+```
+rails-guard: all checks passed
+```
+
+Violations:
+```
+rails-guard: 2 violation(s) found
+  [rail-edit]   test/auth.test.ts  (matched globs: test/**)
+  [suppression] src/foo.ts:12  marker: @ts-ignore
+                  // @ts-ignore
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "tool": "rails-guard",
+  "base": "HEAD",
+  "ticket": "T42",
+  "railGlobs": ["test/**"],
+  "railGlobError": null,
+  "railsDiffEmpty": true,
+  "suppressionsClean": false,
+  "passed": false,
+  "violations": [
+    {
+      "file": "src/foo.ts",
+      "type": "suppression",
+      "marker": "@ts-ignore",
+      "lineNo": 12,
+      "line": "// @ts-ignore"
+    }
+  ]
+}
+```
+
+### Manifest record (`--record`, clean pass only)
+
+Appended to `.adlc/manifest.jsonl`:
+
+```json
+{
+  "ts": "2026-06-10T12:00:00.000Z",
+  "type": "rails-check",
+  "ticket": "T42",
+  "base": "HEAD",
+  "railsDiffEmpty": true,
+  "suppressionsClean": true,
+  "railFiles": {
+    "test/auth.test.ts": "abc123...",
+    "schema/types.ts": "def456..."
+  }
+}
+```
+
+`railFiles` contains the SHA-256 of every repo file that matches a rail glob at
+the time of the clean pass — a content-addressed snapshot usable for auditing.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — no violations |
+| `1` | Operational error — not a git repo, bad input, no rails resolvable |
+| `2` | Gate fails — violations found (list printed to stderr / JSON) |
+
+## Violation types
+
+| `type` | Meaning |
+|--------|---------|
+| `rail-edit` | A changed file matches a frozen rail glob |
+| `suppression` | An added line contains a suppression marker not declared in the ticket |
+
+## Sibling tools
+
+- **flail-detector (C6)**: uses `--record` manifest entries to verify no
+  builder session slipped past the gate.
+- **consensus-fix (C7)**: runs every candidate fix through `rails-guard` before
+  accepting it as a survivor.
+- **merge-forecast**: reads `manifest.jsonl` to surface gate history alongside
+  merge risk.
+
+## Core gaps
+
+None. All required APIs (`globMatch`, `hashFiles`, `appendEntry`, `changedFiles`,
+`gitDiff`, `loadTickets`) are present in `@adlc/core`.

--- a/docs/tools/rejection-mining.md
+++ b/docs/tools/rejection-mining.md
@@ -1,0 +1,181 @@
+---
+title: rejection-mining
+description: Documentation for the rejection-mining tool in the ADLC toolkit.
+---
+
+# rejection-mining
+
+**ADLC Phase:** P7 Distill
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G6{{"GATE: Human Acceptance"}} --> P7["P7 Distill"]
+    P7 -.-> P1["P1 Interrogate (Feedback)"]
+    style P7 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+**ADLC Phase: C13** — org boundaries (the telco pattern, generalized)
+
+Sister of `skill-mining`. Mines human PR review objections into *prosecution lenses* — structured rules for adversarial code review. Converts the recurring "nights of no" from institutional gatekeepers into automated pre-flight checks.
+
+## What it does
+
+1. Fetches PR review threads and comment bodies from the GitHub CLI (`gh`)
+2. Filters for negative-signal language (objections, rejections, criticism)
+3. Clusters similar objections using token-set Jaccard similarity (≥ 0.4)
+4. Authors each cluster into a lens file: `<out-dir>/lens-<slug>.md`
+5. Each lens includes a prosecution charter, checklist item, and anonymized example quotes
+
+Result: "would security reject this?" is answered in seconds pre-submit instead of days post-queue.
+
+## Usage
+
+```
+rejection-mining [--limit N] [--min N] [--out-dir PATH] [--write] [--llm] [--prompt-only] [--json]
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--limit N` | `50` | Maximum number of PRs to fetch |
+| `--min N` | `2` | Minimum cluster size to author a lens |
+| `--out-dir PATH` | `.adlc/lenses` | Directory to write lens files into |
+| `--write` | false | Emit lens files (default: dry-run) |
+| `--llm` | false | Use LLM to sharpen lens title and charter (one `mid` call per cluster) |
+| `--prompt-only` | false | Print LLM prompts and exit 0 (no API key required) |
+| `--json` | false | Machine-readable JSON output |
+
+## Examples
+
+```bash
+# Dry-run: show what would be mined (no files written)
+rejection-mining
+
+# Limit to recent 100 PRs, require 3+ matching comments to form a lens
+rejection-mining --limit 100 --min 3
+
+# Write lens files to default location
+rejection-mining --write
+
+# Write to custom directory with LLM-sharpened titles
+rejection-mining --out-dir .adlc/prosecution-lenses --write --llm
+
+# Get the LLM prompts without calling any API
+rejection-mining --prompt-only
+
+# JSON output for orchestrators
+rejection-mining --json
+```
+
+## Output
+
+### Human-readable table
+
+```
+rejection-mining results
+═══════════════════════
+  PRs scanned:   47
+  Signals found: 23
+  Lenses:        3
+
+  Title                           Signals  PRs    File
+  ────────────────────────────────────────────────────────────────────────
+  Error Exposure Leak             6        4      .adlc/lenses/lens-error-expose-raw.md
+  Hardcoded Credentials           5        3      .adlc/lenses/lens-hardcode-credentials.md
+  missing-null-check-accessing    4        2      .adlc/lenses/lens-missing-null-check.md
+
+  (dry-run — add --write to emit lens files)
+```
+
+### Lens file format
+
+```markdown
+# Lens: Error Exposure Leak
+
+## Charter
+
+When prosecuting a diff, specifically attempt to refute: raw error messages
+or stack traces being passed directly to API response bodies or client UI.
+
+## Checklist
+
+- [ ] Does this diff trigger the pattern: *Error Exposure Leak*?
+
+## Example Objections
+
+> "don't expose the raw error message to the client here — it leaks internals" — A*** on PR #101
+
+> "never expose raw error details to the API response body" — E*** on PR #102
+
+---
+
+*mined from 6 review comments across 4 PRs*
+```
+
+### JSON output shape
+
+```json
+{
+  "totalPRs": 47,
+  "skippedPRs": 0,
+  "totalSignals": 23,
+  "lensCount": 3,
+  "lenses": [
+    {
+      "slug": "error-expose-raw",
+      "title": "Error Exposure Leak",
+      "count": 6,
+      "prCount": 4,
+      "path": ".adlc/lenses/lens-error-expose-raw.md"
+    }
+  ]
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — mining complete |
+| 1 | Operational error — `gh` missing, auth failure, no PRs found |
+| 2 | Gate fails (reserved; currently unused by this tool) |
+
+## Requirements
+
+- `gh` CLI must be installed and authenticated (`gh auth login`)
+- Node.js ≥ 18
+
+## ADLC relationship
+
+- **Phase served:** C13 — institutionalizing "no"s before they become queue delays
+- **Sister tools:** `skill-mining` (mines code patterns), `lesson-foundry` (mines prosecution findings)
+- **Feeds into:** `adversarial-review` (prosecution lenses become review angles), `gate-manifest` (C11)
+
+## Core gaps
+
+None. All required functionality (LLM, CLI, exit codes) is available in `@adlc/core`.
+
+## Architecture
+
+```
+lib/
+  gh.mjs       — gh CLI boundary (injectable for testing)
+  signal.mjs   — negative-signal regex filter and body extraction
+  cluster.mjs  — normalizeBody, jaccard, clusterSignals, deriveSlug
+  mine.mjs     — fetchSignals, buildClusters (pipeline orchestration)
+  lens.mjs     — renderLensFile, planLensEmissions (pure rendering)
+  llm.mjs      — LLM prompt building and refinement
+  report.mjs   — human table and JSON output
+bin/
+  rejection-mining.mjs  — thin CLI entry point
+test/
+  signal.test.mjs   — signal filter positive + negative fixtures
+  cluster.test.mjs  — normalizeBody, jaccard, clustering
+  lens.test.mjs     — lens file rendering
+  mine.test.mjs     — full pipeline with fixture gh JSON (zero real gh calls)
+```

--- a/docs/tools/review-calibration.md
+++ b/docs/tools/review-calibration.md
@@ -1,0 +1,210 @@
+---
+title: review-calibration
+description: Documentation for the review-calibration tool in the ADLC toolkit.
+---
+
+# @adlc/review-calibration
+
+**ADLC phase: P5 Prosecute / Continuous calibration**
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P4["P4 Build"] --> P5["P5 Prosecute"]
+    P7["P7 Distill"] --> Calib["Continuous Calibration"]
+    Calib -.-> P5
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+    style Calib fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Measures reviewer recall via planted bugs. Turns "we do adversarial review"
+from a vibe into a number, exposes category-level blind spots, and re-runs on
+every model change — catching the silent regressions everyone currently absorbs
+unknowingly.
+
+This is mutation testing aimed at the *reviewer* instead of the code (ADLC C8).
+
+## How it works
+
+1. **Target files**: Files changed in `--commit` (`git diff-tree`) filtered to
+   non-test, non-config source code. Falls back to `--files` if the commit
+   touches no eligible files.
+2. **Plant selection**: `mutate.generateMutants` runs over each target file's
+   full content. Up to `--plants` mutants are selected by round-robining across
+   operators for coverage. Each plant carries a real bug **category** (off-by-one,
+   logic-inversion, null-handling, …) and a **defect** description. `--plants-file`
+   plants may also carry a **witness**.
+3. **Equivalent-mutant filter**: a plant with a witness must DISCRIMINATE
+   (pass on the original, fail on the mutant). Plants whose witness does not
+   discriminate are equivalent mutants — there is no bug to find, so they are
+   excluded from the denominator rather than scored as missed.
+4. **Control self-test**: before scoring, two reference reviewers run — an
+   *echoer* (must score ~0) and an *oracle* (must score 1.0). If either is wrong
+   the scorer itself is broken and the tool exits 1. This bound is what makes the
+   recall number trustworthy.
+5. **Apply all plants**, **run `--review-cmd`** (`{base}` → commit ref), **restore**
+   (always, via `finally` + SIGINT handler).
+6. **Parse findings**: the reviewer's output is parsed as structured findings
+   (adversarial-review `--json` shape, or a weak prose fallback).
+7. **Score**: a plant is CAUGHT only when a finding LOCATES it (file + line ±3)
+   **AND** identifies the defect — verified behaviorally (a reviewer-supplied
+   `repro` that discriminates) or judged semantically by a cheap model. There is
+   **no string-match shortcut**: a reviewer that echoes changed lines scores ~0.
+   Recall = caught / valid plants. Precision = true / (true + spurious findings).
+8. **Gate**: Exit 2 if recall < `--min-recall` (or precision < `--min-precision`
+   when set); exit 0 otherwise. Exit 1 on operational error or a failed control.
+
+### Scorer modes (`--scorer`)
+
+- **`judge`** (default) — cheap-model semantic match. Requires an LLM provider
+  (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`). With no provider
+  the tool **fails closed** (exit 1) rather than emit an untrustworthy number.
+  A reviewer-supplied `repro` is verified behaviorally and bypasses the judge.
+- **`string`** — LEGACY location-only matching. Gameable by a reviewer that
+  echoes changed lines; prints a warning and is not a trustworthy recall number.
+  Provided only as an offline escape hatch.
+
+See `REDESIGN.md` for the full design and the rationale for each decision.
+
+## Safety
+
+- **Refuses to run on a dirty working tree** (opError, exit 1). Commit or stash first.
+- Files are **always restored** — `finally` block in the runner + SIGINT handler
+  in the CLI.
+- Exit codes from the review command: 0 and 2 are valid (pass / gate-fail).
+  Any other exit code is treated as a crash (opError, exit 1).
+
+## Usage
+
+```
+review-calibration --review-cmd "cmd with {base} placeholder" [options]
+```
+
+### Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--review-cmd <cmd>` | (required) | Shell command to run the reviewer. `{base}` is substituted with the commit ref. |
+| `--commit <ref>` | `HEAD` | Commit whose changed files are used as plant targets. |
+| `--plants <n>` | `8` | Number of bugs to plant. |
+| `--min-recall <f>` | `0.5` | Minimum recall fraction required to pass (0–1). |
+| `--files <list>` | — | Comma-separated fallback file list when commit has no eligible code files. |
+| `--json` | false | Machine-readable JSON output. |
+| `--help` | — | Show help. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Gate passes — recall ≥ `--min-recall` |
+| `1` | Operational error — dirty tree, no plants generatable, review command crashed (exit ∉ {0,2}), or bad arguments |
+| `2` | Gate fails — recall < `--min-recall` |
+
+## Examples
+
+**Basic calibration with adversarial-review:**
+```bash
+review-calibration \
+  --review-cmd "adversarial-review --base {base} --json" \
+  --commit HEAD \
+  --plants 8 \
+  --min-recall 0.6
+```
+
+**JSON output for orchestrators:**
+```bash
+review-calibration \
+  --review-cmd "my-reviewer {base}" \
+  --json
+```
+
+**Custom file fallback (when commit has no eligible source files):**
+```bash
+review-calibration \
+  --review-cmd "my-reviewer {base}" \
+  --commit HEAD \
+  --files "src/auth.mjs,src/api.mjs"
+```
+
+**Testing with a trivial fake reviewer (CI smoke test):**
+```bash
+review-calibration \
+  --review-cmd 'node -e "process.stdout.write(\"LGTM\\n\")"' \
+  --min-recall 0 \
+  --json
+```
+
+## JSON output shape
+
+```json
+{
+  "recall": 0.625,
+  "caught": 5,
+  "total": 8,
+  "precision": 0.83,
+  "truePositives": 5,
+  "falsePositives": 1,
+  "minRecall": 0.5,
+  "minPrecision": null,
+  "gatePass": true,
+  "scorer": "judge",
+  "judgeAgreement": null,
+  "equivalentExcluded": 0,
+  "commit": "HEAD",
+  "reviewExitCode": 0,
+  "perCategory": {
+    "off-by-one":      { "caught": 2, "total": 2, "recall": 1.0 },
+    "logic-inversion": { "caught": 2, "total": 4, "recall": 0.5 },
+    "null-handling":   { "caught": 1, "total": 2, "recall": 0.5 }
+  },
+  "plants": [
+    {
+      "file": "src/auth.mjs",
+      "line": 42,
+      "category": "logic-inversion",
+      "operator": "invert-comparison",
+      "status": "caught",
+      "original": "  if (user.role === 'admin') {",
+      "mutated":  "  if (user.role !== 'admin') {"
+    }
+  ]
+}
+```
+
+`precision` is real: `truePositives / (truePositives + falsePositives)`, where a
+false positive is a finding that locates no plant (in a clean base + only-our-plants
+tree, nothing else is broken).
+
+## Scoring logic
+
+**Caught** — a plant is caught only when a finding does BOTH:
+1. **Locates** it — mentions the file's basename and a line within ±3.
+2. **Identifies** it — a reviewer-supplied `repro` discriminates the mutant from
+   the original (model-free), or a cheap-model judge confirms the finding
+   describes *this* defect.
+
+There is no "output contains a substring of the changed line" rule: that is
+exactly what let a line-echoing reviewer score 1.0. Echoing locates but does not
+identify, so it scores ~0 — enforced by the built-in echo control on every run.
+
+**Per-category recall** — the catch rate broken down by real bug category
+(off-by-one, logic-inversion, null-handling, …), so low recall on a category
+points at a specific reviewer blind spot.
+
+## Relationship to sibling tools
+
+| Tool | Role |
+|---|---|
+| `hollow-test` (C4) | Mutation testing aimed at tests — kills mutants via the test suite |
+| `review-calibration` (C8) | Mutation testing aimed at the reviewer — measures reviewer recall |
+| `adversarial-review` | The reviewer under test; wire its output to `--review-cmd` |
+| `gate-manifest` (C11) | Records the calibration score alongside each review verdict |
+
+## Core gaps
+
+None — all required functionality (`mutate.generateMutants`, `mutate.applyMutant`,
+`isDirty`, `isGitRepo`, `git`, `parseArgs`, `pass`, `gateFail`, `opError`,
+`printJson`) is available in `@adlc/core`.

--- a/docs/tools/runner.md
+++ b/docs/tools/runner.md
@@ -1,0 +1,64 @@
+---
+title: runner
+description: Documentation for the runner tool in the ADLC toolkit.
+---
+
+# @adlc/runner
+
+**ADLC Phase:** Execution supervision
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P0["P0 Triage"] --> P7["P7 Distill"]
+    Super["Execution Supervision (Runner)"] -.-> P0
+    Super -.-> P7
+    style Super fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Artifact-asserting phase runner for ADLC.
+
+## Usage
+
+```sh
+adlc run p5 --ticket T1 --dir .adlc --json
+adlc run p6 --ticket T1 --dir .adlc
+```
+
+The runner does not treat "a command ran" as a gate. It checks `.adlc/manifest.jsonl`
+for the evidence each phase requires. P3, P4, P5, and P6 evidence must be scoped to a
+ticket; `adlc run p3`, `adlc run p4`, `adlc run p5`, and `adlc run p6` fail operationally
+without `--ticket`.
+
+For normal git worktree use, omit `--revision`. P5 and P6 use the current content
+fingerprint and fail closed if reviewed content changes. Committing the exact content
+reviewed at P5 does not move the fingerprint; changing tracked content, ignored ADLC
+control files such as `.adlc/tickets.json`, or untracked non-artifact files after P5 makes
+P6 fail closed until P5 is re-run.
+
+Explicit `--revision` is an offline selector for recorded manifest and artifact evidence.
+When supplied, the runner verifies the matching manifest entries, transcript hashes, review
+packet hashes, ticket hash when available, and P6 packet/snapshot hashes without comparing
+against the live git worktree.
+
+Standard generated artifacts such as the active manifest/lock files, the exact packet path
+passed to `adlc accept --packet ...`, and any exact snapshot paths passed with
+`--before`/`--after` do not move the P6 fingerprint. In-worktree P6 packet and snapshot
+paths must live under `.adlc/` or `.omo/evidence/`; source paths are rejected before they
+can become fingerprint exclusions. The runner records hashes for the packet and snapshots
+and re-verifies them at `adlc run p6`, so accepted behavior evidence is tamper-evident even
+though its paths are excluded from the worktree fingerprint.
+
+## Exit codes
+
+- `0`: required phase artifacts are present
+- `1`: operational error
+- `2`: required phase artifacts are missing
+
+## ADLC phase
+
+Cross-phase. This package gives CI and Codex skills one stable command for asserting
+phase completion.

--- a/docs/tools/skill-rot.md
+++ b/docs/tools/skill-rot.md
@@ -1,0 +1,106 @@
+---
+title: skill-rot
+description: Documentation for the skill-rot tool in the ADLC toolkit.
+---
+
+# skill-rot
+
+**ADLC phase: P7 Distill**
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    G6{{"GATE: Human Acceptance"}} --> P7["P7 Distill"]
+    P7 -.-> P1["P1 Interrogate (Feedback)"]
+    style P7 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Skills are caches. `skill-rot` validates that the verifiable claims inside each
+`SKILL.md` file still hold against the current repository. Stale skills deliver
+misinformation with the authority of a cached expert — worse than no skill at
+all. Run weekly in CI to keep the skill corpus honest.
+
+## Usage
+
+```
+skill-rot [path ...] [--write] [--json]
+```
+
+Default search roots (searched only when they exist):
+- `.claude/skills`
+- `.agents/skills`
+- `skills`
+
+Pass one or more explicit path arguments to override the defaults.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--write` | When **all** claims in a skill are ok, upsert `last-verified: <YYYY-MM-DD>` into the skill's frontmatter (created if absent). Skills with stale claims are never stamped. |
+| `--json` | Machine-readable output for orchestrators. Prints a JSON object with `skills[]` and `summary`. |
+
+## What gets verified
+
+For each `SKILL.md` file found recursively (skipping `node_modules` and `.git`):
+
+1. **Commands** — backtick-enclosed spans and fenced code block lines whose
+   first token looks like a command name. Verified via:
+   - `./node_modules/.bin/<cmd>` presence, OR
+   - `sh -c 'command -v <cmd>'`
+
+   Placeholder tokens are skipped: `<ANGLE_BRACKETS>` and `UPPERCASE_VARS`
+   (3+ chars, all caps/underscores/digits) are never counted as stale.
+
+2. **File paths** — tokens containing `/` and a file extension (e.g.
+   `src/index.mjs`). Checked via `existsSync` from the repo root and from the
+   skill's own directory.
+
+3. **Script references** — `npm run X`, `npx X`, `pnpm X`, `yarn X` patterns.
+   Key `X` is looked up in `scripts` of the root `package.json`. If no
+   `package.json` exists, the claim is `unverifiable`.
+
+**Claim statuses:**
+- `ok` — verifiable and passes
+- `stale` — verifiable but fails (counts toward gate failure)
+- `unverifiable` — cannot determine truth (URLs, no `package.json`, ambiguous)
+
+Unverifiable claims are never counted as stale.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — all skills clean |
+| `1` | Operational error — no `SKILL.md` files found, bad input |
+| `2` | Gate fails — at least one skill has stale claims |
+
+## Examples
+
+```bash
+# Check defaults (.claude/skills, .agents/skills, skills)
+skill-rot
+
+# Check specific directories
+skill-rot .claude/skills .agents/skills
+
+# Stamp clean skills with today's date
+skill-rot --write
+
+# JSON output for CI integrations
+skill-rot --json
+```
+
+## Relationship to sibling tools
+
+- **lesson-foundry (C9)** — produces skills; `skill-rot` validates they stay fresh
+- **review-calibration (C8)** — calibrates review quality; `skill-rot` prevents outdated guidance corrupting that calibration loop
+- **gate-manifest (C11)** — can consume `skill-rot` exit code as a provenance signal
+
+## Core gaps
+
+None. This tool uses only Node 18+ built-ins and `@adlc/core` for CLI
+utilities (`parseArgs`, `pass`, `gateFail`, `opError`, `printJson`).

--- a/docs/tools/spec-lint.md
+++ b/docs/tools/spec-lint.md
@@ -1,0 +1,125 @@
+---
+title: spec-lint
+description: Documentation for the spec-lint tool in the ADLC toolkit.
+---
+
+# spec-lint
+
+**ADLC phase: P1 Interrogate**
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P0["P0 Triage"] --> P1["P1 Interrogate"]
+    P1 --> G1{{"GATE: Spec Approved"}}
+    G1 --> P2["P2 Decompose"]
+    style P1 fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+
+
+Audits a spec for acceptance criteria that lack a concrete verification method.
+Every acceptance criterion must name how it will be checked — a test file, a
+command whose output is asserted, an explicit `verify:` label, an `assert`
+statement, or an `exit code` reference. Criteria without one are **wishes**.
+Wishes get flagged at exit 2, blocking CI until the spec is tightened.
+
+## Usage
+
+```sh
+spec-lint <spec.md> [--llm] [--json] [--prompt-only]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--llm` | Run a cheap-tier LLM pass on VERIFIED criteria to catch vacuous methods ("works correctly", "run tests"). Demoted criteria become WISH. Requires a provider env var (see core). |
+| `--json` | Emit machine-readable JSON (for orchestrators). All other output is suppressed. |
+| `--prompt-only` | Print the exact LLM prompt and exit 0. Works with zero API keys — paste into any harness. |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Gate passes — all criteria are verified (or no criteria found; warns loudly). |
+| `1` | Operational error — file missing, unreadable, or LLM call failed. |
+| `2` | Gate fails — one or more criteria are wishes (line numbers printed). |
+
+## What counts as a verification method?
+
+A criterion is **VERIFIED** if its text contains any of:
+
+- A backtick command: `` `npm test` ``
+- A path matching `*.test.<ext>` or `*.spec.<ext>`: `auth.spec.ts`
+- `verify:` or `verified by` followed by text
+- `test:` followed by text
+- The phrase `exit code`
+- The word `assert`
+
+Everything else is a **WISH**.
+
+## Where criteria are found
+
+Criteria are extracted from:
+
+1. **List items** (`-`, `*`, `1.`, `- [ ]`, `- [x]`) under any heading matching
+   `/acceptance|criteria|requirements|definition of done|success/i`
+2. **Standalone lines** starting with `MUST` or `SHOULD` (anywhere in the file)
+
+## LLM demotion (--llm)
+
+Even VERIFIED criteria can be vacuous. "Run tests and verify it works correctly"
+contains a backtick command but conveys nothing checkable. The `--llm` flag sends
+VERIFIED criteria to a cheap model asking it to identify vacuous methods and
+returns a `{ vacuous: [indices], reason: {...} }` JSON object. Vacuous criteria
+are demoted to WISH.
+
+Use `--prompt-only` to get the exact prompt without making any API calls — useful
+for testing, auditing, or pasting into a different model.
+
+## JSON output
+
+```json
+{
+  "file": "spec.md",
+  "total": 5,
+  "verified": 3,
+  "wishes": 2,
+  "criteria": [
+    { "line": 8, "status": "VERIFIED", "text": "...", "reason": "..." },
+    { "line": 9, "status": "WISH",     "text": "...", "reason": "no verification method found" }
+  ]
+}
+```
+
+## Example
+
+```sh
+# Run gate — exit 2 if any wishes
+spec-lint docs/spec.md
+
+# Machine-readable for CI
+spec-lint docs/spec.md --json
+
+# Inspect LLM prompt without API key
+spec-lint docs/spec.md --prompt-only
+
+# Full LLM-backed demotion pass
+ANTHROPIC_API_KEY=sk-... spec-lint docs/spec.md --llm
+```
+
+## Relationship to sibling tools
+
+- **C2 premortem** — after spec-lint passes, stress-test the approved spec with a
+  frontier model (postmortem framing).
+- **C3 coldstart** — per-ticket gap analysis; spec-lint gates the spec, coldstart
+  gates individual tickets.
+- **C11 gate-manifest** — spec-lint results should be appended to the manifest
+  ledger after a gate run.
+
+## Core gaps
+
+None. All required functionality (`complete`, `extractJson`, `parseArgs`,
+`pass`, `gateFail`, `opError`, `printJson`, `promptOnly`) is present in core.

--- a/scripts/generate-tool-docs.mjs
+++ b/scripts/generate-tool-docs.mjs
@@ -1,0 +1,179 @@
+import fs from 'fs';
+import path from 'path';
+
+const packagesDir = 'packages';
+const docsToolsDir = 'docs/tools';
+
+const packages = fs.readdirSync(packagesDir).filter(p => fs.statSync(path.join(packagesDir, p)).isDirectory());
+
+const phaseMap = {
+  'behavior-diff': 'P6 Integrate',
+  'cli': 'Shared foundation',
+  'coldstart': 'P2 Decompose',
+  'consensus-fix': 'P4 Build',
+  'core': 'Shared foundation',
+  'flail-detector': 'P4 Build',
+  'gate-fuzzing': 'Continuous calibration',
+  'gate-manifest': 'P5/P6 Prosecute/Integrate',
+  'hollow-test': 'P3/P5 Rail/Prosecute',
+  'lesson-foundry': 'P7 Distill',
+  'merge-forecast': 'P2 Decompose',
+  'model-ratchet': 'Continuous calibration',
+  'model-router': 'P2 Decompose',
+  'parallax': 'P1/D3 Spec shaping',
+  'preflight': 'P0 Triage / Preflight',
+  'premortem': 'P1 Interrogate',
+  'prosecute': 'P5 Prosecute',
+  'rails-guard': 'P3 Rail',
+  'rejection-mining': 'P7 Distill',
+  'review-calibration': 'P5 Prosecute / Continuous calibration',
+  'runner': 'Execution supervision',
+  'skill-rot': 'P7 Distill',
+  'spec-lint': 'P1 Interrogate'
+};
+
+const mermaidDiagrams = {
+  'P0 Triage / Preflight': `\`\`\`mermaid
+flowchart TD
+    Req([Request]) --> P0{"P0 Triage"}
+    P0 --> P1["P1 Interrogate"]
+    P0 -.-> Preflight["Preflight (Baseline check)"]
+    style Preflight fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P1 Interrogate': `\`\`\`mermaid
+flowchart TD
+    P0["P0 Triage"] --> P1["P1 Interrogate"]
+    P1 --> G1{{"GATE: Spec Approved"}}
+    G1 --> P2["P2 Decompose"]
+    style P1 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P1/D3 Spec shaping': `\`\`\`mermaid
+flowchart TD
+    P0["P0 Triage"] --> P1["P1 Interrogate / Parallax"]
+    P1 --> G1{{"GATE: Spec Approved"}}
+    G1 --> P2["P2 Decompose"]
+    style P1 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P2 Decompose': `\`\`\`mermaid
+flowchart TD
+    G1{{"GATE: Spec Approved"}} --> P2["P2 Decompose"]
+    P2 --> G2{{"GATE: Coldstart Pass"}}
+    G2 --> P3["P3 Rail"]
+    style P2 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P3 Rail': `\`\`\`mermaid
+flowchart TD
+    G2{{"GATE: Coldstart Pass"}} --> P3["P3 Rail"]
+    P3 --> G3{{"GATE: Rails Frozen"}}
+    G3 --> P4["P4 Build"]
+    style P3 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P4 Build': `\`\`\`mermaid
+flowchart TD
+    G3{{"GATE: Rails Frozen"}} --> P4["P4 Build"]
+    P4 --> G4{{"GATE: Build Pass"}}
+    G4 --> P5["P5 Prosecute"]
+    style P4 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P5 Prosecute': `\`\`\`mermaid
+flowchart TD
+    G4{{"GATE: Build Pass"}} --> P5["P5 Prosecute"]
+    P5 --> G5{{"GATE: Zero Findings"}}
+    G5 --> P6["P6 Integrate"]
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P6 Integrate': `\`\`\`mermaid
+flowchart TD
+    G5{{"GATE: Zero Findings"}} --> P6["P6 Integrate"]
+    P6 --> G6{{"GATE: Human Acceptance"}}
+    G6 --> P7["P7 Distill"]
+    style P6 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P5/P6 Prosecute/Integrate': `\`\`\`mermaid
+flowchart TD
+    P4["P4 Build"] --> P5["P5 Prosecute"]
+    P5 --> P6["P6 Integrate"]
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+    style P6 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P3/P5 Rail/Prosecute': `\`\`\`mermaid
+flowchart TD
+    P3["P3 Rail"] --> P4["P4 Build"]
+    P4 --> P5["P5 Prosecute"]
+    style P3 fill:#f9f,stroke:#333,stroke-width:2px
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P7 Distill': `\`\`\`mermaid
+flowchart TD
+    G6{{"GATE: Human Acceptance"}} --> P7["P7 Distill"]
+    P7 -.-> P1["P1 Interrogate (Feedback)"]
+    style P7 fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'Continuous calibration': `\`\`\`mermaid
+flowchart TD
+    P7["P7 Distill"] --> Calib["Continuous Calibration"]
+    Calib -.-> P5["P5 Prosecute (Update Reviewers)"]
+    style Calib fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'Execution supervision': `\`\`\`mermaid
+flowchart TD
+    P0["P0 Triage"] --> P7["P7 Distill"]
+    Super["Execution Supervision (Runner)"] -.-> P0
+    Super -.-> P7
+    style Super fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'Shared foundation': `\`\`\`mermaid
+flowchart TD
+    Found["Shared Foundation (Core/CLI)"] -.-> P1["P1 Interrogate"]
+    Found -.-> P2["P2 Decompose"]
+    Found -.-> P3["P3 Rail"]
+    Found -.-> P4["P4 Build"]
+    Found -.-> P5["P5 Prosecute"]
+    Found -.-> P6["P6 Integrate"]
+    Found -.-> P7["P7 Distill"]
+    style Found fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``,
+  'P5 Prosecute / Continuous calibration': `\`\`\`mermaid
+flowchart TD
+    P4["P4 Build"] --> P5["P5 Prosecute"]
+    P7["P7 Distill"] --> Calib["Continuous Calibration"]
+    Calib -.-> P5
+    style P5 fill:#f9f,stroke:#333,stroke-width:2px
+    style Calib fill:#f9f,stroke:#333,stroke-width:2px
+\`\`\``
+};
+
+for (const pkg of packages) {
+  const readmePath = path.join(packagesDir, pkg, 'README.md');
+  if (!fs.existsSync(readmePath)) continue;
+
+  const content = fs.readFileSync(readmePath, 'utf-8');
+  const phase = phaseMap[pkg] || 'Unknown';
+  const diagram = mermaidDiagrams[phase] || '';
+
+  const frontmatter = `---
+title: ${pkg}
+description: Documentation for the ${pkg} tool in the ADLC toolkit.
+---
+
+`;
+
+  let newContent = frontmatter + content;
+
+  // Insert diagram under ADLC phase or at the top if ADLC phase section doesn't exist
+  if (diagram) {
+    const phaseMarker = '**ADLC phase:**';
+    const otherMarker = '**ADLC phase:';
+    if (newContent.includes(phaseMarker)) {
+        newContent = newContent.replace(phaseMarker, `**ADLC phase:** ${phase}\n\n### ADLC Lifecycle Context\n\n${diagram}\n\n`);
+    } else if (newContent.includes(otherMarker)) {
+        newContent = newContent.replace(/\*\*ADLC phase:.*?\*\*/i, `**ADLC phase: ${phase}**\n\n### ADLC Lifecycle Context\n\n${diagram}\n\n`);
+    } else {
+        newContent = newContent.replace(/# [^\n]+/, `$& \n\n**ADLC Phase:** ${phase}\n\n### ADLC Lifecycle Context\n\n${diagram}\n\n`);
+    }
+  }
+
+  const outputPath = path.join(docsToolsDir, `${pkg}.md`);
+  fs.writeFileSync(outputPath, newContent);
+  console.log(`Generated ${outputPath}`);
+}

--- a/scripts/update-toolkit.mjs
+++ b/scripts/update-toolkit.mjs
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+
+const toolkitPath = 'docs/toolkit.md';
+let content = fs.readFileSync(toolkitPath, 'utf-8');
+
+// Use regex to replace \`adlc tool\` with [\`adlc tool\`](./tools/tool.md)
+// This requires a bit of parsing since some are in table cells, some in text.
+// Or just globally replace \`adlc <tool>\` where <tool> is one of our known tools.
+
+const tools = [
+  'behavior-diff', 'cli', 'coldstart', 'consensus-fix', 'core', 'flail-detector',
+  'gate-fuzzing', 'gate-manifest', 'hollow-test', 'lesson-foundry', 'merge-forecast',
+  'model-ratchet', 'model-router', 'parallax', 'preflight', 'premortem', 'prosecute',
+  'rails-guard', 'rejection-mining', 'review-calibration', 'runner', 'skill-rot', 'spec-lint'
+];
+
+for (const tool of tools) {
+  // Replace `adlc tool`
+  const regex = new RegExp(`\\\`adlc ${tool}\\\``, 'g');
+  content = content.replace(regex, `[\`adlc ${tool}\`](./tools/${tool}.md)`);
+}
+
+fs.writeFileSync(toolkitPath, content);
+console.log('Updated docs/toolkit.md');


### PR DESCRIPTION
This commit builds out individual documentation files for each of the 23 ADLC tools inside `docs/tools/`. It adds a node script `scripts/generate-tool-docs.mjs` to auto-generate markdown files for each tool by reading their source `README.md` from `packages/`, appending frontmatter, specifying their ADLC phase, and embedding an explicit `mermaid.js` lifecycle visualization. Additionally, the commit updates `docs/toolkit.md` and `docs/package-reference.md` to link to these newly generated tool pages instead of referencing raw paths or plain text names.

---
*PR created automatically by Jules for task [10837604689307465616](https://jules.google.com/task/10837604689307465616) started by @voodootikigod*