### PR TITLE
🔒 Fix unhandled JSON.parse exceptions in gh.mjs

### DIFF
--- a/packages/rejection-mining/lib/gh.mjs
+++ b/packages/rejection-mining/lib/gh.mjs
@@ -54,7 +54,14 @@ export function fetchPRList(limit, ghRunner = runGh) {
     '--limit', String(limit),
     '--json', 'number,title',
   ]);
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw Object.assign(
+      new Error(`Failed to parse PR list: ${err.message}`),
+      { code: 'GH_PARSE_ERROR' }
+    );
+  }
 }
 
 /**
@@ -68,5 +75,12 @@ export function fetchPRDetail(prNumber, ghRunner = runGh) {
     'pr', 'view', String(prNumber),
     '--json', 'reviews,comments',
   ]);
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw Object.assign(
+      new Error(`Failed to parse PR detail for PR #${prNumber}: ${err.message}`),
+      { code: 'GH_PARSE_ERROR' }
+    );
+  }
 }

--- a/packages/rejection-mining/test/mine.test.mjs
+++ b/packages/rejection-mining/test/mine.test.mjs
@@ -104,6 +104,44 @@ test('fetchSignals: counts skipped PRs on fetch error', async () => {
   assert.strictEqual(signals.length, 0);
 });
 
+test('fetchSignals: counts skipped PRs on JSON parse error in detail', async () => {
+  const invalidJsonRunner = (args) => {
+    const key = args.join(',');
+    // PR list succeeds
+    if (key === 'pr,list,--state,all,--limit,10,--json,number,title') {
+      return JSON.stringify([{ number: 99, title: 'Bad JSON PR' }]);
+    }
+    // PR view returns invalid JSON
+    return 'Gateway Timeout 504';
+  };
+
+  const { signals, totalPRs, skippedPRs } = await fetchSignals({
+    limit: 10,
+    ghRunner: invalidJsonRunner,
+  });
+
+  assert.strictEqual(totalPRs, 1);
+  assert.strictEqual(skippedPRs, 1);
+  assert.strictEqual(signals.length, 0);
+});
+
+test('fetchPRList: throws GH_PARSE_ERROR on JSON parse error', async () => {
+  const invalidJsonRunner = (args) => {
+    // PR list returns invalid JSON
+    return 'Gateway Timeout 504';
+  };
+
+  try {
+    await fetchSignals({
+      limit: 10,
+      ghRunner: invalidJsonRunner,
+    });
+    assert.fail('Should have thrown an error');
+  } catch (err) {
+    assert.strictEqual(err.code, 'GH_PARSE_ERROR');
+  }
+});
+
 test('fetchSignals: empty PR list returns zero', async () => {
   const emptyRunner = (args) => {
     if (args.join(',').includes('pr,list')) return JSON.stringify([]);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an unhandled `JSON.parse` exception when parsing API responses from GitHub CLI in `packages/rejection-mining/lib/gh.mjs`.

⚠️ **Risk:** If the GitHub API returned an invalid JSON response (like an HTML error page during an outage or 504 Gateway Timeout), the application would crash due to the unhandled `SyntaxError` from `JSON.parse`. This could potentially be abused to cause Denial of Service (DoS) of the mining pipeline.

🛡️ **Solution:** The `JSON.parse(raw)` logic in both `fetchPRDetail` and `fetchPRList` has been wrapped in a `try/catch` block. On failure, it throws a custom `Error` with a standard `GH_PARSE_ERROR` code. This is handled cleanly upstream and allows the pipeline to skip failing records instead of crashing.

---
*PR created automatically by Jules for task [9840785416091093621](https://jules.google.com/task/9840785416091093621) started by @voodootikigod*