### PR TITLE
🔒 Fix unhandled JSON.parse in gate.mjs

### DIFF
--- a/packages/coldstart/lib/gate.mjs
+++ b/packages/coldstart/lib/gate.mjs
@@ -44,7 +44,12 @@ export function buildCheckTicket(completeFn, extractJsonFn) {
 export async function checkTicket(ticket) {
   const mockEnv = process.env.ADLC_GATE_MOCK_RESPONSE;
   if (mockEnv !== undefined && process.env.NODE_ENV === 'test') {
-    const parsed = JSON.parse(mockEnv);
+    let parsed = {};
+    try {
+      parsed = JSON.parse(mockEnv);
+    } catch (e) {
+      // Ignored: fallback to {}
+    }
     const gaps = Array.isArray(parsed?.gaps) ? parsed.gaps : [];
     return { id: ticket.id, gaps };
   }

--- a/packages/coldstart/test/coldstart.test.mjs
+++ b/packages/coldstart/test/coldstart.test.mjs
@@ -394,6 +394,31 @@ describe('gate checkTicket / checkAll (unit, no network)', () => {
     await assert.rejects(() => checkTicketWith(ticket), /network failure/);
   });
 
+  test('checkTicket handles invalid JSON in ADLC_GATE_MOCK_RESPONSE gracefully', async () => {
+    // Save original env
+    const origEnv = process.env.ADLC_GATE_MOCK_RESPONSE;
+    const origNodeEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'test';
+    process.env.ADLC_GATE_MOCK_RESPONSE = 'invalid json';
+
+    // Import the real checkTicket function for this test to trigger the mock branch
+    const { checkTicket } = await import('../lib/gate.mjs');
+
+    const ticket = { id: 'T_INVALID', title: 'Test invalid JSON' };
+    let result;
+    try {
+      result = await checkTicket(ticket);
+    } finally {
+      // Restore env
+      process.env.ADLC_GATE_MOCK_RESPONSE = origEnv;
+      process.env.NODE_ENV = origNodeEnv;
+    }
+
+    assert.equal(result.id, 'T_INVALID');
+    assert.deepEqual(result.gaps, []);
+  });
+
   test('checkAll runs checkTicket for every ticket in order', async () => {
     const responses = [
       { gaps: [] },


### PR DESCRIPTION
🎯 **What:** The `JSON.parse` call on the environment variable `ADLC_GATE_MOCK_RESPONSE` in `packages/coldstart/lib/gate.mjs` lacked error handling, making it susceptible to unhandled exceptions when invalid JSON was provided.

⚠️ **Risk:** An unhandled `JSON.parse` exception crashes the Node process. An attacker or faulty automated test could intentionally provide invalid JSON via `ADLC_GATE_MOCK_RESPONSE`, leading to Denial of Service (DoS) during tests or any environment pretending to be `NODE_ENV=test`.

🛡️ **Solution:** Wrapped the `JSON.parse` call in a `try...catch` block. If a parsing exception occurs, it safely falls back to `{}` (which results in `gaps` resolving to `[]`). Additionally, a new unit test was added to verify the graceful fallback behavior on invalid JSON strings.

---
*PR created automatically by Jules for task [16789311537742033568](https://jules.google.com/task/16789311537742033568) started by @voodootikigod*