### PR TITLE
chore: add .npmignore file to resolve npm install warning

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+.worktrees/
+.adlc/*
+!.adlc/tickets.example.json


### PR DESCRIPTION
Resolves a warning emitted by npm about a missing `.npmignore` file.

Steps taken:
1. Copied the contents of `.gitignore` into a new `.npmignore` file in the root repository.
2. Verified that `npm install` and `npm pack` no longer log a warning regarding `gitignore-fallback`.
3. Verified the tests still pass.

---
*PR created automatically by Jules for task [15946027825257024592](https://jules.google.com/task/15946027825257024592) started by @voodootikigod*