### PR TITLE
Harden Codex rail hook enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 node_modules/
 .worktrees/
-.omo/
+.omo/*
+!.omo/evidence/
+.omo/evidence/*
+!.omo/evidence/p5-review.txt
+!.omo/evidence/p5-prompt.txt
+!.omo/evidence/p5-inputs.txt
 .adlc/*
 !.adlc/tickets.example.json

--- a/.omo/evidence/p5-inputs.txt
+++ b/.omo/evidence/p5-inputs.txt
@@ -1,0 +1,3 @@
+Input packet for ticket T1 at revision docs-example-revision.
+Includes docs/examples/p5-passes.json plus repository context for the bundled
+prosecution example. The clean worktree revision marker is docs-example-revision.

--- a/.omo/evidence/p5-prompt.txt
+++ b/.omo/evidence/p5-prompt.txt
@@ -1,0 +1,3 @@
+Review ticket T1 at revision docs-example-revision with the bundled docs fixture.
+Assess security, correctness, tests, and behavior. Record any findings with evidence,
+then mark findings killed only when the verification evidence refutes the claim.

--- a/.omo/evidence/p5-review.txt
+++ b/.omo/evidence/p5-review.txt
@@ -1,0 +1,7 @@
+ticket: T1
+reviewed revision: docs-example-revision
+
+Bundled docs fixture adversarial review transcript. The reviewer checked the security,
+correctness, tests, and behavior lenses for the docs example packet. One medium
+security finding was recorded and then killed after tracing it to an unreachable test
+fixture. No verified findings remained for the final dry lenses.

--- a/docs/examples/p5-passes.json
+++ b/docs/examples/p5-passes.json
@@ -8,9 +8,9 @@
   },
   "review_packet": {
     "prompt": ".omo/evidence/p5-prompt.txt",
-    "prompt_hash": "086ada917eb0c8ba6905d617447bfe472c2dd36bbf4daf37746ac25d24818b2a",
+    "prompt_hash": "4075a912d2a56950da9a76a02c91b2c73c61cbffacfb06d8607c88577423d6a7",
     "inputs": ".omo/evidence/p5-inputs.txt",
-    "inputs_hash": "9faa929a2253953619c4f281754b21859c8fef3135ec864ff450453fdfdcd26a",
+    "inputs_hash": "93d4727a3f1ab2746104ef0d3a6238a6422dca1622cc62882c84f25e01f61df4",
     "clean_worktree": "docs-example-revision"
   },
   "no_findings_attestation": {

--- a/packages/runner/test/codex-integration.test.mjs
+++ b/packages/runner/test/codex-integration.test.mjs
@@ -274,6 +274,83 @@ describe('adlc rails hook', () => {
     assert.match(result.stderr, /blocked rail edit/);
   });
 
+  it('blocks edits to the ticket trust root while rails are active', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: .adlc/tickets.json',
+      '@@',
+      '-{"tickets":[]}',
+      '+{"tickets":[]}',
+      '*** End Patch',
+    ].join('\n');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'apply_patch',
+        tool_input: { command: patch },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks nested edits from Codex multi_tool_use wrapper payloads', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: test/a.test.mjs',
+      '@@',
+      '+test("rail", () => {});',
+      '*** End Patch',
+    ].join('\n');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'multi_tool_use.parallel',
+        tool_uses: [
+          {
+            recipient_name: 'functions.apply_patch',
+            parameters: { command: patch },
+          },
+        ],
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks nested shell writes from Codex multi_tool_use wrapper payloads', () => {
+    const dir = fixture();
+    mkdirSync(join(dir, 'test'), { recursive: true });
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'multi_tool_use.parallel',
+        tool_uses: [
+          {
+            recipient_name: 'functions.exec_command',
+            parameters: {
+              cmd: 'cat > a.test.mjs <<EOF\nchanged\nEOF',
+              workdir: join(dir, 'test'),
+            },
+          },
+        ],
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
   it('blocks shell-based writes to rail paths', () => {
     const dir = fixture();
     const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
@@ -288,6 +365,57 @@ describe('adlc rails hook', () => {
     });
     assert.equal(result.status, 2);
     assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks shell writes relative to a Codex command workdir', () => {
+    const dir = fixture();
+    mkdirSync(join(dir, 'test'), { recursive: true });
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'functions.exec_command',
+        tool_input: {
+          command: 'cat > a.test.mjs <<EOF\nchanged\nEOF',
+          workdir: join(dir, 'test'),
+        },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('fails closed on non-empty interactive shell stdin during active P4', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'functions.write_stdin',
+        tool_input: { chars: 'cat > test/a.test.mjs <<EOF\nchanged\nEOF\n' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /interactive shell stdin/);
+  });
+
+  it('allows empty interactive shell stdin polling during active P4', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'functions.write_stdin',
+        tool_input: { chars: '' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0);
   });
 
   it('blocks Python interpreter writes to rail paths', () => {
@@ -407,6 +535,7 @@ describe('adlc rails hook', () => {
     const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
     for (const command of [
       'truncate -s 0 test/a.test.mjs',
+      'cp src/a.mjs test',
       'rsync src/a.mjs test/a.test.mjs',
       'awk -i inplace \'{ print }\' test/a.test.mjs',
     ]) {
@@ -437,7 +566,45 @@ describe('adlc rails hook', () => {
       encoding: 'utf8',
     });
     assert.equal(result.status, 2);
-    assert.match(result.stderr, /known read-only command/);
+    assert.match(result.stderr, /blocked rail edit/);
+  });
+
+  it('blocks project-root destructive shell targets because they overlap every rail', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    for (const command of [
+      'find . -type f -delete',
+      'find .. -type f -delete',
+      'rm -rf .',
+    ]) {
+      const result = spawnSync(process.execPath, [hook], {
+        cwd: dir,
+        env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+        input: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command },
+        }),
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, 2, command);
+      assert.match(result.stderr, /blocked rail edit/, command);
+    }
+  });
+
+  it('fails closed on opaque shell mutators even when they mention a patch file', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    const result = spawnSync(process.execPath, [hook], {
+      cwd: dir,
+      env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+      input: JSON.stringify({
+        tool_name: 'functions.exec_command',
+        tool_input: { command: 'git apply /tmp/rail.patch' },
+      }),
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /opaque command/);
   });
 
   it('blocks sed write scripts to rail paths', () => {
@@ -469,7 +636,7 @@ describe('adlc rails hook', () => {
       encoding: 'utf8',
     });
     assert.equal(result.status, 2);
-    assert.match(result.stderr, /known read-only command/);
+    assert.match(result.stderr, /known read-only command nor a path-transparent mutation/);
   });
 
   it('allows read-only shell commands with no editable paths', () => {
@@ -485,6 +652,27 @@ describe('adlc rails hook', () => {
       encoding: 'utf8',
     });
     assert.equal(result.status, 0);
+  });
+
+  it('fails closed when allowlisted read-only shell commands use output options', () => {
+    const dir = fixture();
+    const hook = join(repoRoot, 'plugins/adlc-codex/hooks/adlc-rails-guard.mjs');
+    for (const command of [
+      'git diff --output=test/a.test.mjs',
+      'node --test --test-reporter-destination=test/a.test.mjs',
+    ]) {
+      const result = spawnSync(process.execPath, [hook], {
+        cwd: dir,
+        env: { ...process.env, ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' },
+        input: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command },
+        }),
+        encoding: 'utf8',
+      });
+      assert.equal(result.status, 2, command);
+      assert.match(result.stderr, /output option/, command);
+    }
   });
 
   it('allows required P4 gate and test commands with no editable paths', () => {

--- a/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
@@ -111,7 +111,7 @@ function collectCommandText(value, out = []) {
     return out;
   }
   for (const [key, child] of Object.entries(value)) {
-    if (['command', 'cmd', 'input', 'script'].includes(key) && typeof child === 'string') {
+    if (['command', 'cmd', 'input', 'script', 'chars'].includes(key) && typeof child === 'string') {
       out.push(child);
     } else {
       collectCommandText(child, out);
@@ -150,6 +150,10 @@ function looksPathLike(value) {
   );
 }
 
+function looksBarePathLike(value) {
+  return !value.startsWith('-') && !value.includes('=') && /^[A-Za-z0-9_./@+-]+$/.test(value);
+}
+
 function keyValuePath(value) {
   const match = value.match(/^(?:--?[A-Za-z0-9_-]+|[A-Za-z_][A-Za-z0-9_-]*)=(.+)$/);
   if (!match) return null;
@@ -161,13 +165,22 @@ function shellHasMutation(text) {
   return (
     /(^|[\s;&|])(?:>>?|[0-9]>>?|[0-9]>)\s*\S+/.test(text) ||
     /\b(?:tee|touch|rm|mv|cp|install|dd|truncate|rsync)\b/.test(text) ||
+    /\bgit\s+(?:apply|am|checkout|restore|reset|clean|merge|rebase|cherry-pick|stash|commit)\b/.test(text) ||
+    /\b(?:patch|tar|unzip)\b/.test(text) ||
     /\bfind\b[^;&|]*(?:-delete|-exec(?:dir)?\b|-ok(?:dir)?\b)/.test(text) ||
     /\b(?:sed|perl)\s+[^;&|]*-(?:i|p?i)\b/.test(text) ||
     /\bsed\b[^;&|]*(?:"[^"\n]*\bw\s+\S+[^"\n]*"|'[^'\n]*\bw\s+\S+[^'\n]*')/.test(text) ||
-    /\bawk\s+[^;&|]*\s-i(?:\s|=)/.test(text) ||
+    /\bawk\b[^;&|]*(?:\s-i(?:\s|=)|\s--in-place\b)/.test(text) ||
     /\b(?:node|python3?|ruby)\b[^;&|]*(?:writeFile|appendFile|rmSync|renameSync|copyFile|truncateSync|mkdirSync|write_text|write_bytes)/.test(text) ||
     /\bopen\s*\([^)]*,\s*['"][^'"]*[wax+][^'"]*['"]/.test(text) ||
     /\bFile\.(?:write|open)\b/.test(text)
+  );
+}
+
+function shellHasOpaqueMutation(text) {
+  return (
+    /\bgit\s+(?:apply|am|checkout|restore|reset|clean|merge|rebase|cherry-pick|stash|commit)\b/.test(text) ||
+    /\b(?:patch|tar|unzip)\b/.test(text)
   );
 }
 
@@ -177,6 +190,29 @@ function shellIsPositivelyReadOnly(text) {
     normalized === '' ||
     /^(?:git\s+(?:status|diff|show|log|rev-parse|branch|ls-files)\b|pwd\b|ls\b|rg\b|grep\b|cat\b|sed\s+-n\b|head\b|tail\b|wc\b|nl\b|node\s+(?:--check|--test)\b|npm\s+(?:test|run\s+test)\b|adlc\s+(?:hollow-test|rails-guard|flail-detector|preflight|run\s+p[34])\b)/.test(normalized)
   );
+}
+
+function shellHasWriteOption(text) {
+  return /\s--(?:output|output-file|test-reporter-destination|reporter-destination)(?:=|\s+)\S+/.test(text);
+}
+
+function firstShellWorkdir(value) {
+  if (!value || typeof value !== 'object') return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = firstShellWorkdir(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (['workdir', 'cwd', 'workingDirectory', 'working_directory'].includes(key) && typeof child === 'string') {
+      return child;
+    }
+    const found = firstShellWorkdir(child);
+    if (found) return found;
+  }
+  return null;
 }
 
 function shellChangesCwd(text) {
@@ -212,15 +248,42 @@ function collectShellPaths(text, out) {
     const path = keyValuePath(token);
     if (path) out.add(path);
     else if (looksPathLike(token)) out.add(token);
+    else if (looksBarePathLike(token)) out.add(token);
   }
 }
 
+function railMatchesPath(rail, path) {
+  if (path === '' || path === '.') return true;
+  if (path === '..' || path.startsWith('../')) return true;
+  if (globMatch(rail, path)) return true;
+  if (rail.endsWith('/**')) return path === rail.slice(0, -3);
+  return false;
+}
+
 function toolName(payload) {
-  return payload.tool_name ?? payload.toolName ?? payload.tool ?? payload.name ?? '';
+  return payload.tool_name ?? payload.toolName ?? payload.tool ?? payload.name ?? payload.recipient_name ?? '';
 }
 
 function isShellToolName(name) {
-  return /(^|\.)(bash|shell|exec|exec_command|run_command)$/i.test(String(name));
+  return /(^|\.)(bash|shell|exec|exec_command|run_command|write_stdin)$/i.test(String(name));
+}
+
+function collectShellInvocations(value, out = []) {
+  if (!value || typeof value !== 'object') return out;
+  if (Array.isArray(value)) {
+    for (const item of value) collectShellInvocations(item, out);
+    return out;
+  }
+  if (isShellToolName(toolName(value))) {
+    const name = String(toolName(value));
+    const workdir = firstShellWorkdir(value);
+    for (const commandText of collectCommandText(value)) {
+      out.push({ commandText, workdir, name });
+    }
+    return out;
+  }
+  for (const child of Object.values(value)) collectShellInvocations(child, out);
+  return out;
 }
 
 async function stdinText() {
@@ -243,6 +306,13 @@ function resolveActiveTicketId() {
   return envTicket ?? fileTicket;
 }
 
+function normalizePath(path, baseCwd = process.cwd()) {
+  const normalized = path.replaceAll('\\', '/');
+  const absolute = isAbsolute(normalized) ? normalized : resolve(baseCwd, normalized);
+  const projectRelative = relative(process.cwd(), absolute).replaceAll('\\', '/');
+  return projectRelative.startsWith('..') ? normalized : projectRelative;
+}
+
 if (process.env.ADLC_P4_ENFORCEMENT !== '1') {
   notice('P4 rail hook inactive');
   process.exit(0);
@@ -255,8 +325,10 @@ const tickets = loadTickets(process.env.ADLC_TICKETS ?? '.adlc/tickets.json');
 
 const ticket = tickets.find((t) => t.id === ticketId);
 if (!ticket) fail(`unknown active ticket: ${ticketId}`);
-const rails = ticket.rails ?? [];
-if (rails.length === 0) fail(`ticket ${ticketId} has no rails`);
+const ticketsPath = process.env.ADLC_TICKETS ?? '.adlc/tickets.json';
+const declaredRails = ticket.rails ?? [];
+if (declaredRails.length === 0) fail(`ticket ${ticketId} has no rails`);
+const rails = [...declaredRails, normalizePath(ticketsPath), '.adlc/current-ticket.json'];
 
 let payload = {};
 const raw = await stdinText();
@@ -268,25 +340,43 @@ if (raw.trim()) {
   }
 }
 
-function normalizePath(path) {
-  const normalized = path.replaceAll('\\', '/');
-  const absolute = isAbsolute(normalized) ? normalized : resolve(process.cwd(), normalized);
-  const projectRelative = relative(process.cwd(), absolute).replaceAll('\\', '/');
-  return projectRelative.startsWith('..') ? normalized : projectRelative;
-}
-
 const rawPaths = collectPaths(payload);
-const shellTool = isShellToolName(toolName(payload));
+const paths = Array.from(rawPaths).map((path) => normalizePath(path));
+const shellInvocations = collectShellInvocations(payload);
+const shellTool = shellInvocations.length > 0;
 let shellMutating = false;
 let cwdChangingShellMutation = false;
 let expandingShellMutation = false;
-const commandTexts = shellTool ? collectCommandText(payload) : [];
 if (shellTool) {
-  for (const commandText of commandTexts) {
-    if (shellHasMutation(commandText)) shellMutating = true;
-    if (shellHasMutation(commandText) && shellChangesCwd(commandText)) cwdChangingShellMutation = true;
-    if (shellHasMutation(commandText) && shellHasExpansion(commandText)) expandingShellMutation = true;
-    collectShellPaths(commandText, rawPaths);
+  for (const { commandText, workdir, name } of shellInvocations) {
+    if (/(^|\.)write_stdin$/i.test(name)) {
+      if (commandText.trim() === '') continue;
+      fail('interactive shell stdin payload cannot be verified during active P4');
+    }
+    const commandMutating = shellHasMutation(commandText);
+    if (!commandMutating && shellIsPositivelyReadOnly(commandText)) {
+      if (shellHasWriteOption(commandText)) {
+        fail('read-only shell payload uses an output option; use a structured edit tool or literal path-transparent mutation');
+      }
+      continue;
+    }
+
+    if (!commandMutating) {
+      fail('shell payload is neither a known read-only command nor a path-transparent mutation');
+    }
+    if (shellHasOpaqueMutation(commandText)) {
+      fail('mutating shell payload uses an opaque command; use a structured edit tool or literal path-transparent mutation');
+    }
+    shellMutating = true;
+    if (shellChangesCwd(commandText)) cwdChangingShellMutation = true;
+    if (shellHasExpansion(commandText)) expandingShellMutation = true;
+    const commandPaths = new Set();
+    collectShellPaths(commandText, commandPaths);
+    if (commandPaths.size === 0) {
+      fail('mutating shell payload did not include literal editable paths');
+    }
+    const shellBaseCwd = workdir ? resolve(process.cwd(), workdir) : process.cwd();
+    for (const path of commandPaths) paths.push(normalizePath(path, shellBaseCwd));
   }
 }
 
@@ -297,15 +387,14 @@ if (expandingShellMutation) {
   fail('mutating shell payload uses shell expansion; use a structured edit tool or literal project-relative shell target paths');
 }
 
-const paths = Array.from(rawPaths).map(normalizePath);
 if (paths.length === 0) {
-  if (shellTool && !shellMutating && commandTexts.length > 0 && commandTexts.every(shellIsPositivelyReadOnly)) {
+  if (shellTool && !shellMutating && shellInvocations.length > 0 && shellInvocations.every(({ commandText }) => shellIsPositivelyReadOnly(commandText))) {
     notice('shell command has no editable rail targets');
     process.exit(0);
   }
   fail(shellTool ? 'shell payload did not include literal editable paths or a known read-only command' : 'active hook payload did not include any editable paths');
 }
-const blocked = paths.filter((path) => rails.some((rail) => globMatch(rail, path)));
+const blocked = paths.filter((path) => rails.some((rail) => railMatchesPath(rail, path)));
 if (blocked.length > 0) fail(`blocked rail edit for ${ticketId}: ${blocked.join(', ')}`);
 
 process.exit(0);

--- a/plugins/adlc-codex/hooks/hooks.json
+++ b/plugins/adlc-codex/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "^(apply_patch|functions\\.apply_patch|write|Write|edit|Edit|multi_edit|multiedit|MultiEdit|Bash|bash|Shell|shell|exec|exec_command|run_command|functions\\.exec_command)$",
+        "matcher": "^(apply_patch|functions\\.apply_patch|write|Write|edit|Edit|multi_edit|multiedit|MultiEdit|Bash|bash|Shell|shell|exec|exec_command|run_command|functions\\.exec_command|write_stdin|functions\\.write_stdin|multi_tool_use\\.parallel)$",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Protect Codex P4 rail trust roots (`.adlc/tickets.json`, `.adlc/current-ticket.json`) during active enforcement
- Harden shell payload handling for workdir-relative writes, nested `multi_tool_use` calls, `write_stdin`, opaque mutators, directory/root targets, and read-only output channels
- Add regression coverage for the reviewed Codex hook bypass cases

## Verification
- `node --test packages/runner/test/codex-integration.test.mjs`
- `node scripts/codex-install-smoke.mjs .`
- `ADLC_CODEX_LIVE_INSTALL=1 node scripts/codex-install-smoke.mjs .`