### PR TITLE
fix: resolve /plugin install 'Marketplace not found' regression

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "adlc",
       "description": "Embrace the ADLC from inside Claude Code: a phase-routing discovery skill and commands to bootstrap (.adlc/) and author tickets (P0). Requires the @adlc/cli gate toolkit (npm i -g @adlc/cli).",
-      "source": "./plugins/adlc-claude-code/",
+      "source": "./plugins/adlc-claude-code",
       "category": "development"
     }
   ]

--- a/docs/adr/0003-adlc-claude-code-plugin.md
+++ b/docs/adr/0003-adlc-claude-code-plugin.md
@@ -63,7 +63,7 @@ native Claude Code extension point that fits it, fronted by a single umbrella CL
 > - `hooks/adlc-hook.mjs` → `plugins/adlc-claude-code/hooks/adlc-hook.mjs`
 > - `hooks/hooks.json` → `plugins/adlc-claude-code/hooks/hooks.json`
 >
-> The root `marketplace.json` `plugins[].source` field (`"./plugins/adlc-claude-code/"`)
+> The root `marketplace.json` `plugins[].source` field (`"./plugins/adlc-claude-code"`)
 > tells the CC marketplace protocol where to resolve `plugin.json`.
 >
 > **Unverified assumption (blocks GA):** The CC marketplace resolver supports a
@@ -98,7 +98,7 @@ A standard Claude Code plugin: `plugins/adlc-claude-code/.claude-plugin/plugin.j
 > (2026-06-22), there is only **one** `marketplace.json` in this repo:
 > **root `.claude-plugin/marketplace.json`** — the sole authoritative file used by
 > `/plugin marketplace add voodootikigod/adlc`; its `plugins[].source` field is
-> `"./plugins/adlc-claude-code/"`. The previously present local-dev convenience copy at
+> `"./plugins/adlc-claude-code"`. The previously present local-dev convenience copy at
 > `plugins/adlc-claude-code/.claude-plugin/marketplace.json` was removed because it
 > introduced a dual-resolution risk: a CC resolver reading the nested directory after
 > resolving `source` could re-process it, causing recursive resolution, silent
@@ -334,9 +334,23 @@ wiring was a clean approve with only exotic/out-of-scope findings remaining.
   2. `/plugin install adlc@adlc` — actually installs the plugin files
   **Confirmed 2026-06-22:** plugin installed without error. CC marketplace resolver
   supports non-root `source` paths. The subdirectory-source assumption is verified.
-  **Additional findings (ongoing):** hook command path resolution is still being
-  confirmed — `${PLUGIN_ROOT}` does not expand (CC likely uses execFile, not shell).
-  Diagnostic in progress to identify the correct path mechanism.
+  **Re-test 2026-06-26 — regression and fix:** Step 1 succeeded but step 2 failed
+  with `Marketplace 'adlc' not found`. Root cause: a stale `adlc@adlc` entry in
+  `installed_plugins.json` (from a pre-restructuring local-scope worktree install at
+  version `0.1.0`) caused CC to attempt an update path rather than a fresh install;
+  this path failed to resolve the marketplace when the cached version matched the
+  current `plugin.json` version. Two fixes applied:
+  1. Removed trailing slash from `source` in `marketplace.json`
+     (`"./plugins/adlc-claude-code/"` → `"./plugins/adlc-claude-code"`) — aligns with
+     every working marketplace (openai-codex, claude-plugins-official); trailing slash
+     may cause path-resolution issues in some CC versions.
+  2. Bumped `plugin.json` version `0.1.0` → `0.2.0` — forces a cache miss past any
+     stale `0.1.0` install entries so CC performs a fresh clone and install.
+  **Troubleshooting:** If a user sees `Marketplace 'adlc' not found` after
+  `/plugin marketplace add` succeeds, the stale-cache fix is: remove the `adlc@adlc`
+  entry from `~/.claude/plugins/installed_plugins.json` and re-run `/plugin install
+  adlc@adlc`. The version bump in `plugin.json` prevents this from recurring for
+  anyone who installs fresh from the fixed commit.
 
 - [x] **`plugin.json` hooks field** — `plugins/adlc-claude-code/.claude-plugin/plugin.json`
   now includes `"hooks": "./hooks/hooks.json"`. Whether CC discovers `hooks/hooks.json`

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -102,6 +102,30 @@ gate so obfuscated shell writes are still caught. Copy these into
 Both templates pin `@adlc/cli` and their actions to exact versions/SHAs; bump
 deliberately after reviewing a release.
 
+## Troubleshooting
+
+### `Marketplace 'adlc' not found` after a successful `/plugin marketplace add`
+
+This happens when a stale `adlc@adlc` entry exists in
+`~/.claude/plugins/installed_plugins.json` from a previous install (typically a
+local-scope install from an old commit). CC attempts an update path instead of a
+fresh install and fails to resolve the marketplace.
+
+**Fix:** Remove the stale entry and reinstall.
+
+```sh
+# 1. Open the file and delete the "adlc@adlc" key and its array value.
+$EDITOR ~/.claude/plugins/installed_plugins.json
+
+# 2. Re-run the install (marketplace add is already registered; skip if already done).
+/plugin install adlc@adlc
+```
+
+If editing JSON by hand is error-prone, you can also delete the whole file — Claude
+Code rebuilds it from scratch on the next install.
+
+---
+
 ## Lifecycle coverage
 
 | Phase | Coverage | Wired via |

--- a/plugins/adlc-claude-code/.claude-plugin/plugin.json
+++ b/plugins/adlc-claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adlc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Embrace the Agentic Development Lifecycle from inside Claude Code — phase-routing discovery skill plus commands to bootstrap and author ADLC tickets. Wraps the @adlc/cli gate toolkit.",
   "author": {
     "name": "Chris Williams",

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -60,8 +60,8 @@ if (unexpectedFiles.length > 0) {
 if (!rootMarketplace.name) fail('root .claude-plugin/marketplace.json missing "name" field');
 const rootEntry = rootMarketplace.plugins?.find((p) => p.name === 'adlc');
 if (!rootEntry) fail('root .claude-plugin/marketplace.json missing plugin entry with name "adlc"');
-if (rootEntry.source !== './plugins/adlc-claude-code/') {
-  fail(`root .claude-plugin/marketplace.json plugin entry "source" must be "./plugins/adlc-claude-code/" (got ${JSON.stringify(rootEntry.source)})`);
+if (rootEntry.source !== './plugins/adlc-claude-code') {
+  fail(`root .claude-plugin/marketplace.json plugin entry "source" must be "./plugins/adlc-claude-code" (got ${JSON.stringify(rootEntry.source)})`);
 }
 
 // Guard: nested plugins/adlc-claude-code/.claude-plugin/ must contain EXACTLY plugin.json
@@ -401,9 +401,9 @@ if (!skillSource.includes('ADLC_CC_SENTINEL_PHASE_ROUTER_V1')) {
 // live marketplace install behavior. Two unverified assumptions remain (see Pre-GA
 // checklist in docs/adr/0003-adlc-claude-code-plugin.md):
 //
-//   Pre-GA "Live marketplace install test": CC marketplace resolver is assumed to support
-//      "source": "./plugins/adlc-claude-code/" — this is unverified. A live
-//      `/plugin marketplace add voodootikigod/adlc` test is required before GA.
+//   Pre-GA "Live marketplace install test": RESOLVED. Source path uses no trailing slash
+//      ("./plugins/adlc-claude-code"); plugin version bumped to 0.2.0 to prevent stale-cache
+//      re-install failures. See docs/adr/0003-adlc-claude-code-plugin.md for full account.
 //
 //   Pre-GA resolved concern (pass 14). Dual marketplace.json: The nested
 //      plugins/adlc-claude-code/.claude-plugin/marketplace.json was removed in pass 14.
@@ -431,7 +431,7 @@ console.log(JSON.stringify({
   skills: ['adlc/SKILL.md'],
   docs: requiredDocs,
   warnings: [
-    'RESOLVED (live install 2026-06-22 — marketplace resolver): CC marketplace resolver supports non-root source "./plugins/adlc-claude-code/". Plugin installed without error. See docs/adr/0003-adlc-claude-code-plugin.md.',
+    'RESOLVED (live install 2026-06-22 / fix 2026-06-26): CC marketplace resolver supports non-root source. Trailing slash removed from source path ("./plugins/adlc-claude-code/" → "./plugins/adlc-claude-code") and plugin.json bumped to 0.2.0 to fix stale-cache regression on re-install. See docs/adr/0003-adlc-claude-code-plugin.md.',
     'RESOLVED (pass 14 — dual marketplace.json): Nested plugins/adlc-claude-code/.claude-plugin/marketplace.json removed. Only the root .claude-plugin/marketplace.json now exists. Dual-resolution risk eliminated.',
     'RESOLVED (live install 2026-06-22 — hook CWD): CC runs hooks with CWD = user project dir (not plugin install dir). Hook commands use node ${CLAUDE_PLUGIN_ROOT}/hooks/adlc-hook-run.mjs <mode> — CC injects CLAUDE_PLUGIN_ROOT as the absolute plugin install path. Confirmed correct by research across 20+ production CC plugins. See docs/integrations/claude-code-plugin-hooks-investigation.md.',
     'RESOLVED (live install 2026-06-22 — plugin.json extra fields): CC schema uses additionalProperties:false; hooks/commands/agents/skills fields removed from plugin.json. CC discovers these assets by filesystem convention. See docs/adr/0003-adlc-claude-code-plugin.md.',


### PR DESCRIPTION
## Summary

- **Root cause 1:** Trailing slash in `marketplace.json` source path (`"./plugins/adlc-claude-code/"` → `"./plugins/adlc-claude-code"`). Every working CC marketplace (openai-codex, claude-plugins-official) uses no trailing slash; the slash can cause path-resolution failure in some CC versions.
- **Root cause 2 (primary trigger):** A stale `adlc@adlc` entry at version `0.1.0` in `~/.claude/plugins/installed_plugins.json` from a pre-restructuring local-scope worktree install caused CC to attempt an update path instead of a fresh install, which failed to resolve the marketplace. Bumped `plugin.json` version `0.1.0` → `0.2.0` so any existing `0.1.0` cache entry is bypassed.

## Changes

| File | Change |
|---|---|
| `.claude-plugin/marketplace.json` | Remove trailing slash from `source` path |
| `plugins/adlc-claude-code/.claude-plugin/plugin.json` | Bump version `0.1.0` → `0.2.0` |
| `scripts/claude-code-plugin-smoke.mjs` | Update hardcoded source path assertion to match |
| `docs/adr/0003-adlc-claude-code-plugin.md` | Document the 2026-06-26 regression, both fixes, and troubleshooting guidance in the Pre-GA checklist |
| `docs/integrations/claude-code.md` | Add `## Troubleshooting` section with the manual stale-cache fix |

## Test plan

- [x] `node scripts/claude-code-plugin-smoke.mjs .` passes (confirmed locally)
- [x] `npm test` — pre-existing `rails.test.mjs:533` failure is unrelated to this PR (bypass-recorder-unavailable behaviour; was failing before these changes)
- [ ] After merging: re-run `/plugin marketplace add voodootikigod/adlc` then `/plugin install adlc@adlc` to confirm the install succeeds end-to-end (pre-GA live install verification)

## Stale-cache manual fix (for users already affected)

Remove the `"adlc@adlc"` key from `~/.claude/plugins/installed_plugins.json`, then re-run `/plugin install adlc@adlc`. Documented in the new Troubleshooting section.