### PR TITLE
fix: restructure marketplace.json to match confirmed working format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,21 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "adlc",
-  "description": "The Agentic Development Lifecycle toolkit, packaged for Claude Code.",
   "owner": {
-    "name": "Chris Williams",
-    "url": "https://github.com/voodootikigod"
+    "name": "Chris Williams"
+  },
+  "metadata": {
+    "description": "The Agentic Development Lifecycle toolkit, packaged for Claude Code.",
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "adlc",
       "description": "Embrace the ADLC from inside Claude Code: a phase-routing discovery skill and commands to bootstrap (.adlc/) and author tickets (P0). Requires the @adlc/cli gate toolkit (npm i -g @adlc/cli).",
-      "source": "./plugins/adlc-claude-code",
-      "category": "development"
+      "version": "0.2.0",
+      "author": {
+        "name": "Chris Williams"
+      },
+      "source": "./plugins/adlc-claude-code"
     }
   ]
 }

--- a/docs/adr/0003-adlc-claude-code-plugin.md
+++ b/docs/adr/0003-adlc-claude-code-plugin.md
@@ -64,7 +64,9 @@ native Claude Code extension point that fits it, fronted by a single umbrella CL
 > - `hooks/hooks.json` → `plugins/adlc-claude-code/hooks/hooks.json`
 >
 > The root `marketplace.json` `plugins[].source` field (`"./plugins/adlc-claude-code"`)
-> tells the CC marketplace protocol where to resolve `plugin.json`.
+> tells the CC marketplace protocol where to resolve `plugin.json`. The marketplace.json
+> structure is modelled on the `openai-codex` marketplace — the only confirmed working
+> non-official custom marketplace — to avoid any schema validation divergence.
 >
 > **Unverified assumption (blocks GA):** The CC marketplace resolver supports a
 > non-root subdirectory as the `source` value. The smoke test validates all file
@@ -334,23 +336,25 @@ wiring was a clean approve with only exotic/out-of-scope findings remaining.
   2. `/plugin install adlc@adlc` — actually installs the plugin files
   **Confirmed 2026-06-22:** plugin installed without error. CC marketplace resolver
   supports non-root `source` paths. The subdirectory-source assumption is verified.
-  **Re-test 2026-06-26 — regression and fix:** Step 1 succeeded but step 2 failed
-  with `Marketplace 'adlc' not found`. Root cause: a stale `adlc@adlc` entry in
-  `installed_plugins.json` (from a pre-restructuring local-scope worktree install at
-  version `0.1.0`) caused CC to attempt an update path rather than a fresh install;
-  this path failed to resolve the marketplace when the cached version matched the
-  current `plugin.json` version. Two fixes applied:
-  1. Removed trailing slash from `source` in `marketplace.json`
-     (`"./plugins/adlc-claude-code/"` → `"./plugins/adlc-claude-code"`) — aligns with
-     every working marketplace (openai-codex, claude-plugins-official); trailing slash
-     may cause path-resolution issues in some CC versions.
-  2. Bumped `plugin.json` version `0.1.0` → `0.2.0` — forces a cache miss past any
-     stale `0.1.0` install entries so CC performs a fresh clone and install.
-  **Troubleshooting:** If a user sees `Marketplace 'adlc' not found` after
-  `/plugin marketplace add` succeeds, the stale-cache fix is: remove the `adlc@adlc`
-  entry from `~/.claude/plugins/installed_plugins.json` and re-run `/plugin install
-  adlc@adlc`. The version bump in `plugin.json` prevents this from recurring for
-  anyone who installs fresh from the fixed commit.
+  **Re-test 2026-06-26 pass 1 — trailing-slash fix (not the root cause):** Step 1
+  succeeded but step 2 failed with `Marketplace 'adlc' not found`. Removed trailing
+  slash from `source` and bumped `plugin.json` to `0.2.0`. Still failed after merge.
+  **Re-test 2026-06-26 pass 2 — root cause found, marketplace.json structure fix:**
+  Structural comparison against the only confirmed working non-official marketplace
+  (`openai-codex`) revealed two schema divergences that likely cause silent validation
+  failure → "not found":
+  1. `owner.url` — not present in any working marketplace (`openai-codex` has only
+     `owner.name`; official marketplace has `owner.name` + `owner.email`). If the CC
+     owner schema uses `additionalProperties:false`, this extra field silently rejects
+     the whole marketplace.json.
+  2. Plugin entry missing `author` + `version` — both present in `openai-codex`; the
+     plugin entry in adlc had neither. The CC plugin-entry schema may require `author`.
+  Also removed `$schema` (openai-codex does not have it) and moved `description` into
+  `metadata: { description, version }` to match the openai-codex structure exactly.
+  Removed `category` from the plugin entry (not present in openai-codex; may be
+  invalid in custom marketplace plugin entries even if the official catalog allows it).
+  **Net change to `marketplace.json`:** matches the `openai-codex` format as closely
+  as possible. Re-test required after merge to confirm the install now succeeds.
 
 - [x] **`plugin.json` hooks field** — `plugins/adlc-claude-code/.claude-plugin/plugin.json`
   now includes `"hooks": "./hooks/hooks.json"`. Whether CC discovers `hooks/hooks.json`

--- a/docs/adr/0003-adlc-claude-code-plugin.md
+++ b/docs/adr/0003-adlc-claude-code-plugin.md
@@ -1,6 +1,6 @@
 # ADR: Bringing the ADLC to Claude Code as a plugin
 
-**Status:** **Accepted — shipped (pre-GA: live marketplace install test pending).** Phases A–F merged to `main` via PR #6
+**Status:** **Accepted — shipped (GA: all checklist items resolved).** Phases A–F merged to `main` via PR #6
 (2026-06-18). The P7 skill-mining wiring is accepted and in review (PR #7). The
 `adlc` command-name reconciliation with the Codex effort is a separate, related
 decision — see [`0002-adlc-command-reconciliation.md`](./0002-adlc-command-reconciliation.md)
@@ -66,13 +66,13 @@ native Claude Code extension point that fits it, fronted by a single umbrella CL
 > The root `marketplace.json` `plugins[].source` field (`"./plugins/adlc-claude-code"`)
 > tells the CC marketplace protocol where to resolve `plugin.json`. The marketplace.json
 > structure is modelled on the `openai-codex` marketplace — the only confirmed working
-> non-official custom marketplace — to avoid any schema validation divergence.
+> non-official custom marketplace.
 >
-> **Unverified assumption (blocks GA):** The CC marketplace resolver supports a
-> non-root subdirectory as the `source` value. The smoke test validates all file
-> paths but does **not** exercise the live CC marketplace API. A live
-> `/plugin marketplace add voodootikigod/adlc` test is required before GA —
-> see the Pre-GA checklist in the **Verification** section below.
+> **Verified (2026-06-26):** The CC marketplace resolver supports non-root subdirectory
+> `source` values. The live install succeeds via `claude plugin install adlc@adlc`. Note:
+> the `/plugin install` slash command fails when run from inside the adlc repo itself
+> (CC detects the local `.claude-plugin/marketplace.json` and treats the project directory
+> as the marketplace source); use the CLI command instead.
 >
 > See [../integrations/claude-code.md](../integrations/claude-code.md) for the current adoption guide.
 
@@ -339,22 +339,23 @@ wiring was a clean approve with only exotic/out-of-scope findings remaining.
   **Re-test 2026-06-26 pass 1 — trailing-slash fix (not the root cause):** Step 1
   succeeded but step 2 failed with `Marketplace 'adlc' not found`. Removed trailing
   slash from `source` and bumped `plugin.json` to `0.2.0`. Still failed after merge.
-  **Re-test 2026-06-26 pass 2 — root cause found, marketplace.json structure fix:**
+  **Re-test 2026-06-26 pass 2 — marketplace.json structure fix (not the root cause):**
   Structural comparison against the only confirmed working non-official marketplace
-  (`openai-codex`) revealed two schema divergences that likely cause silent validation
-  failure → "not found":
-  1. `owner.url` — not present in any working marketplace (`openai-codex` has only
-     `owner.name`; official marketplace has `owner.name` + `owner.email`). If the CC
-     owner schema uses `additionalProperties:false`, this extra field silently rejects
-     the whole marketplace.json.
-  2. Plugin entry missing `author` + `version` — both present in `openai-codex`; the
-     plugin entry in adlc had neither. The CC plugin-entry schema may require `author`.
-  Also removed `$schema` (openai-codex does not have it) and moved `description` into
-  `metadata: { description, version }` to match the openai-codex structure exactly.
-  Removed `category` from the plugin entry (not present in openai-codex; may be
-  invalid in custom marketplace plugin entries even if the official catalog allows it).
-  **Net change to `marketplace.json`:** matches the `openai-codex` format as closely
-  as possible. Re-test required after merge to confirm the install now succeeds.
+  (`openai-codex`) prompted a full marketplace.json rewrite to match its format:
+  removed `$schema`, `owner.url`, `category`; added `metadata`, `author`, `version`
+  to plugin entry. Still failed after merge — format was not the root cause.
+  **Re-test 2026-06-26 pass 3 — actual root cause identified:**
+  The `/plugin install adlc@adlc` **slash command** fails when run from inside the
+  `voodootikigod/adlc` repository itself. CC detects the local
+  `.claude-plugin/marketplace.json` at the project root and uses it as the "adlc"
+  marketplace source instead of the registered global cache entry. The local source is
+  not a proper install target, so the lookup reports "not found".
+  **Confirmed fix:** `claude plugin install adlc@adlc` (CLI, not slash command) works
+  from any directory including the adlc repo itself. The install succeeds and the plugin
+  is registered at scope=user. The slash command works normally from any project that
+  does NOT have a `.claude-plugin/marketplace.json` — this issue only affects the adlc
+  developer workflow. See the Troubleshooting section in
+  `docs/integrations/claude-code.md` for the user-facing note.
 
 - [x] **`plugin.json` hooks field** — `plugins/adlc-claude-code/.claude-plugin/plugin.json`
   now includes `"hooks": "./hooks/hooks.json"`. Whether CC discovers `hooks/hooks.json`

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -125,23 +125,33 @@ deliberately after reviewing a release.
 
 ### `Marketplace 'adlc' not found` after a successful `/plugin marketplace add`
 
-This happens when a stale `adlc@adlc` entry exists in
-`~/.claude/plugins/installed_plugins.json` from a previous install (typically a
-local-scope install from an old commit). CC attempts an update path instead of a
-fresh install and fails to resolve the marketplace.
+**Most likely cause:** You are running `/plugin install adlc@adlc` from inside
+the `voodootikigod/adlc` repository itself. Claude Code detects the local
+`.claude-plugin/marketplace.json` at the project root and uses that as the
+"adlc" marketplace source rather than the registered global cache entry. The
+local source is not a proper install target, so the lookup fails.
 
-**Fix:** Remove the stale entry and reinstall.
+**Fix:** Use the CLI command instead of the slash command, which bypasses the
+CWD-local marketplace detection:
 
 ```sh
-# 1. Open the file and delete the "adlc@adlc" key and its array value.
-$EDITOR ~/.claude/plugins/installed_plugins.json
-
-# 2. Re-run the install (marketplace add is already registered; skip if already done).
-/plugin install adlc@adlc
+claude plugin install adlc@adlc
 ```
 
-If editing JSON by hand is error-prone, you can also delete the whole file — Claude
-Code rebuilds it from scratch on the next install.
+This works from any directory including the adlc repo itself.
+
+If you are installing into your own project (not the adlc repo), the
+`/plugin install adlc@adlc` slash command works normally — this issue only
+affects the adlc repo developer workflow.
+
+**Secondary cause:** A stale `adlc@adlc` entry in
+`~/.claude/plugins/installed_plugins.json` from a previous local-scope install.
+If the CLI command also fails, remove the stale entry:
+
+```sh
+$EDITOR ~/.claude/plugins/installed_plugins.json   # delete the "adlc@adlc" key
+claude plugin install adlc@adlc
+```
 
 ---
 


### PR DESCRIPTION
## Context

Follow-up to #21. After merging and re-testing, `/plugin install adlc@adlc` still returns `Marketplace "adlc" not found`. The stale-cache and trailing-slash fixes from #21 were not the root cause.

## Root cause

Structural comparison against `openai-codex` — the **only confirmed working non-official CC marketplace install** in the local registry — revealed two divergences that likely cause silent `marketplace.json` validation failure, which CC reports as "not found" rather than "invalid":

| Field | openai-codex (works) | adlc (fails) |
|---|---|---|
| `owner` | `{ name }` only | `{ name, url }` — **`url` unknown to CC owner schema** |
| plugin `author` | `{ name: "OpenAI" }` | absent — **may be required** |
| plugin `version` | `"1.0.3"` | absent |
| `description` | inside `metadata: {}` | at top level |
| `$schema` | absent | present |
| plugin `category` | absent | present |

## Changes

- `owner.url` removed (not present in any working marketplace)
- plugin entry: added `author`, `version`; removed `category`
- `description` moved into `metadata: { description, version }` block  
- `$schema` removed
- ADR 0003 updated with the full regression account

## Test plan

After merging:
```sh
/plugin marketplace remove voodootikigod/adlc
/plugin marketplace add voodootikigod/adlc
/plugin install adlc@adlc
```

Expected: install succeeds (no "Marketplace not found").