### PR TITLE
docs: unify plugin install on the `plugins` npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,19 @@ the ADLC flow.
 This repo is also a Claude Code plugin — it makes the whole lifecycle usable from
 inside the editor (phase-routing skill, ticket/distill/maintain commands, a
 prosecutor subagent, and hooks that fire the gates automatically), with no API
-keys (Claude is the model via `--prompt-only`):
+keys (Claude is the model via `--prompt-only`).
+
+**Recommended:** install with [`plugins`](https://www.npmjs.com/package/plugins), the
+vendor-neutral installer that auto-detects your agent tools (Claude Code, Cursor) and
+installs the plugin into each:
+
+```sh
+npx plugins add voodootikigod/adlc   # install the plugin into your agent tool(s)
+npm install -g @adlc/cli             # the gate toolkit the plugin shells out to
+/adlc-init                           # bootstrap .adlc/ in your repo (once)
+```
+
+Already using Claude Code's native plugin marketplace? That path still works:
 
 ```sh
 npm install -g @adlc/cli
@@ -84,7 +96,7 @@ See **[docs/integrations/claude-code.md](./docs/integrations/claude-code.md)** f
 | `.claude/commands/` | Maintainer commands for this repo (release workflow) |
 | `scripts/` | Release, smoke test, and CI helper scripts (not published; run by `npm test` and CI) |
 | `.adlc/` | Runtime data directory (tickets, gate evidence — gitignored except example) |
-| `.claude-plugin/` | Repo-root marketplace manifest (`marketplace.json`) used by `/plugin marketplace add voodootikigod/adlc`. See [ADR 0003](./docs/adr/0003-adlc-claude-code-plugin.md) for the subdirectory-source assumption and Pre-GA checklist. |
+| `.claude-plugin/` | Repo-root marketplace manifest (`marketplace.json`) — the index `npx plugins add voodootikigod/adlc` (and the native `/plugin marketplace add voodootikigod/adlc`) read to resolve the plugin. See [ADR 0003](./docs/adr/0003-adlc-claude-code-plugin.md) for the subdirectory-source assumption and Pre-GA checklist. |
 
 ## Design principles
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -10,6 +10,25 @@ the right gate without you memorizing 20 tools.
 
 ## Install
 
+**Recommended.** Install with [`plugins`](https://www.npmjs.com/package/plugins) — the
+vendor-neutral installer that reads this repo's `marketplace.json`, translates the plugin
+into the target's native format, and installs it. It auto-detects your agent tools (Claude
+Code, Cursor) and installs into each, so the same one-liner works everywhere:
+
+```sh
+npx plugins add voodootikigod/adlc           # install the plugin into your agent tool(s)
+npm install -g @adlc/cli                     # the gate toolkit the plugin shells out to
+/adlc-init                                    # bootstrap .adlc/ in your repo (once)
+```
+
+The plugin's gates shell out to the `adlc` binary, so the `@adlc/cli` toolkit is a
+prerequisite either way — the `plugins` installer handles the plugin, not the toolkit.
+Pin a specific release with `npx plugins@<version> add …`; scope the install with
+`--scope user|project|local` (default `user`) and skip the prompt with `--yes`.
+
+**Alternative — native Claude Code marketplace.** If you'd rather use Claude Code's
+built-in plugin marketplace commands, they resolve the same `marketplace.json`:
+
 ```sh
 npm install -g @adlc/cli                     # the toolkit, behind one `adlc <tool>` command
 /plugin marketplace add voodootikigod/adlc   # register this repo as a marketplace


### PR DESCRIPTION
## Summary

Unifies the ADLC installation docs on [`plugins`](https://www.npmjs.com/package/plugins) (vercel-labs/plugins) — the vendor-neutral installer — as the **recommended** pathway, while keeping the native Claude Code marketplace flow as an explicit alternative. No install method was removed.

The headline command everywhere is now:

```sh
npx plugins add voodootikigod/adlc
```

## Changes

- **`README.md`** — "Use it in Claude Code" now leads with `npx plugins add voodootikigod/adlc` + `npm install -g @adlc/cli` + `/adlc-init`, with the native `/plugin marketplace add` → `/plugin install` flow kept below as "still works". The `.claude-plugin/` project-layout note now reflects both consumers of `marketplace.json`.
- **`docs/integrations/claude-code.md`** — Install section leads with the `plugins` installer (explains it reads the repo's `marketplace.json`, translates to the target's native format, auto-detects Claude Code / Cursor), documents the `@<version>` / `--scope` / `--yes` flags, and keeps the native marketplace commands as a labeled alternative.

## Correctness note

`plugins` installs **the plugin**, not **the toolkit**. The plugin's gates shell out to the `adlc` binary, so `npm install -g @adlc/cli` remains a prerequisite in both pathways — the docs state this explicitly rather than implying `npx plugins add` is sufficient alone.

## Deliberately untouched

- `docs/adr/0003-*` and `docs/integrations/claude-code-plugin-hooks-investigation.md` — historical decision/investigation records.
- `docs/archive/*` — explicitly archived.
- Package-level `@adlc/cli` / toolkit-prerequisite install mentions — those install the toolkit/packages, not the plugin.

## Test plan

- [ ] Render the two docs and confirm both blocks (recommended + alternative) read correctly.
- [ ] Confirm `npx plugins add voodootikigod/adlc` resolves the plugin once this lands on `main` (the installer clones the default branch and reads `.claude-plugin/marketplace.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)