### PR TITLE
test: make rails bypass recorder-unavailable test environment-robust

### DIFF
--- a/plugins/adlc-claude-code/hooks/test/rails.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/rails.test.mjs
@@ -516,7 +516,6 @@ for (const [name, json] of [
 const NODE_DIR = dirname(process.execPath);
 const REPO_BIN = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', 'node_modules', '.bin');
 const WITH_ADLC = `${REPO_BIN}:${NODE_DIR}:${process.env.PATH ?? ''}`; // recorder reachable
-const WITHOUT_ADLC = NODE_DIR; // node only — `adlc` not resolvable
 
 test('bypass on a rail WITH a working recorder → allow + audited entry', () => {
   const t = '{"tickets":[{"id":"T1","rails":["test/**"]}]}';
@@ -531,9 +530,21 @@ test('bypass on schema-invalid tickets WITH recorder → allow (audited)', () =>
 });
 
 test('bypass with the recorder UNAVAILABLE → deny (an unaudited override is refused)', () => {
-  const t = '{"tickets":[{"id":"T1","rails":["test/**"]}]}';
-  const r = runRails(t, 'test/x.mjs', { env: { ADLC_RAILS_BYPASS: '1', PATH: WITHOUT_ADLC } });
-  assert.equal(r.verdict, 'deny');
+  // Simulate an unreachable recorder with an EMPTY PATH dir. Pointing PATH at
+  // node's own directory is NOT sufficient: a globally-installed `adlc` lands
+  // alongside the node binary (npm global bins under fnm/nvm share node's dir),
+  // so it would still resolve there and the bypass would be (wrongly) audited.
+  // An empty dir guarantees `adlc` is off PATH regardless of where it is
+  // installed. The hook is launched via an absolute node path, so it needs
+  // nothing on PATH to run — only the recorder lookup is affected.
+  const noAdlcDir = mkdtempSync(join(tmpdir(), 'adlc-no-recorder-'));
+  try {
+    const t = '{"tickets":[{"id":"T1","rails":["test/**"]}]}';
+    const r = runRails(t, 'test/x.mjs', { env: { ADLC_RAILS_BYPASS: '1', PATH: noAdlcDir } });
+    assert.equal(r.verdict, 'deny');
+  } finally {
+    rmSync(noAdlcDir, { recursive: true, force: true });
+  }
 });
 
 test('bypass on a multi-file edit hitting two rails → allow + BOTH audited', () => {


### PR DESCRIPTION
## Summary

Fixes a pre-existing **false test failure** in `plugins/adlc-claude-code/hooks/test/rails.test.mjs` that reproduces on any dev machine with a global `@adlc/cli` install. `npm test` was red locally on `main`; CI was green.

## Root cause

The test *"bypass with the recorder UNAVAILABLE → deny (an unaudited override is refused)"* simulated an unreachable audit recorder by setting `PATH=NODE_DIR` (node's own directory), assuming that excludes the `adlc` binary.

That assumption breaks with a global install: npm places global bins **in the same directory as the `node` binary** (e.g. under fnm/nvm). So `adlc` stays resolvable via `NODE_DIR`, `recordBypass` succeeds, the bypass is (correctly, given a reachable recorder) audited, and the verdict is `allow` — but the test asserts `deny`. CI has no global install, so the recorder really is absent there and the test passed, masking the fragility.

Verified locally: `adlc` is a symlink right next to `node` at `…/v24.14.1/installation/bin/adlc`.

## Fix

Simulate the unavailable recorder with a **dedicated empty `PATH` directory** (created per-test, cleaned up in `finally`) so `adlc` is off `PATH` regardless of where it is installed. The hook is launched via an absolute node path, so it needs nothing on `PATH` to run — only the recorder lookup is affected. Removed the now-unused `WITHOUT_ADLC` constant.

**This is a test-harness fix only — no production/hook behavior changed.** The "unaudited bypass is refused" contract is unchanged.

## Verification

- `node --test …/rails.test.mjs` → 43/43 pass (was 42/43).
- **Load-bearing check (mutation):** replacing the `recordBypass` guard with `return true` (i.e. allowing an unaudited bypass) makes this test **fail** — confirming it still catches the regression it's meant to.
- Full `npm test` suite green end-to-end.

## Test plan

- [x] Rails suite passes locally
- [x] Mutation test confirms the assertion is load-bearing
- [x] Full suite green
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)