### PR TITLE
fix: sync package-lock to 1.1.0 + prevent release version drift

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -14,12 +14,14 @@ Release a new lockstep version of the `@adlc` suite (all 21 packages publish tog
    - Up to date with remote (`git pull --dry-run` shows no changes)
    - Tests pass (`npm test`)
 
-3. **Bump versions:** run `node scripts/release.mjs <NEW_VERSION>` (no `--publish`). This sets the new version across `@adlc/core` + all 19 phase CLIs + the `@adlc/cli` umbrella + the root, and repins **every** `"@adlc/*"` dependency (core *and* the 19 siblings that `@adlc/cli` depends on) to match. Do NOT hand-edit package.json files.
+3. **Bump versions:** run `node scripts/release.mjs <NEW_VERSION>` (no `--publish`). This sets the new version across `@adlc/core` + all 19 phase CLIs + the `@adlc/cli` umbrella, **every versioned `plugins/*` package** (e.g. `@adlc/pi-package`), and the root; repins **every** `"@adlc/*"` dependency to match (preserving each one's existing `^`/`~`/exact range style); and **regenerates `package-lock.json`** so the lockfile tracks the new versions. Do NOT hand-edit package.json or package-lock.json.
+   - The script then runs a **drift gate**: if any versioned `package.json`, the root, or `package-lock.json` is not at `<NEW_VERSION>`, it prints the offenders and exits non-zero. A non-zero exit means the release is incomplete — fix it before continuing, do not commit a partial bump. (This gate exists because v1.1.0 once shipped with `package-lock.json` stranded at 1.0.2 and `plugins/adlc-pi` missed entirely.)
 
-4. **Commit the version bump:**
+4. **Commit the version bump** — stage everything the script touched, including `package-lock.json` and every `package.json` (packages *and* plugins):
    ```
    chore: bump version to X.Y.Z
    ```
+   Sanity check before committing: `git status --porcelain` should show `package-lock.json` among the changes, and `npm ci` (or `node scripts/release.mjs X.Y.Z` re-run, which is idempotent) must report no drift.
 
 5. **Create the version tag:** `vX.Y.Z`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adlc",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adlc",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -126,10 +126,10 @@
     },
     "packages/behavior-diff": {
       "name": "@adlc/behavior-diff",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "behavior-diff": "bin/behavior-diff.mjs"
@@ -140,30 +140,30 @@
     },
     "packages/cli": {
       "name": "@adlc/cli",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/behavior-diff": "1.0.2",
-        "@adlc/coldstart": "1.0.2",
-        "@adlc/consensus-fix": "1.0.2",
-        "@adlc/flail-detector": "1.0.2",
-        "@adlc/gate-fuzzing": "1.0.2",
-        "@adlc/gate-manifest": "1.0.2",
-        "@adlc/hollow-test": "1.0.2",
-        "@adlc/lesson-foundry": "1.0.2",
-        "@adlc/merge-forecast": "1.0.2",
-        "@adlc/model-ratchet": "1.0.2",
-        "@adlc/model-router": "1.0.2",
-        "@adlc/parallax": "1.0.2",
-        "@adlc/preflight": "1.0.2",
-        "@adlc/premortem": "1.0.2",
-        "@adlc/prosecute": "1.0.2",
-        "@adlc/rails-guard": "1.0.2",
-        "@adlc/rejection-mining": "1.0.2",
-        "@adlc/review-calibration": "1.0.2",
-        "@adlc/runner": "1.0.2",
-        "@adlc/skill-rot": "1.0.2",
-        "@adlc/spec-lint": "1.0.2"
+        "@adlc/behavior-diff": "1.1.0",
+        "@adlc/coldstart": "1.1.0",
+        "@adlc/consensus-fix": "1.1.0",
+        "@adlc/flail-detector": "1.1.0",
+        "@adlc/gate-fuzzing": "1.1.0",
+        "@adlc/gate-manifest": "1.1.0",
+        "@adlc/hollow-test": "1.1.0",
+        "@adlc/lesson-foundry": "1.1.0",
+        "@adlc/merge-forecast": "1.1.0",
+        "@adlc/model-ratchet": "1.1.0",
+        "@adlc/model-router": "1.1.0",
+        "@adlc/parallax": "1.1.0",
+        "@adlc/preflight": "1.1.0",
+        "@adlc/premortem": "1.1.0",
+        "@adlc/prosecute": "1.1.0",
+        "@adlc/rails-guard": "1.1.0",
+        "@adlc/rejection-mining": "1.1.0",
+        "@adlc/review-calibration": "1.1.0",
+        "@adlc/runner": "1.1.0",
+        "@adlc/skill-rot": "1.1.0",
+        "@adlc/spec-lint": "1.1.0"
       },
       "bin": {
         "adlc": "bin/adlc.mjs"
@@ -174,10 +174,10 @@
     },
     "packages/coldstart": {
       "name": "@adlc/coldstart",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "coldstart": "bin/coldstart.mjs"
@@ -188,10 +188,10 @@
     },
     "packages/consensus-fix": {
       "name": "@adlc/consensus-fix",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "consensus-fix": "bin/consensus-fix.mjs"
@@ -202,7 +202,7 @@
     },
     "packages/core": {
       "name": "@adlc/core",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -210,10 +210,10 @@
     },
     "packages/flail-detector": {
       "name": "@adlc/flail-detector",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "flail-detector": "bin/flail-detector.mjs"
@@ -224,10 +224,10 @@
     },
     "packages/gate-fuzzing": {
       "name": "@adlc/gate-fuzzing",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "gate-fuzzing": "bin/gate-fuzzing.mjs"
@@ -238,10 +238,10 @@
     },
     "packages/gate-manifest": {
       "name": "@adlc/gate-manifest",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "gate-manifest": "bin/gate-manifest.mjs"
@@ -252,10 +252,10 @@
     },
     "packages/hollow-test": {
       "name": "@adlc/hollow-test",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "hollow-test": "bin/hollow-test.mjs"
@@ -266,10 +266,10 @@
     },
     "packages/lesson-foundry": {
       "name": "@adlc/lesson-foundry",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "lesson-foundry": "bin/lesson-foundry.mjs"
@@ -280,10 +280,10 @@
     },
     "packages/merge-forecast": {
       "name": "@adlc/merge-forecast",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "merge-forecast": "bin/merge-forecast.mjs"
@@ -294,10 +294,10 @@
     },
     "packages/model-ratchet": {
       "name": "@adlc/model-ratchet",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "model-ratchet": "bin/model-ratchet.mjs"
@@ -308,10 +308,10 @@
     },
     "packages/model-router": {
       "name": "@adlc/model-router",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "model-router": "bin/model-router.mjs"
@@ -322,10 +322,10 @@
     },
     "packages/parallax": {
       "name": "@adlc/parallax",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "parallax": "bin/parallax.mjs"
@@ -336,10 +336,10 @@
     },
     "packages/preflight": {
       "name": "@adlc/preflight",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "preflight": "bin/preflight.mjs"
@@ -350,10 +350,10 @@
     },
     "packages/premortem": {
       "name": "@adlc/premortem",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "premortem": "bin/premortem.mjs"
@@ -364,10 +364,10 @@
     },
     "packages/prosecute": {
       "name": "@adlc/prosecute",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "adlc-prosecute": "bin/adlc-prosecute.mjs"
@@ -378,10 +378,10 @@
     },
     "packages/rails-guard": {
       "name": "@adlc/rails-guard",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "rails-guard": "bin/rails-guard.mjs"
@@ -392,10 +392,10 @@
     },
     "packages/rejection-mining": {
       "name": "@adlc/rejection-mining",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "rejection-mining": "bin/rejection-mining.mjs"
@@ -406,10 +406,10 @@
     },
     "packages/review-calibration": {
       "name": "@adlc/review-calibration",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "review-calibration": "bin/review-calibration.mjs"
@@ -420,10 +420,10 @@
     },
     "packages/runner": {
       "name": "@adlc/runner",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "adlc-runner": "bin/adlc.mjs"
@@ -434,10 +434,10 @@
     },
     "packages/skill-rot": {
       "name": "@adlc/skill-rot",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "skill-rot": "bin/skill-rot.mjs"
@@ -448,10 +448,10 @@
     },
     "packages/spec-lint": {
       "name": "@adlc/spec-lint",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.0.2"
+        "@adlc/core": "1.1.0"
       },
       "bin": {
         "spec-lint": "bin/spec-lint.mjs"

--- a/plugins/adlc-pi/package.json
+++ b/plugins/adlc-pi/package.json
@@ -1,18 +1,22 @@
 {
   "name": "@adlc/pi-package",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "description": "ADLC integration for Pi terminal coding agent",
   "type": "module",
   "pi": {
-    "extensions": ["./index.ts"],
-    "skills": ["./skills/"]
+    "extensions": [
+      "./index.ts"
+    ],
+    "skills": [
+      "./skills/"
+    ]
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.79.0"
   },
   "dependencies": {
-    "@adlc/core": "^1.0.2",
-    "@adlc/rails-guard": "^1.0.2"
+    "@adlc/core": "^1.1.0",
+    "@adlc/rails-guard": "^1.1.0"
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -15,6 +15,7 @@ import { execFileSync } from 'node:child_process';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PKGS = join(ROOT, 'packages');
+const PLUGINS = join(ROOT, 'plugins');
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -22,6 +23,16 @@ function readJson(path) {
 
 function writeJson(path, value) {
   writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+}
+
+/**
+ * Regenerate package-lock.json so it tracks the freshly-bumped versions. Pure
+ * lockfile resolution (the suite is zero-dependency / workspace-only), so this is
+ * offline and fast. Injectable via the `regenerateLockfile` option so the unit
+ * tests can drive releaseMain without shelling out to npm.
+ */
+function defaultRegenerateLockfile(root) {
+  execFileSync('npm', ['install', '--package-lock-only'], { cwd: root, stdio: 'inherit' });
 }
 
 export function packagePublishOrder(names) {
@@ -38,7 +49,13 @@ export function repinInternalDependencies(pkg, version) {
   for (const dependencyKind of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
     if (!next[dependencyKind]) continue;
     for (const name of Object.keys(next[dependencyKind])) {
-      if (name.startsWith('@adlc/')) next[dependencyKind][name] = version;
+      if (!name.startsWith('@adlc/')) continue;
+      // Preserve the existing range style: packages/* pin exactly (`1.2.0`), but a
+      // consumer-style package (e.g. plugins/adlc-pi) may use `^`/`~` ranges —
+      // forcing those to exact would silently change its dependency intent.
+      const prev = next[dependencyKind][name];
+      const prefix = typeof prev === 'string' && /^[\^~]/.test(prev) ? prev[0] : '';
+      next[dependencyKind][name] = prefix + version;
     }
   }
   next.version = version;
@@ -49,7 +66,50 @@ function workspacePackageNames(packagesDir) {
   return readdirSync(packagesDir).filter((name) => existsSync(join(packagesDir, name, 'package.json')));
 }
 
-export function releaseMain(argv = process.argv.slice(2), { root = ROOT, packagesDir = PKGS } = {}) {
+/**
+ * Every versioned package.json in the suite: each `packages/*` AND each
+ * `plugins/*` that ships a package.json. Plugins without one (skill/command-only
+ * integrations like adlc-claude-code) are skipped. The root is handled separately.
+ */
+function versionedPackageJsonPaths({ packagesDir = PKGS, pluginsDir = PLUGINS } = {}) {
+  const paths = [];
+  for (const base of [packagesDir, pluginsDir]) {
+    if (!existsSync(base)) continue;
+    for (const name of readdirSync(base)) {
+      const pj = join(base, name, 'package.json');
+      if (existsSync(pj)) paths.push(pj);
+    }
+  }
+  return paths;
+}
+
+/**
+ * Deterministic post-bump gate: return a list of every place still NOT at
+ * `version` — any versioned package.json (packages/* + plugins/*), the root, and
+ * package-lock.json. An empty list means the suite is fully in lockstep. This is
+ * what makes "the v1.1.0 drift can't happen again" machine-checkable rather than
+ * a thing a human has to remember.
+ */
+export function findVersionDrift(version, { root = ROOT, packagesDir = PKGS, pluginsDir = PLUGINS } = {}) {
+  const problems = [];
+  for (const pj of versionedPackageJsonPaths({ packagesDir, pluginsDir })) {
+    const v = readJson(pj).version;
+    if (v !== version) problems.push(`${pj}: ${v} != ${version}`);
+  }
+  const rootV = readJson(join(root, 'package.json')).version;
+  if (rootV !== version) problems.push(`${join(root, 'package.json')}: ${rootV} != ${version}`);
+  const lockPath = join(root, 'package-lock.json');
+  if (existsSync(lockPath)) {
+    const lockV = readJson(lockPath).version;
+    if (lockV !== version) problems.push(`${lockPath}: ${lockV} != ${version}`);
+  }
+  return problems;
+}
+
+export function releaseMain(
+  argv = process.argv.slice(2),
+  { root = ROOT, packagesDir = PKGS, pluginsDir = PLUGINS, regenerateLockfile = defaultRegenerateLockfile } = {}
+) {
   const version = argv[0];
   const publish = argv.includes('--publish');
 
@@ -69,12 +129,38 @@ export function releaseMain(argv = process.argv.slice(2), { root = ROOT, package
     console.log(`set ${pkg.name}@${version}`);
   }
 
+  // Versioned plugin packages (e.g. @adlc/pi-package) are part of the suite and
+  // must move in lockstep — skipping them is exactly how plugins/adlc-pi got
+  // stranded at 1.0.2 while everything else went to 1.1.0.
+  if (existsSync(pluginsDir)) {
+    for (const name of readdirSync(pluginsDir)) {
+      const pj = join(pluginsDir, name, 'package.json');
+      if (!existsSync(pj)) continue; // skill/command-only plugins have no package.json
+      const pkg = repinInternalDependencies(readJson(pj), version);
+      writeJson(pj, pkg);
+      console.log(`set ${pkg.name}@${version} (plugin)`);
+    }
+  }
+
   // Keep the (private) root version in lockstep too.
   const rootPj = join(root, 'package.json');
   const rootPkg = readJson(rootPj);
   rootPkg.version = version;
   writeJson(rootPj, rootPkg);
   console.log(`set ${rootPkg.name}@${version} (root)`);
+
+  // 2. Regenerate the lockfile so package-lock.json tracks the new versions.
+  // Omitting this is the bug that left the lockfile at 1.0.2 (npm ci broke).
+  regenerateLockfile(root);
+  console.log('regenerated package-lock.json');
+
+  // 3. Fail closed on any residual drift — a missed package.json or a stale
+  // lockfile aborts the release instead of shipping an inconsistent suite.
+  const drift = findVersionDrift(version, { root, packagesDir, pluginsDir });
+  if (drift.length > 0) {
+    console.error(`version drift after bump — aborting:\n  ${drift.join('\n  ')}`);
+    return 1;
+  }
 
   if (!publish) {
     console.log(`\nversions set to ${version} (no publish). Commit, tag v${version}, push.`);

--- a/scripts/test/release.test.mjs
+++ b/scripts/test/release.test.mjs
@@ -1,0 +1,124 @@
+// release.test.mjs — the lockstep release is the moment version drift creeps in
+// (a bump that misses a package.json, or leaves package-lock.json stale), so the
+// release helper gets a committed regression test. Drives releaseMain against a
+// throwaway fake repo with an injected lockfile-regen spy (no real npm, offline,
+// leaves no trace).
+//
+// Regression context: v1.1.0 was bumped across packages/* + root but the bump
+// (a) never regenerated package-lock.json (it stayed at 1.0.2 → npm ci broke) and
+// (b) skipped plugins/adlc-pi (stranded at 1.0.2). These tests pin BOTH gaps shut.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { releaseMain, repinInternalDependencies, packagePublishOrder, findVersionDrift } from '../release.mjs';
+
+/** Build a throwaway repo: root + packages/{core,cli} + plugins/{adlc-pi, adlc-claude-code}. */
+function makeRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-release-'));
+  const packagesDir = join(root, 'packages');
+  const pluginsDir = join(root, 'plugins');
+  mkdirSync(packagesDir);
+  mkdirSync(pluginsDir);
+  const write = (p, obj) => writeFileSync(p, JSON.stringify(obj, null, 2) + '\n');
+  write(join(root, 'package.json'), { name: 'adlc', version: '1.0.0', private: true });
+  mkdirSync(join(packagesDir, 'core'));
+  write(join(packagesDir, 'core', 'package.json'), { name: '@adlc/core', version: '1.0.0' });
+  mkdirSync(join(packagesDir, 'cli'));
+  write(join(packagesDir, 'cli', 'package.json'), {
+    name: '@adlc/cli',
+    version: '1.0.0',
+    dependencies: { '@adlc/core': '1.0.0' }, // packages pin exactly
+  });
+  mkdirSync(join(pluginsDir, 'adlc-pi'));
+  write(join(pluginsDir, 'adlc-pi', 'package.json'), {
+    name: '@adlc/pi-package',
+    version: '1.0.0',
+    private: true,
+    dependencies: { '@adlc/core': '^1.0.0' }, // plugin uses a caret range
+  });
+  // A plugin directory with NO package.json (e.g. adlc-claude-code) must be skipped.
+  mkdirSync(join(pluginsDir, 'adlc-claude-code'));
+  return { root, packagesDir, pluginsDir };
+}
+
+const ver = (p) => JSON.parse(readFileSync(p, 'utf8')).version;
+
+test('releaseMain bumps packages, versioned plugins, and root in lockstep', () => {
+  const { root, packagesDir, pluginsDir } = makeRepo();
+  try {
+    let regen = 0;
+    const rc = releaseMain(['1.2.0'], { root, packagesDir, pluginsDir, regenerateLockfile: () => regen++ });
+    assert.equal(rc, 0);
+    assert.equal(ver(join(root, 'package.json')), '1.2.0');
+    assert.equal(ver(join(packagesDir, 'core', 'package.json')), '1.2.0');
+    assert.equal(ver(join(packagesDir, 'cli', 'package.json')), '1.2.0');
+    assert.equal(ver(join(pluginsDir, 'adlc-pi', 'package.json')), '1.2.0'); // NOT stranded
+    assert.equal(regen, 1); // lockfile regenerated exactly once
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('releaseMain repins internal @adlc deps, preserving range prefixes', () => {
+  const { root, packagesDir, pluginsDir } = makeRepo();
+  try {
+    releaseMain(['1.2.0'], { root, packagesDir, pluginsDir, regenerateLockfile() {} });
+    const cli = JSON.parse(readFileSync(join(packagesDir, 'cli', 'package.json'), 'utf8'));
+    assert.equal(cli.dependencies['@adlc/core'], '1.2.0'); // exact stays exact
+    const pi = JSON.parse(readFileSync(join(pluginsDir, 'adlc-pi', 'package.json'), 'utf8'));
+    assert.equal(pi.dependencies['@adlc/core'], '^1.2.0'); // caret preserved, version moved
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findVersionDrift flags a stranded plugin package', () => {
+  const { root, packagesDir, pluginsDir } = makeRepo();
+  try {
+    const drift = findVersionDrift('1.2.0', { root, packagesDir, pluginsDir });
+    assert.ok(drift.length >= 1);
+    assert.ok(drift.some((d) => d.includes('adlc-pi')), `expected a plugin entry, got: ${drift.join(' | ')}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findVersionDrift returns empty once releaseMain has bumped everything', () => {
+  const { root, packagesDir, pluginsDir } = makeRepo();
+  try {
+    releaseMain(['1.2.0'], { root, packagesDir, pluginsDir, regenerateLockfile() {} });
+    assert.deepEqual(findVersionDrift('1.2.0', { root, packagesDir, pluginsDir }), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('releaseMain rejects an invalid version (and does not regenerate the lockfile)', () => {
+  const { root, packagesDir, pluginsDir } = makeRepo();
+  try {
+    let regen = 0;
+    const rc = releaseMain(['not-semver'], { root, packagesDir, pluginsDir, regenerateLockfile: () => regen++ });
+    assert.equal(rc, 1);
+    assert.equal(regen, 0);
+    assert.equal(ver(join(root, 'package.json')), '1.0.0'); // untouched
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('packagePublishOrder keeps core first and cli last', () => {
+  assert.deepEqual(packagePublishOrder(['cli', 'rails-guard', 'core']), ['core', 'rails-guard', 'cli']);
+});
+
+test('repinInternalDependencies leaves non-@adlc deps alone', () => {
+  const out = repinInternalDependencies(
+    { name: 'x', version: '1.0.0', dependencies: { '@adlc/core': '1.0.0', chalk: '^5.0.0' } },
+    '2.0.0'
+  );
+  assert.equal(out.version, '2.0.0');
+  assert.equal(out.dependencies['@adlc/core'], '2.0.0');
+  assert.equal(out.dependencies.chalk, '^5.0.0'); // untouched
+});


### PR DESCRIPTION
## Summary

Fixes pre-existing version drift on `main` and updates the release tooling so it can't recur.

The `v1.1.0` bump (`30e9654`) updated `packages/*` + root `package.json` versions but:
1. **never regenerated `package-lock.json`** → lockfile stranded at `1.0.2`, so `npm ci` failed its lockfile/`package.json` sync check; and
2. **skipped `plugins/adlc-pi`** entirely → its version and internal `@adlc/*` ranges stayed at `1.0.2`.

## Changes

### Data fix — bring the suite to a consistent `1.1.0` (`af6cf91`)
- Regenerate `package-lock.json` (`npm install --package-lock-only`; diff is **version-fields only**, no dependency/integrity changes). Restores `npm ci` reproducibility.
- Bring `plugins/adlc-pi` (`@adlc/pi-package`, private) fully to `1.1.0`: its `version` and its `@adlc/core` / `@adlc/rails-guard` ranges (`^1.0.2` → `^1.1.0`).

### Prevention — fix the release process at the source (`13352a8`)
- **`scripts/release.mjs`**
  - regenerates `package-lock.json` after the bump (injectable so unit tests don't shell out to npm);
  - bumps **every versioned `plugins/*` package** in lockstep (skips plugins with no `package.json`);
  - `repinInternalDependencies` now **preserves each dep's range style** (`^`/`~`/exact) so a plugin's caret ranges aren't silently pinned to exact;
  - new **`findVersionDrift` gate**: after the bump, `releaseMain` aborts non-zero if any `package.json`, the root, or `package-lock.json` isn't at the target version — drift is machine-checked, not human-remembered.
- **`scripts/test/release.test.mjs`** — new coverage (the script was previously untested): lockstep bump incl. plugins, range-prefix-preserving repin, the drift gate, invalid-version rejection.
- **`.claude/commands/release.md`** — documents the lockfile regen, plugin coverage, and drift gate; adds a pre-commit sanity check.

## Verification
- `npm ci --dry-run` → in sync (was failing on `main`).
- Full `npm test` green; `scripts/test` 8 → 15 tests.
- **End-to-end:** running the real `node scripts/release.mjs 1.1.0` exits 0, regenerates the lockfile, repins `adlc-pi` deps (caret preserved), and the drift gate reports clean.
- Lockfile diff audited: every changed line is a version field.

## Test plan
- [x] `npm ci` in sync
- [x] Full suite green; new release tests pass
- [x] Real release-script dry run is clean and idempotent
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)