### PR TITLE
feat(opencode): rails-guard plugin MVP (ticket T1)

### DIFF
--- a/docs/adr/0004-adlc-opencode-integration.md
+++ b/docs/adr/0004-adlc-opencode-integration.md
@@ -1,0 +1,88 @@
+# ADR: OpenCode integration — rails-guard plugin MVP
+
+**Status:** **Accepted — MVP shipped (P3 rail guard); Phases A/B/C/E follow-on.**
+The detailed design is the [OpenCode integration plan](../integrations/../opencode-integration-plan.md);
+this ADR records the decisions for the first shippable increment (ticket T1) and
+the verified facts the build rests on.
+
+**Date:** 2026-06-27
+**Deciders:** Chris Williams (with an independent adversarial-review counter-model).
+
+> Companion to [ADR 0003](./0003-adlc-claude-code-plugin.md) (Claude Code) and
+> [ADR 0001](./0001-codex-native-adlc-integration.md) (Codex). The risk-gated
+> pre-build review that shaped this ticket is [ADR 0005](./0005-adversarial-design-review-gate.md).
+
+## Context
+
+The OpenCode integration was designed in full (`docs/opencode-integration-plan.md`,
+6 phases A–F) and its Phase F CI backstop shipped in #15. What remained unbuilt was
+the actual plugin. This ADR covers the **MVP**: the in-session rails-guard hook
+(plan Phase D) plus the discovery skill — the smallest increment that makes rail
+enforcement real in OpenCode.
+
+## Decision
+
+Ship `plugins/adlc-opencode/` as a small ESM plugin that wires OpenCode's
+`tool.execute.before` hook to a rail-enforcement decision, **delegating every
+rail/glob/ticket primitive to `@adlc/core`** (no re-implementation — this avoids
+the duplicated-legacy-hook tech debt the plan flags in §6.6).
+
+### Resolved OpenCode plugin API (pinned)
+
+```
+package:           @opencode-ai/plugin   (peerDependency >=1.17.11)
+edit-interception: tool.execute.before   async (input, output) => { ... }
+mutating tools:    input.tool === "edit" | "write"   (Bash writes fall to the CI gate)
+edited path:       input.args.filePath   (handler also falls back to output.args.filePath)
+deny mechanism:    throw new Error(reason)   — IFF the host SDK honors it (see capability gate)
+plugin shape:      export const adlcRailsGuard: Plugin = async ({ directory, worktree, project }) => ({ ... })
+load path:         .opencode/plugin/adlc-opencode/  or the "plugin" array in opencode.json
+```
+
+### Enforcement-capability gate (resolves the "does throw abort the write?" question)
+
+Per the plan's Phase D, the in-session hook is **not treated as enforcing** unless
+the host SDK is confirmed to honor a thrown denial (`onFailure: deny`). A runtime
+probe (`probeEnforcementCapability`) gates this; absent the capability the hook is
+**advisory** and fails closed unless `ADLC_ALLOW_ADVISORY_HOOKS=1`. The unbypassable
+control is always the commit-time CI gate (`docs/ci/rails-guard.yml`).
+
+### Rail contract (delegated, sibling-faithful)
+
+Active ticket via `ADLC_TICKET` or `.adlc/current-ticket.json` (conflict → fail
+closed); enforcement phase-gated on `ADLC_P4_ENFORCEMENT=1`; rails = the single
+active ticket's `rails` plus the trust-root rails `.adlc/tickets.json` and
+`.adlc/current-ticket.json`; no-op when uninitialized / off / no active ticket.
+
+## Threat Model
+
+The in-session hook is **bypassable by design** and must not be mistaken for the
+control:
+
+- The agent controls its own environment, so it can leave `ADLC_P4_ENFORCEMENT`
+  unset, point `ADLC_TICKET` / `.adlc/current-ticket.json` at a rail-free ticket,
+  or (if the SDK lacks `onFailure: deny`) ignore an advisory denial.
+- Bash-driven writes are not gated in-session (Turing-complete shell).
+
+Mitigation: the unbypassable commit-time CI gate (`docs/ci/rails-guard.yml`) reads
+the frozen rail set from the trusted base ref and rejects offending PRs regardless
+of how the edit was made. It protects the trust roots (including `.adlc/admin.pub`,
+added in #15) so the rail set and recovery key can't be quietly rewritten.
+
+## Unverified / follow-on
+
+- **`input.args.filePath` vs `output.args.filePath`** — official docs and the
+  community gist disagree; the handler reads `input` first and falls back to
+  `output`. Pinning this against a captured real payload is pending a live install.
+- **Live deny proof (AC7)** — a maintainer-only end-to-end test against a real
+  OpenCode binary remains the GA gate.
+- **TS + bundled `dist/index.js`** — the MVP ships plain `.mjs` (no build step);
+  the plan's bundled-distribution form is a follow-on.
+- **Phases A/B/C/E** — command suite, keyless bridge, advisory hooks, prosecutor
+  lenses (follow-on tickets T2–T5).
+
+## Consequences
+
+Rail enforcement is real in OpenCode for the common structured-edit path, with the
+rail engine delegated to a single source of truth. The advisory/CI two-layer model
+is honest about what the in-session hook can and cannot guarantee.

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,13 +1,106 @@
-# opencode Integration
+# Adopt the ADLC in OpenCode
 
-> **Status: proposal / implementation target.**
-> The OpenCode integration is specified in this branch, but no installable
-> `@adlc/opencode-plugin` package or `plugins/adlc-opencode` source tree ships yet.
+The `@adlc/*` toolkit is a set of gate-shaped CLIs. This plugin brings the
+**Agentic Development Lifecycle** into the [OpenCode](https://opencode.ai)
+terminal agent: an in-session rail-guard hook plus the `adlc` phase-routing
+discovery skill.
 
-The current design is documented in:
+> Design and rationale: [OpenCode integration plan](../opencode-integration-plan.md)
+> (the authoritative contract) and [ADR 0004](../adr/0004-adlc-opencode-integration.md).
+> Adoption guide: [`../opencode.md`](../opencode.md). The full thesis: [`../../ADLC.md`](../../ADLC.md).
 
-- [OpenCode adoption guide](../opencode.md)
-- [OpenCode integration plan](../opencode-integration-plan.md)
+## Status
 
-Until the implementation artifacts land, treat those documents as the integration
-contract for future work rather than runnable installation instructions.
+This is the **MVP increment**: the rails-guard plugin (`plugins/adlc-opencode/`)
+and the discovery skill ship and are tested. The broader lifecycle surface — the
+full slash-command suite, the keyless LLM bridge, advisory session hooks, and the
+prosecutor lenses — is designed in the integration plan and tracked as follow-on
+work (plan Phases A/B/C/E).
+
+## Install
+
+```sh
+npm install -g @adlc/cli                       # the toolkit, behind one `adlc <tool>` command
+npm install -g @opencode-ai/plugin             # peer dependency (>=1.17.11)
+# deploy the plugin into your project's OpenCode plugin directory:
+#   .opencode/plugin/adlc-opencode/   (or register it in opencode.json "plugin")
+```
+
+Local verification:
+
+```sh
+node scripts/opencode-install-smoke.mjs .
+```
+
+That smoke test validates the plugin manifest, the `tool.execute.before` hook
+wiring, skill registration, the `@adlc/core` delegation (the rail engine is not
+re-implemented), and runs the real enforcement unit test. It does not require the
+`opencode` binary and does not mutate your environment.
+
+## Rail enforcement — two layers
+
+The integration enforces frozen rails at two layers, and **the in-session layer is
+deliberately advisory**:
+
+1. **In-session hook (advisory).** The plugin's `tool.execute.before` hook denies
+   structured `edit`/`write` to a frozen rail declared by the active ticket. It
+   only *actually blocks* when the host OpenCode SDK honors a thrown denial
+   (`onFailure: deny`); a runtime capability probe gates this. When the capability
+   is unproven the hook runs advisory (it surfaces the violation but cannot block)
+   unless `ADLC_ALLOW_ADVISORY_HOOKS=1` is set — otherwise it fails closed. The
+   hook also no-ops unless the repo is ADLC-initialized and `ADLC_P4_ENFORCEMENT=1`.
+   It is inherently bypassable (the agent controls its own environment and the
+   active-ticket selector), so it is **not** the real control.
+2. **Commit-time CI gate (mandatory, unbypassable).** The real control is
+   [`../ci/rails-guard.yml`](../ci/rails-guard.yml) driving `scripts/rails-guard-ci.mjs`
+   — a harness-agnostic diff gate that reads the frozen rail set from the trusted
+   base ref and rejects a PR that touches it. Make it a required check. Because it
+   inspects the git diff, it already covers OpenCode-authored changes and the
+   shell-driven writes the in-session hook cannot see.
+
+## Rail contract
+
+Mirrors the sibling integrations (`adlc-codex`, `adlc-pi`), delegating all
+glob/ticket logic to `@adlc/core`:
+
+- Active ticket resolved from `ADLC_TICKET` or `.adlc/current-ticket.json`
+  (conflict → fail closed).
+- Rails in force = the **single active ticket's** `rails` plus the implicit
+  trust-root rails `.adlc/tickets.json` and `.adlc/current-ticket.json` (frozen so
+  the rail set can't be quietly edited away).
+- No-op when the repo isn't ADLC-initialized, enforcement is off, no active ticket
+  is resolved, or the path isn't a frozen rail.
+
+## Formal ADLC Coverage
+
+| Phase | Status | Wired via |
+| --- | --- | --- |
+| P0 Triage | Planned | plan Phase A (`/adlc-ticket`) — follow-on ticket T2 |
+| P1 Interrogate | Planned | plan Phase A (`/adlc-spec`) + the `adlc` skill |
+| P2 Decompose | Planned | plan Phase A — follow-on T2 |
+| P3 Rail | **MVP** | the in-session rails-guard hook (this plugin) + CI gate |
+| P4 Build | Partial | rails-guard hook; flail-detection is follow-on |
+| P5 Prosecute | Planned | plan Phase E prosecutor lenses — follow-on T5 |
+| P6 Integrate | Planned | gate-manifest evidence (human gate) |
+| P7 Distill | Planned | plan Phase E (`/adlc-distill`) — follow-on T5 |
+
+## Gaps
+
+1. **In-session enforcement depends on host SDK capability.** Until OpenCode's
+   plugin SDK is confirmed to honor a thrown denial (`onFailure: deny`), the hook
+   is advisory; the CI gate is the real control.
+2. **Bash-driven writes are not gated in-session** (Turing-complete shell) — caught
+   by the CI diff gate, mirroring the Claude Code posture.
+3. **Lifecycle breadth.** Only P3 ships in this MVP; the command suite, keyless
+   bridge, advisory session hooks, and prosecutor lenses are follow-on tickets
+   (T2–T5).
+4. **Live deny proof pending.** A maintainer-only end-to-end check against a real
+   OpenCode binary (driving an actual edit-to-rail and asserting the block) is the
+   remaining GA gate — see ADR 0004.
+
+## Boundary
+
+- `.adlc/` is the runtime state area for tickets, manifests, and gate evidence.
+- The plugin delegates every rail/glob/ticket primitive to `@adlc/core`; it adds
+  only the OpenCode-specific hook wiring and the enforcement-capability gate.
+- Package READMEs remain the source of truth for exact flags, schemas, and exit codes.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "scripts": {
-    "test": "for d in packages/*/test; do node --test \"$d\"/*.test.mjs || exit 1; done && node --test plugins/adlc-claude-code/hooks/test/*.test.mjs && node --test scripts/test/*.test.mjs && (npx tsc --target es2022 --module nodenext --moduleResolution nodenext --noEmitOnError false --skipLibCheck true --noImplicitAny false --declaration false plugins/adlc-pi/index.ts || true) && node --test plugins/adlc-pi/test/*.test.mjs",
+    "test": "for d in packages/*/test; do node --test \"$d\"/*.test.mjs || exit 1; done && node --test plugins/adlc-claude-code/hooks/test/*.test.mjs && node --test scripts/test/*.test.mjs && (npx tsc --target es2022 --module nodenext --moduleResolution nodenext --noEmitOnError false --skipLibCheck true --noImplicitAny false --declaration false plugins/adlc-pi/index.ts || true) && node --test plugins/adlc-pi/test/*.test.mjs && node --test plugins/adlc-opencode/test/*.test.mjs",
     "release": "node scripts/release.mjs"
   },
   "engines": {

--- a/plugins/adlc-opencode/index.mjs
+++ b/plugins/adlc-opencode/index.mjs
@@ -1,0 +1,48 @@
+// index.mjs — the ADLC OpenCode plugin entrypoint.
+//
+// Wires OpenCode's `tool.execute.before` hook to the rail-enforcement decision in
+// rails-checker.mjs (which delegates to @adlc/core). It does NOT reimplement any
+// gate. The deny path imports only Node builtins + @adlc/core (first-party,
+// zero third-party dependency).
+//
+// Enforcement-capability gate (integration-plan Phase D): a thrown error in
+// `tool.execute.before` only blocks the write if the host SDK honors it
+// (onFailure:deny). When the capability is unproven, the hook runs ADVISORY
+// (surfaces the violation, does not claim to block) unless the operator opts into
+// advisory mode; otherwise it signals that preflight should fail closed.
+
+import { checkRail, probeEnforcementCapability } from './rails-checker.mjs';
+
+/** @typedef {import('@opencode-ai/plugin').Plugin} Plugin */
+
+/** @type {Plugin} */
+export const adlcRailsGuard = async ({ directory, worktree, project } = {}) => {
+  // The repo root used to locate .adlc/ and to canonicalize edited paths.
+  const root = worktree ?? directory ?? project?.worktree ?? process.cwd();
+  const enforces = probeEnforcementCapability({ directory, worktree, project });
+  const advisoryAllowed = process.env.ADLC_ALLOW_ADVISORY_HOOKS === '1';
+
+  return {
+    'tool.execute.before': async (input, output) => {
+      const tool = input?.tool;
+      // Sources disagree on whether the edited path is on input.args or
+      // output.args; read input first, fall back to output. (ADR 0004 tracks
+      // pinning this against a captured real payload.)
+      const filePath = input?.args?.filePath ?? output?.args?.filePath;
+      if (!filePath || !tool) return;
+
+      const verdict = checkRail({ filePath, tool, root, env: process.env });
+      if (verdict.decision !== 'deny') return;
+
+      const message = `ADLC rails-guard: blocked edit to ${verdict.reason}`;
+      if (enforces || !advisoryAllowed) {
+        // Enforcing (or refusing to silently downgrade): throw to abort the tool.
+        throw new Error(message);
+      }
+      // Advisory mode: cannot abort, so surface loudly without claiming to block.
+      console.error(`${message} [ADVISORY — host SDK does not honor deny; rely on the CI rail-freeze gate]`);
+    },
+  };
+};
+
+export default adlcRailsGuard;

--- a/plugins/adlc-opencode/package.json
+++ b/plugins/adlc-opencode/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@adlc/opencode-package",
+  "version": "1.1.0",
+  "private": true,
+  "description": "ADLC integration for the OpenCode terminal coding agent",
+  "type": "module",
+  "main": "index.mjs",
+  "opencode": {
+    "plugin": "./index.mjs",
+    "skill": "./skill/"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=1.17.11"
+  },
+  "dependencies": {
+    "@adlc/core": "^1.1.0"
+  }
+}

--- a/plugins/adlc-opencode/rails-checker.mjs
+++ b/plugins/adlc-opencode/rails-checker.mjs
@@ -1,0 +1,112 @@
+// rails-checker.mjs — the ADLC rail-enforcement decision for OpenCode.
+//
+// This is a THIN adapter: every rail/glob/ticket primitive is delegated to
+// @adlc/core (the single source of truth, per ADR 0004 / integration-plan §6.6).
+// It must NOT re-implement glob or ticket loading. The only non-core logic here
+// is mapping OpenCode's hook arguments onto that core and the sibling-hook
+// enforcement contract (active-ticket resolution, phase gating, trust-root
+// freeze) that adlc-codex and adlc-pi already implement.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
+import { loadTickets, globMatch } from '@adlc/core';
+
+// The ticket file and the active-ticket pointer are the rail trust root: they are
+// frozen whenever enforcement is active, even if no ticket declares them, so the
+// rail set cannot be quietly edited away. Mirrors adlc-codex/hooks/adlc-rails-guard.mjs.
+export const TRUST_ROOT_RAILS = ['.adlc/tickets.json', '.adlc/current-ticket.json'];
+
+// OpenCode's structured file-mutation tools. Bash-style writes are intentionally
+// NOT gated in-session (Turing-complete shell); they fall to the CI diff gate.
+export const MUTATING_TOOLS = ['edit', 'write'];
+
+/** Canonicalize a path to a forward-slash path relative to the repo root. */
+export function canonicalizePath(filePath, root) {
+  const abs = isAbsolute(filePath) ? filePath : join(root, filePath);
+  return relative(root, abs).split('\\').join('/');
+}
+
+/**
+ * Resolve the active ticket id from process.env.ADLC_TICKET OR
+ * .adlc/current-ticket.json. If both are set and disagree, that is a tamper
+ * signal — return { conflict: true } so the caller fails closed.
+ */
+export function resolveActiveTicketId(root, env) {
+  const envTicket = (env.ADLC_TICKET ?? '').trim() || null;
+  let fileTicket = null;
+  const currentPath = join(root, '.adlc', 'current-ticket.json');
+  if (existsSync(currentPath)) {
+    try {
+      const data = JSON.parse(readFileSync(currentPath, 'utf8'));
+      const raw = typeof data === 'string' ? data : data.id ?? data.ticket;
+      fileTicket = (raw ?? '').toString().trim() || null;
+    } catch {
+      // An unparseable pointer is itself a tamper signal: fail closed.
+      return { id: null, conflict: true };
+    }
+  }
+  if (envTicket && fileTicket && envTicket !== fileTicket) {
+    return { id: null, conflict: true };
+  }
+  return { id: envTicket ?? fileTicket, conflict: false };
+}
+
+/**
+ * Decide whether a structured edit/write should be allowed or denied.
+ * Pure and fail-safe: returns { decision: 'allow' | 'deny', reason }.
+ *
+ * Enforcement contract (identical to the sibling hooks):
+ *  - only the structured mutating tools are gated;
+ *  - enforcement is phase-scoped to ADLC_P4_ENFORCEMENT === '1';
+ *  - no-op when the repo is not ADLC-initialized;
+ *  - the active ticket is the SINGLE source of declared rails; a conflicting
+ *    active-ticket signal fails closed;
+ *  - rails in force = active ticket's declared rails PLUS the trust-root rails.
+ */
+export function checkRail({ filePath, tool, root = process.cwd(), env = process.env }) {
+  if (!MUTATING_TOOLS.includes(tool)) {
+    return { decision: 'allow', reason: `tool "${tool}" is not a structured mutating tool` };
+  }
+  if (env.ADLC_P4_ENFORCEMENT !== '1') {
+    return { decision: 'allow', reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
+  }
+  const ticketsPath = join(root, '.adlc', 'tickets.json');
+  if (!existsSync(ticketsPath)) {
+    return { decision: 'allow', reason: 'repo not ADLC-initialized (no .adlc/tickets.json)' };
+  }
+
+  const active = resolveActiveTicketId(root, env);
+  if (active.conflict) {
+    return { decision: 'deny', reason: 'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json)' };
+  }
+  if (!active.id) {
+    return { decision: 'allow', reason: 'no active ticket resolved' };
+  }
+
+  const { tickets } = loadTickets(ticketsPath);
+  const ticket = tickets.find((t) => t.id === active.id);
+  const declaredRails = ticket?.rails ?? [];
+  const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
+
+  const canonical = canonicalizePath(filePath, root);
+  const hit = rails.find((rail) => rail === canonical || globMatch(rail, canonical));
+  if (hit) {
+    return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${active.id})` };
+  }
+  return { decision: 'allow', reason: 'path is not a frozen rail' };
+}
+
+/**
+ * Probe whether the host OpenCode SDK can actually ENFORCE a denial (abort the
+ * tool via a thrown error / onFailure:deny). Per integration-plan Phase D, the
+ * in-session hook must not be treated as enforcing unless this is true; otherwise
+ * it is advisory and preflight should fail closed unless advisory hooks are
+ * explicitly allowed. We cannot introspect the SDK contract portably, so we treat
+ * an explicit capability flag as the signal and default to "unknown".
+ */
+export function probeEnforcementCapability(api, env = process.env) {
+  if (env.ADLC_OPENCODE_ENFORCES === '1') return true;
+  if (env.ADLC_OPENCODE_ENFORCES === '0') return false;
+  // The SDK may advertise the capability; absent that, enforcement is unproven.
+  return Boolean(api?.capabilities?.toolExecuteBeforeDeny);
+}

--- a/plugins/adlc-opencode/skill/adlc.md
+++ b/plugins/adlc-opencode/skill/adlc.md
@@ -1,0 +1,37 @@
+---
+name: adlc
+description: >-
+  Routes agentic development work to the right Agentic Development Lifecycle
+  (ADLC) gate from inside OpenCode. Use when shaping a spec or ticket, deciding
+  how to fan work out to models, protecting frozen rails during a build,
+  prosecuting a change before merge, or distilling repeated findings into
+  defenses. Triggers on "shape this spec", "is this ticket ready", "freeze these
+  tests", "prosecute this change", "is this safe to merge", "ADLC", "which gate",
+  "spec-lint", "premortem", "coldstart", "rails-guard", "hollow-test".
+---
+
+# ADLC phase router (OpenCode)
+
+Describe what you're doing; this routes you to the gate that fits. Gates run via
+the `adlc <tool>` dispatcher (`npm i -g @adlc/cli`). LLM-backed gates support
+`--prompt-only` — inside OpenCode, the model answers the printed prompt, so no
+API key is required.
+
+| You're trying to… | Phase | Gate |
+| --- | --- | --- |
+| Triage / author a ticket | P0 | `adlc preflight`, `/adlc-ticket` |
+| Pin down a vague spec | P1 | `adlc spec-lint`, `adlc premortem`, `adlc parallax` |
+| Slice work across models | P2 | `adlc coldstart`, `adlc merge-forecast`, `adlc model-router` |
+| Freeze tests/contracts as rails | P3 | `adlc rails-guard` + the in-session rails-guard hook |
+| Build under supervision | P4 | `adlc flail-detector`, `adlc consensus-fix` |
+| Prosecute before merge | P5 | `adlc hollow-test`, `adlc behavior-diff`, `adlc review-calibration` |
+| Decide to integrate | P6 | `adlc gate-manifest` (human gate) |
+| Distill findings into defenses | P7 | `adlc lesson-foundry`, `adlc rejection-mining` |
+
+## Rail enforcement in this harness
+
+The bundled plugin wires a `tool.execute.before` hook that denies structured
+`edit`/`write` to frozen rails declared by the active ticket. It is **advisory in
+session and gated on host SDK capability** — the unbypassable layer is the
+commit-time CI gate (`docs/ci/rails-guard.yml`). See
+[`docs/integrations/opencode.md`](../../../docs/integrations/opencode.md).

--- a/plugins/adlc-opencode/test/rails-checker.test.mjs
+++ b/plugins/adlc-opencode/test/rails-checker.test.mjs
@@ -1,0 +1,134 @@
+// rails-checker.test.mjs — AC3 enforcement proof for the OpenCode rails guard.
+// Exercises the pure decision (checkRail) and the REAL exported
+// tool.execute.before handler against representative payloads. Offline, no
+// opencode binary, leaves no trace.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkRail, resolveActiveTicketId, probeEnforcementCapability } from '../rails-checker.mjs';
+import { adlcRailsGuard } from '../index.mjs';
+
+function repo({ tickets, current } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'oc-rails-'));
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  if (tickets !== undefined) writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify(tickets));
+  if (current !== undefined) writeFileSync(join(dir, '.adlc', 'current-ticket.json'), JSON.stringify(current));
+  return dir;
+}
+const ON = { ADLC_P4_ENFORCEMENT: '1' };
+const T1_RAILED = { tickets: [{ id: 'T1', rails: ['test/**'] }] };
+
+// ---- (a) no-op when .adlc/tickets.json absent ----
+test('a: no tickets.json → allow (no-op)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'oc-rails-'));
+  try {
+    const r = checkRail({ filePath: 'test/x.mjs', tool: 'edit', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (b) no-op when ADLC_P4_ENFORCEMENT != '1' ----
+test('b: enforcement off → allow even on a declared rail', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkRail({ filePath: 'test/x.mjs', tool: 'edit', root: dir, env: { ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (c) no-op when no active ticket ----
+test('c: no active ticket → allow', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkRail({ filePath: 'test/x.mjs', tool: 'edit', root: dir, env: { ...ON } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (d) DENY edit AND write to the active ticket's declared rail ----
+for (const tool of ['edit', 'write']) {
+  test(`d: ${tool} to a declared rail → deny`, () => {
+    const dir = repo({ tickets: T1_RAILED });
+    try {
+      const r = checkRail({ filePath: 'test/x.mjs', tool, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+      assert.equal(r.decision, 'deny');
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+}
+
+// ---- (e) DENY edit to .adlc/tickets.json (trust root) even when not declared ----
+test('e: edit .adlc/tickets.json (trust root) → deny even when rails do not list it', () => {
+  const dir = repo({ tickets: { tickets: [{ id: 'T1', rails: ['src/**'] }] } });
+  try {
+    const r = checkRail({ filePath: '.adlc/tickets.json', tool: 'edit', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (f) a DIFFERENT ticket's rail does NOT block (scope = active ticket only) ----
+test('f: another ticket\'s rail does not block (single-active-ticket scope)', () => {
+  const dir = repo({ tickets: { tickets: [{ id: 'T1', rails: ['a/**'] }, { id: 'T2', rails: ['b/**'] }] } });
+  try {
+    const r = checkRail({ filePath: 'b/x.mjs', tool: 'edit', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (g) conflicting ADLC_TICKET vs current-ticket.json fails closed ----
+test('g: conflicting ADLC_TICKET vs current-ticket.json → deny (fail closed)', () => {
+  const dir = repo({ tickets: T1_RAILED, current: { id: 'T2' } });
+  try {
+    const r = checkRail({ filePath: 'unrelated/x.mjs', tool: 'edit', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+  assert.equal(resolveActiveTicketId(dir, {}).conflict, false); // sanity: no env, dir gone is fine
+});
+
+// ---- (h) capability gate: advisory vs fail-closed via the REAL handler ----
+test('h: handler throws to enforce when SDK honors deny', async () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const saved = { ...process.env };
+  try {
+    process.env.ADLC_P4_ENFORCEMENT = '1';
+    process.env.ADLC_TICKET = 'T1';
+    process.env.ADLC_OPENCODE_ENFORCES = '1';
+    delete process.env.ADLC_ALLOW_ADVISORY_HOOKS;
+    const hooks = await adlcRailsGuard({ worktree: dir });
+    await assert.rejects(() => hooks['tool.execute.before']({ tool: 'edit', args: { filePath: 'test/x.mjs' } }));
+  } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('h: no deny capability + advisory NOT allowed → fail closed (handler throws)', async () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const saved = { ...process.env };
+  try {
+    process.env.ADLC_P4_ENFORCEMENT = '1';
+    process.env.ADLC_TICKET = 'T1';
+    process.env.ADLC_OPENCODE_ENFORCES = '0';
+    delete process.env.ADLC_ALLOW_ADVISORY_HOOKS;
+    const hooks = await adlcRailsGuard({ worktree: dir });
+    await assert.rejects(() => hooks['tool.execute.before']({ tool: 'edit', args: { filePath: 'test/x.mjs' } }));
+  } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('h: no deny capability + advisory ALLOWED → advisory (handler does not throw)', async () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const saved = { ...process.env };
+  try {
+    process.env.ADLC_P4_ENFORCEMENT = '1';
+    process.env.ADLC_TICKET = 'T1';
+    process.env.ADLC_OPENCODE_ENFORCES = '0';
+    process.env.ADLC_ALLOW_ADVISORY_HOOKS = '1';
+    const hooks = await adlcRailsGuard({ worktree: dir });
+    await hooks['tool.execute.before']({ tool: 'edit', args: { filePath: 'test/x.mjs' } }); // resolves, no throw
+  } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('h: probeEnforcementCapability honors explicit flags', () => {
+  assert.equal(probeEnforcementCapability(null, { ADLC_OPENCODE_ENFORCES: '1' }), true);
+  assert.equal(probeEnforcementCapability(null, { ADLC_OPENCODE_ENFORCES: '0' }), false);
+  assert.equal(probeEnforcementCapability(null, {}), false);
+});

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// opencode-install-smoke.mjs — local verification for the ADLC OpenCode plugin
+// MVP. Mirrors scripts/codex-install-smoke.mjs / claude-code-plugin-smoke.mjs:
+// validates the plugin package shape, the hook wiring, skill registration, the
+// @adlc/core delegation (no inlined rail engine), and runs the real enforcement
+// unit test. Does NOT require the opencode binary and does not mutate the user
+// environment.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), '..'));
+const PLUGIN = join(ROOT, 'plugins', 'adlc-opencode');
+let failures = 0;
+const fail = (m) => { console.error(`opencode-install-smoke: FAIL — ${m}`); failures++; };
+const ok = (m) => console.log(`  ok — ${m}`);
+const read = (p) => readFileSync(p, 'utf8');
+
+// ---- AC1: package + manifest shape ----
+const pkgPath = join(PLUGIN, 'package.json');
+if (!existsSync(pkgPath)) fail('plugins/adlc-opencode/package.json missing');
+else {
+  const pkg = JSON.parse(read(pkgPath));
+  if (pkg.name !== '@adlc/opencode-package') fail(`package name is ${pkg.name}`); else ok('package name');
+  if (pkg.type !== 'module') fail('package is not type:module'); else ok('type:module');
+  if (!pkg.peerDependencies?.['@opencode-ai/plugin']) fail('missing @opencode-ai/plugin peerDependency'); else ok('peerDependency @opencode-ai/plugin');
+  if (!pkg.dependencies?.['@adlc/core']) fail('missing @adlc/core dependency'); else ok('dependency @adlc/core');
+  if (!pkg.opencode?.plugin) fail('package.json opencode.plugin entry missing'); else ok('opencode.plugin manifest entry');
+}
+
+// ---- AC1: hook wiring + plugin export ----
+const indexPath = join(PLUGIN, 'index.mjs');
+if (!existsSync(indexPath)) fail('index.mjs missing');
+else {
+  const idx = read(indexPath);
+  if (!/tool\.execute\.before/.test(idx)) fail('index.mjs does not wire tool.execute.before'); else ok('wires tool.execute.before');
+  if (!/export (const|default) /.test(idx)) fail('index.mjs has no plugin export'); else ok('exports a plugin');
+}
+
+// ---- AC1: skill registration ----
+if (!existsSync(join(PLUGIN, 'skill', 'adlc.md'))) fail('skill/adlc.md missing'); else ok('skill/adlc.md present');
+
+// ---- AC2: delegate to @adlc/core, do NOT re-implement the rail engine ----
+const checkerPath = join(PLUGIN, 'rails-checker.mjs');
+if (!existsSync(checkerPath)) fail('rails-checker.mjs missing');
+else {
+  const chk = read(checkerPath);
+  if (!/from '@adlc\/core'/.test(chk)) fail('rails-checker does not import @adlc/core'); else ok('rails-checker imports @adlc/core');
+  if (!/globMatch/.test(chk) || !/loadTickets/.test(chk)) fail('rails-checker does not use globMatch+loadTickets from core'); else ok('delegates globMatch+loadTickets to core');
+  if (/function\s+globMatch\s*\(/.test(chk)) fail('rails-checker RE-IMPLEMENTS globMatch (must delegate to @adlc/core)'); else ok('no inlined globMatch (engine delegated)');
+  // deny-path source must not pull a third-party runtime dependency
+  const imports = [...chk.matchAll(/from '([^']+)'/g), ...read(indexPath).matchAll(/from '([^']+)'/g)].map((m) => m[1]);
+  const thirdParty = imports.filter((s) => !s.startsWith('node:') && !s.startsWith('.') && s !== '@adlc/core');
+  if (thirdParty.length) fail(`deny path imports third-party deps: ${thirdParty.join(', ')}`); else ok('deny path: only node: builtins + @adlc/core');
+}
+
+// ---- AC3: run the real enforcement unit test (always-on proof) ----
+try {
+  execFileSync(process.execPath, ['--test', ...globTests(join(PLUGIN, 'test'))], { cwd: ROOT, stdio: 'pipe' });
+  ok('enforcement unit test (rails-checker.test.mjs) passes');
+} catch (e) {
+  fail(`enforcement unit test failed:\n${e.stdout?.toString() ?? e.message}`);
+}
+
+// ---- AC8: two-layer enforcement framing in the doc; no competing CI workflow ----
+const docPath = join(ROOT, 'docs', 'integrations', 'opencode.md');
+if (!existsSync(docPath)) fail('docs/integrations/opencode.md missing');
+else {
+  const doc = read(docPath);
+  if (/no integration exists yet/.test(doc)) fail("opencode.md still has the 'no integration exists yet' stub banner");
+  else ok('stub banner removed');
+  if (!/ci\/rails-guard\.yml/.test(doc)) fail('opencode.md does not point at the mandatory CI gate (docs/ci/rails-guard.yml)'); else ok('links the unbypassable CI gate');
+  if (!/advisor/i.test(doc)) fail('opencode.md does not frame the in-session hook as advisory'); else ok('frames in-session hook as advisory');
+}
+
+// AC7 (live deny proof against the real opencode binary) is the remaining GA gate;
+// it requires a disposable OpenCode install and is tracked in ADR 0004.
+console.log('  note — AC7 live-binary deny proof is a maintainer/CI follow-up (no opencode binary here).');
+
+if (failures) { console.error(`\nopencode-install-smoke: ${failures} failure(s)`); process.exit(2); }
+console.log('\nopencode-install-smoke: PASS');
+
+function globTests(dir) {
+  // node --test wants explicit files on this runtime; expand *.test.mjs ourselves.
+  return readFileSync && existsSync(dir)
+    ? execFileSync('ls', [dir]).toString().split('\n').filter((f) => f.endsWith('.test.mjs')).map((f) => join(dir, f))
+    : [];
+}


### PR DESCRIPTION
Implements **ticket T1** — the first shippable increment of the OpenCode integration (plan Phase D), built atop the design + Phase F CI merged in #15.

## What ships
- **`plugins/adlc-opencode/`** — ESM plugin (`@adlc/opencode-package`):
  - `index.mjs` wires OpenCode's `tool.execute.before` hook
  - `rails-checker.mjs` is a **thin adapter over `@adlc/core`** (`loadTickets` + `globMatch`) — the rail engine is delegated, not re-implemented (the §6.6 tech-debt fix)
  - `skill/adlc.md` is the phase-routing discovery skill
- **`scripts/opencode-install-smoke.mjs`** — manifest/hook/skill validation + `@adlc/core` delegation check + runs the enforcement unit test
- **`docs/integrations/opencode.md`** — rewritten landing doc (Install, two-layer enforcement, ADLC coverage, Gaps)
- **`docs/adr/0004-adlc-opencode-integration.md`** — pinned API + threat model
- **`package.json`** — wires the new plugin tests into `npm test` so CI runs them

## Enforcement contract (mirrors `adlc-codex` / `adlc-pi`)
- Active ticket via `ADLC_TICKET` or `.adlc/current-ticket.json` (conflict → fail closed)
- Phase-gated on `ADLC_P4_ENFORCEMENT=1`; rails = active ticket's `rails` + trust-root freeze (`.adlc/tickets.json`, `.adlc/current-ticket.json`)
- No-op fail-safe when uninitialized / off / no active ticket / not a rail
- **Capability gate (plan Phase D):** the hook only *blocks* when the host SDK honors a thrown denial (`onFailure: deny`); otherwise advisory + fail-closed unless `ADLC_ALLOW_ADVISORY_HOOKS=1`. The unbypassable layer is the CI gate from #15.

## Acceptance criteria
- [x] **AC1** `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] **AC2** delegates to `@adlc/core`, no inlined glob engine, deny path imports only `node:` builtins + `@adlc/core`
- [x] **AC3** 12 unit tests: no-op paths, edit/write deny, trust-root freeze, single-active-ticket scope, conflict fail-closed, capability advisory-vs-fail-closed
- [x] **AC4** `opencode.md` rebuilt (Install + Coverage table + Gaps; stub removed)
- [x] **AC5** ADR 0004 with pinned API + Threat Model
- [x] **AC6** sibling smokes still exit 0 (`codex`, `claude-code`)
- [x] **AC8** two-layer framing + links the mandatory CI gate; no competing workflow
- [ ] **AC7** live-binary deny proof against a real OpenCode install (GA follow-up, ADR 0004)

## Known follow-ups (ADR 0004 / tickets T2–T5)
- Pin `input.args.filePath` vs `output.args.filePath` against a captured real payload (docs/gist disagree; handler reads `input`, falls back to `output`)
- TS + bundled `dist/index.js` (MVP ships plain `.mjs`)
- Phases A/B/C/E: command suite, keyless bridge, advisory session hooks, prosecutor lenses

## Test plan
- [x] `npm test` → 1329 tests, 1328 pass, 0 fail (1 skip); +12 new OpenCode tests
- [x] `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] `node scripts/codex-install-smoke.mjs .` / `claude-code-plugin-smoke.mjs .` → exit 0

Depends on #15 (merged). Related planning: #24 (tickets T1–T5 + ADR 0005).