### PR TITLE
feat(opencode): Phase A — command suite + gate-bin mapping + /adlc-init scaffolding (ticket T2)

### DIFF
--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -11,11 +11,27 @@ discovery skill.
 
 ## Status
 
-This is the **MVP increment**: the rails-guard plugin (`plugins/adlc-opencode/`)
-and the discovery skill ship and are tested. The broader lifecycle surface — the
-full slash-command suite, the keyless LLM bridge, advisory session hooks, and the
-prosecutor lenses — is designed in the integration plan and tracked as follow-on
-work (plan Phases A/B/C/E).
+Shipping so far: the rails-guard plugin (`plugins/adlc-opencode/`, plan Phase D),
+the discovery skill, and the **Phase A command surface** — `/adlc-init`,
+`/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`, `/adlc-decompose` plus the
+gate-bin dependency mapping and deterministic `/adlc-init` scaffolding. Still
+follow-on (plan Phases B/C/E): the keyless LLM bridge, advisory session hooks, and
+the prosecutor lenses.
+
+## Commands
+
+OpenCode loads project commands from `.opencode/commands/` (Markdown + YAML
+frontmatter). `/adlc-init` deploys this plugin's `command/*.md` and `skill/*.md`
+into `.opencode/` and creates `.adlc/config.json` (idempotently, via
+`lib/scaffold.mjs`). Phase A commands:
+
+| Command | Phase | Does |
+| --- | --- | --- |
+| `/adlc-init` | — | Bootstrap `.adlc/`, scaffold `.opencode/`, preflight |
+| `/adlc-ticket` | P0 | Author + triage a ticket (lock-safe write, coldstart check) |
+| `/adlc-spec` | P1 | Interrogate the spec (`parallax`, `spec-lint`, `premortem`, prompt-only) |
+| `/adlc-approve-spec` | P1 G1 | Record the human spec approval |
+| `/adlc-decompose` | P2 | Slice into tickets, `coldstart` + `merge-forecast` |
 
 ## Install
 
@@ -75,9 +91,9 @@ glob/ticket logic to `@adlc/core`:
 
 | Phase | Status | Wired via |
 | --- | --- | --- |
-| P0 Triage | Planned | plan Phase A (`/adlc-ticket`) — follow-on ticket T2 |
-| P1 Interrogate | Planned | plan Phase A (`/adlc-spec`) + the `adlc` skill |
-| P2 Decompose | Planned | plan Phase A — follow-on T2 |
+| P0 Triage | **Yes** | `/adlc-ticket` (Phase A) |
+| P1 Interrogate | **Yes** | `/adlc-spec` + `/adlc-approve-spec` (Phase A) + the `adlc` skill |
+| P2 Decompose | **Yes** | `/adlc-decompose` (Phase A) |
 | P3 Rail | **MVP** | the in-session rails-guard hook (this plugin) + CI gate |
 | P4 Build | Partial | rails-guard hook; flail-detection is follow-on |
 | P5 Prosecute | Planned | plan Phase E prosecutor lenses — follow-on T5 |

--- a/plugins/adlc-opencode/command/adlc-approve-spec.md
+++ b/plugins/adlc-opencode/command/adlc-approve-spec.md
@@ -1,0 +1,26 @@
+---
+description: Record human spec approval (P1 Gate 1) before decomposition begins.
+---
+
+# /adlc-approve-spec — human spec approval (P1 G1)
+
+Gate 1 is a human decision: "is this spec what I actually want built?" The model
+cannot self-approve. This command records the human's explicit approval so
+downstream phases have provenance.
+
+Target ticket: **$ARGUMENTS** (default to `.adlc/current-ticket.json`).
+
+## Steps
+1. Show the user the converged spec and its acceptance criteria (from `/adlc-spec`).
+2. Ask the user to explicitly approve, request changes, or reject. Do **not**
+   proceed on silence or assume approval.
+3. On approval, record the evidence via the runner:
+   `adlc-runner accept --ticket <id> --gate p1` (or, if the runner is unavailable,
+   append an unsigned `spec_approval` entry to `.adlc/manifest.jsonl` noting the
+   approver and the spec hash, flagged `unsigned_fallback: true`).
+4. On changes requested, loop back to `/adlc-spec`; on rejection, stop.
+
+## Summarize
+Report what was recorded (ticket id, gate, signed vs unsigned) and point the user
+at `/adlc-decompose` (P2). Never fabricate approval — an unapproved spec must not
+advance.

--- a/plugins/adlc-opencode/command/adlc-decompose.md
+++ b/plugins/adlc-opencode/command/adlc-decompose.md
@@ -1,0 +1,30 @@
+---
+description: Slice an approved spec into executable ticket partitions (P2) and forecast the merge.
+---
+
+# /adlc-decompose — decompose into tickets (P2)
+
+Turn an approved spec into a set of small, independently-executable tickets with
+explicit ordering, then forecast how they merge. Target: **$ARGUMENTS** (default
+to the active ticket).
+
+## 1. Slice
+Break the work into tickets small enough for one fresh agent context. For each,
+follow the `/adlc-ticket` contract (self-contained body, concrete acceptance
+criteria, `scope`, `rails`, `edges`, `duration`). Wire `edges` as prerequisite→
+dependent; tickets that touch the same scope should be serialized to avoid
+concurrent merge conflicts.
+
+## 2. Check executability — `coldstart`
+For each new ticket run `adlc coldstart <id> --prompt-only`, answer the audit, and
+close any gaps that would block a fresh agent.
+
+## 3. Forecast — `merge-forecast` + `model-router`
+- Run `adlc merge-forecast --json`: confirm a clean DAG (no cycles, no high-risk
+  concurrent same-scope pairs). Serialize with edges if it flags conflicts.
+- Run `adlc model-router --json` (or `--prompt-only`) to get a tier/route hint per
+  ticket (cheap / mid / frontier).
+
+## 4. Summarize
+Report the ticket DAG (waves + merge order), each ticket's coldstart verdict, and
+the routing hints. Point the user at `/adlc-rail-write` (P3) for the first ticket.

--- a/plugins/adlc-opencode/command/adlc-init.md
+++ b/plugins/adlc-opencode/command/adlc-init.md
@@ -1,0 +1,49 @@
+---
+description: Bootstrap the ADLC runtime (.adlc/) and scaffold the OpenCode command/skill surface.
+---
+
+# /adlc-init — bootstrap the ADLC workspace (OpenCode)
+
+Set up the shared `.adlc/` runtime every gate reads, scaffold this plugin's
+commands and skill into `.opencode/`, and confirm the toolkit is reachable. Run
+once per repository. Every step is idempotent — never clobber existing files.
+
+## 1. Verify the toolkit
+
+Run `adlc --version`. If not found, STOP and tell the user to install it:
+
+```sh
+npm install -g @adlc/cli
+```
+
+## 2. Runtime + config
+
+- Create `.adlc/` if missing.
+- If `.adlc/tickets.json` is absent, create it as `{ "tickets": [] }`. If present, leave it.
+- Run the deterministic scaffolder to create `.adlc/config.json` (defaults, no
+  clobber) and deploy this plugin's `command/` and `skill/` into `.opencode/`:
+
+  !`node "$(dirname "$(node -e "process.stdout.write(require.resolve('@adlc/opencode-package/package.json'))" 2>/dev/null || echo .)")/lib/scaffold-cli.mjs" .`
+
+  (If the helper is unavailable, scaffold manually: create `.adlc/config.json`
+  with `{"securityMode":"unsigned-fallback"}` and copy the plugin's `command/*.md`
+  into `.opencode/commands/` and `skill/*.md` into `.opencode/skill/`.)
+
+## 3. Separate the contract from runtime evidence in git
+
+Ensure `.gitignore` ignores all of `.adlc/` except the ticket contract:
+
+```
+.adlc/*
+!.adlc/tickets.json
+```
+
+## 4. Preflight
+
+Run `adlc preflight --json` and summarize the verdict (informational for setup).
+
+## 5. Summarize
+
+Report: toolkit version, whether `.adlc/tickets.json`/`config.json` were created or
+already present, what was deployed into `.opencode/`, gitignore changes, and the
+preflight verdict. Point the user at `/adlc-ticket` to author their first ticket.

--- a/plugins/adlc-opencode/command/adlc-spec.md
+++ b/plugins/adlc-opencode/command/adlc-spec.md
@@ -1,0 +1,34 @@
+---
+description: Shape and stress-test a spec (P1 Interrogate) with parallax, spec-lint, and premortem.
+---
+
+# /adlc-spec — interrogate the spec (P1)
+
+Turn a ticket or rough request into an executable spec and stress it before
+decomposition. Target ticket / request: **$ARGUMENTS** (default to the active
+ticket in `.adlc/current-ticket.json` if empty).
+
+All gates are LLM-backed; inside OpenCode *you are the model*, so use the
+`--prompt-only` flow (no API key): run the gate, answer the printed prompt
+yourself, apply the judgment.
+
+## 1. Measure ambiguity — `parallax`
+Run `adlc parallax --file <spec-or-request> --prompt-only`. Produce the N
+independent readings, then the divergence analysis. Every divergence above the
+threshold is an ambiguity you must resolve (ask the user or research) before
+proceeding. Write the converged spec to a file.
+
+## 2. Lint acceptance criteria — `spec-lint`
+Run `adlc spec-lint <spec.md> --prompt-only` and answer the vacuousness audit:
+every acceptance criterion needs a concrete, runnable verification (command, test
+file, or assertion). Rewrite any vacuous criterion.
+
+## 3. Failure-first — `premortem`
+Run `adlc premortem <spec.md> --prompt-only` and answer it: list 5–10 concrete,
+mechanism-specific failure causes. Fold the material ones back into the spec /
+acceptance criteria.
+
+## 4. Summarize
+Report the converged spec, the resolved ambiguities, and the premortem causes you
+folded in. When the spec is clean, point the user at `/adlc-approve-spec` (P1 G1)
+and then `/adlc-decompose` (P2).

--- a/plugins/adlc-opencode/command/adlc-ticket.md
+++ b/plugins/adlc-opencode/command/adlc-ticket.md
@@ -1,0 +1,43 @@
+---
+description: Author and triage an ADLC ticket (P0) into .adlc/tickets.json, then check it is executable.
+---
+
+# /adlc-ticket — author a ticket (P0 Triage)
+
+Tickets are the contract every downstream gate reads (`coldstart`, `model-router`,
+`merge-forecast`, `rails-guard`). Turn the request into a well-formed,
+self-contained ticket appended to `.adlc/tickets.json`.
+
+The request to triage: **$ARGUMENTS** (if empty, ask the user what the ticket is for).
+
+## 1. Preconditions
+- Require `.adlc/tickets.json` (tell the user to run `/adlc-init` if missing).
+- Read it to learn existing ids and pick the next free `T<n>`.
+
+## 2. Shape the ticket (executable without guesswork)
+Gather: `id`, `title` (imperative), `body` (self-contained: what to build,
+acceptance criteria with concrete verification commands, context), `scope` (file
+globs it may touch), `rails` (frozen paths, default `[]`), `edges` (prerequisite→
+dependent ordering, default `[]`), `duration` (positive number), `category`,
+optional `budget`. Ask the user rather than guess if anything required is ambiguous.
+
+## 3. Write safely (mutually exclusive)
+1. Acquire a lock: `mkdir .adlc/tickets.lock` (atomic; retry briefly, else abort).
+   Always `rmdir` it on every exit path.
+2. Re-read the snapshot; re-derive the next free id.
+3. Build the proposed array in memory (append the ticket; add a single
+   prerequisite→new edge to an existing ticket only if needed).
+4. Validate in memory: required fields/types; every `edge.to` resolves; no
+   duplicate id; no dependency cycle. On failure, release the lock and report.
+5. Write atomically: temp file in `.adlc/`, then rename over `tickets.json`.
+6. Confirm: `adlc merge-forecast --json` — if it reports a cycle/gate failure,
+   restore the snapshot and report; else continue.
+7. Release the lock.
+
+## 4. Check executability (coldstart, keyless)
+Run `adlc coldstart <id> --prompt-only`, answer the printed audit yourself, and
+report gaps (none → executable; gaps → offer to revise and re-check).
+
+## 5. Summarize
+Report the new id, title, scope/rails, and the coldstart verdict. Point the user
+at `/adlc-spec` for P1 interrogation next.

--- a/plugins/adlc-opencode/gate-bins.mjs
+++ b/plugins/adlc-opencode/gate-bins.mjs
@@ -1,0 +1,34 @@
+// gate-bins.mjs — the ADLC command surface OpenCode maps to.
+//
+// First use of any gate must not fail with ENOENT, so the integration declares
+// the full set up front (integration-plan §7 Phase A). The dispatcher routes
+// `adlc <tool>`; the runner handles phase-evidence assertions.
+
+/** The umbrella dispatcher and the phase-evidence runner (ADR 0002, Option D). */
+export const DISPATCHERS = ['adlc', 'adlc-runner'];
+
+/** The 19 gate tools dispatched via `adlc <tool>` (integration-plan §7 Phase A). */
+export const GATE_BINS = [
+  'behavior-diff',
+  'coldstart',
+  'consensus-fix',
+  'flail-detector',
+  'gate-fuzzing',
+  'gate-manifest',
+  'hollow-test',
+  'lesson-foundry',
+  'merge-forecast',
+  'model-ratchet',
+  'model-router',
+  'parallax',
+  'preflight',
+  'premortem',
+  'rails-guard',
+  'rejection-mining',
+  'review-calibration',
+  'skill-rot',
+  'spec-lint',
+];
+
+/** Everything the integration expects to be resolvable. */
+export const ALL_BINS = [...DISPATCHERS, ...GATE_BINS];

--- a/plugins/adlc-opencode/lib/scaffold-cli.mjs
+++ b/plugins/adlc-opencode/lib/scaffold-cli.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// scaffold-cli.mjs — thin CLI wrapper around scaffold() for /adlc-init.
+// Usage: node lib/scaffold-cli.mjs [projectRoot]
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { scaffold } from './scaffold.mjs';
+
+const projectRoot = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url))); // plugins/adlc-opencode
+
+const { config, commands, skills } = scaffold(projectRoot, pkgRoot);
+console.log(`adlc-init: config.json ${config.created ? 'created' : 'present'}`);
+console.log(`adlc-init: deployed ${commands.length} command(s) → .opencode/commands/`);
+console.log(`adlc-init: deployed ${skills.length} skill(s) → .opencode/skill/`);

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -1,0 +1,66 @@
+// scaffold.mjs — deterministic /adlc-init scaffolding for OpenCode.
+//
+// Two jobs, both idempotent and non-clobbering (integration-plan §4.1 / §7
+// Phase A):
+//   1. ensure .adlc/config.json exists with safe defaults;
+//   2. deploy the plugin's command + skill sources into the project's
+//      .opencode/ directory so OpenCode discovers them.
+//
+// Pure-ish: every function takes explicit roots, so it is unit-testable against
+// a temp dir without touching the real environment.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DEFAULT_CONFIG = {
+  securityMode: 'unsigned-fallback',
+  signers: {},
+  revokedKeys: [],
+  securitySensitivePatterns: [],
+  maxBundleAgeDays: 14,
+};
+
+/**
+ * Create .adlc/config.json with defaults if absent. Never clobbers an existing
+ * config. Returns { created: boolean, path }.
+ */
+export function ensureConfig(root, defaults = DEFAULT_CONFIG) {
+  const dir = join(root, '.adlc');
+  const path = join(dir, 'config.json');
+  if (existsSync(path)) return { created: false, path };
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(defaults, null, 2) + '\n');
+  return { created: true, path };
+}
+
+/**
+ * Copy *.md sources from a plugin subdir into the project's .opencode/<dest>/.
+ * Idempotent: re-running overwrites with the current source (the package is the
+ * source of truth) but never deletes unrelated files. Returns the deployed names.
+ */
+export function deployDir(pkgRoot, destRoot, sub, destSub = sub) {
+  const srcDir = join(pkgRoot, sub);
+  if (!existsSync(srcDir)) return [];
+  const outDir = join(destRoot, '.opencode', destSub);
+  mkdirSync(outDir, { recursive: true });
+  const deployed = [];
+  for (const name of readdirSync(srcDir)) {
+    if (!name.endsWith('.md')) continue;
+    writeFileSync(join(outDir, name), readFileSync(join(srcDir, name), 'utf8'));
+    deployed.push(name);
+  }
+  return deployed;
+}
+
+/**
+ * Full scaffold: ensure config + deploy command/ and skill/ into .opencode/.
+ * OpenCode discovers project commands under .opencode/commands/ and skills under
+ * .opencode/skill/; the plugin ships them under command/ and skill/ respectively.
+ * Returns a summary of what changed.
+ */
+export function scaffold(root, pkgRoot) {
+  const config = ensureConfig(root);
+  const commands = deployDir(pkgRoot, root, 'command', 'commands');
+  const skills = deployDir(pkgRoot, root, 'skill', 'skill');
+  return { config, commands, skills };
+}

--- a/plugins/adlc-opencode/package.json
+++ b/plugins/adlc-opencode/package.json
@@ -7,6 +7,7 @@
   "main": "index.mjs",
   "opencode": {
     "plugin": "./index.mjs",
+    "command": "./command/",
     "skill": "./skill/"
   },
   "peerDependencies": {

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -1,0 +1,88 @@
+// scaffold.test.mjs — Phase A (T2) coverage: deterministic /adlc-init scaffolding
+// and the gate-bin dependency mapping. Offline, temp-dir only.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ensureConfig, deployDir, scaffold } from '../lib/scaffold.mjs';
+import { ALL_BINS, GATE_BINS, DISPATCHERS } from '../gate-bins.mjs';
+
+const PKG = dirname(dirname(fileURLToPath(import.meta.url))); // plugins/adlc-opencode
+const mkroot = () => mkdtempSync(join(tmpdir(), 'oc-t2-'));
+
+// ---- ensureConfig ----
+test('ensureConfig creates .adlc/config.json with defaults when absent', () => {
+  const root = mkroot();
+  try {
+    const r = ensureConfig(root);
+    assert.equal(r.created, true);
+    const cfg = JSON.parse(readFileSync(r.path, 'utf8'));
+    assert.equal(cfg.securityMode, 'unsigned-fallback');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureConfig never clobbers an existing config (idempotent)', () => {
+  const root = mkroot();
+  try {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'config.json'), '{"securityMode":"signed","mine":true}\n');
+    const r = ensureConfig(root);
+    assert.equal(r.created, false);
+    const cfg = JSON.parse(readFileSync(r.path, 'utf8'));
+    assert.equal(cfg.mine, true); // untouched
+    assert.equal(cfg.securityMode, 'signed');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- deployDir / scaffold ----
+test('scaffold deploys the real command files into .opencode/commands', () => {
+  const root = mkroot();
+  try {
+    const out = scaffold(root, PKG);
+    assert.ok(out.commands.includes('adlc-init.md'), 'adlc-init.md deployed');
+    assert.ok(out.commands.includes('adlc-ticket.md'), 'adlc-ticket.md deployed');
+    assert.ok(existsSync(join(root, '.opencode', 'commands', 'adlc-spec.md')));
+    assert.ok(existsSync(join(root, '.opencode', 'skill', 'adlc.md')));
+    assert.equal(out.config.created, true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('scaffold is idempotent (re-run overwrites from source, no throw)', () => {
+  const root = mkroot();
+  try {
+    scaffold(root, PKG);
+    const second = scaffold(root, PKG);
+    assert.equal(second.config.created, false); // config preserved
+    assert.ok(second.commands.length >= 5); // commands re-deployed from source
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('deployDir on a missing source dir returns [] (no throw)', () => {
+  const root = mkroot();
+  try {
+    assert.deepEqual(deployDir(PKG, root, 'does-not-exist'), []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- gate-bins dependency mapping ----
+test('gate-bins declares the 19 gates + 2 dispatchers, no duplicates', () => {
+  assert.equal(GATE_BINS.length, 19);
+  assert.deepEqual(DISPATCHERS, ['adlc', 'adlc-runner']);
+  assert.equal(ALL_BINS.length, 21);
+  assert.equal(new Set(ALL_BINS).size, 21, 'no duplicate bins');
+  for (const b of ['rails-guard', 'spec-lint', 'coldstart', 'merge-forecast', 'preflight']) {
+    assert.ok(GATE_BINS.includes(b), `${b} present`);
+  }
+});
+
+// ---- every shipped command file is a valid OpenCode command (frontmatter) ----
+test('every command/*.md has a description frontmatter field', () => {
+  const cmdDir = join(PKG, 'command');
+  for (const f of readdirSync(cmdDir).filter((n) => n.endsWith('.md'))) {
+    const body = readFileSync(join(cmdDir, f), 'utf8');
+    assert.match(body, /^---\n[\s\S]*?description:\s*\S+[\s\S]*?\n---/, `${f} has description frontmatter`);
+  }
+});

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -59,7 +59,7 @@ else {
 // ---- AC3: run the real enforcement unit test (always-on proof) ----
 try {
   execFileSync(process.execPath, ['--test', ...globTests(join(PLUGIN, 'test'))], { cwd: ROOT, stdio: 'pipe' });
-  ok('enforcement unit test (rails-checker.test.mjs) passes');
+  ok('plugin unit tests pass (rails-checker + scaffold)');
 } catch (e) {
   fail(`enforcement unit test failed:\n${e.stdout?.toString() ?? e.message}`);
 }
@@ -73,6 +73,27 @@ else {
   else ok('stub banner removed');
   if (!/ci\/rails-guard\.yml/.test(doc)) fail('opencode.md does not point at the mandatory CI gate (docs/ci/rails-guard.yml)'); else ok('links the unbypassable CI gate');
   if (!/advisor/i.test(doc)) fail('opencode.md does not frame the in-session hook as advisory'); else ok('frames in-session hook as advisory');
+}
+
+// ---- Phase A (T2): command suite + gate-bin dependency mapping ----
+const pkg2 = existsSync(pkgPath) ? JSON.parse(read(pkgPath)) : {};
+if (!pkg2.opencode?.command) fail('package.json opencode.command entry missing'); else ok('opencode.command manifest entry');
+const cmdDir = join(PLUGIN, 'command');
+const PHASE_A_CMDS = ['adlc-init.md', 'adlc-ticket.md', 'adlc-spec.md', 'adlc-approve-spec.md', 'adlc-decompose.md'];
+for (const c of PHASE_A_CMDS) {
+  const p = join(cmdDir, c);
+  if (!existsSync(p)) { fail(`command/${c} missing`); continue; }
+  if (!/^---\n[\s\S]*?description:\s*\S+[\s\S]*?\n---/.test(read(p))) fail(`command/${c} lacks description frontmatter`);
+  else ok(`command/${c} valid`);
+}
+if (!existsSync(join(PLUGIN, 'lib', 'scaffold.mjs'))) fail('lib/scaffold.mjs missing'); else ok('scaffold helper present');
+if (!existsSync(join(PLUGIN, 'gate-bins.mjs'))) fail('gate-bins.mjs missing');
+else {
+  const gb = read(join(PLUGIN, 'gate-bins.mjs'));
+  for (const b of ['rails-guard', 'spec-lint', 'coldstart', 'merge-forecast', 'preflight']) {
+    if (!gb.includes(`'${b}'`)) fail(`gate-bins missing ${b}`);
+  }
+  ok('gate-bins declares the core gate tools');
 }
 
 // AC7 (live deny proof against the real opencode binary) is the remaining GA gate;


### PR DESCRIPTION
Implements **ticket T2** (plan Phase A), building on the T1 plugin (#27).

## What ships
- **`command/`** — OpenCode slash commands (Markdown + YAML frontmatter) for the P0–P2 on-ramp:
  `/adlc-init`, `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`, `/adlc-decompose`.
  `init`/`ticket` adapted from the Claude Code plugin; `spec`/`approve-spec`/`decompose` written for OpenCode's prompt-only flow.
- **`lib/scaffold.mjs`** (+ `scaffold-cli.mjs`) — deterministic, idempotent `/adlc-init` scaffolding: ensure `.adlc/config.json` (no clobber) and deploy `command/` + `skill/` into `.opencode/`.
- **`gate-bins.mjs`** — the dependency mapping (2 dispatchers + 19 gate bins) so first use never ENOENTs.
- **`package.json`** — declares `opencode.command` in the manifest.
- **`test/scaffold.test.mjs`** — 7 tests (config create / no-clobber, deploy, idempotency, missing-source, gate-bin completeness, command frontmatter).
- **`scripts/opencode-install-smoke.mjs`** — extended to validate the command suite, manifest entry, scaffold helper, and gate-bins.
- **`docs/integrations/opencode.md`** — Commands section; P0–P2 now covered.

## Verify-against-live notes (tracked, like T1)
- OpenCode docs say project commands live in `.opencode/commands/` (plural); the plan used `command/` (singular). The plugin ships sources under `command/` and the scaffolder deploys them to `.opencode/commands/`. Pinning the runtime dir against a live install is a follow-up.

## Test plan
- [x] `npm test` → 1336 tests, 1335 pass, 0 fail (+7 T2 tests)
- [x] `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] `node scripts/codex-install-smoke.mjs .` / `claude-code-plugin-smoke.mjs .` → exit 0

Depends on #27 (merged). Part of the T1–T5 chain (planning #24, merged). Next: T3 (Phase B keyless bridge).