### PR TITLE
feat(opencode): Phase B — keyless two-phase LLM-gate bridge (ticket T3)

### DIFF
--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -12,11 +12,19 @@ discovery skill.
 ## Status
 
 Shipping so far: the rails-guard plugin (`plugins/adlc-opencode/`, plan Phase D),
-the discovery skill, and the **Phase A command surface** — `/adlc-init`,
+the discovery skill, the **Phase A command surface** — `/adlc-init`,
 `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`, `/adlc-decompose` plus the
-gate-bin dependency mapping and deterministic `/adlc-init` scaffolding. Still
-follow-on (plan Phases B/C/E): the keyless LLM bridge, advisory session hooks, and
-the prosecutor lenses.
+gate-bin dependency mapping and deterministic `/adlc-init` scaffolding — and the
+**Phase B keyless gate bridge** (`lib/keyless-bridge.mjs`): run any LLM-backed gate
+in `--prompt-only` mode, route the prompt(s) to the host model, no API key. Still
+follow-on (plan Phases C/E): advisory session hooks and the prosecutor lenses.
+
+> **Keyless bridge — SDK dependency (plan §6.4).** The bridge's protocol (extract
+> a gate's prompts, ask, thread answers) is implemented and tested, but the
+> isolated-sub-context model call depends on a proposed OpenCode SDK extension. The
+> `ask` function is capability-gated: it uses the SDK isolated-prompt API when
+> present, optionally degrades to the active session model, and otherwise returns
+> `null` so callers fail closed rather than silently skip a gate.
 
 ## Commands
 

--- a/plugins/adlc-opencode/lib/keyless-bridge.mjs
+++ b/plugins/adlc-opencode/lib/keyless-bridge.mjs
@@ -1,0 +1,73 @@
+// keyless-bridge.mjs — run LLM-backed ADLC gates without an API key.
+//
+// Inside OpenCode *the host model is the provider*. Every LLM-backed gate supports
+// `--prompt-only`: it prints the exact prompt(s) and exits 0 without calling a
+// provider. This bridge runs a gate in prompt-only mode, extracts the prompt(s),
+// routes each to an isolated model sub-context, and returns the answers — the
+// "two-phase stdio cascade" of integration-plan §4.3.
+//
+// The model call itself is the only SDK-dependent piece, so it is INJECTED (`ask`)
+// and capability-gated (`makeAsk`). That keeps the protocol pure and unit-testable
+// offline, and lets the integration degrade gracefully when the host SDK lacks the
+// proposed isolated-prompt extension (plan §6.4).
+
+import { spawnSync } from 'node:child_process';
+
+const PROMPT_SPLIT = /^---\s*prompt\s+\d+\s+of\s+\d+\s*---\s*$/im;
+const PROMPT_SPLIT_G = /^---\s*prompt\s+\d+\s+of\s+\d+\s*---\s*$/gim;
+
+/**
+ * Split a gate's --prompt-only stdout into ordered prompt segments. Gates that
+ * fan out (e.g. parallax) emit "--- prompt N of M ---" separators; single-prompt
+ * gates emit one block. Returns [{ index, text }].
+ */
+export function extractPrompts(stdout) {
+  const text = (stdout ?? '').trim();
+  if (!text) return [];
+  if (!PROMPT_SPLIT.test(text)) return [{ index: 1, text }];
+  return text
+    .split(PROMPT_SPLIT_G)
+    .map((seg) => seg.trim())
+    .filter(Boolean)
+    .map((t, i) => ({ index: i + 1, text: t }));
+}
+
+/**
+ * Run an ADLC gate keylessly. `ask(promptText, ctx)` resolves the prompt against
+ * the host model (injected; see makeAsk). `spawnImpl` is injectable for tests.
+ * Multi-prompt cascades are asked in order with prior answers threaded as context.
+ * Returns { prompts, answers } or throws on a gate operational failure.
+ */
+export function runGateKeyless({ bin, args = [], ask, spawnImpl = spawnSync, cwd = process.cwd() }) {
+  if (typeof ask !== 'function') throw new Error('runGateKeyless: an ask(prompt) function is required');
+  const res = spawnImpl(bin, [...args, '--prompt-only'], { cwd, encoding: 'utf8' });
+  if (res.status !== 0) {
+    throw new Error(`gate ${bin} --prompt-only exited ${res.status}: ${(res.stderr || '').trim()}`);
+  }
+  const prompts = extractPrompts(res.stdout);
+  const answers = [];
+  for (const p of prompts) {
+    answers.push(ask(p.text, { index: p.index, total: prompts.length, prior: answers.slice() }));
+  }
+  return { prompts, answers };
+}
+
+/**
+ * Resolve the keyless "ask" function from host capability (plan §6.4).
+ *  - If the SDK exposes an isolated-prompt extension, use it (best: fresh,
+ *    side-effect-free sub-context, optionally a different model).
+ *  - Else, if degraded mode is allowed, fall back to the active session model.
+ *  - Else return null — keyless dispatch is unavailable; the caller must fail
+ *    closed rather than silently skip a gate.
+ */
+export function makeAsk(api, { allowDegraded = false, model } = {}) {
+  const isolated = api?.client?.prompt;
+  if (typeof isolated === 'function') {
+    return (text, ctx) => isolated({ prompt: text, isolated: true, model, context: ctx });
+  }
+  const active = api?.client?.session?.prompt ?? api?.prompt;
+  if (allowDegraded && typeof active === 'function') {
+    return (text, ctx) => active({ prompt: text, context: ctx });
+  }
+  return null;
+}

--- a/plugins/adlc-opencode/test/keyless-bridge.test.mjs
+++ b/plugins/adlc-opencode/test/keyless-bridge.test.mjs
@@ -1,0 +1,82 @@
+// keyless-bridge.test.mjs — Phase B (T3): the keyless two-phase gate cascade.
+// Pure/offline: injects a stub spawn + ask, no real gate or model.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractPrompts, runGateKeyless, makeAsk } from '../lib/keyless-bridge.mjs';
+
+// ---- extractPrompts ----
+test('extractPrompts: single-prompt gate → one segment', () => {
+  const out = '=== system ===\nyou are an auditor\n=== user ===\naudit this';
+  const p = extractPrompts(out);
+  assert.equal(p.length, 1);
+  assert.match(p[0].text, /auditor/);
+});
+
+test('extractPrompts: fan-out gate with "prompt N of M" → ordered segments', () => {
+  const out = [
+    '--- prompt 1 of 2 ---',
+    'reading prompt',
+    '--- prompt 2 of 2 ---',
+    'divergence prompt',
+  ].join('\n');
+  const p = extractPrompts(out);
+  assert.equal(p.length, 2);
+  assert.deepEqual(p.map((x) => x.index), [1, 2]);
+  assert.match(p[0].text, /reading/);
+  assert.match(p[1].text, /divergence/);
+});
+
+test('extractPrompts: empty output → []', () => {
+  assert.deepEqual(extractPrompts(''), []);
+  assert.deepEqual(extractPrompts('   \n'), []);
+});
+
+// ---- runGateKeyless ----
+function stubSpawn(stdout, status = 0, stderr = '') {
+  return (_bin, args) => {
+    assert.ok(args.includes('--prompt-only'), 'gate is run with --prompt-only');
+    return { status, stdout, stderr };
+  };
+}
+
+test('runGateKeyless: asks each prompt in order, threads prior answers', () => {
+  const spawnImpl = stubSpawn('--- prompt 1 of 2 ---\nA\n--- prompt 2 of 2 ---\nB');
+  const seen = [];
+  const ask = (text, ctx) => { seen.push({ text, prior: ctx.prior.length }); return `ans:${text}`; };
+  const { prompts, answers } = runGateKeyless({ bin: 'adlc', args: ['parallax'], ask, spawnImpl });
+  assert.equal(prompts.length, 2);
+  assert.deepEqual(answers, ['ans:A', 'ans:B']);
+  assert.deepEqual(seen.map((s) => s.prior), [0, 1]); // 2nd ask sees 1 prior answer
+});
+
+test('runGateKeyless: gate operational failure (status!=0) throws', () => {
+  const spawnImpl = stubSpawn('', 1, 'no provider');
+  assert.throws(() => runGateKeyless({ bin: 'adlc', args: ['spec-lint'], ask: () => 'x', spawnImpl }), /exited 1/);
+});
+
+test('runGateKeyless: requires an ask function', () => {
+  assert.throws(() => runGateKeyless({ bin: 'adlc', spawnImpl: stubSpawn('p') }), /ask\(prompt\) function is required/);
+});
+
+// ---- makeAsk capability resolution (plan §6.4) ----
+test('makeAsk: uses the SDK isolated-prompt extension when present', () => {
+  const calls = [];
+  const api = { client: { prompt: (o) => { calls.push(o); return 'iso'; } } };
+  const ask = makeAsk(api);
+  assert.equal(typeof ask, 'function');
+  assert.equal(ask('hello', { index: 1 }), 'iso');
+  assert.equal(calls[0].isolated, true);
+});
+
+test('makeAsk: degrades to the active session model only when allowed', () => {
+  const api = { client: { session: { prompt: () => 'active' } } };
+  assert.equal(makeAsk(api, { allowDegraded: false }), null, 'no silent degrade by default');
+  const ask = makeAsk(api, { allowDegraded: true });
+  assert.equal(ask('x', {}), 'active');
+});
+
+test('makeAsk: no capability + not allowed → null (caller fails closed)', () => {
+  assert.equal(makeAsk({}, {}), null);
+  assert.equal(makeAsk(null, { allowDegraded: true }), null);
+});

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -87,6 +87,19 @@ for (const c of PHASE_A_CMDS) {
   else ok(`command/${c} valid`);
 }
 if (!existsSync(join(PLUGIN, 'lib', 'scaffold.mjs'))) fail('lib/scaffold.mjs missing'); else ok('scaffold helper present');
+
+// ---- Phase B (T3): keyless LLM-gate bridge ----
+const bridgePath = join(PLUGIN, 'lib', 'keyless-bridge.mjs');
+if (!existsSync(bridgePath)) fail('lib/keyless-bridge.mjs missing');
+else {
+  const br = read(bridgePath);
+  for (const fn of ['extractPrompts', 'runGateKeyless', 'makeAsk']) {
+    if (!new RegExp(`export function ${fn}\\b`).test(br)) fail(`keyless-bridge missing export ${fn}`);
+  }
+  if (!/--prompt-only/.test(br)) fail('keyless-bridge does not run gates in --prompt-only mode');
+  ok('keyless bridge present (extractPrompts/runGateKeyless/makeAsk, prompt-only)');
+}
+
 if (!existsSync(join(PLUGIN, 'gate-bins.mjs'))) fail('gate-bins.mjs missing');
 else {
   const gb = read(join(PLUGIN, 'gate-bins.mjs'));


### PR DESCRIPTION
Implements **ticket T3** (plan Phase B), building on T1/T2 (#27, #28). Lets any LLM-backed ADLC gate run without an API key — inside OpenCode the host model is the provider.

## What ships
- **`lib/keyless-bridge.mjs`**
  - `extractPrompts()` — split a gate's `--prompt-only` stdout into ordered prompt segments (handles fan-out gates' `prompt N of M` markers and single-prompt gates)
  - `runGateKeyless()` — spawn the gate in `--prompt-only`, ask each prompt via an injected model fn, thread prior answers; throws on gate operational failure
  - `makeAsk()` — **capability-gated** model-call resolution (plan §6.4): SDK isolated-prompt extension when present; optional degrade to the active session model; else `null` so callers **fail closed** rather than silently skip a gate
- **`test/keyless-bridge.test.mjs`** — 9 tests (extraction single/fan-out/empty, cascade ordering + answer threading, gate-failure throw, ask-required, all three `makeAsk` branches)
- **`scripts/opencode-install-smoke.mjs`** — validates the bridge exports + prompt-only use
- **`docs/integrations/opencode.md`** — Phase B shipped + SDK-dependency note

## Design honesty
The model call is **injected**, so the cascade protocol is pure and unit-testable offline. The dependency on OpenCode's *proposed* isolated-prompt SDK extension (plan §6.4) is **capability-gated**, not assumed — when absent, the bridge degrades (if allowed) or returns `null` so a gate is never silently skipped.

## Test plan
- [x] `npm test` → 1345 tests, 1344 pass, 0 fail (+9 T3 tests)
- [x] `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] sibling smokes exit 0

Depends on #28 (merged). Part of the T1–T5 chain. Next: T4 (Phase C advisory session hooks).