### PR TITLE
feat(opencode): Phase C — advisory session hooks (ticket T4)

### DIFF
--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -16,8 +16,16 @@ the discovery skill, the **Phase A command surface** — `/adlc-init`,
 `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`, `/adlc-decompose` plus the
 gate-bin dependency mapping and deterministic `/adlc-init` scaffolding — and the
 **Phase B keyless gate bridge** (`lib/keyless-bridge.mjs`): run any LLM-backed gate
-in `--prompt-only` mode, route the prompt(s) to the host model, no API key. Still
-follow-on (plan Phases C/E): advisory session hooks and the prosecutor lenses.
+in `--prompt-only` mode, route the prompt(s) to the host model, no API key — and
+the **Phase C advisory session hooks** (`session.created` preflight,
+`session.idle` gate-manifest audit). Still follow-on (plan Phase E): the
+prosecutor lenses.
+
+> **Session hooks — event-name note.** The plan specified `session.created` +
+> `session.ended`, but OpenCode has no `session.ended`; the end-of-work signal is
+> `session.idle`, which the gate-manifest audit uses. Both hooks are advisory:
+> they only surface warnings, never throw, and no-op when the repo is not
+> ADLC-initialized.
 
 > **Keyless bridge — SDK dependency (plan §6.4).** The bridge's protocol (extract
 > a gate's prompts, ask, thread answers) is implemented and tested, but the
@@ -103,9 +111,9 @@ glob/ticket logic to `@adlc/core`:
 | P1 Interrogate | **Yes** | `/adlc-spec` + `/adlc-approve-spec` (Phase A) + the `adlc` skill |
 | P2 Decompose | **Yes** | `/adlc-decompose` (Phase A) |
 | P3 Rail | **MVP** | the in-session rails-guard hook (this plugin) + CI gate |
-| P4 Build | Partial | rails-guard hook; flail-detection is follow-on |
+| P4 Build | Partial | rails-guard hook + `session.created` advisory preflight; flail-detection is follow-on |
 | P5 Prosecute | Planned | plan Phase E prosecutor lenses — follow-on T5 |
-| P6 Integrate | Planned | gate-manifest evidence (human gate) |
+| P6 Integrate | Partial | `session.idle` advisory gate-manifest audit; the human gate is by design |
 | P7 Distill | Planned | plan Phase E (`/adlc-distill`) — follow-on T5 |
 
 ## Gaps

--- a/plugins/adlc-opencode/index.mjs
+++ b/plugins/adlc-opencode/index.mjs
@@ -12,6 +12,7 @@
 // advisory mode; otherwise it signals that preflight should fail closed.
 
 import { checkRail, probeEnforcementCapability } from './rails-checker.mjs';
+import { checkPreflight, auditGateManifest } from './lib/session-hooks.mjs';
 
 /** @typedef {import('@opencode-ai/plugin').Plugin} Plugin */
 
@@ -41,6 +42,24 @@ export const adlcRailsGuard = async ({ directory, worktree, project } = {}) => {
       }
       // Advisory mode: cannot abort, so surface loudly without claiming to block.
       console.error(`${message} [ADVISORY — host SDK does not honor deny; rely on the CI rail-freeze gate]`);
+    },
+
+    // session.created (Phase C): advisory environment preflight. Never throws.
+    'session.created': async () => {
+      try {
+        const { skipped, warnings } = checkPreflight(root, { env: process.env });
+        if (!skipped) for (const w of warnings) console.error(`ADLC preflight: ${w}`);
+      } catch { /* advisory: swallow */ }
+    },
+
+    // session.idle (Phase C): advisory gate-evidence audit (the plan's
+    // "session.ended" — OpenCode has no such event; session.idle is the
+    // end-of-work signal). Never throws.
+    'session.idle': async () => {
+      try {
+        const { warning } = auditGateManifest(root);
+        if (warning) console.error(`ADLC gate-manifest audit: ${warning}`);
+      } catch { /* advisory: swallow */ }
     },
   };
 };

--- a/plugins/adlc-opencode/lib/session-hooks.mjs
+++ b/plugins/adlc-opencode/lib/session-hooks.mjs
@@ -1,0 +1,68 @@
+// session-hooks.mjs — advisory session lifecycle checks for OpenCode (plan
+// Phase C). Both are ADVISORY and FAIL-SAFE: they only surface warnings, never
+// throw, and no-op when the repo is not ADLC-initialized.
+//
+// Event-name note: the plan specified `session.created` + `session.ended`, but
+// OpenCode exposes `session.created` and `session.idle` (there is no
+// `session.ended`). We map the end-of-work audit onto `session.idle`.
+//
+// The subprocess calls are injected (`spawnImpl`) so the logic is unit-testable
+// offline without `adlc` or `git` installed.
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function run(spawnImpl, bin, args, cwd) {
+  try {
+    const r = spawnImpl(bin, args, { cwd, encoding: 'utf8' });
+    return { status: r.status ?? (r.error ? 1 : 0), stdout: r.stdout ?? '', stderr: r.stderr ?? '', error: r.error };
+  } catch (err) {
+    return { status: 1, stdout: '', stderr: String(err), error: err };
+  }
+}
+
+/**
+ * session.created check: is the environment ready for ADLC work / fan-out?
+ * Advisory only. Returns { ready, skipped, warnings[] }.
+ */
+export function checkPreflight(root, { spawnImpl = spawnSync, env = process.env } = {}) {
+  if (!existsSync(join(root, '.adlc', 'tickets.json'))) {
+    return { ready: true, skipped: true, warnings: [] }; // not ADLC-initialized → no-op
+  }
+  const warnings = [];
+
+  const ver = run(spawnImpl, 'adlc', ['--version'], root);
+  if (ver.error || ver.status !== 0) {
+    warnings.push('`adlc` is not on PATH — install @adlc/cli (npm i -g @adlc/cli) before running gates.');
+  }
+
+  const git = run(spawnImpl, 'git', ['status', '--porcelain'], root);
+  if (!git.error && git.status === 0 && git.stdout.trim()) {
+    warnings.push('git worktree is dirty — a non-deterministic tree weakens evidence; commit or stash before fan-out.');
+  }
+
+  if (env.ADLC_P4_ENFORCEMENT !== '1') {
+    warnings.push('ADLC_P4_ENFORCEMENT is not set — in-session rail enforcement is inactive (advisory). The CI gate remains authoritative.');
+  }
+
+  return { ready: warnings.length === 0, skipped: false, warnings };
+}
+
+/**
+ * session.idle audit: is the gate-evidence chain intact? Advisory only.
+ * Returns { ok, skipped, warning }.
+ */
+export function auditGateManifest(root, { spawnImpl = spawnSync } = {}) {
+  if (!existsSync(join(root, '.adlc', 'manifest.jsonl'))) {
+    return { ok: true, skipped: true, warning: null }; // nothing recorded yet → no-op
+  }
+  const res = run(spawnImpl, 'adlc', ['gate-manifest', 'verify', '--json'], root);
+  if (res.error) {
+    return { ok: true, skipped: true, warning: null }; // can't run the verifier → stay silent (advisory)
+  }
+  if (res.status !== 0) {
+    return { ok: false, skipped: false, warning: `gate-manifest verify reported a problem: ${(res.stderr || res.stdout || '').trim().slice(0, 300)}` };
+  }
+  return { ok: true, skipped: false, warning: null };
+}

--- a/plugins/adlc-opencode/test/session-hooks.test.mjs
+++ b/plugins/adlc-opencode/test/session-hooks.test.mjs
@@ -1,0 +1,109 @@
+// session-hooks.test.mjs — Phase C (T4): advisory session lifecycle checks.
+// Pure/offline: injects a stub spawn, temp dirs only. Verifies the hooks are
+// advisory (warnings, never throw) and no-op when not ADLC-initialized.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkPreflight, auditGateManifest } from '../lib/session-hooks.mjs';
+import { adlcRailsGuard } from '../index.mjs';
+
+const mkroot = () => mkdtempSync(join(tmpdir(), 'oc-t4-'));
+function initAdlc(root) {
+  mkdirSync(join(root, '.adlc'), { recursive: true });
+  writeFileSync(join(root, '.adlc', 'tickets.json'), '{"tickets":[]}');
+  return root;
+}
+// spawn stub: route by bin → canned {status, stdout, stderr, error}
+function stub(map) {
+  return (bin, args) => {
+    const key = `${bin} ${(args || []).join(' ')}`;
+    for (const [prefix, val] of Object.entries(map)) if (key.startsWith(prefix)) return val;
+    return { status: 0, stdout: '', stderr: '' };
+  };
+}
+
+// ---- checkPreflight ----
+test('checkPreflight: no .adlc/tickets.json → skipped no-op', () => {
+  const root = mkroot();
+  try {
+    const r = checkPreflight(root, { spawnImpl: stub({}), env: { ADLC_P4_ENFORCEMENT: '1' } });
+    assert.equal(r.skipped, true);
+    assert.deepEqual(r.warnings, []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('checkPreflight: adlc missing + dirty tree + enforcement off → 3 advisory warnings', () => {
+  const root = initAdlc(mkroot());
+  try {
+    const spawnImpl = stub({
+      'adlc --version': { status: 1, error: new Error('ENOENT') },
+      'git status': { status: 0, stdout: ' M file.txt\n' },
+    });
+    const r = checkPreflight(root, { spawnImpl, env: {} });
+    assert.equal(r.skipped, false);
+    assert.equal(r.ready, false);
+    assert.equal(r.warnings.length, 3);
+    assert.ok(r.warnings.some((w) => /adlc.* is not on PATH/.test(w)));
+    assert.ok(r.warnings.some((w) => /dirty/.test(w)));
+    assert.ok(r.warnings.some((w) => /ADLC_P4_ENFORCEMENT/.test(w)));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('checkPreflight: all good → ready, no warnings', () => {
+  const root = initAdlc(mkroot());
+  try {
+    const spawnImpl = stub({
+      'adlc --version': { status: 0, stdout: '1.1.0\n' },
+      'git status': { status: 0, stdout: '' },
+    });
+    const r = checkPreflight(root, { spawnImpl, env: { ADLC_P4_ENFORCEMENT: '1' } });
+    assert.equal(r.ready, true);
+    assert.deepEqual(r.warnings, []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- auditGateManifest ----
+test('auditGateManifest: no manifest → skipped no-op', () => {
+  const root = initAdlc(mkroot());
+  try {
+    const r = auditGateManifest(root, { spawnImpl: stub({}) });
+    assert.equal(r.skipped, true);
+    assert.equal(r.ok, true);
+    assert.equal(r.warning, null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('auditGateManifest: verify non-zero → advisory warning', () => {
+  const root = initAdlc(mkroot());
+  writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
+  try {
+    const spawnImpl = stub({ 'adlc gate-manifest verify': { status: 2, stdout: 'chain broken at seq 1' } });
+    const r = auditGateManifest(root, { spawnImpl });
+    assert.equal(r.ok, false);
+    assert.match(r.warning, /chain broken/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('auditGateManifest: verify ok → no warning', () => {
+  const root = initAdlc(mkroot());
+  writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
+  try {
+    const r = auditGateManifest(root, { spawnImpl: stub({ 'adlc gate-manifest verify': { status: 0, stdout: '{}' } }) });
+    assert.equal(r.ok, true);
+    assert.equal(r.warning, null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- the real hooks are advisory: never throw ----
+test('session.created / session.idle hooks never throw (advisory)', async () => {
+  const root = initAdlc(mkroot());
+  try {
+    const hooks = await adlcRailsGuard({ worktree: root });
+    await hooks['session.created'](); // must resolve, not reject
+    await hooks['session.idle']();
+    assert.ok(typeof hooks['session.created'] === 'function');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -37,6 +37,10 @@ else {
   const idx = read(indexPath);
   if (!/tool\.execute\.before/.test(idx)) fail('index.mjs does not wire tool.execute.before'); else ok('wires tool.execute.before');
   if (!/export (const|default) /.test(idx)) fail('index.mjs has no plugin export'); else ok('exports a plugin');
+  // Phase C (T4): advisory session hooks
+  if (!/session\.created/.test(idx)) fail('index.mjs does not wire session.created'); else ok('wires session.created (advisory preflight)');
+  if (!/session\.idle/.test(idx)) fail('index.mjs does not wire session.idle'); else ok('wires session.idle (advisory gate-manifest audit)');
+  if (!existsSync(join(PLUGIN, 'lib', 'session-hooks.mjs'))) fail('lib/session-hooks.mjs missing'); else ok('session-hooks helper present');
 }
 
 // ---- AC1: skill registration ----


### PR DESCRIPTION
Implements **ticket T4** (plan Phase C), building on T1/T2/T3. Two advisory, fail-safe session lifecycle hooks — they surface warnings only, never throw, and no-op when the repo isn't ADLC-initialized.

## What ships
- **`lib/session-hooks.mjs`**
  - `checkPreflight()` — `session.created` readiness: `adlc` on PATH, clean git worktree, enforcement flag → advisory warnings
  - `auditGateManifest()` — `session.idle` evidence audit: runs `adlc gate-manifest verify` → advisory warning on a broken chain
  - subprocess calls injected for offline testing
- **`index.mjs`** — wires `session.created` + `session.idle` (both `try/catch`, advisory)
- **`test/session-hooks.test.mjs`** — 7 tests (preflight skip/warnings/clean, audit skip/warn/ok, hooks-never-throw)
- smoke + docs (Phase C shipped; P4/P6 now partial)

## Verify-against-live correction
The plan specified `session.created` + **`session.ended`**, but OpenCode has **no `session.ended`** — the end-of-work signal is **`session.idle`**, which the audit uses. (Same class of plan-vs-reality fix as T1's `filePath` and T2's `command/commands`.)

## Test plan
- [x] `npm test` → 1352 tests, 1351 pass, 0 fail (+7 T4 tests)
- [x] `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] sibling smokes exit 0

Depends on #29 (merged). Part of the T1–T5 chain. Next: T5 (Phase E prosecutor lenses).