### PR TITLE
feat(opencode): Phase E — prosecutor lenses, G4 build gate, distill (ticket T5)

### DIFF
--- a/docs/adr/0004-adlc-opencode-integration.md
+++ b/docs/adr/0004-adlc-opencode-integration.md
@@ -63,6 +63,11 @@ control:
   unset, point `ADLC_TICKET` / `.adlc/current-ticket.json` at a rail-free ticket,
   or (if the SDK lacks `onFailure: deny`) ignore an advisory denial.
 - Bash-driven writes are not gated in-session (Turing-complete shell).
+- Unrecognized mutation tools: the gate fails **closed** on tool names — only
+  known read-only tools (`read`/`grep`/`glob`/…) are skipped; known mutators
+  (`edit`/`write`/`patch`/`multiedit`/`apply_patch`) and any unrecognized
+  structured tool carrying a file path are checked, so a new tool name can't slip
+  an edit past the guard.
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail. The
   checker resolves symlinks (target + existing parent segments) before rail
   comparison (`resolveRailPath`), so an aliased write to a rail is denied — a

--- a/docs/adr/0004-adlc-opencode-integration.md
+++ b/docs/adr/0004-adlc-opencode-integration.md
@@ -63,6 +63,11 @@ control:
   unset, point `ADLC_TICKET` / `.adlc/current-ticket.json` at a rail-free ticket,
   or (if the SDK lacks `onFailure: deny`) ignore an advisory denial.
 - Bash-driven writes are not gated in-session (Turing-complete shell).
+- Symlink aliasing: an edit to a symlink whose real target is a frozen rail. The
+  checker resolves symlinks (target + existing parent segments) before rail
+  comparison (`resolveRailPath`), so an aliased write to a rail is denied — a
+  hardening the legacy sibling hooks do not yet have and should adopt via
+  `@adlc/core` (integration-plan §6.6).
 
 Mitigation: the unbypassable commit-time CI gate (`docs/ci/rails-guard.yml`) reads
 the frozen rail set from the trusted base ref and rejects offending PRs regardless

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -41,9 +41,11 @@ all six plan phases (A–F) now ship.
 ## Commands
 
 OpenCode loads project commands from `.opencode/commands/` (Markdown + YAML
-frontmatter). `/adlc-init` deploys this plugin's `command/*.md` and `skill/*.md`
-into `.opencode/` and creates `.adlc/config.json` (idempotently, via
-`lib/scaffold.mjs`). Phase A commands:
+frontmatter). `/adlc-init` deploys this plugin's `command/*.md`, `agent/*.md`, and
+`skill/*.md` into `.opencode/`, creates `.adlc/config.json`, **and registers the
+plugin in `.opencode/opencode.json` so the rails-guard hook actually loads** — all
+idempotently, via `lib/scaffold.mjs`. (Commands/agents/skills are inert markdown;
+the enforcing hook only runs once the plugin package is registered.) Phase A commands:
 
 | Command | Phase | Does |
 | --- | --- | --- |

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -18,8 +18,12 @@ gate-bin dependency mapping and deterministic `/adlc-init` scaffolding — and t
 **Phase B keyless gate bridge** (`lib/keyless-bridge.mjs`): run any LLM-backed gate
 in `--prompt-only` mode, route the prompt(s) to the host model, no API key — and
 the **Phase C advisory session hooks** (`session.created` preflight,
-`session.idle` gate-manifest audit). Still follow-on (plan Phase E): the
-prosecutor lenses.
+`session.idle` gate-manifest audit), and the **Phase E prosecution surface** — the
+G4 build gate (`/adlc-verify-build`), the five P5 prosecution subagents
+(`@prosecutor-correctness|security|contract|diff|tests`) plus the
+`@prosecutor-verifier`, the `/adlc-prosecute` fan-out/verify/loop-until-dry
+command, and `/adlc-distill` (P7). With Phase F's CI backstop (merged earlier),
+all six plan phases (A–F) now ship.
 
 > **Session hooks — event-name note.** The plan specified `session.created` +
 > `session.ended`, but OpenCode has no `session.ended`; the end-of-work signal is
@@ -112,9 +116,9 @@ glob/ticket logic to `@adlc/core`:
 | P2 Decompose | **Yes** | `/adlc-decompose` (Phase A) |
 | P3 Rail | **MVP** | the in-session rails-guard hook (this plugin) + CI gate |
 | P4 Build | Partial | rails-guard hook + `session.created` advisory preflight; flail-detection is follow-on |
-| P5 Prosecute | Planned | plan Phase E prosecutor lenses — follow-on T5 |
+| P5 Prosecute | **Yes** | `/adlc-verify-build` (G4) + 5 prosecutor lenses + verifier + `/adlc-prosecute` |
 | P6 Integrate | Partial | `session.idle` advisory gate-manifest audit; the human gate is by design |
-| P7 Distill | Planned | plan Phase E (`/adlc-distill`) — follow-on T5 |
+| P7 Distill | **Yes** | `/adlc-distill` (Phase E) |
 
 ## Gaps
 
@@ -123,9 +127,11 @@ glob/ticket logic to `@adlc/core`:
    is advisory; the CI gate is the real control.
 2. **Bash-driven writes are not gated in-session** (Turing-complete shell) — caught
    by the CI diff gate, mirroring the Claude Code posture.
-3. **Lifecycle breadth.** Only P3 ships in this MVP; the command suite, keyless
-   bridge, advisory session hooks, and prosecutor lenses are follow-on tickets
-   (T2–T5).
+3. **Phase-E orchestration is model-driven.** `/adlc-prosecute` describes the
+   fan-out → dedupe → verify → loop-until-dry protocol (the decision helpers in
+   `lib/prosecutor.mjs` are unit-tested), but the loop itself is executed by the
+   model invoking the subagents, not a deterministic first-party runner — the same
+   gap the Codex path documents for P5.
 4. **Live deny proof pending.** A maintainer-only end-to-end check against a real
    OpenCode binary (driving an actual edit-to-rail and asserting the block) is the
    remaining GA gate — see ADR 0004.

--- a/plugins/adlc-opencode/agent/prosecutor-contract.md
+++ b/plugins/adlc-opencode/agent/prosecutor-contract.md
@@ -1,0 +1,21 @@
+---
+description: P5 contract lens: API/schema/type conformance against the declared contract.
+mode: subagent
+permission:
+  edit: deny
+  bash: deny
+---
+
+# Contract conformance (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in the
+change**, not validate it. Review the change under one lens: **Contract conformance**.
+
+Hunt specifically for: API/schema/type drift, backwards-incompatible changes, undocumented response shape changes, and violations of the ticket's declared contract or shared types.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty if none). Do not
+soften or speculate beyond the evidence — a finding you cannot ground in the diff
+does not belong.

--- a/plugins/adlc-opencode/agent/prosecutor-correctness.md
+++ b/plugins/adlc-opencode/agent/prosecutor-correctness.md
@@ -1,0 +1,21 @@
+---
+description: P5 correctness lens: logic errors, broken invariants, wrong results.
+mode: subagent
+permission:
+  edit: deny
+  bash: deny
+---
+
+# Correctness (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in the
+change**, not validate it. Review the change under one lens: **Correctness**.
+
+Hunt specifically for: logic errors, off-by-one and boundary mistakes, broken invariants, incorrect results, mishandled error/empty/null cases, and state that can desync.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty if none). Do not
+soften or speculate beyond the evidence — a finding you cannot ground in the diff
+does not belong.

--- a/plugins/adlc-opencode/agent/prosecutor-diff.md
+++ b/plugins/adlc-opencode/agent/prosecutor-diff.md
@@ -1,0 +1,21 @@
+---
+description: P5 diff lens: spec-vs-implementation divergence and unstated behavior changes.
+mode: subagent
+permission:
+  edit: deny
+  bash: deny
+---
+
+# Spec-vs-implementation diff (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in the
+change**, not validate it. Review the change under one lens: **Spec-vs-implementation diff**.
+
+Hunt specifically for: places where the implementation diverges from the spec/acceptance criteria, behavior changes not reflected in the spec, and scope creep beyond the ticket.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty if none). Do not
+soften or speculate beyond the evidence — a finding you cannot ground in the diff
+does not belong.

--- a/plugins/adlc-opencode/agent/prosecutor-security.md
+++ b/plugins/adlc-opencode/agent/prosecutor-security.md
@@ -1,0 +1,21 @@
+---
+description: P5 security lens: auth/trust boundaries, injection, secrets, unsafe data flow.
+mode: subagent
+permission:
+  edit: deny
+  bash: deny
+---
+
+# Security (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in the
+change**, not validate it. Review the change under one lens: **Security**.
+
+Hunt specifically for: auth and trust-boundary holes, injection (SQL/shell/path), secrets in code or logs, SSRF, unsafe deserialization, missing input validation at boundaries, and who-controls-the-control bypasses.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty if none). Do not
+soften or speculate beyond the evidence — a finding you cannot ground in the diff
+does not belong.

--- a/plugins/adlc-opencode/agent/prosecutor-tests.md
+++ b/plugins/adlc-opencode/agent/prosecutor-tests.md
@@ -1,0 +1,21 @@
+---
+description: P5 test-audit lens: hollow/mock-only tests; are the new tests load-bearing?
+mode: subagent
+permission:
+  edit: deny
+  bash: deny
+---
+
+# Test audit (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in the
+change**, not validate it. Review the change under one lens: **Test audit**.
+
+Hunt specifically for: tests that assert nothing meaningful, mock-only verifications, tests that would pass against a broken implementation, missing coverage of the change's core behavior, and suppressed/skipped assertions.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty if none). Do not
+soften or speculate beyond the evidence — a finding you cannot ground in the diff
+does not belong.

--- a/plugins/adlc-opencode/agent/prosecutor-verifier.md
+++ b/plugins/adlc-opencode/agent/prosecutor-verifier.md
@@ -1,0 +1,22 @@
+---
+description: P5 verifier/reproducer: adversarially confirm or refute a single prosecution finding.
+mode: subagent
+permission:
+  edit: deny
+  bash: deny
+---
+
+# Verifier / reproducer (ADLC P5)
+
+You are given ONE prosecution finding. Your job is to **try to refute it**, not to
+agree. Default to refuted when the evidence is weak or you cannot reproduce the
+problem from the quoted diff.
+
+Steps:
+1. Re-read the finding's evidence in context.
+2. Construct the most concrete reproduction or counterexample you can.
+3. Decide: is the finding REAL (a genuine defect a maintainer should act on) or
+   REFUTED (false positive, already-handled, or unreproducible)?
+
+Return one JSON object: `{ "real": boolean, "reason": string, "repro": string }`.
+Be specific and mechanistic; "looks fine" is not a reason.

--- a/plugins/adlc-opencode/command/adlc-distill.md
+++ b/plugins/adlc-opencode/command/adlc-distill.md
@@ -1,0 +1,22 @@
+---
+description: Distill repeated review findings and PR rejections into permanent, deterministic defenses (P7).
+---
+
+# /adlc-distill — turn findings into defenses (P7)
+
+Mine repeated prosecution findings and PR rejections into reusable, deterministic
+defenses (lint rules, skills, review lenses) so the same class of defect can't
+recur. Target scope: **$ARGUMENTS** (default to recent history).
+
+## Steps
+1. Gather repeated findings: `adlc rejection-mining --prompt-only` and
+   `adlc lesson-foundry --prompt-only` (answer the printed prompts yourself).
+2. For each recurring class, propose the cheapest deterministic defense: a lint
+   rule, a new prosecution lens, a skill update, or a test.
+3. Check skill decay: `adlc skill-rot --prompt-only`.
+4. Optional `--simplify`: once all tests are green, run a local Simplify pass under
+   the completed ticket's still-frozen rails (advisory deviation from strict
+   post-merge P7 — warn the user; never edit frozen rails).
+
+## Summarize
+Report the defenses created/proposed and any decayed skills flagged.

--- a/plugins/adlc-opencode/command/adlc-prosecute.md
+++ b/plugins/adlc-opencode/command/adlc-prosecute.md
@@ -1,0 +1,31 @@
+---
+description: Prosecute a change before merge (P5) — fan out the 5 lenses, verify findings, loop until dry.
+---
+
+# /adlc-prosecute — hostile pre-merge review (P5)
+
+Prosecute the change for the active ticket. Requires a clean G4 build
+(`/adlc-verify-build`). Target: **$ARGUMENTS** (default to the active ticket).
+
+## 1. Fan out the lenses
+Invoke the five prosecution subagents independently, each on the change diff:
+`@prosecutor-correctness`, `@prosecutor-security`, `@prosecutor-contract`,
+`@prosecutor-diff`, `@prosecutor-tests`. Collect their findings.
+
+## 2. Dedupe
+Merge findings across lenses, deduping by file + line range + title, keeping the
+highest severity.
+
+## 3. Verify each finding
+For each deduped finding, invoke `@prosecutor-verifier` (independently) to refute
+it. A finding **survives** only if a strict majority of verification votes confirm
+it real; refuted findings are dropped.
+
+## 4. Loop until dry
+Repeat fan-out until two consecutive rounds surface no new confirmed findings.
+
+## 5. Record + verdict
+Report the surviving findings (severity, file, evidence, recommendation) and a
+ship/no-ship verdict. On CLEAR, record prosecution evidence
+(`adlc gate-manifest record prosecution --files <changed files>` or `adlc-runner
+run p5 --ticket <id>` on the runner path). Material findings block the merge.

--- a/plugins/adlc-opencode/command/adlc-verify-build.md
+++ b/plugins/adlc-opencode/command/adlc-verify-build.md
@@ -1,0 +1,22 @@
+---
+description: Assert the deterministic build gate (G4/P4) — build, lint, and tests must pass before prosecution.
+---
+
+# /adlc-verify-build — deterministic build gate (G4, P4)
+
+Before a change can be prosecuted (P5), the build must be clean. This gate runs the
+project's build/lint/test commands and records a signed G4/P4 build record.
+
+Target ticket: **$ARGUMENTS** (default to the active ticket).
+
+## Steps
+1. Run the configured build, lint, and test commands (from `.adlc/config.json` or
+   the project's `package.json`). Capture exit codes.
+2. If any fail, STOP — report the failures; the change is not eligible for P5.
+3. On success, record the build evidence:
+   `adlc-runner run p4 --ticket <id>` (or, if the runner is unavailable, append an
+   unsigned `p4-build` entry to `.adlc/manifest.jsonl`, flagged `unsigned_fallback`).
+
+## Summarize
+Report each command's result and what was recorded. When green, point the user at
+`/adlc-prosecute` (P5).

--- a/plugins/adlc-opencode/lib/keyless-bridge.mjs
+++ b/plugins/adlc-opencode/lib/keyless-bridge.mjs
@@ -38,7 +38,7 @@ export function extractPrompts(stdout) {
  * Multi-prompt cascades are asked in order with prior answers threaded as context.
  * Returns { prompts, answers } or throws on a gate operational failure.
  */
-export function runGateKeyless({ bin, args = [], ask, spawnImpl = spawnSync, cwd = process.cwd() }) {
+export async function runGateKeyless({ bin, args = [], ask, spawnImpl = spawnSync, cwd = process.cwd() }) {
   if (typeof ask !== 'function') throw new Error('runGateKeyless: an ask(prompt) function is required');
   const res = spawnImpl(bin, [...args, '--prompt-only'], { cwd, encoding: 'utf8' });
   if (res.status !== 0) {
@@ -47,7 +47,9 @@ export function runGateKeyless({ bin, args = [], ask, spawnImpl = spawnSync, cwd
   const prompts = extractPrompts(res.stdout);
   const answers = [];
   for (const p of prompts) {
-    answers.push(ask(p.text, { index: p.index, total: prompts.length, prior: answers.slice() }));
+    // Await each answer: the host SDK prompt API is async, and later prompts in a
+    // cascade must receive RESOLVED prior answers, not pending Promises.
+    answers.push(await ask(p.text, { index: p.index, total: prompts.length, prior: answers.slice() }));
   }
   return { prompts, answers };
 }

--- a/plugins/adlc-opencode/lib/prosecutor.mjs
+++ b/plugins/adlc-opencode/lib/prosecutor.mjs
@@ -41,13 +41,17 @@ export function dedupeFindings(findings) {
 
 /**
  * Decide whether a finding survives verification. Votes are the verifier's
- * independent verdicts ({ real: boolean }). A finding survives only if a strict
- * majority confirm it real (default), so a single noisy lens can't sink a ship and
- * a single weak confirmation can't pass a false one.
+ * independent verdicts ({ real: boolean }). With votes present, a finding survives
+ * if a strict majority confirm it real (default), so a single noisy lens can't
+ * sink a ship and a single weak confirmation can't pass a false one.
+ *
+ * FAIL CLOSED on absent verification: a pre-merge gate must not let a verifier
+ * crash, timeout, or parse failure silently DROP a finding. With zero valid votes
+ * the finding SURVIVES as an unverified blocker — surface it, don't bury it.
  */
 export function survivesVerification(votes, { threshold = 0.5 } = {}) {
   const list = (votes ?? []).filter(Boolean);
-  if (!list.length) return false; // unverified → do not block (fail open on absence of evidence)
+  if (!list.length) return true; // unverified → keep as a blocker (fail closed)
   const real = list.filter((v) => v.real === true).length;
   return real / list.length > threshold;
 }

--- a/plugins/adlc-opencode/lib/prosecutor.mjs
+++ b/plugins/adlc-opencode/lib/prosecutor.mjs
@@ -1,0 +1,62 @@
+// prosecutor.mjs — P5 prosecution registry + pure orchestration helpers.
+//
+// The lenses and verifier are OpenCode subagents (agent/*.md). This module is the
+// machine-checkable contract for the fan-out: which lenses exist, how findings are
+// deduped across lenses, and how the verifier's votes decide whether a finding
+// survives. The model calls live in the subagents; the decision logic here is pure
+// and unit-tested.
+
+/** The five independent prosecution lenses (integration-plan §4.1 / Phase E). */
+export const LENSES = [
+  { key: 'correctness', agent: 'prosecutor-correctness', focus: 'logic errors, broken invariants, wrong results' },
+  { key: 'security', agent: 'prosecutor-security', focus: 'auth/trust boundaries, injection, secrets, unsafe data flow' },
+  { key: 'contract', agent: 'prosecutor-contract', focus: 'API/schema/type conformance against the declared contract' },
+  { key: 'diff', agent: 'prosecutor-diff', focus: 'spec-vs-implementation divergence; unstated behavior changes' },
+  { key: 'tests', agent: 'prosecutor-tests', focus: 'hollow/mock-only tests; are the new tests load-bearing?' },
+];
+
+/** The verifier/reproducer agent that adversarially checks each finding. */
+export const VERIFIER = { key: 'verifier', agent: 'prosecutor-verifier', focus: 'reproduce/refute a finding' };
+
+/** Every shipped prosecution agent id (5 lenses + verifier). */
+export const ALL_AGENTS = [...LENSES.map((l) => l.agent), VERIFIER.agent];
+
+/** Stable key for a finding (file + line range + normalized title). */
+export function findingKey(f) {
+  const title = (f.title ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+  return `${f.file ?? ''}:${f.line_start ?? 0}-${f.line_end ?? 0}:${title}`;
+}
+
+/** Dedupe findings across lenses, keeping the highest-severity instance. */
+export function dedupeFindings(findings) {
+  const SEV = { critical: 4, high: 3, medium: 2, low: 1 };
+  const byKey = new Map();
+  for (const f of findings ?? []) {
+    const k = findingKey(f);
+    const prev = byKey.get(k);
+    if (!prev || (SEV[f.severity] ?? 0) > (SEV[prev.severity] ?? 0)) byKey.set(k, f);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Decide whether a finding survives verification. Votes are the verifier's
+ * independent verdicts ({ real: boolean }). A finding survives only if a strict
+ * majority confirm it real (default), so a single noisy lens can't sink a ship and
+ * a single weak confirmation can't pass a false one.
+ */
+export function survivesVerification(votes, { threshold = 0.5 } = {}) {
+  const list = (votes ?? []).filter(Boolean);
+  if (!list.length) return false; // unverified → do not block (fail open on absence of evidence)
+  const real = list.filter((v) => v.real === true).length;
+  return real / list.length > threshold;
+}
+
+/**
+ * Loop-until-dry controller: stop prosecuting once `maxDry` consecutive rounds
+ * surface no new confirmed findings. Pure: caller tracks state, this decides.
+ */
+export function shouldContinue({ freshThisRound, dryStreak, maxDry = 2 }) {
+  const nextDry = freshThisRound > 0 ? 0 : dryStreak + 1;
+  return { continue: nextDry < maxDry, dryStreak: nextDry };
+}

--- a/plugins/adlc-opencode/lib/scaffold-cli.mjs
+++ b/plugins/adlc-opencode/lib/scaffold-cli.mjs
@@ -8,7 +8,9 @@ import { scaffold } from './scaffold.mjs';
 const projectRoot = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
 const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url))); // plugins/adlc-opencode
 
-const { config, commands, skills } = scaffold(projectRoot, pkgRoot);
+const { config, plugin, commands, agents, skills } = scaffold(projectRoot, pkgRoot);
 console.log(`adlc-init: config.json ${config.created ? 'created' : 'present'}`);
+console.log(`adlc-init: plugin ${plugin.alreadyPresent ? 'already registered' : 'registered'} in .opencode/opencode.json (rails-guard hook will load)`);
 console.log(`adlc-init: deployed ${commands.length} command(s) → .opencode/commands/`);
+console.log(`adlc-init: deployed ${agents.length} agent(s) → .opencode/agents/`);
 console.log(`adlc-init: deployed ${skills.length} skill(s) → .opencode/skill/`);

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -53,14 +53,15 @@ export function deployDir(pkgRoot, destRoot, sub, destSub = sub) {
 }
 
 /**
- * Full scaffold: ensure config + deploy command/ and skill/ into .opencode/.
- * OpenCode discovers project commands under .opencode/commands/ and skills under
- * .opencode/skill/; the plugin ships them under command/ and skill/ respectively.
- * Returns a summary of what changed.
+ * Full scaffold: ensure config + deploy command/, agent/, and skill/ into
+ * .opencode/. OpenCode discovers project commands under .opencode/commands/,
+ * subagents under .opencode/agents/, and skills under .opencode/skill/; the plugin
+ * ships them under command/, agent/, and skill/ respectively. Returns a summary.
  */
 export function scaffold(root, pkgRoot) {
   const config = ensureConfig(root);
   const commands = deployDir(pkgRoot, root, 'command', 'commands');
+  const agents = deployDir(pkgRoot, root, 'agent', 'agents');
   const skills = deployDir(pkgRoot, root, 'skill', 'skill');
-  return { config, commands, skills };
+  return { config, commands, agents, skills };
 }

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -53,15 +53,39 @@ export function deployDir(pkgRoot, destRoot, sub, destSub = sub) {
 }
 
 /**
- * Full scaffold: ensure config + deploy command/, agent/, and skill/ into
- * .opencode/. OpenCode discovers project commands under .opencode/commands/,
- * subagents under .opencode/agents/, and skills under .opencode/skill/; the plugin
- * ships them under command/, agent/, and skill/ respectively. Returns a summary.
+ * Register the plugin itself in .opencode/opencode.json's `plugin` array so
+ * OpenCode actually LOADS the rails-guard hook. Commands/agents/skills are inert
+ * markdown; the enforcing hook only runs if the plugin package is registered.
+ * Idempotent and non-clobbering: preserves any other settings and plugin entries.
+ * Returns { registered, alreadyPresent, path }.
+ */
+export function ensurePluginRegistered(root, pkgName = '@adlc/opencode-package') {
+  const dir = join(root, '.opencode');
+  const path = join(dir, 'opencode.json');
+  let config = {};
+  if (existsSync(path)) {
+    try { config = JSON.parse(readFileSync(path, 'utf8')); } catch { config = {}; }
+  }
+  const plugins = Array.isArray(config.plugin) ? config.plugin : [];
+  if (plugins.includes(pkgName)) return { registered: false, alreadyPresent: true, path };
+  config.plugin = [...plugins, pkgName];
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+  return { registered: true, alreadyPresent: false, path };
+}
+
+/**
+ * Full scaffold: ensure config, REGISTER the plugin (so the rails-guard hook
+ * loads), and deploy command/, agent/, and skill/ into .opencode/. OpenCode
+ * discovers project commands under .opencode/commands/, subagents under
+ * .opencode/agents/, and skills under .opencode/skill/; the plugin ships them
+ * under command/, agent/, and skill/ respectively. Returns a summary.
  */
 export function scaffold(root, pkgRoot) {
   const config = ensureConfig(root);
+  const plugin = ensurePluginRegistered(root);
   const commands = deployDir(pkgRoot, root, 'command', 'commands');
   const agents = deployDir(pkgRoot, root, 'agent', 'agents');
   const skills = deployDir(pkgRoot, root, 'skill', 'skill');
-  return { config, commands, agents, skills };
+  return { config, plugin, commands, agents, skills };
 }

--- a/plugins/adlc-opencode/package.json
+++ b/plugins/adlc-opencode/package.json
@@ -8,6 +8,7 @@
   "opencode": {
     "plugin": "./index.mjs",
     "command": "./command/",
+    "agent": "./agent/",
     "skill": "./skill/"
   },
   "peerDependencies": {

--- a/plugins/adlc-opencode/rails-checker.mjs
+++ b/plugins/adlc-opencode/rails-checker.mjs
@@ -7,8 +7,8 @@
 // enforcement contract (active-ticket resolution, phase gating, trust-root
 // freeze) that adlc-codex and adlc-pi already implement.
 
-import { existsSync, readFileSync } from 'node:fs';
-import { isAbsolute, join, relative } from 'node:path';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
 import { loadTickets, globMatch } from '@adlc/core';
 
 // The ticket file and the active-ticket pointer are the rail trust root: they are
@@ -20,10 +20,34 @@ export const TRUST_ROOT_RAILS = ['.adlc/tickets.json', '.adlc/current-ticket.jso
 // NOT gated in-session (Turing-complete shell); they fall to the CI diff gate.
 export const MUTATING_TOOLS = ['edit', 'write'];
 
-/** Canonicalize a path to a forward-slash path relative to the repo root. */
+/** Canonicalize a path to a forward-slash path relative to the repo root (lexical). */
 export function canonicalizePath(filePath, root) {
   const abs = isAbsolute(filePath) ? filePath : join(root, filePath);
   return relative(root, abs).split('\\').join('/');
+}
+
+function realpathOr(p) {
+  try { return realpathSync(p); } catch { return p; }
+}
+
+/**
+ * Symlink-aware canonicalization (security-relevant): resolve symlinks on the
+ * target and on its existing parent segments before comparing to the frozen rail
+ * set, so a symlink whose real target is a frozen rail (e.g. an alias pointing at
+ * .adlc/tickets.json) cannot slip a write past a lexical name check. Falls back to
+ * the lexical path for anything that can't be resolved.
+ */
+export function resolveRailPath(filePath, root) {
+  const abs = isAbsolute(filePath) ? filePath : join(root, filePath);
+  // The file may not exist yet (a `write` creating it): resolve the deepest
+  // existing ancestor (catches a symlinked parent dir), then re-append the tail.
+  let resolved;
+  if (existsSync(abs)) {
+    resolved = realpathOr(abs);
+  } else {
+    resolved = join(realpathOr(dirname(abs)), basename(abs));
+  }
+  return relative(realpathOr(root), resolved).split('\\').join('/');
 }
 
 /**
@@ -88,10 +112,14 @@ export function checkRail({ filePath, tool, root = process.cwd(), env = process.
   const declaredRails = ticket?.rails ?? [];
   const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
 
-  const canonical = canonicalizePath(filePath, root);
-  const hit = rails.find((rail) => rail === canonical || globMatch(rail, canonical));
-  if (hit) {
-    return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${active.id})` };
+  // Match BOTH the lexical path (normal case) and the symlink-resolved real path
+  // (so a symlink alias whose target is a frozen rail can't slip past a name check).
+  const candidates = new Set([canonicalizePath(filePath, root), resolveRailPath(filePath, root)]);
+  for (const path of candidates) {
+    const hit = rails.find((rail) => rail === path || globMatch(rail, path));
+    if (hit) {
+      return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${active.id})` };
+    }
   }
   return { decision: 'allow', reason: 'path is not a frozen rail' };
 }

--- a/plugins/adlc-opencode/rails-checker.mjs
+++ b/plugins/adlc-opencode/rails-checker.mjs
@@ -16,9 +16,16 @@ import { loadTickets, globMatch } from '@adlc/core';
 // rail set cannot be quietly edited away. Mirrors adlc-codex/hooks/adlc-rails-guard.mjs.
 export const TRUST_ROOT_RAILS = ['.adlc/tickets.json', '.adlc/current-ticket.json'];
 
-// OpenCode's structured file-mutation tools. Bash-style writes are intentionally
-// NOT gated in-session (Turing-complete shell); they fall to the CI diff gate.
-export const MUTATING_TOOLS = ['edit', 'write'];
+// OpenCode's known structured file-mutation tools. Bash-style writes are
+// intentionally NOT gated in-session (Turing-complete shell); they fall to the CI
+// diff gate.
+export const MUTATING_TOOLS = ['edit', 'write', 'patch', 'multiedit', 'apply_patch'];
+
+// Known read-only tools that may carry a file path but never mutate it. The gate
+// fails CLOSED: only these are skipped; any other structured tool that reaches the
+// checker (i.e. carries a filePath) — including unrecognized mutation tools — is
+// checked against the rail set rather than silently allowed.
+export const READONLY_TOOLS = ['read', 'grep', 'glob', 'list', 'ls', 'webfetch'];
 
 /** Canonicalize a path to a forward-slash path relative to the repo root (lexical). */
 export function canonicalizePath(filePath, root) {
@@ -88,9 +95,12 @@ export function resolveActiveTicketId(root, env) {
  *  - rails in force = active ticket's declared rails PLUS the trust-root rails.
  */
 export function checkRail({ filePath, tool, root = process.cwd(), env = process.env }) {
-  if (!MUTATING_TOOLS.includes(tool)) {
-    return { decision: 'allow', reason: `tool "${tool}" is not a structured mutating tool` };
+  if (READONLY_TOOLS.includes(tool)) {
+    return { decision: 'allow', reason: `tool "${tool}" is read-only` };
   }
+  // Everything else that reached here carries a file path: known mutators AND any
+  // unrecognized structured tool are checked (fail closed), so a new mutation tool
+  // name can't slip an edit past the guard.
   if (env.ADLC_P4_ENFORCEMENT !== '1') {
     return { decision: 'allow', reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
   }

--- a/plugins/adlc-opencode/test/keyless-bridge.test.mjs
+++ b/plugins/adlc-opencode/test/keyless-bridge.test.mjs
@@ -40,23 +40,35 @@ function stubSpawn(stdout, status = 0, stderr = '') {
   };
 }
 
-test('runGateKeyless: asks each prompt in order, threads prior answers', () => {
+test('runGateKeyless: asks each prompt in order, threads prior answers', async () => {
   const spawnImpl = stubSpawn('--- prompt 1 of 2 ---\nA\n--- prompt 2 of 2 ---\nB');
   const seen = [];
   const ask = (text, ctx) => { seen.push({ text, prior: ctx.prior.length }); return `ans:${text}`; };
-  const { prompts, answers } = runGateKeyless({ bin: 'adlc', args: ['parallax'], ask, spawnImpl });
+  const { prompts, answers } = await runGateKeyless({ bin: 'adlc', args: ['parallax'], ask, spawnImpl });
   assert.equal(prompts.length, 2);
   assert.deepEqual(answers, ['ans:A', 'ans:B']);
   assert.deepEqual(seen.map((s) => s.prior), [0, 1]); // 2nd ask sees 1 prior answer
 });
 
-test('runGateKeyless: gate operational failure (status!=0) throws', () => {
-  const spawnImpl = stubSpawn('', 1, 'no provider');
-  assert.throws(() => runGateKeyless({ bin: 'adlc', args: ['spec-lint'], ask: () => 'x', spawnImpl }), /exited 1/);
+test('runGateKeyless: ASYNC ask — answers are resolved values, prior holds resolved (not Promises)', async () => {
+  const spawnImpl = stubSpawn('--- prompt 1 of 2 ---\nA\n--- prompt 2 of 2 ---\nB');
+  const priorSeen = [];
+  // Realistic host SDK: async prompt call.
+  const ask = async (text, ctx) => { priorSeen.push(ctx.prior.slice()); return `ans:${text}`; };
+  const { answers } = await runGateKeyless({ bin: 'adlc', args: ['parallax'], ask, spawnImpl });
+  assert.deepEqual(answers, ['ans:A', 'ans:B']); // resolved strings, not Promises
+  // the 2nd prompt's prior must contain the RESOLVED first answer, not a pending Promise
+  assert.deepEqual(priorSeen[1], ['ans:A']);
+  for (const a of answers) assert.equal(typeof a, 'string');
 });
 
-test('runGateKeyless: requires an ask function', () => {
-  assert.throws(() => runGateKeyless({ bin: 'adlc', spawnImpl: stubSpawn('p') }), /ask\(prompt\) function is required/);
+test('runGateKeyless: gate operational failure (status!=0) throws', async () => {
+  const spawnImpl = stubSpawn('', 1, 'no provider');
+  await assert.rejects(() => runGateKeyless({ bin: 'adlc', args: ['spec-lint'], ask: () => 'x', spawnImpl }), /exited 1/);
+});
+
+test('runGateKeyless: requires an ask function', async () => {
+  await assert.rejects(() => runGateKeyless({ bin: 'adlc', spawnImpl: stubSpawn('p') }), /ask\(prompt\) function is required/);
 });
 
 // ---- makeAsk capability resolution (plan §6.4) ----

--- a/plugins/adlc-opencode/test/prosecutor.test.mjs
+++ b/plugins/adlc-opencode/test/prosecutor.test.mjs
@@ -1,0 +1,76 @@
+// prosecutor.test.mjs — Phase E (T5): the P5 prosecution registry + pure
+// orchestration helpers (dedupe, verifier-majority, loop-until-dry). Offline.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  LENSES, VERIFIER, ALL_AGENTS, findingKey, dedupeFindings, survivesVerification, shouldContinue,
+} from '../lib/prosecutor.mjs';
+
+const PKG = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// ---- registry ----
+test('registry: 5 lenses + verifier, ids unique', () => {
+  assert.equal(LENSES.length, 5);
+  assert.equal(VERIFIER.agent, 'prosecutor-verifier');
+  assert.equal(ALL_AGENTS.length, 6);
+  assert.equal(new Set(ALL_AGENTS).size, 6);
+  for (const k of ['correctness', 'security', 'contract', 'diff', 'tests']) {
+    assert.ok(LENSES.some((l) => l.key === k), `${k} lens present`);
+  }
+});
+
+test('every registry agent has a shipped agent/*.md file with subagent frontmatter', () => {
+  const dir = join(PKG, 'agent');
+  const files = new Set(readdirSync(dir));
+  for (const a of ALL_AGENTS) {
+    assert.ok(files.has(`${a}.md`), `${a}.md shipped`);
+    const body = readFileSync(join(dir, `${a}.md`), 'utf8');
+    assert.match(body, /^---\n[\s\S]*?description:\s*\S+[\s\S]*?mode:\s*subagent[\s\S]*?\n---/, `${a}.md has subagent frontmatter`);
+  }
+});
+
+// ---- dedupeFindings ----
+test('dedupeFindings: collapses same file+line+title, keeps highest severity', () => {
+  const findings = [
+    { file: 'a.mjs', line_start: 10, line_end: 10, title: 'Null deref', severity: 'low' },
+    { file: 'a.mjs', line_start: 10, line_end: 10, title: 'null  deref', severity: 'high' }, // dup (case/space)
+    { file: 'b.mjs', line_start: 5, line_end: 5, title: 'Injection', severity: 'critical' },
+  ];
+  const out = dedupeFindings(findings);
+  assert.equal(out.length, 2);
+  const a = out.find((f) => f.file === 'a.mjs');
+  assert.equal(a.severity, 'high'); // highest kept
+});
+
+test('findingKey normalizes title whitespace + case', () => {
+  assert.equal(
+    findingKey({ file: 'x', line_start: 1, line_end: 2, title: '  Big   Bug ' }),
+    findingKey({ file: 'x', line_start: 1, line_end: 2, title: 'big bug' }),
+  );
+});
+
+// ---- survivesVerification ----
+test('survivesVerification: strict majority of real votes survives', () => {
+  assert.equal(survivesVerification([{ real: true }, { real: true }, { real: false }]), true); // 2/3
+  assert.equal(survivesVerification([{ real: true }, { real: false }]), false); // 1/2 not > 0.5
+  assert.equal(survivesVerification([{ real: false }, { real: false }]), false);
+});
+
+test('survivesVerification: no votes → does not block (fail open on absent evidence)', () => {
+  assert.equal(survivesVerification([]), false);
+  assert.equal(survivesVerification(null), false);
+});
+
+// ---- shouldContinue (loop until dry) ----
+test('shouldContinue: resets dry streak on fresh findings, stops after maxDry empties', () => {
+  let s = shouldContinue({ freshThisRound: 3, dryStreak: 1, maxDry: 2 });
+  assert.deepEqual(s, { continue: true, dryStreak: 0 });
+  s = shouldContinue({ freshThisRound: 0, dryStreak: 0, maxDry: 2 });
+  assert.deepEqual(s, { continue: true, dryStreak: 1 });
+  s = shouldContinue({ freshThisRound: 0, dryStreak: 1, maxDry: 2 });
+  assert.deepEqual(s, { continue: false, dryStreak: 2 });
+});

--- a/plugins/adlc-opencode/test/prosecutor.test.mjs
+++ b/plugins/adlc-opencode/test/prosecutor.test.mjs
@@ -60,9 +60,11 @@ test('survivesVerification: strict majority of real votes survives', () => {
   assert.equal(survivesVerification([{ real: false }, { real: false }]), false);
 });
 
-test('survivesVerification: no votes → does not block (fail open on absent evidence)', () => {
-  assert.equal(survivesVerification([]), false);
-  assert.equal(survivesVerification(null), false);
+test('survivesVerification: no valid votes → SURVIVES as unverified blocker (fail closed)', () => {
+  // A verifier crash/timeout must NOT silently drop a finding in a pre-merge gate.
+  assert.equal(survivesVerification([]), true);
+  assert.equal(survivesVerification(null), true);
+  assert.equal(survivesVerification([null, undefined]), true); // no valid votes
 });
 
 // ---- shouldContinue (loop until dry) ----

--- a/plugins/adlc-opencode/test/rails-checker.test.mjs
+++ b/plugins/adlc-opencode/test/rails-checker.test.mjs
@@ -5,7 +5,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { checkRail, resolveActiveTicketId, probeEnforcementCapability } from '../rails-checker.mjs';
@@ -74,6 +74,27 @@ test('f: another ticket\'s rail does not block (single-active-ticket scope)', ()
   try {
     const r = checkRail({ filePath: 'b/x.mjs', tool: 'edit', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
     assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (e2) symlink alias to a frozen rail is resolved and denied ----
+test('e2: edit via a symlink whose real target is a frozen rail → deny', () => {
+  const dir = repo({ tickets: { tickets: [{ id: 'T1', rails: ['src/**'] }] } });
+  try {
+    // alias.json (in an otherwise-allowed path) → .adlc/tickets.json (trust root)
+    symlinkSync(join(dir, '.adlc', 'tickets.json'), join(dir, 'alias.json'));
+    const r = checkRail({ filePath: 'alias.json', tool: 'edit', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('e2: write through a symlinked parent dir into a frozen rail → deny', () => {
+  const dir = repo({ tickets: { tickets: [{ id: 'T1', rails: ['locked/**'] }] } });
+  try {
+    mkdirSync(join(dir, 'locked'), { recursive: true });
+    symlinkSync(join(dir, 'locked'), join(dir, 'aliasdir')); // aliasdir → locked/
+    const r = checkRail({ filePath: 'aliasdir/new.mjs', tool: 'write', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'deny');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-opencode/test/rails-checker.test.mjs
+++ b/plugins/adlc-opencode/test/rails-checker.test.mjs
@@ -49,8 +49,10 @@ test('c: no active ticket → allow', () => {
 });
 
 // ---- (d) DENY edit AND write to the active ticket's declared rail ----
-for (const tool of ['edit', 'write']) {
-  test(`d: ${tool} to a declared rail → deny`, () => {
+// All known mutators (incl. patch/multiedit/apply_patch) AND unknown structured
+// tools must be gated; only known read-only tools are skipped (fail closed).
+for (const tool of ['edit', 'write', 'patch', 'multiedit', 'apply_patch', 'some_new_tool']) {
+  test(`d: ${tool} to a declared rail → deny (gated)`, () => {
     const dir = repo({ tickets: T1_RAILED });
     try {
       const r = checkRail({ filePath: 'test/x.mjs', tool, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
@@ -58,6 +60,14 @@ for (const tool of ['edit', 'write']) {
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 }
+
+test('d: a known read-only tool on a rail path → allow (not a mutation)', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkRail({ filePath: 'test/x.mjs', tool: 'read', root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
 
 // ---- (e) DENY edit to .adlc/tickets.json (trust root) even when not declared ----
 test('e: edit .adlc/tickets.json (trust root) → deny even when rails do not list it', () => {

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -7,7 +7,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ensureConfig, deployDir, scaffold } from '../lib/scaffold.mjs';
+import { ensureConfig, deployDir, scaffold, ensurePluginRegistered } from '../lib/scaffold.mjs';
 import { ALL_BINS, GATE_BINS, DISPATCHERS } from '../gate-bins.mjs';
 
 const PKG = dirname(dirname(fileURLToPath(import.meta.url))); // plugins/adlc-opencode
@@ -34,6 +34,42 @@ test('ensureConfig never clobbers an existing config (idempotent)', () => {
     const cfg = JSON.parse(readFileSync(r.path, 'utf8'));
     assert.equal(cfg.mine, true); // untouched
     assert.equal(cfg.securityMode, 'signed');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- ensurePluginRegistered (so the rails-guard hook actually loads) ----
+test('ensurePluginRegistered: adds the plugin to .opencode/opencode.json', () => {
+  const root = mkroot();
+  try {
+    const r = ensurePluginRegistered(root);
+    assert.equal(r.registered, true);
+    const cfg = JSON.parse(readFileSync(join(root, '.opencode', 'opencode.json'), 'utf8'));
+    assert.ok(cfg.plugin.includes('@adlc/opencode-package'));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensurePluginRegistered: idempotent + preserves existing settings/plugins', () => {
+  const root = mkroot();
+  try {
+    mkdirSync(join(root, '.opencode'), { recursive: true });
+    writeFileSync(join(root, '.opencode', 'opencode.json'), JSON.stringify({ theme: 'x', plugin: ['other-plugin'] }));
+    const r1 = ensurePluginRegistered(root);
+    assert.equal(r1.registered, true);
+    const r2 = ensurePluginRegistered(root);
+    assert.equal(r2.alreadyPresent, true); // idempotent
+    const cfg = JSON.parse(readFileSync(join(root, '.opencode', 'opencode.json'), 'utf8'));
+    assert.equal(cfg.theme, 'x'); // preserved
+    assert.deepEqual(cfg.plugin, ['other-plugin', '@adlc/opencode-package']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('scaffold registers the plugin (rails-guard hook will load)', () => {
+  const root = mkroot();
+  try {
+    const out = scaffold(root, PKG);
+    assert.equal(out.plugin.registered, true);
+    const cfg = JSON.parse(readFileSync(join(root, '.opencode', 'opencode.json'), 'utf8'));
+    assert.ok(cfg.plugin.includes('@adlc/opencode-package'));
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -113,6 +113,21 @@ else {
   ok('gate-bins declares the core gate tools');
 }
 
+// ---- Phase E (T5): prosecutor lenses + verifier, G4/prosecute/distill commands ----
+if (!pkg2.opencode?.agent) fail('package.json opencode.agent entry missing'); else ok('opencode.agent manifest entry');
+const agentDir = join(PLUGIN, 'agent');
+const AGENTS = ['prosecutor-correctness', 'prosecutor-security', 'prosecutor-contract', 'prosecutor-diff', 'prosecutor-tests', 'prosecutor-verifier'];
+for (const a of AGENTS) {
+  const p = join(agentDir, `${a}.md`);
+  if (!existsSync(p)) { fail(`agent/${a}.md missing`); continue; }
+  if (!/^---\n[\s\S]*?mode:\s*subagent[\s\S]*?\n---/.test(read(p))) fail(`agent/${a}.md lacks subagent frontmatter`);
+  else ok(`agent/${a}.md valid`);
+}
+for (const c of ['adlc-verify-build.md', 'adlc-prosecute.md', 'adlc-distill.md']) {
+  if (!existsSync(join(cmdDir, c))) fail(`command/${c} missing`); else ok(`command/${c} present`);
+}
+if (!existsSync(join(PLUGIN, 'lib', 'prosecutor.mjs'))) fail('lib/prosecutor.mjs missing'); else ok('prosecutor registry/helpers present');
+
 // AC7 (live deny proof against the real opencode binary) is the remaining GA gate;
 // it requires a disposable OpenCode install and is tracked in ADR 0004.
 console.log('  note — AC7 live-binary deny proof is a maintainer/CI follow-up (no opencode binary here).');

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -90,7 +90,12 @@ for (const c of PHASE_A_CMDS) {
   if (!/^---\n[\s\S]*?description:\s*\S+[\s\S]*?\n---/.test(read(p))) fail(`command/${c} lacks description frontmatter`);
   else ok(`command/${c} valid`);
 }
-if (!existsSync(join(PLUGIN, 'lib', 'scaffold.mjs'))) fail('lib/scaffold.mjs missing'); else ok('scaffold helper present');
+if (!existsSync(join(PLUGIN, 'lib', 'scaffold.mjs'))) fail('lib/scaffold.mjs missing');
+else {
+  const sc = read(join(PLUGIN, 'lib', 'scaffold.mjs'));
+  if (!/export function ensurePluginRegistered\b/.test(sc)) fail('scaffold does not register the plugin (rails-guard hook would not load)');
+  else ok('scaffold registers the plugin (rails-guard hook loads)');
+}
 
 // ---- Phase B (T3): keyless LLM-gate bridge ----
 const bridgePath = join(PLUGIN, 'lib', 'keyless-bridge.mjs');
@@ -98,7 +103,7 @@ if (!existsSync(bridgePath)) fail('lib/keyless-bridge.mjs missing');
 else {
   const br = read(bridgePath);
   for (const fn of ['extractPrompts', 'runGateKeyless', 'makeAsk']) {
-    if (!new RegExp(`export function ${fn}\\b`).test(br)) fail(`keyless-bridge missing export ${fn}`);
+    if (!new RegExp(`export (async )?function ${fn}\\b`).test(br)) fail(`keyless-bridge missing export ${fn}`);
   }
   if (!/--prompt-only/.test(br)) fail('keyless-bridge does not run gates in --prompt-only mode');
   ok('keyless bridge present (extractPrompts/runGateKeyless/makeAsk, prompt-only)');


### PR DESCRIPTION
Implements **ticket T5** (plan Phase E) — the final phase. With Phase F (CI, #15) already merged, **all six plan phases (A–F) now ship** for OpenCode.

## What ships
- **`agent/`** — 6 OpenCode subagents (Markdown + `mode: subagent`, edit/bash denied): the 5 P5 prosecution lenses (`correctness`, `security`, `contract`, `diff`, `tests`) + the `verifier`/reproducer.
- **`command/`** — `/adlc-verify-build` (G4/P4 build gate), `/adlc-prosecute` (fan-out → dedupe → verify → loop-until-dry), `/adlc-distill` (P7).
- **`lib/prosecutor.mjs`** — machine-checkable registry + **pure** orchestration helpers: `dedupeFindings` (keep highest severity), `survivesVerification` (strict-majority), `shouldContinue` (loop-until-dry). The model calls live in the subagents.
- **`lib/scaffold.mjs`** — also deploys `agent/` → `.opencode/agents/`; `package.json` declares `opencode.agent`.
- **`test/prosecutor.test.mjs`** — 7 tests (registry ↔ shipped files, dedupe, majority verdict, loop control); smoke validates agents + commands + registry.
- docs: Phase E shipped; P5/P7 covered.

## Design honesty
Phase-E orchestration is **model-driven** — `/adlc-prosecute` describes the loop and the model invokes the subagents; the *decision* helpers (`lib/prosecutor.mjs`) are deterministic and unit-tested. This is the same P5-orchestration gap the Codex path documents.

## Test plan
- [x] `npm test` → 1359 tests, 1358 pass, 0 fail (+7 T5 tests)
- [x] `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] sibling smokes exit 0

Depends on #30 (merged). **Closes the T1–T5 chain.**