### PR TITLE
docs(opencode): accurate install instructions for the shipped integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,9 @@ package READMEs.
 - [Claude Code integration](./integrations/claude-code.md) explains how to install and
   use the Claude Code plugin, including lifecycle coverage and known gaps.
 - [Pi integration](./integrations/pi.md) explains the Raspberry Pi harness integration.
-- [opencode integration](./integrations/opencode.md) [planned]
+- [opencode integration](./integrations/opencode.md) explains how to install and use the
+  OpenCode plugin (rails-guard hook, command suite, keyless gate bridge, session hooks,
+  prosecutor lenses) — all six plan phases shipped.
 - [Package reference](./package-reference.md) lists every package, binary, phase, and
   primary README source.
 - [Ticket authoring](./ticket-authoring.md) defines the canonical ticket schema that

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -57,23 +57,55 @@ the enforcing hook only runs once the plugin package is registered.) Phase A com
 
 ## Install
 
+The plugin ships in this repo at `plugins/adlc-opencode/`. The
+`@adlc/opencode-package` package is **not yet published to npm**, so install from
+source for now (peer dependency: `@opencode-ai/plugin` >= 1.17.11).
+
+**1. Install the gate toolkit** — the plugin shells out to the `adlc` binary:
+
 ```sh
-npm install -g @adlc/cli                       # the toolkit, behind one `adlc <tool>` command
-npm install -g @opencode-ai/plugin             # peer dependency (>=1.17.11)
-# deploy the plugin into your project's OpenCode plugin directory:
-#   .opencode/plugin/adlc-opencode/   (or register it in opencode.json "plugin")
+npm install -g @adlc/cli
 ```
 
-Local verification:
+**2. Make the plugin available to OpenCode** — symlink the source into your
+project's plugin directory, or register its path in `opencode.json`:
+
+```sh
+ln -s /path/to/adlc/plugins/adlc-opencode .opencode/plugin/adlc-opencode
+# …or add "/path/to/adlc/plugins/adlc-opencode" to the "plugin" array in
+#    .opencode/opencode.json (project) or ~/.config/opencode/opencode.json (global)
+```
+
+**3. Bootstrap the workspace** — in the OpenCode TUI:
+
+```
+/adlc-init
+```
+
+`/adlc-init` creates `.adlc/` (the committable ticket contract + `config.json`),
+deploys the command/agent/skill surface into `.opencode/`, **registers the plugin
+in `opencode.json` so the rails-guard hook loads**, and runs preflight. First-time,
+before the `/adlc-init` command is available, run the scaffolder directly:
+
+```sh
+node /path/to/adlc/plugins/adlc-opencode/lib/scaffold-cli.mjs .
+```
+
+**4. Restart OpenCode** so it loads the plugin — the `tool.execute.before`
+rails-guard hook and the `session.created` / `session.idle` advisory hooks become
+active. `/adlc-ticket`, `/adlc-spec`, `/adlc-prosecute`, etc. are then available.
+
+Local verification (no `opencode` binary needed, does not mutate your environment):
 
 ```sh
 node scripts/opencode-install-smoke.mjs .
 ```
 
 That smoke test validates the plugin manifest, the `tool.execute.before` hook
-wiring, skill registration, the `@adlc/core` delegation (the rail engine is not
-re-implemented), and runs the real enforcement unit test. It does not require the
-`opencode` binary and does not mutate your environment.
+wiring, command/agent/skill registration, the scaffolder, the `@adlc/core`
+delegation (the rail engine is not re-implemented), and runs the plugin unit tests.
+An end-to-end deny proof against a live `opencode` binary is the remaining GA
+verification — see [ADR 0004](../adr/0004-adlc-opencode-integration.md).
 
 ## Rail enforcement — two layers
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -45,24 +45,19 @@ This package automatically installs the `adlc` dispatcher, `adlc-runner`, and al
 The plugin initialization check will verify that both `adlc` and `adlc-runner` bins are available on PATH and output a clear installation error if missing.
 
 ### 2. Install the OpenCode Plugin
-> [!NOTE]
-> The plugin manager command (`opencode plugin add`) and configuration file format (`opencode.json` plugin registry mapping) described below are target specifications that must be verified against the official OpenCode SDK specification during implementation. Do not treat them as runnable install instructions until the implementation adds the package or source tree.
 
-Once implemented and published, the expected package install path is:
-
-```sh
-opencode plugin add @adlc/opencode-plugin
-```
-
-For local development after the implementation lands, copy or symlink the expected plugin source directory (`plugins/adlc-opencode`) to your project-local `.opencode/` directory:
+The plugin ships at `plugins/adlc-opencode/` (`@adlc/opencode-package`). It is
+**not yet published to npm**, so install from source. See the
+[integration guide](./integrations/opencode.md#install) for the canonical steps;
+in short, symlink the source into your project's plugin directory, or register its
+path in `opencode.json`:
 
 ```sh
-mkdir -p .opencode/plugin/
-# Copy or symlink the integration code:
-ln -s /path/to/adlc/plugins/adlc-opencode/ .opencode/plugin/adlc-opencode
+ln -s /path/to/adlc/plugins/adlc-opencode .opencode/plugin/adlc-opencode
 ```
 
-Alternatively, register the implemented plugin globally in your `~/.config/opencode/opencode.json`:
+Alternatively, register the plugin in your project or global
+`opencode.json` (`/adlc-init` does this for you — see step 3):
 
 ```json
 {
@@ -71,6 +66,11 @@ Alternatively, register the implemented plugin globally in your `~/.config/openc
   ]
 }
 ```
+
+> [!NOTE]
+> Peer dependency: `@opencode-ai/plugin` >= 1.17.11. A published-package install
+> (`opencode plugin add @adlc/opencode-package`) will be the path once the package
+> is published; until then, use the source/symlink install above.
 
 ### 3. Initialize your Repository
 Bootstrap the ADLC workspace context in your repository by typing the following slash command directly into the OpenCode TUI chat interface:


### PR DESCRIPTION
The OpenCode integration shipped (T1–T5, all six plan phases A–F), but the docs still read as planned/unbuilt. This aligns them with reality.

- **`docs/integrations/opencode.md`** (canonical) — rewritten **Install** with the real source-based path: `@adlc/opencode-package` is private (not npm-published), so symlink the source into `.opencode/plugin/` or register its path in `opencode.json`; then `/adlc-init` (or `lib/scaffold-cli.mjs`) bootstraps `.adlc/`, deploys the command/agent/skill surface, **registers the plugin so the rails-guard hook loads**, and runs preflight; restart OpenCode to load the hooks. Notes the `@opencode-ai/plugin` peer dep and the pending live-binary GA check (ADR 0004).
- **`docs/README.md`** — drop the stale `[planned]` tag.
- **`docs/opencode.md`** (adoption guide) — de-stale §2 (was "not runnable until the implementation lands"); point at the canonical install; keep the published-package path as a future note.

## Test plan
- [x] opencode smoke green (doc content assertions hold: no stub banner, CI gate linked, advisory framing)
- [x] all doc links resolve (ADR 0004, ci/rails-guard.yml, scaffold-cli.mjs, adoption guide)
- [x] purely docs — no code change