### PR TITLE
feat(cursor): native ADLC rails-guard integration (MVP)

### DIFF
--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -120,9 +120,18 @@ control:
   against the right repo.
 
 Mitigation: the unbypassable commit-time CI gate (`docs/ci/rails-guard.yml`) reads
-the frozen rail set from the trusted base ref and rejects offending PRs regardless
-of how the edit was made. It is the same gate the OpenCode and Codex integrations
-rely on; this ADR adds **no competing CI workflow**.
+the frozen rail set from the trusted base ref and rejects PRs that edit a
+base-frozen rail regardless of how the edit was made. It is the same gate the
+OpenCode and Codex integrations rely on; this ADR adds **no competing CI workflow**.
+
+**Known scope limit (do not overstate this gate):** because the rail set is read
+from the base ref, the gate protects rails **already frozen on the base branch**.
+A PR that introduces a new rail *and* edits that path in the same PR is **not**
+caught — the template documents this as a SECURITY LIMITATION and requires an
+explicit `acknowledgedNewRailBypass` before it can serve as a required check, until
+a new-rail-aware union gate ships. Same-PR protection requires freezing the rail in
+a separate, already-merged commit first. The integration docs must not claim the
+gate catches *every* rail edit.
 
 ## Unverified / follow-on
 

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -81,9 +81,23 @@ control:
 - Unrecognized mutation tools: the gate fails **closed** on tool names — only known
   read-only tools (`read`/`grep`/`codebase_search`/…) are skipped; known mutators
   and any unrecognized structured tool carrying a file path are checked, so a new
-  tool name can't slip an edit past the guard.
+  tool name can't slip an edit past the guard. To make this true at the *routing*
+  layer (not just the decision layer), the `preToolUse` hook uses a **catch-all
+  matcher (`.*`)** — every tool reaches the guard and the classifier decides; a
+  narrow allowlist matcher would let a novel mutator name (`modify_file`,
+  `save_file`) bypass the guard before the fail-closed classifier ran. The cost is
+  one hook invocation per tool call; read-only tools return `allow` immediately.
+- Corrupt `tickets.json`: `@adlc/core`'s `loadTickets` signals corruption three
+  ways — it throws on some malformed schemas, returns an `errors` array on others,
+  and returns an empty list when `tickets` is absent. The checker fails **closed**
+  on all three (and on a resolved active ticket that isn't found), so a corrupt or
+  truncated rail trust root cannot silently drop the declared rail set.
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
   resolved (target + existing parent segments) before rail comparison and denied.
+- Multi-root workspaces: in a Cursor workspace with several `workspace_roots`, the
+  guard resolves the root that **owns** the edited absolute path (longest match)
+  rather than the first listed root, so a rail edit in a later root is checked
+  against the right repo.
 
 Mitigation: the unbypassable commit-time CI gate (`docs/ci/rails-guard.yml`) reads
 the frozen rail set from the trusted base ref and rejects offending PRs regardless

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -100,6 +100,11 @@ control:
   enforcement is off the guard is a no-op, so it fails open to avoid bricking the
   editor. This closes the whole "exception → silent allow" class, not just the
   triggers found so far.
+- Batch / MultiEdit payloads: a structured mutator can carry its paths only in
+  nested `edits[]`/`files[]` arrays with no top-level scalar path. The extractor
+  collects **every** target path (scalars + nested batch items, mirroring the
+  Claude sibling) and the guard denies if **any** one is a frozen rail — a
+  single-scalar extractor would wave a MultiEdit through.
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
   resolved (target + existing parent segments) before rail comparison and denied.
 - Multi-root workspaces: in a Cursor workspace with several `workspace_roots`, the

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -102,9 +102,10 @@ control:
   triggers found so far.
 - Batch / MultiEdit payloads: a structured mutator can carry its paths only in
   nested `edits[]`/`files[]` arrays with no top-level scalar path. The extractor
-  collects **every** target path (scalars + nested batch items, mirroring the
-  Claude sibling) and the guard denies if **any** one is a frozen rail — a
-  single-scalar extractor would wave a MultiEdit through.
+  collects **every** target path (every path-key including a rename/move source
+  *and* destination, plus nested batch items, mirroring the Claude sibling) and the
+  guard denies if **any** one is a frozen rail — a single-path extractor would wave
+  a MultiEdit or a rename-onto-a-rail through.
 - Patch-envelope payloads: an `apply_patch`-style tool names its targets inside a
   `command`/`patch` string (`*** Update File: …`). The extractor parses those
   headers so the named paths are rail-checked. As a categorical backstop, a tool

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -108,10 +108,12 @@ control:
   a MultiEdit or a rename-onto-a-rail through.
 - Patch-envelope payloads: an `apply_patch`-style tool names its targets inside a
   `command`/`patch` string (`*** Update File: …`). The extractor parses those
-  headers so the named paths are rail-checked. As a categorical backstop, a tool
-  that **classifies as mutating** but exposes **no inspectable path** under active
-  enforcement (an opaque/unparsed format) fails **closed** — only read-only/no-path
-  tools are allowed through.
+  headers so the named paths are rail-checked. As a categorical backstop, a
+  **structured mutating** tool that exposes **no inspectable path** under active
+  enforcement (an opaque/unparsed format) fails **closed**. Read-only tools **and
+  shell/terminal tools** are exempt from this branch: shell runs a Turing-complete
+  command (e.g. `npm test`) that is intentionally not rail-gated in-session, so
+  denying it would break the P4 build/test loop — its writes fall to the CI gate.
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
   resolved (target + existing parent segments) before rail comparison and denied.
 - Multi-root workspaces: in a Cursor workspace with several `workspace_roots`, the

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -90,8 +90,16 @@ control:
 - Corrupt `tickets.json`: `@adlc/core`'s `loadTickets` signals corruption three
   ways — it throws on some malformed schemas, returns an `errors` array on others,
   and returns an empty list when `tickets` is absent. The checker fails **closed**
-  on all three (and on a resolved active ticket that isn't found), so a corrupt or
+  on all three (and on a resolved active ticket that isn't found, and on a
+  malformed rail entry such as a non-string in the `rails` array), so a corrupt or
   truncated rail trust root cannot silently drop the declared rail set.
+- Categorical fail-safe: rather than enumerate every way the deny path could throw,
+  the adapter's catch is **enforcement-aware** — when `ADLC_P4_ENFORCEMENT=1`, any
+  unexpected error in the decision fails **closed** (deny), because under active
+  enforcement an error is likelier corruption/tamper than a benign bug; when
+  enforcement is off the guard is a no-op, so it fails open to avoid bricking the
+  editor. This closes the whole "exception → silent allow" class, not just the
+  triggers found so far.
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
   resolved (target + existing parent segments) before rail comparison and denied.
 - Multi-root workspaces: in a Cursor workspace with several `workspace_roots`, the

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -105,6 +105,12 @@ control:
   collects **every** target path (scalars + nested batch items, mirroring the
   Claude sibling) and the guard denies if **any** one is a frozen rail — a
   single-scalar extractor would wave a MultiEdit through.
+- Patch-envelope payloads: an `apply_patch`-style tool names its targets inside a
+  `command`/`patch` string (`*** Update File: …`). The extractor parses those
+  headers so the named paths are rail-checked. As a categorical backstop, a tool
+  that **classifies as mutating** but exposes **no inspectable path** under active
+  enforcement (an opaque/unparsed format) fails **closed** — only read-only/no-path
+  tools are allowed through.
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
   resolved (target + existing parent segments) before rail comparison and denied.
 - Multi-root workspaces: in a Cursor workspace with several `workspace_roots`, the

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -1,0 +1,112 @@
+# ADR 0006: Cursor native integration — rails-guard MVP
+
+**Status:** **Accepted — MVP shipped (P3 rail guard); command suite + prosecutor
+lenses follow-on.** This ADR records the decisions for the first shippable
+increment (ticket T1) and the verified facts the build rests on. The working spec
+is `.adlc/cursor-spec.md`.
+
+**Date:** 2026-06-27
+**Deciders:** Chris Williams.
+
+> Companion to [ADR 0003](./0003-adlc-claude-code-plugin.md) (Claude Code),
+> [ADR 0004](./0004-adlc-opencode-integration.md) (OpenCode), and
+> [ADR 0001](./0001-codex-native-adlc-integration.md) (Codex).
+
+## Context
+
+ADLC already integrates with Claude Code, OpenCode, and Codex. Cursor is the
+remaining major agentic editor. Unlike Claude Code it has **no plugin
+marketplace**, so the integration must use Cursor's native surfaces directly:
+**hooks** (`.cursor/hooks.json`), **rules** (`.cursor/rules/*.mdc`), and
+**commands** (`.cursor/commands/*.md`). This ADR covers the **MVP**: the
+in-session rails-guard hook plus the discovery rule and a scaffolder — the
+smallest increment that makes rail enforcement real in Cursor.
+
+## Decision
+
+Ship `plugins/adlc-cursor/` as a small Node package that wires Cursor's
+`preToolUse` hook to a rail-enforcement decision, **delegating every rail / glob /
+ticket primitive to `@adlc/core`** (no re-implementation — same single-source-of-
+truth rule as ADR 0004). A scaffolder writes the `.cursor/` config into the user's
+repo and merges into any existing hooks.
+
+### Resolved Cursor hook facts (pinned)
+
+```
+config file:        .cursor/hooks.json   (version: 1; hooks map; per-entry
+                    command / matcher / timeout / failClosed)
+hook transport:     external script — JSON on stdin, JSON on stdout (NOT exit codes)
+edit interception:  preToolUse   (fires before any tool, incl. Write/Edit)
+  stdin:   { tool_name, tool_input: { file_path, ... }, workspace_roots, ... }
+  stdout:  { permission: "allow" | "deny" | "ask", user_message, agent_message }
+post-edit observe:  afterFileEdit   (fires AFTER the edit; OBSERVATIONAL — cannot block)
+shell:              beforeShellExecution   (Bash writes NOT rail-gated in-session)
+rule host:          .cursor/rules/adlc.mdc   (frontmatter: description / globs / alwaysApply)
+```
+
+### Enforcement honesty (the load-bearing constraint)
+
+Cursor's in-session deny is **best-effort**, for two independent reasons:
+
+1. `afterFileEdit` is documented as firing **after** the edit and **cannot block**
+   it — so it is used only for a post-hoc audit notice, never as a control.
+2. `preToolUse`'s `permission: "deny"` has **open community bug reports** of edits
+   slipping through. We therefore treat the in-session hook as **advisory** and
+   make the unbypassable control the commit-time CI gate
+   (`docs/ci/rails-guard.yml`).
+
+The hook is wired `failClosed: false` so a hook crash can never brick the editor;
+internal adapter errors **fail open** in-session (the CI gate still catches the
+edit). The one deliberate fail-closed path is a conflicting active-ticket signal,
+which the checker reports as a denial.
+
+### Rail contract (delegated, sibling-faithful)
+
+Active ticket via `ADLC_TICKET` or `.adlc/current-ticket.json` (conflict → fail
+closed); enforcement phase-gated on `ADLC_P4_ENFORCEMENT=1`; rails = the single
+active ticket's `rails` plus the trust-root rails `.adlc/tickets.json` and
+`.adlc/current-ticket.json`; no-op when uninitialized / off / no active ticket;
+symlink targets resolved before comparison.
+
+## Threat Model
+
+The in-session hook is **bypassable by design** and must not be mistaken for the
+control:
+
+- The agent controls its environment, so it can leave `ADLC_P4_ENFORCEMENT` unset,
+  point `ADLC_TICKET` / `.adlc/current-ticket.json` at a rail-free ticket, or
+  exploit Cursor's unreliable `deny` to land an edit anyway.
+- `afterFileEdit` cannot block, so a slipped edit is *observed*, not prevented.
+- Bash-driven writes are not gated in-session (Turing-complete shell).
+- Unrecognized mutation tools: the gate fails **closed** on tool names — only known
+  read-only tools (`read`/`grep`/`codebase_search`/…) are skipped; known mutators
+  and any unrecognized structured tool carrying a file path are checked, so a new
+  tool name can't slip an edit past the guard.
+- Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
+  resolved (target + existing parent segments) before rail comparison and denied.
+
+Mitigation: the unbypassable commit-time CI gate (`docs/ci/rails-guard.yml`) reads
+the frozen rail set from the trusted base ref and rejects offending PRs regardless
+of how the edit was made. It is the same gate the OpenCode and Codex integrations
+rely on; this ADR adds **no competing CI workflow**.
+
+## Unverified / follow-on
+
+- **`preToolUse` payload field names** — Cursor's public docs pin the
+  `beforeShellExecution` / `beforeReadFile` contracts precisely but not the exact
+  `preToolUse` `tool_input` shape. The adapter extracts the tool name and edited
+  path **defensively** across the documented and sibling field names; pinning the
+  exact shape against a captured real payload is pending a live install.
+- **Live deny proof** — a maintainer-only end-to-end test against a real Cursor
+  binary (does `permission: "deny"` actually abort the Write on the target
+  platform?) remains the GA gate.
+- **Command suite + prosecutor lenses** — `.cursor/commands/adlc-*` beyond
+  `/adlc-init`, and the 5-lens P5 prosecution, are follow-on.
+
+## Consequences
+
+Rail enforcement is real in Cursor for the common structured-edit path, with the
+rail engine delegated to a single source of truth (`@adlc/core`) and the
+advisory/CI two-layer model honest about what the in-session hook can and cannot
+guarantee. Cursor joins Claude Code, OpenCode, and Codex with a consistent rail
+contract and the same unbypassable backstop.

--- a/docs/adr/0006-adlc-cursor-integration.md
+++ b/docs/adr/0006-adlc-cursor-integration.md
@@ -117,9 +117,15 @@ control:
 - Symlink aliasing: an edit to a symlink whose real target is a frozen rail is
   resolved (target + existing parent segments) before rail comparison and denied.
 - Multi-root workspaces: in a Cursor workspace with several `workspace_roots`, the
-  guard resolves the root that **owns** the edited absolute path (longest match)
-  rather than the first listed root, so a rail edit in a later root is checked
-  against the right repo.
+  guard resolves the root that **owns** the edited path (longest normalized,
+  symlink-resolved containment match) rather than the first listed root — for
+  **relative** paths too, which are resolved against the primary root first, so a
+  `../sibling-root/rail` traversal is attributed to the repo it resolves into and
+  checked against the right rails (not waved through against `roots[0]`).
+- Unparseable payloads: a tool payload that fails `JSON.parse` cannot be verified;
+  the hook fails **closed** (deny) under active enforcement and open otherwise —
+  the same enforcement-aware fail-safe as the decision path, so a malformed payload
+  can't slip an edit through.
 
 Mitigation: the unbypassable commit-time CI gate (`docs/ci/rails-guard.yml`) reads
 the frozen rail set from the trusted base ref and rejects PRs that edit a

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,114 @@
+# Adopt the ADLC in Cursor
+
+Wire the Agentic Development Lifecycle into [Cursor](https://cursor.com) using its
+**native** extension surfaces — hooks, rules, and commands. Cursor has no plugin
+marketplace, so the integration ships as a small Node package
+(`plugins/adlc-cursor`) plus a scaffolder that writes the `.cursor/` config into
+your repo.
+
+> Companion to [Claude Code](./claude-code.md), [OpenCode](./opencode.md), and
+> [Codex](./codex.md). Design rationale: [ADR 0006](../adr/0006-adlc-cursor-integration.md).
+
+## Status
+
+**MVP shipped — the in-session rails-guard hook + the gate-router rule.** This is
+the smallest increment that makes rail enforcement real inside Cursor. The phase
+command suite, the prosecutor subagents, and a live deny-proof against the Cursor
+binary are follow-on (see [Gaps](#gaps)).
+
+## What you get
+
+- **`preToolUse` rails-guard hook** — before Cursor's agent runs a `Write`/`Edit`,
+  the hook denies edits to paths frozen by the active ticket.
+- **`afterFileEdit` audit hook** — surfaces a loud notice when a frozen rail was
+  edited. Cursor's `afterFileEdit` fires *after* the write and **cannot block**,
+  so this is observational only.
+- **`.cursor/rules/adlc.mdc`** — the ADLC phase-router rule, available to the agent
+  in-session.
+
+## Install
+
+1. Install the toolkit and this package:
+
+   ```sh
+   npm install -g @adlc/cli
+   npm install --save-dev @adlc/cursor-package    # or reference the repo path
+   ```
+
+2. Bootstrap (idempotent — merges into any existing `.cursor/hooks.json`):
+
+   ```sh
+   node ./node_modules/@adlc/cursor-package/lib/scaffold-cli.mjs .
+   ```
+
+   This writes `.adlc/config.json`, `.cursor/hooks.json` (wiring the rails-guard +
+   audit hooks), and `.cursor/rules/adlc.mdc`. Inside Cursor you can also run the
+   `/adlc-init` command.
+
+3. Verify locally (no Cursor binary required):
+
+   ```sh
+   node scripts/cursor-install-smoke.mjs .
+   ```
+
+## Rail enforcement — two layers
+
+Cursor's hooks are a **best-effort, in-session** layer, not the control:
+
+1. **In-session (advisory).** The `preToolUse` hook returns
+   `{ "permission": "deny" }` on a frozen-rail edit. Cursor *should* block it — but
+   `permission: "deny"` has [open reliability reports](https://forum.cursor.com/t/hooks-returning-deny-do-not-seem-to-block-tool-execution-possible-security-concern/154377),
+   and `afterFileEdit` cannot block at all. The hook is configured `failClosed:
+   false` so a hook bug can never brick your editor. Bash/shell writes are **not**
+   gated in-session (a Turing-complete shell can't be reliably parsed).
+
+2. **Commit-time (unbypassable).** The real control is the CI rail-freeze gate
+   ([`docs/ci/rails-guard.yml`](../ci/rails-guard.yml)). It reads the frozen rail
+   set from the trusted base ref and rejects any PR that touched a rail, regardless
+   of how the edit was made. **Make it a required check.**
+
+## Rail contract
+
+Enforcement is identical to the sibling integrations (the engine is `@adlc/core`,
+not re-implemented here):
+
+- Active ticket via `ADLC_TICKET` **or** `.adlc/current-ticket.json`; a conflict
+  between the two fails closed (denied).
+- Enforcement is phase-scoped to `ADLC_P4_ENFORCEMENT=1`; otherwise no-op.
+- Rails in force = the **single** active ticket's `rails` plus the trust-root rails
+  `.adlc/tickets.json` and `.adlc/current-ticket.json` (not a union across tickets).
+- No-op when the repo is not ADLC-initialized, enforcement is off, or no active
+  ticket resolves.
+- Symlink aliases whose real target is a frozen rail are resolved and denied.
+
+## Formal ADLC Coverage
+
+| Phase | Surface in Cursor | Mechanism |
+| --- | --- | --- |
+| P0 Triage | `.adlc/tickets.json` | author a ticket (shared runtime) |
+| P1 Interrogate | `adlc spec-lint` / `premortem` | dispatcher (`--prompt-only` in-session) |
+| P2 Decompose | `adlc coldstart` / `merge-forecast` | dispatcher |
+| **P3 Rail** | **`preToolUse` rails-guard hook** | **this package + CI gate** |
+| P4 Build | `adlc flail-detector` | dispatcher |
+| P5 Prosecute | `adlc hollow-test` / `behavior-diff` | dispatcher |
+| P6 Integrate | `adlc gate-manifest` | human gate |
+| P7 Distill | `adlc lesson-foundry` | dispatcher |
+
+The gate-router rule (`.cursor/rules/adlc.mdc`) points the in-session agent at the
+right gate for whatever it's doing.
+
+## Gaps
+
+- **Phase command suite** (`.cursor/commands/adlc-*`) beyond `/adlc-init` — follow-on.
+- **Prosecutor subagents** (the 5-lens P5 prosecution) — follow-on.
+- **Live deny-proof** against a real Cursor binary, and pinning the exact
+  `preToolUse` payload field names — tracked in [ADR 0006](../adr/0006-adlc-cursor-integration.md);
+  the adapter extracts the path defensively until then.
+- **Shell-write gating** in-session — out of scope by design; covered by the CI gate.
+
+## Boundary
+
+The in-session hook is a convenience that fails safe; it is **not** a security
+boundary. The frozen-rail guarantee is the CI gate. Treat the two as designed: the
+hook keeps an honest agent on the rails during a build, and CI stops a dishonest or
+buggy one at the door.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -37,7 +37,15 @@ package is **not yet published to npm**, so install from source for now.
    npm install -g @adlc/cli
    ```
 
-2. Bootstrap from the plugin source (idempotent — **merges** into any existing
+2. Install the repo's workspace dependencies so the rails-guard hook can resolve
+   `@adlc/core` at runtime (the bootstrap scaffolder itself has no third-party
+   dependency, but the hook it wires imports `@adlc/core`):
+
+   ```sh
+   cd /path/to/adlc && npm install
+   ```
+
+3. Bootstrap from the plugin source (idempotent — **merges** into any existing
    `.cursor/hooks.json`; if that file is present but unparseable it is preserved
    verbatim in a `.bak` sibling before a fresh one is written, never silently
    dropped):
@@ -51,7 +59,7 @@ package is **not yet published to npm**, so install from source for now.
    `/adlc-init` command. (Once the package is published, the same scaffolder will be
    runnable from `node_modules/@adlc/cursor-package/`.)
 
-3. Verify locally (no Cursor binary required):
+4. Verify locally (no Cursor binary required):
 
    ```sh
    node scripts/cursor-install-smoke.mjs .

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -64,8 +64,16 @@ Cursor's hooks are a **best-effort, in-session** layer, not the control:
 
 2. **Commit-time (unbypassable).** The real control is the CI rail-freeze gate
    ([`docs/ci/rails-guard.yml`](../ci/rails-guard.yml)). It reads the frozen rail
-   set from the trusted base ref and rejects any PR that touched a rail, regardless
-   of how the edit was made. **Make it a required check.**
+   set **from the trusted base ref** and rejects any PR that edits a path frozen
+   there, regardless of how the edit was made. **Make it a required check.**
+
+   **Scope limit (read the template's own SECURITY LIMITATION):** because the rail
+   set is read from the base ref, the gate protects rails **already frozen on the
+   base branch**. A PR that *introduces* a new rail **and** edits that path in the
+   same PR is **not** caught — first-time rails are enforced only once they land on
+   the base branch, and the template requires an explicit `acknowledgedNewRailBypass`
+   acknowledgement before it can be a required check. Freeze rails in a separate,
+   merged commit before the build PR if you need same-PR protection.
 
 ## Rail contract
 
@@ -109,6 +117,8 @@ right gate for whatever it's doing.
 ## Boundary
 
 The in-session hook is a convenience that fails safe; it is **not** a security
-boundary. The frozen-rail guarantee is the CI gate. Treat the two as designed: the
+boundary. The frozen-rail guarantee is the CI gate — **for rails already frozen on
+the base branch** (see the scope limit above; a rail first introduced in the same
+PR is not protected until it lands on the base). Treat the two as designed: the
 hook keeps an honest agent on the rails during a build, and CI stops a dishonest or
-buggy one at the door.
+buggy one at the door — provided the rail was frozen in a merged commit first.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -28,22 +28,28 @@ binary are follow-on (see [Gaps](#gaps)).
 
 ## Install
 
-1. Install the toolkit and this package:
+The plugin ships in this repo at `plugins/adlc-cursor/`. The `@adlc/cursor-package`
+package is **not yet published to npm**, so install from source for now.
+
+1. Install the gate toolkit (the hooks/commands shell out to the `adlc` binary):
 
    ```sh
    npm install -g @adlc/cli
-   npm install --save-dev @adlc/cursor-package    # or reference the repo path
    ```
 
-2. Bootstrap (idempotent — merges into any existing `.cursor/hooks.json`):
+2. Bootstrap from the plugin source (idempotent — **merges** into any existing
+   `.cursor/hooks.json`; if that file is present but unparseable it is preserved
+   verbatim in a `.bak` sibling before a fresh one is written, never silently
+   dropped):
 
    ```sh
-   node ./node_modules/@adlc/cursor-package/lib/scaffold-cli.mjs .
+   node /path/to/adlc/plugins/adlc-cursor/lib/scaffold-cli.mjs .
    ```
 
    This writes `.adlc/config.json`, `.cursor/hooks.json` (wiring the rails-guard +
    audit hooks), and `.cursor/rules/adlc.mdc`. Inside Cursor you can also run the
-   `/adlc-init` command.
+   `/adlc-init` command. (Once the package is published, the same scaffolder will be
+   runnable from `node_modules/@adlc/cursor-package/`.)
 
 3. Verify locally (no Cursor binary required):
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "scripts": {
-    "test": "for d in packages/*/test; do node --test \"$d\"/*.test.mjs || exit 1; done && node --test plugins/adlc-claude-code/hooks/test/*.test.mjs && node --test scripts/test/*.test.mjs && (npx tsc --target es2022 --module nodenext --moduleResolution nodenext --noEmitOnError false --skipLibCheck true --noImplicitAny false --declaration false plugins/adlc-pi/index.ts || true) && node --test plugins/adlc-pi/test/*.test.mjs && node --test plugins/adlc-opencode/test/*.test.mjs",
+    "test": "for d in packages/*/test; do node --test \"$d\"/*.test.mjs || exit 1; done && node --test plugins/adlc-claude-code/hooks/test/*.test.mjs && node --test scripts/test/*.test.mjs && (npx tsc --target es2022 --module nodenext --moduleResolution nodenext --noEmitOnError false --skipLibCheck true --noImplicitAny false --declaration false plugins/adlc-pi/index.ts || true) && node --test plugins/adlc-pi/test/*.test.mjs && node --test plugins/adlc-opencode/test/*.test.mjs && node --test plugins/adlc-cursor/test/*.test.mjs && node scripts/cursor-install-smoke.mjs .",
     "release": "node scripts/release.mjs"
   },
   "engines": {

--- a/plugins/adlc-cursor/command/adlc-init.md
+++ b/plugins/adlc-cursor/command/adlc-init.md
@@ -1,0 +1,54 @@
+---
+description: Bootstrap the ADLC runtime (.adlc/) and scaffold the Cursor hooks + rule.
+---
+
+# /adlc-init — bootstrap the ADLC workspace (Cursor)
+
+Set up the shared `.adlc/` runtime every gate reads, scaffold the Cursor
+`preToolUse`/`afterFileEdit` hooks and the gate-router rule into `.cursor/`, and
+confirm the toolkit is reachable. Run once per repository. Every step is
+idempotent — never clobber existing files.
+
+## 1. Verify the toolkit
+
+Run `adlc --version`. If not found, STOP and tell the user to install it:
+
+```sh
+npm install -g @adlc/cli
+```
+
+## 2. Runtime + Cursor wiring
+
+- Create `.adlc/` if missing.
+- If `.adlc/tickets.json` is absent, create it as `{ "tickets": [] }`. If present, leave it.
+- Run the deterministic scaffolder to create `.adlc/config.json` (no clobber) and
+  wire `.cursor/hooks.json` + `.cursor/rules/adlc.mdc`:
+
+  ```sh
+  node "$(dirname "$(node -e "process.stdout.write(require.resolve('@adlc/cursor-package/package.json'))" 2>/dev/null || echo .)")/lib/scaffold-cli.mjs" .
+  ```
+
+  The scaffolder MERGES the ADLC `preToolUse` (rails-guard) and `afterFileEdit`
+  (audit) entries into any existing `.cursor/hooks.json` without removing your
+  other hooks.
+
+## 3. Separate the contract from runtime evidence in git
+
+Ensure `.gitignore` ignores all of `.adlc/` except the ticket contract:
+
+```
+.adlc/*
+!.adlc/tickets.json
+```
+
+## 4. Preflight
+
+Run `adlc preflight --json` and summarize the verdict (informational for setup).
+
+## 5. Summarize
+
+Report: toolkit version, whether `.adlc/tickets.json`/`config.json` were created or
+already present, what was wired into `.cursor/`, gitignore changes, and the
+preflight verdict. Remind the user that the in-session hook is **advisory** —
+Cursor's `permission: "deny"` is best-effort — and that the unbypassable control
+is the CI rail-freeze gate (`docs/ci/rails-guard.yml`).

--- a/plugins/adlc-cursor/constants.mjs
+++ b/plugins/adlc-cursor/constants.mjs
@@ -1,0 +1,9 @@
+// constants.mjs — pure setup-time constants with NO dependencies (not even
+// @adlc/core). The scaffolder imports from here so it can write .cursor/ config in
+// a fresh checkout before `npm install` has linked the workspace packages. The
+// runtime hooks still need @adlc/core, but bootstrapping must not.
+
+// The Cursor preToolUse `matcher`: catch-all so EVERY tool reaches the guard and
+// the classifier — not an allowlist matcher — is the single decision point. A
+// narrower matcher would let a novel mutator name bypass the fail-closed classifier.
+export const PRETOOL_MATCHER = '.*';

--- a/plugins/adlc-cursor/hooks.json
+++ b/plugins/adlc-cursor/hooks.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "node ./node_modules/@adlc/cursor-package/hooks/adlc-rails-guard.mjs",
+        "matcher": "(?i)(write|edit|patch|create|delete|rename|move|apply|search_replace)",
+        "timeout": 10,
+        "failClosed": false
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "node ./node_modules/@adlc/cursor-package/hooks/adlc-audit.mjs",
+        "timeout": 10,
+        "failClosed": false
+      }
+    ]
+  }
+}

--- a/plugins/adlc-cursor/hooks.json
+++ b/plugins/adlc-cursor/hooks.json
@@ -4,7 +4,7 @@
     "preToolUse": [
       {
         "command": "node ./node_modules/@adlc/cursor-package/hooks/adlc-rails-guard.mjs",
-        "matcher": "(?i)(write|edit|patch|create|delete|rename|move|apply|search_replace)",
+        "matcher": "(?i)(write|edit|replace|patch|create|delete|remove|rename|move|apply|insert|append)",
         "timeout": 10,
         "failClosed": false
       }

--- a/plugins/adlc-cursor/hooks.json
+++ b/plugins/adlc-cursor/hooks.json
@@ -4,7 +4,7 @@
     "preToolUse": [
       {
         "command": "node ./node_modules/@adlc/cursor-package/hooks/adlc-rails-guard.mjs",
-        "matcher": "(?i)(write|edit|replace|patch|create|delete|remove|rename|move|apply|insert|append)",
+        "matcher": ".*",
         "timeout": 10,
         "failClosed": false
       }

--- a/plugins/adlc-cursor/hooks/adlc-audit.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-audit.mjs
@@ -10,7 +10,7 @@
 
 import { fileURLToPath } from 'node:url';
 import { checkRail } from '../rails-checker.mjs';
-import { extractFilePath, resolveRoot } from './adlc-rails-guard.mjs';
+import { extractFilePaths, resolveRoot } from './adlc-rails-guard.mjs';
 
 /**
  * Observe an afterFileEdit payload. Returns { rail: boolean, reason } and, when a
@@ -18,17 +18,23 @@ import { extractFilePath, resolveRoot } from './adlc-rails-guard.mjs';
  */
 export function audit(payload, { root, env = process.env } = {}) {
   try {
-    // afterFileEdit names the file directly; reuse the same defensive extractor.
-    const filePath = extractFilePath(payload) ?? firstAfterEditPath(payload);
-    if (!filePath) return { rail: false };
-    // Treat the edit as a structured mutation for classification purposes.
-    const verdict = checkRail({ filePath, tool: 'edit', root: root ?? resolveRoot(payload, filePath), env });
-    if (verdict.decision === 'deny') {
-      process.stderr.write(
-        `adlc-audit: POST-EDIT rail touch — ${verdict.reason}. ` +
-        `afterFileEdit cannot block; the CI rail-freeze gate will reject this change.\n`,
-      );
-      return { rail: true, reason: verdict.reason };
+    // afterFileEdit names the file(s) directly; reuse the same extractor so batch
+    // shapes (edits[]/files[]) are observed too.
+    const paths = extractFilePaths(payload);
+    if (!paths.length) {
+      const fallback = firstAfterEditPath(payload);
+      if (fallback) paths.push(fallback);
+    }
+    if (!paths.length) return { rail: false };
+    for (const filePath of paths) {
+      const verdict = checkRail({ filePath, tool: 'edit', root: root ?? resolveRoot(payload, filePath), env });
+      if (verdict.decision === 'deny') {
+        process.stderr.write(
+          `adlc-audit: POST-EDIT rail touch — ${verdict.reason}. ` +
+          `afterFileEdit cannot block; the CI rail-freeze gate will reject this change.\n`,
+        );
+        return { rail: true, reason: verdict.reason };
+      }
     }
     return { rail: false };
   } catch {

--- a/plugins/adlc-cursor/hooks/adlc-audit.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-audit.mjs
@@ -10,7 +10,7 @@
 
 import { fileURLToPath } from 'node:url';
 import { checkRail } from '../rails-checker.mjs';
-import { extractFilePaths, resolveRoot } from './adlc-rails-guard.mjs';
+import { extractFilePaths, resolveOwning } from './adlc-rails-guard.mjs';
 
 /**
  * Observe an afterFileEdit payload. Returns { rail: boolean, reason } and, when a
@@ -27,7 +27,8 @@ export function audit(payload, { root, env = process.env } = {}) {
     }
     if (!paths.length) return { rail: false };
     for (const filePath of paths) {
-      const verdict = checkRail({ filePath, tool: 'edit', root: root ?? resolveRoot(payload, filePath), env });
+      const owned = root != null ? { root, absFile: undefined } : resolveOwning(payload, filePath);
+      const verdict = checkRail({ filePath: owned.absFile ?? filePath, tool: 'edit', root: owned.root, env });
       if (verdict.decision === 'deny') {
         process.stderr.write(
           `adlc-audit: POST-EDIT rail touch — ${verdict.reason}. ` +

--- a/plugins/adlc-cursor/hooks/adlc-audit.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-audit.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// adlc-audit.mjs — the Cursor `afterFileEdit` hook.
+//
+// Cursor's afterFileEdit fires AFTER an edit is written and CANNOT block it
+// (ADR 0006). This hook is therefore purely OBSERVATIONAL: if the edited path is
+// a frozen rail, it surfaces a loud post-hoc notice so a slipped edit is visible
+// in the session log — but it never denies. It always emits a no-op verdict and
+// exits 0; the actual control is the preToolUse guard (best-effort) plus the
+// unbypassable CI rail-freeze gate.
+
+import { fileURLToPath } from 'node:url';
+import { checkRail } from '../rails-checker.mjs';
+import { extractFilePath, resolveRoot } from './adlc-rails-guard.mjs';
+
+/**
+ * Observe an afterFileEdit payload. Returns { rail: boolean, reason } and, when a
+ * rail was touched, writes a notice to stderr. Never blocks, never throws.
+ */
+export function audit(payload, { root, env = process.env } = {}) {
+  try {
+    // afterFileEdit names the file directly; reuse the same defensive extractor.
+    const filePath = extractFilePath(payload) ?? firstAfterEditPath(payload);
+    if (!filePath) return { rail: false };
+    // Treat the edit as a structured mutation for classification purposes.
+    const verdict = checkRail({ filePath, tool: 'edit', root: root ?? resolveRoot(payload), env });
+    if (verdict.decision === 'deny') {
+      process.stderr.write(
+        `adlc-audit: POST-EDIT rail touch — ${verdict.reason}. ` +
+        `afterFileEdit cannot block; the CI rail-freeze gate will reject this change.\n`,
+      );
+      return { rail: true, reason: verdict.reason };
+    }
+    return { rail: false };
+  } catch {
+    // Observational only: swallow everything.
+    return { rail: false };
+  }
+}
+
+// afterFileEdit payloads carry the path at file_path / path at the top level.
+function firstAfterEditPath(payload) {
+  if (!payload || typeof payload !== 'object') return undefined;
+  for (const k of ['file_path', 'filePath', 'path']) {
+    if (typeof payload[k] === 'string' && payload[k].trim()) return payload[k];
+  }
+  return undefined;
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function main() {
+  let payload = {};
+  const raw = await readStdin();
+  if (raw.trim()) {
+    try { payload = JSON.parse(raw); } catch { /* observational: ignore */ }
+  }
+  audit(payload, { root: resolveRoot(payload), env: process.env });
+  // afterFileEdit has no deny channel; emit an empty no-op object.
+  process.stdout.write('{}');
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/plugins/adlc-cursor/hooks/adlc-audit.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-audit.mjs
@@ -22,7 +22,7 @@ export function audit(payload, { root, env = process.env } = {}) {
     const filePath = extractFilePath(payload) ?? firstAfterEditPath(payload);
     if (!filePath) return { rail: false };
     // Treat the edit as a structured mutation for classification purposes.
-    const verdict = checkRail({ filePath, tool: 'edit', root: root ?? resolveRoot(payload), env });
+    const verdict = checkRail({ filePath, tool: 'edit', root: root ?? resolveRoot(payload, filePath), env });
     if (verdict.decision === 'deny') {
       process.stderr.write(
         `adlc-audit: POST-EDIT rail touch — ${verdict.reason}. ` +
@@ -58,7 +58,8 @@ async function main() {
   if (raw.trim()) {
     try { payload = JSON.parse(raw); } catch { /* observational: ignore */ }
   }
-  audit(payload, { root: resolveRoot(payload), env: process.env });
+  // audit() resolves the owning workspace root from the payload + edited path.
+  audit(payload, { env: process.env });
   // afterFileEdit has no deny channel; emit an empty no-op object.
   process.stdout.write('{}');
 }

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// adlc-rails-guard.mjs — the Cursor `preToolUse` hook adapter.
+//
+// Cursor runs this script before the agent calls a tool, passing a JSON payload
+// on stdin and reading a JSON verdict on stdout:
+//   stdin :  { tool_name, tool_input: { file_path, ... }, workspace_roots, ... }
+//   stdout:  { permission: "allow" | "deny" | "ask", user_message, agent_message }
+//
+// The rail DECISION is delegated entirely to checkRail() in ../rails-checker.mjs
+// (which delegates glob/ticket primitives to @adlc/core). This file only maps the
+// Cursor wire format onto that decision. It imports ONLY Node builtins + the
+// sibling checker (no third-party deps).
+//
+// Honesty about enforcement (ADR 0006): Cursor's `permission: "deny"` has open
+// reliability reports, so this hook is BEST-EFFORT/ADVISORY. The unbypassable
+// control is the commit-time CI gate (docs/ci/rails-guard.yml). To avoid bricking
+// the editor on a hook bug, internal errors FAIL OPEN in-session (allow + stderr
+// notice); the CI gate still catches the edit. The one deliberate fail-closed
+// path is a conflicting active-ticket signal, which checkRail reports as a denial.
+
+import { fileURLToPath } from 'node:url';
+import { checkRail } from '../rails-checker.mjs';
+
+// Field names Cursor (and sibling agents) have used for the tool name, the tool
+// input bag, and the edited path. Read defensively — the exact preToolUse shape
+// is pinned against a real payload in ADR 0006 (Unverified).
+const TOOL_NAME_KEYS = ['tool_name', 'toolName', 'tool', 'name'];
+const INPUT_BAG_KEYS = ['tool_input', 'toolInput', 'input', 'args', 'arguments', 'params', 'parameters'];
+const PATH_KEYS = ['file_path', 'filePath', 'path', 'target_file', 'targetFile', 'target', 'target_path', 'targetPath'];
+const ROOT_KEYS = ['workspace_roots', 'workspaceRoots', 'workspace_root', 'workspaceRoot', 'project_root', 'projectRoot', 'cwd', 'root'];
+
+function firstString(obj, keys) {
+  if (!obj || typeof obj !== 'object') return undefined;
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string' && v.trim()) return v;
+    if (Array.isArray(v) && typeof v[0] === 'string' && v[0].trim()) return v[0];
+  }
+  return undefined;
+}
+
+export function extractToolName(payload) {
+  return firstString(payload, TOOL_NAME_KEYS) ?? '';
+}
+
+/** Pull the edited path from the input bag (or the top-level payload as fallback). */
+export function extractFilePath(payload) {
+  if (!payload || typeof payload !== 'object') return undefined;
+  for (const bagKey of INPUT_BAG_KEYS) {
+    const bag = payload[bagKey];
+    const hit = firstString(bag, PATH_KEYS);
+    if (hit) return hit;
+  }
+  return firstString(payload, PATH_KEYS);
+}
+
+export function resolveRoot(payload, fallback = process.cwd()) {
+  return firstString(payload, ROOT_KEYS) ?? fallback;
+}
+
+/**
+ * Pure decision over a parsed Cursor preToolUse payload. Returns the exact stdout
+ * object Cursor expects. Never throws: internal errors fail OPEN (advisory).
+ */
+export function decide(payload, { root, env = process.env } = {}) {
+  try {
+    const tool = extractToolName(payload);
+    const filePath = extractFilePath(payload);
+    // Nothing path-shaped to gate (e.g. a non-file tool slipped past the matcher):
+    // allow. Bash/shell writes are intentionally not gated here.
+    if (!filePath) return { permission: 'allow' };
+
+    const verdict = checkRail({ filePath, tool, root: root ?? resolveRoot(payload), env });
+    if (verdict.decision === 'deny') {
+      return {
+        permission: 'deny',
+        user_message: `ADLC rails-guard: blocked edit to ${verdict.reason}`,
+        agent_message:
+          `This path is a FROZEN ADLC rail: ${verdict.reason}. ` +
+          `Do not edit it during the active build. If the rail must change, update the ticket spec ` +
+          `and re-freeze — do not work around the guard.`,
+      };
+    }
+    return { permission: 'allow' };
+  } catch (err) {
+    // Advisory layer: a hook crash must not brick the editor. Fail open and let
+    // the unbypassable CI rail-freeze gate catch the edit.
+    process.stderr.write(
+      `adlc-rails-guard: internal error (failing OPEN, advisory) — ${err?.message ?? err}\n`,
+    );
+    return { permission: 'allow' };
+  }
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function main() {
+  let payload = {};
+  const raw = await readStdin();
+  if (raw.trim()) {
+    try {
+      payload = JSON.parse(raw);
+    } catch (err) {
+      process.stderr.write(`adlc-rails-guard: malformed payload JSON (failing OPEN) — ${err.message}\n`);
+      process.stdout.write(JSON.stringify({ permission: 'allow' }));
+      return;
+    }
+  }
+  const verdict = decide(payload, { root: resolveRoot(payload), env: process.env });
+  process.stdout.write(JSON.stringify(verdict));
+}
+
+// Run as a hook only when invoked directly (tests import `decide` instead).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -200,7 +200,12 @@ export function decide(payload, { root, env = process.env } = {}) {
       // active enforcement is opaque: fail CLOSED rather than wave it through (e.g. a
       // patch format we don't parse).
       const enforcing = env?.ADLC_P4_ENFORCEMENT === '1';
-      if (enforcing && classifyTool(tool) !== 'readonly' && !isShellTool(tool)) {
+      const cls = classifyTool(tool);
+      // Opaque = a structured mutator (mutating classification ALWAYS wins, so a
+      // name like `terminal_edit` can't masquerade as shell), OR an unrecognized
+      // non-shell tool. Read-only and genuine shell/terminal tools are exempt.
+      const opaque = cls === 'mutating' || (cls === 'other' && !isShellTool(tool));
+      if (enforcing && opaque) {
         return {
           permission: 'deny',
           user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — a structured mutating tool with no verifiable target path while enforcement is active`,

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -204,20 +204,30 @@ export function decide(payload, { root, env = process.env } = {}) {
       // is off / the repo is uninitialized / no active ticket is resolved, and fails
       // closed on a conflict or corrupt ticket state — never denying on the bare
       // ADLC_P4_ENFORCEMENT flag alone.
-      const pre = railPreconditions({ root: root ?? resolveRoot(payload), env });
-      if (pre.state === 'deny') {
+      //
+      // A pathless tool gives NO ownership signal, so in a multi-root workspace we
+      // can't tell which root it targets. Evaluate EVERY candidate root and take the
+      // strictest outcome: any 'deny' root → deny; else (for an opaque tool) any
+      // 'active' root → deny; else allow. Picking only roots[0] would let an opaque
+      // mutator slip when a *later* root is the actively-enforcing ADLC repo.
+      const roots = root != null ? [root] : (candidateRoots(payload).length ? candidateRoots(payload) : [process.cwd()]);
+      const states = roots.map((r) => railPreconditions({ root: r, env }));
+      const denied = states.find((s) => s.state === 'deny');
+      if (denied) {
         return {
           permission: 'deny',
-          user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — ${pre.reason}`,
-          agent_message: `The rail trust state failed closed: ${pre.reason}. Fix the ticket/rail state rather than working around the guard.`,
+          user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — ${denied.reason}`,
+          agent_message: `The rail trust state failed closed: ${denied.reason}. Fix the ticket/rail state rather than working around the guard.`,
         };
       }
-      if (pre.state === 'inactive') return { permission: 'allow' };
+      const anyActive = states.some((s) => s.state === 'active');
+      if (!anyActive) return { permission: 'allow' };
 
-      // Enforcing with a valid active ticket: a structured mutator (mutating
-      // classification ALWAYS wins, so `terminal_edit` can't masquerade as shell) or
-      // an unrecognized non-shell tool that exposes no inspectable path is opaque and
-      // cannot be verified — fail CLOSED. Read-only and genuine shell tools are exempt.
+      // Some root is enforcing with a valid active ticket: a structured mutator
+      // (mutating classification ALWAYS wins, so `terminal_edit` can't masquerade as
+      // shell) or an unrecognized non-shell tool that exposes no inspectable path is
+      // opaque and cannot be verified — fail CLOSED. Read-only and genuine shell
+      // tools are exempt.
       const cls = classifyTool(tool);
       const opaque = cls === 'mutating' || (cls === 'other' && !isShellTool(tool));
       if (opaque) {

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -19,8 +19,14 @@
 // path is a conflicting active-ticket signal, which checkRail reports as a denial.
 
 import { fileURLToPath } from 'node:url';
-import { isAbsolute } from 'node:path';
+import { isAbsolute, resolve, relative } from 'node:path';
+import { realpathSync } from 'node:fs';
 import { checkRail } from '../rails-checker.mjs';
+
+/** Best-effort realpath; falls back to the lexical path (a write may create it). */
+function realOr(p) {
+  try { return realpathSync(p); } catch { return p; }
+}
 
 // Field names Cursor (and sibling agents) have used for the tool name, the tool
 // input bag, and the edited path. Read defensively — the exact preToolUse shape
@@ -75,14 +81,25 @@ export function candidateRoots(payload) {
  * wrong repo and miss a frozen-rail edit. So when the edited path is absolute, pick
  * the workspace root that actually CONTAINS it (longest match wins); otherwise fall
  * back to the first declared root, then the process cwd.
+ *
+ * Ownership is decided on NORMALIZED, symlink-resolved paths with a boundary-aware
+ * containment check (`relative()` not starting with `..`) — never raw string
+ * prefixes. A non-normalized payload path like `/repo-b/../repo-a/src/frozen.js`
+ * (or a symlinked root alias) must be attributed to the repo it actually resolves
+ * into, not the one whose name lexically prefixes it.
  */
 export function resolveRoot(payload, filePath, fallback = process.cwd()) {
   const roots = candidateRoots(payload);
   if (filePath && isAbsolute(filePath)) {
+    const absFile = realOr(resolve(filePath));
     const owning = roots
-      .filter((r) => { const rr = r.endsWith('/') ? r : `${r}/`; return filePath === r || filePath.startsWith(rr); })
-      .sort((a, b) => b.length - a.length)[0];
-    if (owning) return owning;
+      .map((raw) => ({ raw, real: realOr(resolve(raw)) }))
+      .filter(({ real }) => {
+        const rel = relative(real, absFile);
+        return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+      })
+      .sort((a, b) => b.real.length - a.real.length)[0];
+    if (owning) return owning.raw;
   }
   return roots[0] ?? fallback;
 }

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -199,17 +199,21 @@ export function decide(payload, { root, env = process.env } = {}) {
       // unrecognized) tool that reached the guard with an unparseable target under
       // active enforcement is opaque: fail CLOSED rather than wave it through (e.g. a
       // patch format we don't parse).
-      // Respect the SAME rail-state preconditions as a path-bearing edit (via the
-      // shared railPreconditions), so a pathless opaque tool no-ops when enforcement
-      // is off / the repo is uninitialized / no active ticket is resolved, and fails
-      // closed on a conflict or corrupt ticket state — never denying on the bare
-      // ADLC_P4_ENFORCEMENT flag alone.
-      //
-      // A pathless tool gives NO ownership signal, so in a multi-root workspace we
-      // can't tell which root it targets. Evaluate EVERY candidate root and take the
-      // strictest outcome: any 'deny' root → deny; else (for an opaque tool) any
-      // 'active' root → deny; else allow. Picking only roots[0] would let an opaque
-      // mutator slip when a *later* root is the actively-enforcing ADLC repo.
+      // Classify FIRST. Read-only tools and genuine shell/terminal tools are NEVER
+      // rail-gated in-session and must be exempt unconditionally — a no-path shell
+      // command (`npm test`) or a read-only search has to run even if some *other*
+      // workspace root has a broken/conflicting ticket state. Only a structured
+      // mutator (mutating classification ALWAYS wins, so `terminal_edit` can't
+      // masquerade as shell) or an unrecognized non-shell tool is "opaque".
+      const cls = classifyTool(tool);
+      const opaque = cls === 'mutating' || (cls === 'other' && !isShellTool(tool));
+      if (!opaque) return { permission: 'allow' };
+
+      // Opaque mutator with no inspectable path. It gives NO ownership signal, so in
+      // a multi-root workspace we can't tell which root it targets: evaluate EVERY
+      // candidate root via the shared railPreconditions and take the strictest
+      // outcome — any 'deny' (conflict/corrupt) → deny; else any 'active' root → deny
+      // (can't verify it against that root's frozen rails); else (all inactive) allow.
       const roots = root != null ? [root] : (candidateRoots(payload).length ? candidateRoots(payload) : [process.cwd()]);
       const states = roots.map((r) => railPreconditions({ root: r, env }));
       const denied = states.find((s) => s.state === 'deny');
@@ -220,17 +224,7 @@ export function decide(payload, { root, env = process.env } = {}) {
           agent_message: `The rail trust state failed closed: ${denied.reason}. Fix the ticket/rail state rather than working around the guard.`,
         };
       }
-      const anyActive = states.some((s) => s.state === 'active');
-      if (!anyActive) return { permission: 'allow' };
-
-      // Some root is enforcing with a valid active ticket: a structured mutator
-      // (mutating classification ALWAYS wins, so `terminal_edit` can't masquerade as
-      // shell) or an unrecognized non-shell tool that exposes no inspectable path is
-      // opaque and cannot be verified — fail CLOSED. Read-only and genuine shell
-      // tools are exempt.
-      const cls = classifyTool(tool);
-      const opaque = cls === 'mutating' || (cls === 'other' && !isShellTool(tool));
-      if (opaque) {
+      if (states.some((s) => s.state === 'active')) {
         return {
           permission: 'deny',
           user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — a structured mutating tool with no verifiable target path while enforcement is active`,

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -50,15 +50,42 @@ export function extractToolName(payload) {
   return firstString(payload, TOOL_NAME_KEYS) ?? '';
 }
 
-/** Pull the edited path from the input bag (or the top-level payload as fallback). */
-export function extractFilePath(payload) {
-  if (!payload || typeof payload !== 'object') return undefined;
-  for (const bagKey of INPUT_BAG_KEYS) {
-    const bag = payload[bagKey];
-    const hit = firstString(bag, PATH_KEYS);
-    if (hit) return hit;
+// Keys whose VALUE is an array of per-item edits (MultiEdit) or a string/object
+// list of files (batch edit). Mirrors the Claude sibling's targetFilePaths — a
+// structured mutator can carry its paths ONLY here, with no top-level scalar.
+const BATCH_KEYS = ['edits', 'files', 'changes', 'operations', 'fileEdits', 'file_edits'];
+
+/**
+ * EVERY file path a structured edit would touch — the scalar path keys at the top
+ * level and in each input bag, PLUS any per-item paths nested in `edits[]`/`files[]`
+ * (MultiEdit / batch shapes). Returns a de-duplicated array; the gate checks every
+ * one. Missing this is a bypass: a MultiEdit payload carries no top-level path.
+ */
+export function extractFilePaths(payload) {
+  const out = new Set();
+  const addScalars = (obj) => {
+    if (!obj || typeof obj !== 'object') return;
+    const s = firstString(obj, PATH_KEYS);
+    if (s) out.add(s);
+    for (const bk of BATCH_KEYS) {
+      const arr = obj[bk];
+      if (!Array.isArray(arr)) continue;
+      for (const el of arr) {
+        if (typeof el === 'string' && el.trim()) out.add(el);
+        else if (el && typeof el === 'object') { const es = firstString(el, PATH_KEYS); if (es) out.add(es); }
+      }
+    }
+  };
+  if (payload && typeof payload === 'object') {
+    addScalars(payload);
+    for (const bagKey of INPUT_BAG_KEYS) addScalars(payload[bagKey]);
   }
-  return firstString(payload, PATH_KEYS);
+  return [...out];
+}
+
+/** The first target path (used by the observational audit hook). */
+export function extractFilePath(payload) {
+  return extractFilePaths(payload)[0];
 }
 
 /** Collect every candidate workspace root (handles single-root keys and arrays). */
@@ -111,21 +138,25 @@ export function resolveRoot(payload, filePath, fallback = process.cwd()) {
 export function decide(payload, { root, env = process.env } = {}) {
   try {
     const tool = extractToolName(payload);
-    const filePath = extractFilePath(payload);
+    const filePaths = extractFilePaths(payload);
     // Nothing path-shaped to gate (e.g. a non-file tool slipped past the matcher):
     // allow. Bash/shell writes are intentionally not gated here.
-    if (!filePath) return { permission: 'allow' };
+    if (!filePaths.length) return { permission: 'allow' };
 
-    const verdict = checkRail({ filePath, tool, root: root ?? resolveRoot(payload, filePath), env });
-    if (verdict.decision === 'deny') {
-      return {
-        permission: 'deny',
-        user_message: `ADLC rails-guard: blocked edit to ${verdict.reason}`,
-        agent_message:
-          `This path is a FROZEN ADLC rail: ${verdict.reason}. ` +
-          `Do not edit it during the active build. If the rail must change, update the ticket spec ` +
-          `and re-freeze — do not work around the guard.`,
-      };
+    // Check EVERY target path (a MultiEdit/batch payload touches several) and deny
+    // if ANY is a frozen rail. Resolve the owning root per path (multi-root safe).
+    for (const filePath of filePaths) {
+      const verdict = checkRail({ filePath, tool, root: root ?? resolveRoot(payload, filePath), env });
+      if (verdict.decision === 'deny') {
+        return {
+          permission: 'deny',
+          user_message: `ADLC rails-guard: blocked edit to ${verdict.reason}`,
+          agent_message:
+            `This path is a FROZEN ADLC rail: ${verdict.reason}. ` +
+            `Do not edit it during the active build. If the rail must change, update the ticket spec ` +
+            `and re-freeze — do not work around the guard.`,
+        };
+      }
     }
     return { permission: 'allow' };
   } catch (err) {

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -21,7 +21,7 @@
 import { fileURLToPath } from 'node:url';
 import { isAbsolute, resolve, relative, dirname, basename } from 'node:path';
 import { realpathSync, existsSync } from 'node:fs';
-import { checkRail, classifyTool, isShellTool } from '../rails-checker.mjs';
+import { checkRail, classifyTool, isShellTool, railPreconditions } from '../rails-checker.mjs';
 
 /** Best-effort realpath; falls back to the lexical path (a write may create it). */
 function realOr(p) {
@@ -199,13 +199,28 @@ export function decide(payload, { root, env = process.env } = {}) {
       // unrecognized) tool that reached the guard with an unparseable target under
       // active enforcement is opaque: fail CLOSED rather than wave it through (e.g. a
       // patch format we don't parse).
-      const enforcing = env?.ADLC_P4_ENFORCEMENT === '1';
+      // Respect the SAME rail-state preconditions as a path-bearing edit (via the
+      // shared railPreconditions), so a pathless opaque tool no-ops when enforcement
+      // is off / the repo is uninitialized / no active ticket is resolved, and fails
+      // closed on a conflict or corrupt ticket state — never denying on the bare
+      // ADLC_P4_ENFORCEMENT flag alone.
+      const pre = railPreconditions({ root: root ?? resolveRoot(payload), env });
+      if (pre.state === 'deny') {
+        return {
+          permission: 'deny',
+          user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — ${pre.reason}`,
+          agent_message: `The rail trust state failed closed: ${pre.reason}. Fix the ticket/rail state rather than working around the guard.`,
+        };
+      }
+      if (pre.state === 'inactive') return { permission: 'allow' };
+
+      // Enforcing with a valid active ticket: a structured mutator (mutating
+      // classification ALWAYS wins, so `terminal_edit` can't masquerade as shell) or
+      // an unrecognized non-shell tool that exposes no inspectable path is opaque and
+      // cannot be verified — fail CLOSED. Read-only and genuine shell tools are exempt.
       const cls = classifyTool(tool);
-      // Opaque = a structured mutator (mutating classification ALWAYS wins, so a
-      // name like `terminal_edit` can't masquerade as shell), OR an unrecognized
-      // non-shell tool. Read-only and genuine shell/terminal tools are exempt.
       const opaque = cls === 'mutating' || (cls === 'other' && !isShellTool(tool));
-      if (enforcing && opaque) {
+      if (opaque) {
         return {
           permission: 'deny',
           user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — a structured mutating tool with no verifiable target path while enforcement is active`,

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -169,8 +169,15 @@ export function candidateRoots(payload) {
  */
 export function resolveRoot(payload, filePath, fallback = process.cwd()) {
   const roots = candidateRoots(payload);
-  if (filePath && isAbsolute(filePath)) {
-    const absFile = realpathDeepest(resolve(filePath));
+  if (filePath) {
+    // Resolve RELATIVE paths too (not just absolute): a relative path with `..`
+    // traversal — e.g. `../backend/src/auth.js` — must be attributed to the root it
+    // actually resolves into, not blindly to roots[0]. Resolve it against the
+    // primary root (roots[0]) / fallback the way the agent's cwd would, then do the
+    // normalized, symlink-resolved containment check. Skipping relative paths let a
+    // traversal edit a frozen rail in a SIBLING workspace root.
+    const base = roots[0] ?? fallback;
+    const absFile = realpathDeepest(isAbsolute(filePath) ? resolve(filePath) : resolve(base, filePath));
     const owning = roots
       .map((raw) => ({ raw, real: realpathDeepest(resolve(raw)) }))
       .filter(({ real }) => {
@@ -291,8 +298,18 @@ async function main() {
     try {
       payload = JSON.parse(raw);
     } catch (err) {
-      process.stderr.write(`adlc-rails-guard: malformed payload JSON (failing OPEN) — ${err.message}\n`);
-      process.stdout.write(JSON.stringify({ permission: 'allow' }));
+      // Enforcement-aware (consistent with decide()'s categorical fail-safe): an
+      // unparseable payload while enforcement is active cannot be verified, so fail
+      // CLOSED; otherwise the guard is a no-op, so fail open to avoid bricking the editor.
+      const enforcing = process.env.ADLC_P4_ENFORCEMENT === '1';
+      process.stderr.write(`adlc-rails-guard: malformed payload JSON (failing ${enforcing ? 'CLOSED' : 'OPEN'}) — ${err.message}\n`);
+      process.stdout.write(JSON.stringify(enforcing
+        ? {
+            permission: 'deny',
+            user_message: 'ADLC rails-guard: unparseable tool payload while enforcement is active — failing closed',
+            agent_message: 'The rail guard received a tool payload it could not parse during an active build, so the edit cannot be verified against the frozen rails and is denied. Retry with a well-formed structured edit.',
+          }
+        : { permission: 'allow' }));
       return;
     }
   }

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -19,13 +19,33 @@
 // path is a conflicting active-ticket signal, which checkRail reports as a denial.
 
 import { fileURLToPath } from 'node:url';
-import { isAbsolute, resolve, relative } from 'node:path';
-import { realpathSync } from 'node:fs';
+import { isAbsolute, resolve, relative, dirname, basename } from 'node:path';
+import { realpathSync, existsSync } from 'node:fs';
 import { checkRail } from '../rails-checker.mjs';
 
 /** Best-effort realpath; falls back to the lexical path (a write may create it). */
 function realOr(p) {
   try { return realpathSync(p); } catch { return p; }
+}
+
+/**
+ * Realpath the DEEPEST EXISTING ancestor of an absolute path, then re-append the
+ * not-yet-existing tail. A plain realpath of the full path fails for a file being
+ * CREATED, which would leave a symlinked parent (e.g. repoB/link -> repoA)
+ * unresolved and mis-attribute the file to the wrong workspace root. Mirrors the
+ * checker's resolveRailPath strategy.
+ */
+function realpathDeepest(absPath) {
+  if (existsSync(absPath)) return realOr(absPath);
+  const tail = [];
+  let cur = absPath;
+  while (!existsSync(cur)) {
+    const parent = dirname(cur);
+    if (parent === cur) break; // reached filesystem root
+    tail.unshift(basename(cur));
+    cur = parent;
+  }
+  return tail.length ? resolve(realOr(cur), ...tail) : realOr(cur);
 }
 
 // Field names Cursor (and sibling agents) have used for the tool name, the tool
@@ -118,9 +138,9 @@ export function candidateRoots(payload) {
 export function resolveRoot(payload, filePath, fallback = process.cwd()) {
   const roots = candidateRoots(payload);
   if (filePath && isAbsolute(filePath)) {
-    const absFile = realOr(resolve(filePath));
+    const absFile = realpathDeepest(resolve(filePath));
     const owning = roots
-      .map((raw) => ({ raw, real: realOr(resolve(raw)) }))
+      .map((raw) => ({ raw, real: realpathDeepest(resolve(raw)) }))
       .filter(({ real }) => {
         const rel = relative(real, absFile);
         return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -129,11 +129,25 @@ export function decide(payload, { root, env = process.env } = {}) {
     }
     return { permission: 'allow' };
   } catch (err) {
-    // Advisory layer: a hook crash must not brick the editor. Fail open and let
-    // the unbypassable CI rail-freeze gate catch the edit.
+    // Categorical fail-safe (closes the whole "exception → bypass" class):
+    //  - when enforcement is ACTIVE, an unexpected error is more likely corruption
+    //    or tamper than a benign bug, so fail CLOSED (deny) — never let a throw in
+    //    the deny path become a silent allow on a frozen rail;
+    //  - when enforcement is OFF the guard is a no-op anyway, so fail OPEN to avoid
+    //    bricking the editor on a hook bug. The CI gate remains the real control.
+    const enforcing = env?.ADLC_P4_ENFORCEMENT === '1';
     process.stderr.write(
-      `adlc-rails-guard: internal error (failing OPEN, advisory) — ${err?.message ?? err}\n`,
+      `adlc-rails-guard: internal error (failing ${enforcing ? 'CLOSED' : 'OPEN'}) — ${err?.message ?? err}\n`,
     );
+    if (enforcing) {
+      return {
+        permission: 'deny',
+        user_message: `ADLC rails-guard: internal error while enforcing — failing closed (${err?.message ?? err})`,
+        agent_message:
+          'The rail guard hit an unexpected error while enforcement is active and failed closed. ' +
+          'Fix the rail/ticket state (e.g. a malformed .adlc/tickets.json) rather than working around the guard.',
+      };
+    }
     return { permission: 'allow' };
   }
 }

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -100,16 +100,26 @@ function collectPatchPaths(text, out) {
  */
 export function extractFilePaths(payload) {
   const out = new Set();
+  // Collect EVERY path-key value on an object — not just the first. A rename/move
+  // payload carries a source AND a destination (path + target_path); checking only
+  // the first would miss a frozen rail hidden in the second slot.
+  const addEveryPathKey = (obj) => {
+    if (!obj || typeof obj !== 'object') return;
+    for (const k of PATH_KEYS) {
+      const v = obj[k];
+      if (typeof v === 'string' && v.trim()) out.add(v);
+      else if (Array.isArray(v)) for (const e of v) if (typeof e === 'string' && e.trim()) out.add(e);
+    }
+  };
   const addScalars = (obj) => {
     if (!obj || typeof obj !== 'object') return;
-    const s = firstString(obj, PATH_KEYS);
-    if (s) out.add(s);
+    addEveryPathKey(obj);
     for (const bk of BATCH_KEYS) {
       const arr = obj[bk];
       if (!Array.isArray(arr)) continue;
       for (const el of arr) {
         if (typeof el === 'string' && el.trim()) out.add(el);
-        else if (el && typeof el === 'object') { const es = firstString(el, PATH_KEYS); if (es) out.add(es); }
+        else if (el && typeof el === 'object') addEveryPathKey(el);
       }
     }
     // apply_patch-style payloads name their targets inside a patch/command string.

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -167,27 +167,35 @@ export function candidateRoots(payload) {
  * (or a symlinked root alias) must be attributed to the repo it actually resolves
  * into, not the one whose name lexically prefixes it.
  */
-export function resolveRoot(payload, filePath, fallback = process.cwd()) {
+export function resolveOwning(payload, filePath, fallback = process.cwd()) {
   const roots = candidateRoots(payload);
-  if (filePath) {
-    // Resolve RELATIVE paths too (not just absolute): a relative path with `..`
-    // traversal — e.g. `../backend/src/auth.js` — must be attributed to the root it
-    // actually resolves into, not blindly to roots[0]. Resolve it against the
-    // primary root (roots[0]) / fallback the way the agent's cwd would, then do the
-    // normalized, symlink-resolved containment check. Skipping relative paths let a
-    // traversal edit a frozen rail in a SIBLING workspace root.
-    const base = roots[0] ?? fallback;
-    const absFile = realpathDeepest(isAbsolute(filePath) ? resolve(filePath) : resolve(base, filePath));
+  const base = roots[0] ?? fallback;
+  // Resolve the edited path to an ABSOLUTE path. A relative path with `..`
+  // traversal (e.g. `../backend/src/auth.js`) is resolved against the primary root
+  // the way the agent's cwd would, so it's attributed to the root it actually
+  // resolves into — not blindly to roots[0]. The absolute path is returned and used
+  // for the rail check: passing the ORIGINAL relative path plus the owning root to
+  // checkRail would make it `join(owningRoot, relativeToPrimary)` and mangle the
+  // path whenever the roots differ in depth/name (caught by Gemini round-19).
+  const absFile = filePath
+    ? (isAbsolute(filePath) ? resolve(filePath) : resolve(base, filePath))
+    : undefined;
+  if (absFile) {
     const owning = roots
       .map((raw) => ({ raw, real: realpathDeepest(resolve(raw)) }))
       .filter(({ real }) => {
-        const rel = relative(real, absFile);
+        const rel = relative(real, realpathDeepest(absFile));
         return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
       })
       .sort((a, b) => b.real.length - a.real.length)[0];
-    if (owning) return owning.raw;
+    if (owning) return { root: owning.raw, absFile };
   }
-  return roots[0] ?? fallback;
+  return { root: roots[0] ?? fallback, absFile };
+}
+
+/** The owning workspace root for an edited path (back-compat wrapper). */
+export function resolveRoot(payload, filePath, fallback = process.cwd()) {
+  return resolveOwning(payload, filePath, fallback).root;
 }
 
 /**
@@ -246,9 +254,12 @@ export function decide(payload, { root, env = process.env } = {}) {
     }
 
     // Check EVERY target path (a MultiEdit/batch payload touches several) and deny
-    // if ANY is a frozen rail. Resolve the owning root per path (multi-root safe).
+    // if ANY is a frozen rail. Resolve the owning root AND the absolute path per
+    // path (multi-root safe) — pass the ABSOLUTE path to checkRail so it never
+    // re-joins a primary-root-relative path against a different owning root.
     for (const filePath of filePaths) {
-      const verdict = checkRail({ filePath, tool, root: root ?? resolveRoot(payload, filePath), env });
+      const owned = root != null ? { root, absFile: undefined } : resolveOwning(payload, filePath);
+      const verdict = checkRail({ filePath: owned.absFile ?? filePath, tool, root: owned.root, env });
       if (verdict.decision === 'deny') {
         return {
           permission: 'deny',

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -21,7 +21,7 @@
 import { fileURLToPath } from 'node:url';
 import { isAbsolute, resolve, relative, dirname, basename } from 'node:path';
 import { realpathSync, existsSync } from 'node:fs';
-import { checkRail, classifyTool } from '../rails-checker.mjs';
+import { checkRail, classifyTool, isShellTool } from '../rails-checker.mjs';
 
 /** Best-effort realpath; falls back to the lexical path (a write may create it). */
 function realOr(p) {
@@ -192,20 +192,23 @@ export function decide(payload, { root, env = process.env } = {}) {
     const tool = extractToolName(payload);
     const filePaths = extractFilePaths(payload);
     if (!filePaths.length) {
-      // No path we could see. For a read-only / non-file tool that's fine — allow.
-      // But a MUTATING (or unrecognized) tool that reached the guard with an
-      // unparseable target under active enforcement is opaque: fail CLOSED rather
-      // than wave it through (e.g. a patch format we don't parse). Bash/shell writes
-      // are intentionally not gated here and fall to the CI gate.
+      // No path we could see. Allow read-only tools AND shell/terminal tools — the
+      // latter run a Turing-complete command (e.g. `npm test`) and are intentionally
+      // not rail-gated in-session; their writes fall to the CI gate. Denying them
+      // would break the normal P4 build/test workflow. But a structured MUTATING (or
+      // unrecognized) tool that reached the guard with an unparseable target under
+      // active enforcement is opaque: fail CLOSED rather than wave it through (e.g. a
+      // patch format we don't parse).
       const enforcing = env?.ADLC_P4_ENFORCEMENT === '1';
-      if (enforcing && classifyTool(tool) !== 'readonly') {
+      if (enforcing && classifyTool(tool) !== 'readonly' && !isShellTool(tool)) {
         return {
           permission: 'deny',
-          user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — a mutating tool with no verifiable target path while enforcement is active`,
+          user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — a structured mutating tool with no verifiable target path while enforcement is active`,
           agent_message:
-            `A mutating tool reached the rail guard during an active build but exposed no inspectable ` +
-            `file path, so it cannot be verified against the frozen rails and is denied. Use a structured ` +
-            `edit/write with an explicit path rather than an opaque patch/command payload.`,
+            `A structured mutating tool reached the rail guard during an active build but exposed no ` +
+            `inspectable file path, so it cannot be verified against the frozen rails and is denied. Use a ` +
+            `structured edit/write with an explicit path rather than an opaque patch payload. ` +
+            `(Shell commands are allowed in-session and gated by the CI rail-freeze check instead.)`,
         };
       }
       return { permission: 'allow' };

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -19,6 +19,7 @@
 // path is a conflicting active-ticket signal, which checkRail reports as a denial.
 
 import { fileURLToPath } from 'node:url';
+import { isAbsolute } from 'node:path';
 import { checkRail } from '../rails-checker.mjs';
 
 // Field names Cursor (and sibling agents) have used for the tool name, the tool
@@ -54,8 +55,36 @@ export function extractFilePath(payload) {
   return firstString(payload, PATH_KEYS);
 }
 
-export function resolveRoot(payload, fallback = process.cwd()) {
-  return firstString(payload, ROOT_KEYS) ?? fallback;
+/** Collect every candidate workspace root (handles single-root keys and arrays). */
+export function candidateRoots(payload) {
+  const roots = [];
+  if (payload && typeof payload === 'object') {
+    for (const k of ROOT_KEYS) {
+      const v = payload[k];
+      if (typeof v === 'string' && v.trim()) roots.push(v.trim());
+      else if (Array.isArray(v)) for (const e of v) if (typeof e === 'string' && e.trim()) roots.push(e.trim());
+    }
+  }
+  return roots;
+}
+
+/**
+ * Resolve the repo root to check against. In a Cursor MULTI-ROOT workspace,
+ * `workspace_roots` lists several roots and the edited file may belong to any of
+ * them — picking the first one blindly can check an absolute rail path against the
+ * wrong repo and miss a frozen-rail edit. So when the edited path is absolute, pick
+ * the workspace root that actually CONTAINS it (longest match wins); otherwise fall
+ * back to the first declared root, then the process cwd.
+ */
+export function resolveRoot(payload, filePath, fallback = process.cwd()) {
+  const roots = candidateRoots(payload);
+  if (filePath && isAbsolute(filePath)) {
+    const owning = roots
+      .filter((r) => { const rr = r.endsWith('/') ? r : `${r}/`; return filePath === r || filePath.startsWith(rr); })
+      .sort((a, b) => b.length - a.length)[0];
+    if (owning) return owning;
+  }
+  return roots[0] ?? fallback;
 }
 
 /**
@@ -70,7 +99,7 @@ export function decide(payload, { root, env = process.env } = {}) {
     // allow. Bash/shell writes are intentionally not gated here.
     if (!filePath) return { permission: 'allow' };
 
-    const verdict = checkRail({ filePath, tool, root: root ?? resolveRoot(payload), env });
+    const verdict = checkRail({ filePath, tool, root: root ?? resolveRoot(payload, filePath), env });
     if (verdict.decision === 'deny') {
       return {
         permission: 'deny',
@@ -110,7 +139,8 @@ async function main() {
       return;
     }
   }
-  const verdict = decide(payload, { root: resolveRoot(payload), env: process.env });
+  // decide() resolves the owning workspace root from the payload + edited path.
+  const verdict = decide(payload, { env: process.env });
   process.stdout.write(JSON.stringify(verdict));
 }
 

--- a/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-cursor/hooks/adlc-rails-guard.mjs
@@ -21,7 +21,7 @@
 import { fileURLToPath } from 'node:url';
 import { isAbsolute, resolve, relative, dirname, basename } from 'node:path';
 import { realpathSync, existsSync } from 'node:fs';
-import { checkRail } from '../rails-checker.mjs';
+import { checkRail, classifyTool } from '../rails-checker.mjs';
 
 /** Best-effort realpath; falls back to the lexical path (a write may create it). */
 function realOr(p) {
@@ -75,6 +75,23 @@ export function extractToolName(payload) {
 // structured mutator can carry its paths ONLY here, with no top-level scalar.
 const BATCH_KEYS = ['edits', 'files', 'changes', 'operations', 'fileEdits', 'file_edits'];
 
+// Keys whose VALUE is a free-form patch / command string that names its target
+// files inline (the apply_patch envelope), e.g. "*** Update File: test/a.mjs".
+const PATCH_TEXT_KEYS = ['command', 'cmd', 'patch', 'input', 'content', 'text', 'diff'];
+const PATCH_PREFIXES = ['*** Add File: ', '*** Update File: ', '*** Delete File: ', '*** Move to: '];
+
+/** Pull every `*** <verb> File: <path>` target out of an apply_patch-style string. */
+function collectPatchPaths(text, out) {
+  for (const line of String(text).split(/\r?\n/)) {
+    for (const pre of PATCH_PREFIXES) {
+      if (line.startsWith(pre)) {
+        const p = line.slice(pre.length).trim();
+        if (p) out.add(p);
+      }
+    }
+  }
+}
+
 /**
  * EVERY file path a structured edit would touch — the scalar path keys at the top
  * level and in each input bag, PLUS any per-item paths nested in `edits[]`/`files[]`
@@ -94,6 +111,11 @@ export function extractFilePaths(payload) {
         if (typeof el === 'string' && el.trim()) out.add(el);
         else if (el && typeof el === 'object') { const es = firstString(el, PATH_KEYS); if (es) out.add(es); }
       }
+    }
+    // apply_patch-style payloads name their targets inside a patch/command string.
+    for (const tk of PATCH_TEXT_KEYS) {
+      const v = obj[tk];
+      if (typeof v === 'string' && v.includes('*** ')) collectPatchPaths(v, out);
     }
   };
   if (payload && typeof payload === 'object') {
@@ -159,9 +181,25 @@ export function decide(payload, { root, env = process.env } = {}) {
   try {
     const tool = extractToolName(payload);
     const filePaths = extractFilePaths(payload);
-    // Nothing path-shaped to gate (e.g. a non-file tool slipped past the matcher):
-    // allow. Bash/shell writes are intentionally not gated here.
-    if (!filePaths.length) return { permission: 'allow' };
+    if (!filePaths.length) {
+      // No path we could see. For a read-only / non-file tool that's fine — allow.
+      // But a MUTATING (or unrecognized) tool that reached the guard with an
+      // unparseable target under active enforcement is opaque: fail CLOSED rather
+      // than wave it through (e.g. a patch format we don't parse). Bash/shell writes
+      // are intentionally not gated here and fall to the CI gate.
+      const enforcing = env?.ADLC_P4_ENFORCEMENT === '1';
+      if (enforcing && classifyTool(tool) !== 'readonly') {
+        return {
+          permission: 'deny',
+          user_message: `ADLC rails-guard: blocked "${tool || 'unknown'}" — a mutating tool with no verifiable target path while enforcement is active`,
+          agent_message:
+            `A mutating tool reached the rail guard during an active build but exposed no inspectable ` +
+            `file path, so it cannot be verified against the frozen rails and is denied. Use a structured ` +
+            `edit/write with an explicit path rather than an opaque patch/command payload.`,
+        };
+      }
+      return { permission: 'allow' };
+    }
 
     // Check EVERY target path (a MultiEdit/batch payload touches several) and deny
     // if ANY is a frozen rail. Resolve the owning root per path (multi-root safe).

--- a/plugins/adlc-cursor/lib/scaffold-cli.mjs
+++ b/plugins/adlc-cursor/lib/scaffold-cli.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// scaffold-cli.mjs — CLI wrapper around scaffold.mjs. Invoked by /adlc-init to
+// bootstrap the Cursor integration into the target repo:
+//
+//   node lib/scaffold-cli.mjs <project-root>
+//
+// Idempotent; prints a human summary of what was created vs already present.
+
+import { resolve } from 'node:path';
+import { scaffold } from './scaffold.mjs';
+
+const projectRoot = resolve(process.argv[2] ?? '.');
+const { config, hooks, rule } = scaffold(projectRoot);
+
+const tag = (r) => (r.created ? 'created' : 'present');
+console.log(`adlc-cursor scaffold (${projectRoot}):`);
+console.log(`  .adlc/config.json     — ${tag(config)}`);
+console.log(`  .cursor/hooks.json    — ${hooks.created ? 'created' : 'merged'} (rails-guard + audit wired)`);
+console.log(`  .cursor/rules/adlc.mdc — ${tag(rule)}`);
+console.log('Next: author a ticket in .adlc/tickets.json, then `adlc rails-guard` to freeze rails.');

--- a/plugins/adlc-cursor/lib/scaffold-cli.mjs
+++ b/plugins/adlc-cursor/lib/scaffold-cli.mjs
@@ -16,5 +16,8 @@ const tag = (r) => (r.created ? 'created' : 'present');
 console.log(`adlc-cursor scaffold (${projectRoot}):`);
 console.log(`  .adlc/config.json     — ${tag(config)}`);
 console.log(`  .cursor/hooks.json    — ${hooks.created ? 'created' : 'merged'} (rails-guard + audit wired)`);
+if (hooks.backedUp) {
+  console.log(`  ⚠ existing .cursor/hooks.json was unparseable — preserved verbatim at ${hooks.backedUp} before writing a fresh file`);
+}
 console.log(`  .cursor/rules/adlc.mdc — ${tag(rule)}`);
 console.log('Next: author a ticket in .adlc/tickets.json, then `adlc rails-guard` to freeze rails.');

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -6,13 +6,16 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { MUTATING_MATCHER } from '../rails-checker.mjs';
 
 // The installed @adlc/cursor-package root (this file lives at <root>/lib/scaffold.mjs).
 export const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const RAILS_GUARD_REL = 'hooks/adlc-rails-guard.mjs';
 const AUDIT_REL = 'hooks/adlc-audit.mjs';
-const PRETOOL_MATCHER = '(?i)(write|edit|patch|create|delete|rename|move|apply|search_replace)';
+// Single source of truth: the matcher is derived from MUTATING_TOOL_HINTS in the
+// checker, so the scaffolded .cursor/hooks.json and the classifier can't drift.
+const PRETOOL_MATCHER = MUTATING_MATCHER;
 
 /** A hook entry is "ours" if its command points at one of our hook scripts. */
 function isAdlcHook(entry) {

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -6,16 +6,16 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { MUTATING_MATCHER } from '../rails-checker.mjs';
+import { PRETOOL_MATCHER } from '../rails-checker.mjs';
 
 // The installed @adlc/cursor-package root (this file lives at <root>/lib/scaffold.mjs).
 export const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const RAILS_GUARD_REL = 'hooks/adlc-rails-guard.mjs';
 const AUDIT_REL = 'hooks/adlc-audit.mjs';
-// Single source of truth: the matcher is derived from MUTATING_TOOL_HINTS in the
-// checker, so the scaffolded .cursor/hooks.json and the classifier can't drift.
-const PRETOOL_MATCHER = MUTATING_MATCHER;
+// Catch-all (".*"): every tool reaches the guard so the classifier — not an
+// allowlist matcher — is the single decision point (see PRETOOL_MATCHER in the
+// checker). Imported, not duplicated, so the scaffold and template can't drift.
 
 /** A hook entry is "ours" if its command points at one of our hook scripts. */
 function isAdlcHook(entry) {

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -1,0 +1,100 @@
+// scaffold.mjs — deterministic, idempotent setup of the Cursor integration into a
+// user's repo. Writes `.cursor/hooks.json` (wiring the rails-guard + audit hooks)
+// and `.cursor/rules/adlc.mdc` (the gate-router rule). Never clobbers a user's
+// existing hooks — it MERGES the ADLC entries into the hooks map.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The installed @adlc/cursor-package root (this file lives at <root>/lib/scaffold.mjs).
+export const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const RAILS_GUARD_REL = 'hooks/adlc-rails-guard.mjs';
+const AUDIT_REL = 'hooks/adlc-audit.mjs';
+const PRETOOL_MATCHER = '(?i)(write|edit|patch|create|delete|rename|move|apply|search_replace)';
+
+/** A hook entry is "ours" if its command points at one of our hook scripts. */
+function isAdlcHook(entry) {
+  return typeof entry?.command === 'string' && /adlc-(rails-guard|audit)\.mjs/.test(entry.command);
+}
+
+/** Build the two hook command strings, resolved against the installed plugin. */
+export function buildHookCommands(pluginRoot = PLUGIN_ROOT) {
+  return {
+    railsGuard: `node "${join(pluginRoot, RAILS_GUARD_REL)}"`,
+    audit: `node "${join(pluginRoot, AUDIT_REL)}"`,
+  };
+}
+
+/**
+ * Merge the ADLC hook entries into an existing hooks.json object (or a fresh one),
+ * returning a NEW object (no mutation of the input). Idempotent: re-running does
+ * not duplicate our entries.
+ */
+export function mergeHooks(existing, pluginRoot = PLUGIN_ROOT) {
+  const cmds = buildHookCommands(pluginRoot);
+  const base = existing && typeof existing === 'object' ? existing : {};
+  const hooks = { ...(base.hooks ?? {}) };
+
+  const preToolUse = (hooks.preToolUse ?? []).filter((e) => !isAdlcHook(e));
+  preToolUse.push({ command: cmds.railsGuard, matcher: PRETOOL_MATCHER, timeout: 10, failClosed: false });
+
+  const afterFileEdit = (hooks.afterFileEdit ?? []).filter((e) => !isAdlcHook(e));
+  afterFileEdit.push({ command: cmds.audit, timeout: 10, failClosed: false });
+
+  return { ...base, version: base.version ?? 1, hooks: { ...hooks, preToolUse, afterFileEdit } };
+}
+
+/** Write `.cursor/hooks.json`, merging into any existing config. Returns the action taken. */
+export function ensureCursorHooks(projectRoot, { pluginRoot = PLUGIN_ROOT } = {}) {
+  const cursorDir = join(projectRoot, '.cursor');
+  mkdirSync(cursorDir, { recursive: true });
+  const hooksPath = join(cursorDir, 'hooks.json');
+
+  let existing;
+  if (existsSync(hooksPath)) {
+    try { existing = JSON.parse(readFileSync(hooksPath, 'utf8')); }
+    catch { existing = undefined; } // unparseable: replace with a fresh, valid file
+  }
+  const merged = mergeHooks(existing, pluginRoot);
+  writeFileSync(hooksPath, `${JSON.stringify(merged, null, 2)}\n`);
+  return { path: hooksPath, created: !existing };
+}
+
+/** Copy the gate-router rule into `.cursor/rules/adlc.mdc`. Never clobbers a user edit. */
+export function ensureRule(projectRoot, { pluginRoot = PLUGIN_ROOT } = {}) {
+  const rulesDir = join(projectRoot, '.cursor', 'rules');
+  mkdirSync(rulesDir, { recursive: true });
+  const dest = join(rulesDir, 'adlc.mdc');
+  if (existsSync(dest)) return { path: dest, created: false };
+  copyFileSync(join(pluginRoot, 'rules', 'adlc.mdc'), dest);
+  return { path: dest, created: true };
+}
+
+/**
+ * Register the Cursor integration in the user's repo: wire the hooks and install
+ * the rule. Named to parallel the sibling scaffolds. Returns a summary.
+ */
+export function ensurePluginRegistered(projectRoot, opts = {}) {
+  const hooks = ensureCursorHooks(projectRoot, opts);
+  const rule = ensureRule(projectRoot, opts);
+  return { hooks, rule };
+}
+
+/** Create `.adlc/config.json` with defaults if absent (never clobber). */
+export function ensureConfig(projectRoot) {
+  const adlcDir = join(projectRoot, '.adlc');
+  mkdirSync(adlcDir, { recursive: true });
+  const cfgPath = join(adlcDir, 'config.json');
+  if (existsSync(cfgPath)) return { path: cfgPath, created: false };
+  writeFileSync(cfgPath, `${JSON.stringify({ securityMode: 'unsigned-fallback' }, null, 2)}\n`);
+  return { path: cfgPath, created: true };
+}
+
+/** Full bootstrap: config + hooks + rule. */
+export function scaffold(projectRoot, opts = {}) {
+  const config = ensureConfig(projectRoot);
+  const { hooks, rule } = ensurePluginRegistered(projectRoot, opts);
+  return { config, hooks, rule };
+}

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -56,13 +56,26 @@ export function ensureCursorHooks(projectRoot, { pluginRoot = PLUGIN_ROOT } = {}
   const hooksPath = join(cursorDir, 'hooks.json');
 
   let existing;
+  let backedUp;
   if (existsSync(hooksPath)) {
-    try { existing = JSON.parse(readFileSync(hooksPath, 'utf8')); }
-    catch { existing = undefined; } // unparseable: replace with a fresh, valid file
+    const raw = readFileSync(hooksPath, 'utf8');
+    try {
+      existing = JSON.parse(raw);
+    } catch {
+      // Unparseable existing config: do NOT silently drop the user's other hooks.
+      // Preserve the original VERBATIM in a sibling .bak (never overwriting an
+      // existing backup), then write a fresh valid file. The merge promise can't be
+      // honored on corrupt JSON, but data loss is unacceptable.
+      backedUp = `${hooksPath}.bak`;
+      let n = 0;
+      while (existsSync(backedUp)) backedUp = `${hooksPath}.bak.${++n}`;
+      writeFileSync(backedUp, raw);
+      existing = undefined;
+    }
   }
   const merged = mergeHooks(existing, pluginRoot);
   writeFileSync(hooksPath, `${JSON.stringify(merged, null, 2)}\n`);
-  return { path: hooksPath, created: !existing };
+  return { path: hooksPath, created: !existing, backedUp };
 }
 
 /** Copy the gate-router rule into `.cursor/rules/adlc.mdc`. Never clobbers a user edit. */

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -6,7 +6,10 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PRETOOL_MATCHER } from '../rails-checker.mjs';
+// Import the matcher from the dependency-free constants module — NOT rails-checker
+// (which imports @adlc/core). The scaffolder must run in a fresh source checkout
+// before `npm install` has linked the workspace packages.
+import { PRETOOL_MATCHER } from '../constants.mjs';
 
 // The installed @adlc/cursor-package root (this file lives at <root>/lib/scaffold.mjs).
 export const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');

--- a/plugins/adlc-cursor/package.json
+++ b/plugins/adlc-cursor/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@adlc/cursor-package",
+  "version": "1.1.0",
+  "private": true,
+  "description": "ADLC native integration for the Cursor agent (rails-guard hooks + discovery rule)",
+  "type": "module",
+  "main": "hooks/adlc-rails-guard.mjs",
+  "cursor": {
+    "hooks": "./hooks.json",
+    "rules": "./rules/",
+    "command": "./command/"
+  },
+  "bin": {
+    "adlc-cursor-scaffold": "./lib/scaffold-cli.mjs"
+  },
+  "dependencies": {
+    "@adlc/core": "^1.1.0"
+  }
+}

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -182,6 +182,14 @@ export function checkRail({ filePath, tool, root = process.cwd(), env = process.
     return { decision: 'deny', reason: `active ticket ${active.id} not found in tickets.json — failing closed` };
   }
   const declaredRails = ticket.rails ?? [];
+  // @adlc/core validates that `rails` is an array but NOT that its entries are
+  // strings, so a malformed entry (e.g. rails: [123]) would make globMatch throw
+  // mid-match — and that exception would escape to the adapter's catch, which
+  // fails OPEN. A corrupt rail set under active enforcement must fail CLOSED, so
+  // reject any non-string/empty rail here rather than letting it bypass the guard.
+  if (declaredRails.some((rail) => typeof rail !== 'string' || rail.length === 0)) {
+    return { decision: 'deny', reason: `active ticket ${active.id} has a malformed rail entry — failing closed` };
+  }
   const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
 
   // Match BOTH the lexical path and the symlink-resolved real path (so a symlink

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -94,7 +94,20 @@ export function resolveRailPath(filePath, root) {
   if (existsSync(abs)) {
     resolved = realpathOr(abs);
   } else {
-    resolved = join(realpathOr(dirname(abs)), basename(abs));
+    // The file may not exist yet (a `write` creating it) and several parent
+    // segments may also be missing. Walk up to the DEEPEST EXISTING ancestor,
+    // realpath THAT (catching a symlinked ancestor like repoB/link -> repoA), then
+    // re-append the not-yet-existing tail. A single-level dirname would miss a
+    // symlink two or more levels above a new file.
+    const tail = [];
+    let cur = abs;
+    while (!existsSync(cur)) {
+      const parent = dirname(cur);
+      if (parent === cur) break; // filesystem root
+      tail.unshift(basename(cur));
+      cur = parent;
+    }
+    resolved = tail.length ? join(realpathOr(cur), ...tail) : realpathOr(cur);
   }
   return relative(realpathOr(root), resolved).split('\\').join('/');
 }

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -29,12 +29,10 @@ export const MUTATING_TOOL_HINTS = ['write', 'edit', 'replace', 'patch', 'create
 // The Cursor preToolUse hook is wired with a catch-all matcher (".*") so EVERY
 // tool call reaches the guard and the classifier is the single decision point —
 // read-only tools return allow immediately, known mutators are checked, and an
-// unrecognized tool ('other') carrying a rail path FAILS CLOSED. A narrow,
-// hint-derived matcher was rejected: it is an allowlist, so a novel mutator name
-// (modify_file, save_file, …) would bypass the in-session guard before the
-// fail-closed classifier could run. Routing everything is the only design under
-// which the documented in-session fail-closed behavior is actually true.
-export const PRETOOL_MATCHER = '.*';
+// unrecognized tool ('other') carrying a rail path FAILS CLOSED. Defined in the
+// dependency-free constants module (so the scaffolder can read it without pulling
+// @adlc/core) and re-exported here for the hook/test importers.
+export { PRETOOL_MATCHER } from './constants.mjs';
 
 // Known pure-read tools (WHOLE normalized token — never substring). Only these
 // short-circuit to "allow"; everything unrecognized falls through to "other",

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -52,6 +52,23 @@ export function normalizeToolName(name) {
   return String(name ?? '').toLowerCase().replace(/[^a-z]/g, '');
 }
 
+// Shell / terminal execution tools. These run a Turing-complete command string, not
+// a structured file edit, so they are INTENTIONALLY not rail-gated in-session
+// (their writes fall to the CI gate). They must be recognized so the no-path
+// fail-closed branch — meant for opaque *structured* mutators — doesn't deny a
+// normal `npm test`/build command and break the P4 workflow.
+const SHELL_TOOL_TOKENS = new Set([
+  'bash', 'sh', 'zsh', 'shell', 'terminal', 'cmd', 'powershell', 'pwsh', 'exec',
+  'run', 'runcommand', 'runterminalcmd', 'runinterminal', 'executecommand',
+  'execcommand', 'terminalcmd', 'shellexec', 'execcommandline',
+]);
+export function isShellTool(name) {
+  const n = normalizeToolName(name);
+  if (!n) return false;
+  if (SHELL_TOOL_TOKENS.has(n)) return true;
+  return ['bash', 'shell', 'terminal', 'powershell'].some((h) => n.includes(h));
+}
+
 /**
  * Classify a Cursor tool name: 'mutating' | 'readonly' | 'other'.
  *

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -57,16 +57,28 @@ export function normalizeToolName(name) {
 // (their writes fall to the CI gate). They must be recognized so the no-path
 // fail-closed branch — meant for opaque *structured* mutators — doesn't deny a
 // normal `npm test`/build command and break the P4 workflow.
-const SHELL_TOOL_TOKENS = new Set([
+// Whole normalized names that are shell-execution tools.
+const SHELL_TOOL_NAMES = new Set([
   'bash', 'sh', 'zsh', 'shell', 'terminal', 'cmd', 'powershell', 'pwsh', 'exec',
   'run', 'runcommand', 'runterminalcmd', 'runinterminal', 'executecommand',
-  'execcommand', 'terminalcmd', 'shellexec', 'execcommandline',
+  'execcommand', 'terminalcmd', 'shellexec', 'execcommandline', 'runterminalcommand',
 ]);
+// Individual word-TOKENS (split on non-alphanumerics) that mark shell execution.
+const SHELL_WORDS = new Set(['bash', 'sh', 'zsh', 'shell', 'terminal', 'cmd', 'powershell', 'pwsh', 'console']);
+
+/**
+ * True only for genuine shell/terminal execution tools. Matching is whole-name or
+ * whole-TOKEN (never loose substring), so `flush`/`publish` don't match `sh`. NOTE:
+ * this is necessary-but-not-sufficient for the shell exemption — the caller must
+ * still let a MUTATING classification win first, so a structured mutator named
+ * `terminal_edit` (which contains the token `terminal` but also `edit`) is treated
+ * as a mutator, not waved through as a shell.
+ */
 export function isShellTool(name) {
-  const n = normalizeToolName(name);
-  if (!n) return false;
-  if (SHELL_TOOL_TOKENS.has(n)) return true;
-  return ['bash', 'shell', 'terminal', 'powershell'].some((h) => n.includes(h));
+  const raw = String(name ?? '').toLowerCase();
+  if (!raw) return false;
+  if (SHELL_TOOL_NAMES.has(normalizeToolName(raw))) return true;
+  return raw.split(/[^a-z0-9]+/).filter(Boolean).some((tok) => SHELL_WORDS.has(tok));
 }
 
 /**

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -26,14 +26,15 @@ export const TRUST_ROOT_RAILS = ['.adlc/tickets.json', '.adlc/current-ticket.jso
 // they fall to the CI diff gate.
 export const MUTATING_TOOL_HINTS = ['write', 'edit', 'replace', 'patch', 'create', 'delete', 'remove', 'rename', 'move', 'apply', 'insert', 'append'];
 
-// The Cursor preToolUse `matcher` regex, DERIVED from MUTATING_TOOL_HINTS so the
-// hook-routing pre-filter can never drift from the classifier. If a mutation tool
-// name shares no hint with this set it would bypass the in-session hook entirely
-// (the matcher decides what reaches the guard) — but it would also classify as
-// 'other' and, on the paths that do reach the guard, fail closed. Anything the
-// matcher misses still falls to the unbypassable CI rail-freeze gate. Used by both
-// the committed hooks.json template and the scaffolder (single source of truth).
-export const MUTATING_MATCHER = `(?i)(${MUTATING_TOOL_HINTS.join('|')})`;
+// The Cursor preToolUse hook is wired with a catch-all matcher (".*") so EVERY
+// tool call reaches the guard and the classifier is the single decision point —
+// read-only tools return allow immediately, known mutators are checked, and an
+// unrecognized tool ('other') carrying a rail path FAILS CLOSED. A narrow,
+// hint-derived matcher was rejected: it is an allowlist, so a novel mutator name
+// (modify_file, save_file, …) would bypass the in-session guard before the
+// fail-closed classifier could run. Routing everything is the only design under
+// which the documented in-session fail-closed behavior is actually true.
+export const PRETOOL_MATCHER = '.*';
 
 // Known pure-read tools (WHOLE normalized token — never substring). Only these
 // short-circuit to "allow"; everything unrecognized falls through to "other",
@@ -157,17 +158,30 @@ export function checkRail({ filePath, tool, root = process.cwd(), env = process.
     return { decision: 'allow', reason: 'no active ticket resolved' };
   }
 
-  const { tickets, errors } = loadTickets(ticketsPath);
-  // A corrupt/invalid tickets.json makes @adlc/core return an empty ticket list
-  // plus errors (it does NOT throw). Honoring that is load-bearing: ignoring it
-  // would silently drop the active ticket's declared rails to just the trust
-  // roots — i.e. fail OPEN for declared rails exactly when the rail trust root is
-  // corrupt. Under active enforcement with an active ticket, fail CLOSED instead.
+  // A corrupt/invalid tickets.json must FAIL CLOSED under active enforcement —
+  // never silently drop the active ticket's declared rails to just the trust
+  // roots. @adlc/core surfaces corruption three different ways, so we cover all:
+  //  (1) it THROWS on some malformed schemas (e.g. {"tickets":{}});
+  //  (2) it returns an `errors` array on others (e.g. a non-object ticket);
+  //  (3) it returns an empty list with no errors when `tickets` is absent —
+  //      in which case the resolved active ticket simply won't be found.
+  let tickets, errors;
+  try {
+    ({ tickets, errors } = loadTickets(ticketsPath));
+  } catch (err) {
+    return { decision: 'deny', reason: `tickets.json failed to load (${err.message}) — failing closed` };
+  }
   if (errors && errors.length) {
-    return { decision: 'deny', reason: `tickets.json failed to load/validate (${errors.length} error(s)) — failing closed` };
+    return { decision: 'deny', reason: `tickets.json failed to validate (${errors.length} error(s)) — failing closed` };
   }
   const ticket = tickets.find((t) => t.id === active.id);
-  const declaredRails = ticket?.rails ?? [];
+  if (!ticket) {
+    // An active-ticket signal that resolves to no ticket is a misconfig/tamper
+    // signal while enforcement is on — fail closed rather than enforce trust
+    // roots only.
+    return { decision: 'deny', reason: `active ticket ${active.id} not found in tickets.json — failing closed` };
+  }
+  const declaredRails = ticket.rails ?? [];
   const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
 
   // Match BOTH the lexical path and the symlink-resolved real path (so a symlink

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -57,28 +57,30 @@ export function normalizeToolName(name) {
 // (their writes fall to the CI gate). They must be recognized so the no-path
 // fail-closed branch — meant for opaque *structured* mutators — doesn't deny a
 // normal `npm test`/build command and break the P4 workflow.
-// Whole normalized names that are shell-execution tools.
+// EXACT whole normalized names of shell-execution tools. The shell exemption used
+// by the no-path fail-closed branch matches ONLY these — never a substring or even
+// a token. A token/substring predicate is unsafe here: a novel structured mutator
+// named `terminal_modify` or `shell_set` (whose verb isn't in MUTATING_TOOL_HINTS,
+// so it classifies as 'other') would carry a shell token and be waved through. An
+// unrecognized shell tool name not in this set fails CLOSED under enforcement — the
+// safe direction (a blocked command is visible and reportable; a silent mutator
+// bypass is not). Real Cursor/agent shell tools are a small known set; extend here.
 const SHELL_TOOL_NAMES = new Set([
-  'bash', 'sh', 'zsh', 'shell', 'terminal', 'cmd', 'powershell', 'pwsh', 'exec',
-  'run', 'runcommand', 'runterminalcmd', 'runinterminal', 'executecommand',
-  'execcommand', 'terminalcmd', 'shellexec', 'execcommandline', 'runterminalcommand',
+  'bash', 'sh', 'zsh', 'fish', 'shell', 'terminal', 'cmd', 'powershell', 'pwsh', 'console',
+  'exec', 'run', 'runcommand', 'runcmd', 'runterminalcmd', 'runterminalcommand',
+  'runinterminal', 'runinterminalcommand', 'runshell', 'shellexec', 'shellcommand',
+  'executecommand', 'execcommand', 'executecommandline', 'execcommandline',
+  'executeshell', 'executeterminalcommand', 'terminalcmd', 'terminalcommand',
 ]);
-// Individual word-TOKENS (split on non-alphanumerics) that mark shell execution.
-const SHELL_WORDS = new Set(['bash', 'sh', 'zsh', 'shell', 'terminal', 'cmd', 'powershell', 'pwsh', 'console']);
 
 /**
- * True only for genuine shell/terminal execution tools. Matching is whole-name or
- * whole-TOKEN (never loose substring), so `flush`/`publish` don't match `sh`. NOTE:
- * this is necessary-but-not-sufficient for the shell exemption — the caller must
- * still let a MUTATING classification win first, so a structured mutator named
- * `terminal_edit` (which contains the token `terminal` but also `edit`) is treated
- * as a mutator, not waved through as a shell.
+ * True ONLY for a recognized shell/terminal execution tool (exact whole-name match
+ * after normalization). Used by the no-path exemption, which must NOT be fooled by a
+ * structured mutator whose name merely contains a shell word. Mutating classification
+ * also wins first in the caller, so `terminal_edit` is denied regardless.
  */
 export function isShellTool(name) {
-  const raw = String(name ?? '').toLowerCase();
-  if (!raw) return false;
-  if (SHELL_TOOL_NAMES.has(normalizeToolName(raw))) return true;
-  return raw.split(/[^a-z0-9]+/).filter(Boolean).some((tok) => SHELL_WORDS.has(tok));
+  return SHELL_TOOL_NAMES.has(normalizeToolName(name));
 }
 
 /**

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -167,80 +167,77 @@ export function resolveActiveTicketId(root, env) {
 }
 
 /**
- * Decide whether a structured edit/write should be allowed or denied.
- * Pure and fail-safe: returns { decision: 'allow' | 'deny', reason }.
+ * Evaluate the rail-state PRECONDITIONS (independent of any specific path) so that
+ * both the path-bearing `checkRail` and the adapter's no-path branch make the SAME
+ * no-op / fail-closed / enforcing decision and cannot drift.
  *
- * Enforcement contract (identical to the sibling hooks):
- *  - only structured mutating tools are gated; read-only tools always allow;
- *  - enforcement is phase-scoped to ADLC_P4_ENFORCEMENT === '1';
- *  - no-op when the repo is not ADLC-initialized;
- *  - the active ticket is the SINGLE source of declared rails; a conflicting
- *    active-ticket signal fails closed;
- *  - rails in force = active ticket's declared rails PLUS the trust-root rails.
+ * Returns one of:
+ *  - { state: 'inactive', reason } — enforcement off, repo not initialized, or no
+ *    active ticket → the gate is a no-op (allow);
+ *  - { state: 'deny', reason } — a conflict, corrupt/unloadable tickets.json, an
+ *    active ticket that isn't found, or a malformed rail entry → fail closed;
+ *  - { state: 'active', rails, activeId } — enforcing with a valid ticket + rails.
+ */
+export function railPreconditions({ root = process.cwd(), env = process.env } = {}) {
+  if (env.ADLC_P4_ENFORCEMENT !== '1') {
+    return { state: 'inactive', reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
+  }
+  const ticketsPath = join(root, '.adlc', 'tickets.json');
+  if (!existsSync(ticketsPath)) {
+    return { state: 'inactive', reason: 'repo not ADLC-initialized (no .adlc/tickets.json)' };
+  }
+  const active = resolveActiveTicketId(root, env);
+  if (active.conflict) {
+    return { state: 'deny', reason: 'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json)' };
+  }
+  if (!active.id) {
+    return { state: 'inactive', reason: 'no active ticket resolved' };
+  }
+  // A corrupt/invalid tickets.json must FAIL CLOSED under active enforcement. core
+  // surfaces corruption three ways: it throws on some malformed schemas, returns an
+  // `errors` array on others, and returns an empty list when `tickets` is absent.
+  let tickets, errors;
+  try {
+    ({ tickets, errors } = loadTickets(ticketsPath));
+  } catch (err) {
+    return { state: 'deny', reason: `tickets.json failed to load (${err.message}) — failing closed` };
+  }
+  if (errors && errors.length) {
+    return { state: 'deny', reason: `tickets.json failed to validate (${errors.length} error(s)) — failing closed` };
+  }
+  const ticket = tickets.find((t) => t.id === active.id);
+  if (!ticket) {
+    return { state: 'deny', reason: `active ticket ${active.id} not found in tickets.json — failing closed` };
+  }
+  const declaredRails = ticket.rails ?? [];
+  // core validates rails is an array but NOT its element types; a non-string entry
+  // would make globMatch throw mid-match. Reject it here so it fails CLOSED.
+  if (declaredRails.some((rail) => typeof rail !== 'string' || rail.length === 0)) {
+    return { state: 'deny', reason: `active ticket ${active.id} has a malformed rail entry — failing closed` };
+  }
+  return { state: 'active', rails: [...declaredRails, ...TRUST_ROOT_RAILS], activeId: active.id };
+}
+
+/**
+ * Decide whether a structured edit/write to a specific path should be allowed or
+ * denied. Pure and fail-safe: returns { decision: 'allow' | 'deny', reason }.
+ * Preconditions are delegated to railPreconditions (single source of truth).
  */
 export function checkRail({ filePath, tool, root = process.cwd(), env = process.env }) {
   if (classifyTool(tool) === 'readonly') {
     return { decision: 'allow', reason: `tool "${tool}" is read-only` };
   }
-  // Mutating and unrecognized structured tools that carry a path are checked
-  // (fail closed): a new mutation tool name can't slip an edit past the guard.
-  if (env.ADLC_P4_ENFORCEMENT !== '1') {
-    return { decision: 'allow', reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
-  }
-  const ticketsPath = join(root, '.adlc', 'tickets.json');
-  if (!existsSync(ticketsPath)) {
-    return { decision: 'allow', reason: 'repo not ADLC-initialized (no .adlc/tickets.json)' };
-  }
+  const pre = railPreconditions({ root, env });
+  if (pre.state === 'inactive') return { decision: 'allow', reason: pre.reason };
+  if (pre.state === 'deny') return { decision: 'deny', reason: pre.reason };
 
-  const active = resolveActiveTicketId(root, env);
-  if (active.conflict) {
-    return { decision: 'deny', reason: 'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json)' };
-  }
-  if (!active.id) {
-    return { decision: 'allow', reason: 'no active ticket resolved' };
-  }
-
-  // A corrupt/invalid tickets.json must FAIL CLOSED under active enforcement —
-  // never silently drop the active ticket's declared rails to just the trust
-  // roots. @adlc/core surfaces corruption three different ways, so we cover all:
-  //  (1) it THROWS on some malformed schemas (e.g. {"tickets":{}});
-  //  (2) it returns an `errors` array on others (e.g. a non-object ticket);
-  //  (3) it returns an empty list with no errors when `tickets` is absent —
-  //      in which case the resolved active ticket simply won't be found.
-  let tickets, errors;
-  try {
-    ({ tickets, errors } = loadTickets(ticketsPath));
-  } catch (err) {
-    return { decision: 'deny', reason: `tickets.json failed to load (${err.message}) — failing closed` };
-  }
-  if (errors && errors.length) {
-    return { decision: 'deny', reason: `tickets.json failed to validate (${errors.length} error(s)) — failing closed` };
-  }
-  const ticket = tickets.find((t) => t.id === active.id);
-  if (!ticket) {
-    // An active-ticket signal that resolves to no ticket is a misconfig/tamper
-    // signal while enforcement is on — fail closed rather than enforce trust
-    // roots only.
-    return { decision: 'deny', reason: `active ticket ${active.id} not found in tickets.json — failing closed` };
-  }
-  const declaredRails = ticket.rails ?? [];
-  // @adlc/core validates that `rails` is an array but NOT that its entries are
-  // strings, so a malformed entry (e.g. rails: [123]) would make globMatch throw
-  // mid-match — and that exception would escape to the adapter's catch, which
-  // fails OPEN. A corrupt rail set under active enforcement must fail CLOSED, so
-  // reject any non-string/empty rail here rather than letting it bypass the guard.
-  if (declaredRails.some((rail) => typeof rail !== 'string' || rail.length === 0)) {
-    return { decision: 'deny', reason: `active ticket ${active.id} has a malformed rail entry — failing closed` };
-  }
-  const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
-
-  // Match BOTH the lexical path and the symlink-resolved real path (so a symlink
-  // alias whose target is a frozen rail can't slip past a name check).
+  // Enforcing: match BOTH the lexical path and the symlink-resolved real path (so a
+  // symlink alias whose target is a frozen rail can't slip past a name check).
   const candidates = new Set([canonicalizePath(filePath, root), resolveRailPath(filePath, root)]);
   for (const path of candidates) {
-    const hit = rails.find((rail) => rail === path || globMatch(rail, path));
+    const hit = pre.rails.find((rail) => rail === path || globMatch(rail, path));
     if (hit) {
-      return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${active.id})` };
+      return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${pre.activeId})` };
     }
   }
   return { decision: 'allow', reason: 'path is not a frozen rail' };

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -1,0 +1,166 @@
+// rails-checker.mjs — the ADLC rail-enforcement decision for Cursor.
+//
+// This is a THIN adapter: every rail/glob/ticket primitive is delegated to
+// @adlc/core (the single source of truth, per ADR 0006 / ADR 0004). It must NOT
+// re-implement glob or ticket loading. The only non-core logic here is the
+// sibling-hook enforcement contract (active-ticket resolution, phase gating,
+// trust-root freeze) that adlc-opencode and adlc-codex already implement, plus a
+// Cursor-specific tool classifier. The Cursor wire-format mapping (preToolUse
+// stdin/stdout) lives in hooks/adlc-rails-guard.mjs; this file is editor-agnostic.
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { loadTickets, globMatch } from '@adlc/core';
+
+// The ticket file and the active-ticket pointer are the rail trust root: they are
+// frozen whenever enforcement is active, even if no ticket declares them, so the
+// rail set cannot be quietly edited away. Mirrors adlc-opencode/rails-checker.mjs.
+export const TRUST_ROOT_RAILS = ['.adlc/tickets.json', '.adlc/current-ticket.json'];
+
+// Cursor's structured file-mutation tools (normalized to lowercase, non-alpha
+// stripped). Cursor exposes Write/Edit/MultiEdit/search_replace/delete_file-style
+// tools to the agent. We classify a tool as MUTATING if its normalized name
+// contains any of these substrings — note "replace" so search_replace/str_replace
+// classify as mutating even though they also contain the read word "search".
+// Shell writes are intentionally NOT gated in-session (Turing-complete shell);
+// they fall to the CI diff gate.
+export const MUTATING_TOOL_HINTS = ['write', 'edit', 'replace', 'patch', 'create', 'delete', 'remove', 'rename', 'move', 'apply', 'insert', 'append'];
+
+// Known pure-read tools (WHOLE normalized token — never substring). Only these
+// short-circuit to "allow"; everything unrecognized falls through to "other",
+// which checkRail treats as a checked mutation (FAIL CLOSED) so a novel or
+// disguised edit tool can't slip a rail write past the guard. Reads of a frozen
+// rail are fine, but we list reads explicitly rather than guessing by substring
+// (substring matching let "frobnicate" match "cat" and "search_replace" match
+// "search" — see ADR 0006 / the P5 prosecution that caught it).
+export const PURE_READS = new Set([
+  'read', 'readfile', 'readlints', 'grep', 'grepsearch', 'glob', 'globsearch',
+  'codebasesearch', 'semanticsearch', 'filesearch', 'list', 'listdir', 'ls',
+  'cat', 'view', 'viewfile', 'webfetch', 'websearch', 'fetch', 'fetchrules', 'search',
+]);
+
+/** Normalize a raw Cursor tool name to a lowercase alpha token for classification. */
+export function normalizeToolName(name) {
+  return String(name ?? '').toLowerCase().replace(/[^a-z]/g, '');
+}
+
+/**
+ * Classify a Cursor tool name: 'mutating' | 'readonly' | 'other'.
+ *
+ * Order is load-bearing and FAIL-CLOSED:
+ *  1. mutating hints (substring) win first — so "search_replace" (contains
+ *     "replace") is mutating despite also containing "search";
+ *  2. then known pure reads (whole token) are allowed;
+ *  3. everything else is 'other', which checkRail CHECKS (treats as a mutation),
+ *     so an unrecognized tool carrying a rail path is denied, not waved through.
+ */
+export function classifyTool(name) {
+  const n = normalizeToolName(name);
+  if (!n) return 'other';
+  if (MUTATING_TOOL_HINTS.some((h) => n.includes(h))) return 'mutating';
+  if (PURE_READS.has(n)) return 'readonly';
+  return 'other';
+}
+
+/** Canonicalize a path to a forward-slash path relative to the repo root (lexical). */
+export function canonicalizePath(filePath, root) {
+  const abs = isAbsolute(filePath) ? filePath : join(root, filePath);
+  return relative(root, abs).split('\\').join('/');
+}
+
+function realpathOr(p) {
+  try { return realpathSync(p); } catch { return p; }
+}
+
+/**
+ * Symlink-aware canonicalization (security-relevant): resolve symlinks on the
+ * target and on its existing parent segments before comparing to the frozen rail
+ * set, so a symlink whose real target is a frozen rail cannot slip a write past a
+ * lexical name check. Falls back to the lexical path for anything unresolvable.
+ */
+export function resolveRailPath(filePath, root) {
+  const abs = isAbsolute(filePath) ? filePath : join(root, filePath);
+  let resolved;
+  if (existsSync(abs)) {
+    resolved = realpathOr(abs);
+  } else {
+    resolved = join(realpathOr(dirname(abs)), basename(abs));
+  }
+  return relative(realpathOr(root), resolved).split('\\').join('/');
+}
+
+/**
+ * Resolve the active ticket id from process.env.ADLC_TICKET OR
+ * .adlc/current-ticket.json. If both are set and disagree, that is a tamper
+ * signal — return { conflict: true } so the caller fails closed.
+ */
+export function resolveActiveTicketId(root, env) {
+  const envTicket = (env.ADLC_TICKET ?? '').trim() || null;
+  let fileTicket = null;
+  const currentPath = join(root, '.adlc', 'current-ticket.json');
+  if (existsSync(currentPath)) {
+    try {
+      const data = JSON.parse(readFileSync(currentPath, 'utf8'));
+      const raw = typeof data === 'string' ? data : data.id ?? data.ticket;
+      fileTicket = (raw ?? '').toString().trim() || null;
+    } catch {
+      // An unparseable pointer is itself a tamper signal: fail closed.
+      return { id: null, conflict: true };
+    }
+  }
+  if (envTicket && fileTicket && envTicket !== fileTicket) {
+    return { id: null, conflict: true };
+  }
+  return { id: envTicket ?? fileTicket, conflict: false };
+}
+
+/**
+ * Decide whether a structured edit/write should be allowed or denied.
+ * Pure and fail-safe: returns { decision: 'allow' | 'deny', reason }.
+ *
+ * Enforcement contract (identical to the sibling hooks):
+ *  - only structured mutating tools are gated; read-only tools always allow;
+ *  - enforcement is phase-scoped to ADLC_P4_ENFORCEMENT === '1';
+ *  - no-op when the repo is not ADLC-initialized;
+ *  - the active ticket is the SINGLE source of declared rails; a conflicting
+ *    active-ticket signal fails closed;
+ *  - rails in force = active ticket's declared rails PLUS the trust-root rails.
+ */
+export function checkRail({ filePath, tool, root = process.cwd(), env = process.env }) {
+  if (classifyTool(tool) === 'readonly') {
+    return { decision: 'allow', reason: `tool "${tool}" is read-only` };
+  }
+  // Mutating and unrecognized structured tools that carry a path are checked
+  // (fail closed): a new mutation tool name can't slip an edit past the guard.
+  if (env.ADLC_P4_ENFORCEMENT !== '1') {
+    return { decision: 'allow', reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
+  }
+  const ticketsPath = join(root, '.adlc', 'tickets.json');
+  if (!existsSync(ticketsPath)) {
+    return { decision: 'allow', reason: 'repo not ADLC-initialized (no .adlc/tickets.json)' };
+  }
+
+  const active = resolveActiveTicketId(root, env);
+  if (active.conflict) {
+    return { decision: 'deny', reason: 'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json)' };
+  }
+  if (!active.id) {
+    return { decision: 'allow', reason: 'no active ticket resolved' };
+  }
+
+  const { tickets } = loadTickets(ticketsPath);
+  const ticket = tickets.find((t) => t.id === active.id);
+  const declaredRails = ticket?.rails ?? [];
+  const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
+
+  // Match BOTH the lexical path and the symlink-resolved real path (so a symlink
+  // alias whose target is a frozen rail can't slip past a name check).
+  const candidates = new Set([canonicalizePath(filePath, root), resolveRailPath(filePath, root)]);
+  for (const path of candidates) {
+    const hit = rails.find((rail) => rail === path || globMatch(rail, path));
+    if (hit) {
+      return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${active.id})` };
+    }
+  }
+  return { decision: 'allow', reason: 'path is not a frozen rail' };
+}

--- a/plugins/adlc-cursor/rails-checker.mjs
+++ b/plugins/adlc-cursor/rails-checker.mjs
@@ -26,6 +26,15 @@ export const TRUST_ROOT_RAILS = ['.adlc/tickets.json', '.adlc/current-ticket.jso
 // they fall to the CI diff gate.
 export const MUTATING_TOOL_HINTS = ['write', 'edit', 'replace', 'patch', 'create', 'delete', 'remove', 'rename', 'move', 'apply', 'insert', 'append'];
 
+// The Cursor preToolUse `matcher` regex, DERIVED from MUTATING_TOOL_HINTS so the
+// hook-routing pre-filter can never drift from the classifier. If a mutation tool
+// name shares no hint with this set it would bypass the in-session hook entirely
+// (the matcher decides what reaches the guard) — but it would also classify as
+// 'other' and, on the paths that do reach the guard, fail closed. Anything the
+// matcher misses still falls to the unbypassable CI rail-freeze gate. Used by both
+// the committed hooks.json template and the scaffolder (single source of truth).
+export const MUTATING_MATCHER = `(?i)(${MUTATING_TOOL_HINTS.join('|')})`;
+
 // Known pure-read tools (WHOLE normalized token — never substring). Only these
 // short-circuit to "allow"; everything unrecognized falls through to "other",
 // which checkRail treats as a checked mutation (FAIL CLOSED) so a novel or
@@ -148,7 +157,15 @@ export function checkRail({ filePath, tool, root = process.cwd(), env = process.
     return { decision: 'allow', reason: 'no active ticket resolved' };
   }
 
-  const { tickets } = loadTickets(ticketsPath);
+  const { tickets, errors } = loadTickets(ticketsPath);
+  // A corrupt/invalid tickets.json makes @adlc/core return an empty ticket list
+  // plus errors (it does NOT throw). Honoring that is load-bearing: ignoring it
+  // would silently drop the active ticket's declared rails to just the trust
+  // roots — i.e. fail OPEN for declared rails exactly when the rail trust root is
+  // corrupt. Under active enforcement with an active ticket, fail CLOSED instead.
+  if (errors && errors.length) {
+    return { decision: 'deny', reason: `tickets.json failed to load/validate (${errors.length} error(s)) — failing closed` };
+  }
   const ticket = tickets.find((t) => t.id === active.id);
   const declaredRails = ticket?.rails ?? [];
   const rails = [...declaredRails, ...TRUST_ROOT_RAILS];

--- a/plugins/adlc-cursor/rules/adlc.mdc
+++ b/plugins/adlc-cursor/rules/adlc.mdc
@@ -1,0 +1,38 @@
+---
+description: >-
+  Routes agentic development work to the right Agentic Development Lifecycle
+  (ADLC) gate from inside Cursor. Use when shaping a spec or ticket, deciding how
+  to fan work out to models, protecting frozen rails during a build, prosecuting a
+  change before merge, or distilling repeated findings into defenses. Triggers on
+  "shape this spec", "is this ticket ready", "freeze these tests", "prosecute this
+  change", "is this safe to merge", "ADLC", "which gate", "spec-lint", "premortem",
+  "coldstart", "rails-guard", "hollow-test".
+alwaysApply: false
+---
+
+# ADLC phase router (Cursor)
+
+Describe what you're doing; this routes you to the gate that fits. Gates run via
+the `adlc <tool>` dispatcher (`npm i -g @adlc/cli`). LLM-backed gates support
+`--prompt-only` — inside Cursor the model answers the printed prompt, so no API
+key is required.
+
+| You're trying to… | Phase | Gate |
+| --- | --- | --- |
+| Triage / author a ticket | P0 | `adlc preflight`, author into `.adlc/tickets.json` |
+| Pin down a vague spec | P1 | `adlc spec-lint`, `adlc premortem`, `adlc parallax` |
+| Slice work across models | P2 | `adlc coldstart`, `adlc merge-forecast`, `adlc model-router` |
+| Freeze tests/contracts as rails | P3 | `adlc rails-guard` + the in-session rails-guard hook |
+| Build under supervision | P4 | `adlc flail-detector`, `adlc consensus-fix` |
+| Prosecute before merge | P5 | `adlc hollow-test`, `adlc behavior-diff`, `adlc review-calibration` |
+| Decide to integrate | P6 | `adlc gate-manifest` (human gate) |
+| Distill findings into defenses | P7 | `adlc lesson-foundry`, `adlc rejection-mining` |
+
+## Rail enforcement in this harness
+
+The bundled hooks wire Cursor's `preToolUse` hook to deny structured `Write`/`Edit`
+to frozen rails declared by the active ticket, and `afterFileEdit` to surface a
+post-edit notice (it cannot block). Both are **best-effort / advisory** — Cursor's
+`permission: "deny"` is not guaranteed, and `afterFileEdit` is observational. The
+**unbypassable** layer is the commit-time CI gate (`docs/ci/rails-guard.yml`). See
+[`docs/integrations/cursor.md`](../../../docs/integrations/cursor.md).

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -259,6 +259,25 @@ test('(F2-rails) a malformed rail entry (non-string) fails CLOSED, not open', ()
   } finally { cleanup(root); }
 });
 
+test('(multi-root symlink) a NEW file under a symlinked root, in a frozen glob, is denied', () => {
+  // repoB/link -> repoA; repoA freezes src/contracts/**. A not-yet-existing file
+  // addressed as repoB/link/src/contracts/new.json must resolve into repoA and deny.
+  const repoA = mkdtempSync(join(tmpdir(), 'adlc-a-'));
+  mkdirSync(join(repoA, '.adlc'), { recursive: true });
+  mkdirSync(join(repoA, 'src'), { recursive: true });
+  writeFileSync(join(repoA, '.adlc', 'tickets.json'),
+    JSON.stringify({ tickets: [{ id: 'T1', title: 'x', rails: ['src/contracts/**'] }] }));
+  const repoB = mkdtempSync(join(tmpdir(), 'adlc-b-'));
+  let linked = false;
+  try { symlinkSync(repoA, join(repoB, 'link')); linked = true; } catch { /* FS w/o symlink */ }
+  try {
+    if (!linked) return;
+    const abs = join(repoB, 'link', 'src', 'contracts', 'new.schema.json'); // new file, deep non-existent tail
+    const p = { tool_name: 'Write', tool_input: { file_path: abs }, workspace_roots: [repoB, repoA] };
+    assert.equal(decide(p, { env: env() }).permission, 'deny', 'new file under a symlinked frozen glob must deny');
+  } finally { cleanup(repoA); cleanup(repoB); }
+});
+
 test('(multi-root ..) a non-normalized path is attributed to the repo it RESOLVES into', () => {
   // repoB (uninitialized, listed first) and repoA (has the rail). The payload path
   // lexically prefixes repoB but ../-resolves into repoA — raw prefix matching would

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -391,20 +391,22 @@ test('(multi-root symlink) a NEW file under a symlinked root, in a frozen glob, 
   } finally { cleanup(repoA); cleanup(repoB); }
 });
 
-test('(multi-root relative) a RELATIVE ../ traversal into a sibling root rail is denied', () => {
-  // Gemini caught this: resolveRoot skipped ownership for relative paths, so a
-  // relative ../sibling/rail edit was checked against roots[0] (wrong root) -> allow.
+test('(multi-root relative) a RELATIVE ../ traversal into a DIFFERENT-DEPTH sibling root rail is denied', () => {
+  // Gemini round-18: resolveRoot skipped ownership for relative paths (bypass).
+  // Gemini round-19: the fix was incomplete — checkRail re-joined the primary-root-
+  // relative path against the owning root, mangling it when roots differ in depth.
+  // Use DIFFERENT-depth roots (app vs shared/libs) so a join-mismatch can't pass.
   const tmp = mkdtempSync(join(tmpdir(), 'adlc-ws-'));
-  const fe = join(tmp, 'frontend'); // roots[0], uninitialized
-  const be = join(tmp, 'backend');  // has the active rail
-  mkdirSync(fe, { recursive: true });
-  mkdirSync(join(be, '.adlc'), { recursive: true });
-  writeFileSync(join(be, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'x', rails: ['src/auth.js'] }] }));
+  const app = join(tmp, 'app');             // roots[0], uninitialized, depth 1
+  const libs = join(tmp, 'shared', 'libs'); // active rail, depth 2, different name
+  mkdirSync(app, { recursive: true });
+  mkdirSync(join(libs, '.adlc'), { recursive: true });
+  writeFileSync(join(libs, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'x', rails: ['src/frozen.js'] }] }));
   try {
-    const w = (fp) => ({ tool_name: 'Write', tool_input: { file_path: fp }, workspace_roots: [fe, be] });
-    assert.equal(decide(w('../backend/src/auth.js'), { env: env() }).permission, 'deny', 'relative traversal into a sibling rail must deny');
-    assert.equal(decide(w('../backend/src/ok.js'), { env: env() }).permission, 'allow', 'relative non-rail must allow');
-    assert.equal(decide(w('src/app.js'), { env: env() }).permission, 'allow', 'frontend-local edit (inactive root) must allow');
+    const w = (fp) => ({ tool_name: 'Write', tool_input: { file_path: fp }, workspace_roots: [app, libs] });
+    assert.equal(decide(w('../shared/libs/src/frozen.js'), { env: env() }).permission, 'deny', 'relative traversal into a different-depth sibling rail must deny');
+    assert.equal(decide(w('../shared/libs/src/ok.js'), { env: env() }).permission, 'allow', 'relative non-rail must allow');
+    assert.equal(decide(w('src/app.js'), { env: env() }).permission, 'allow', 'app-local edit (inactive root) must allow');
   } finally { rmSync(tmp, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'node:url';
 
 import { decide, extractToolName, extractFilePath } from '../hooks/adlc-rails-guard.mjs';
 import { audit } from '../hooks/adlc-audit.mjs';
-import { MUTATING_MATCHER } from '../rails-checker.mjs';
+import { PRETOOL_MATCHER } from '../rails-checker.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GUARD_SCRIPT = join(HERE, '..', 'hooks', 'adlc-rails-guard.mjs');
@@ -167,29 +167,53 @@ test('(d4) a symlink whose real target is a frozen rail is denied', () => {
 // --- Cross-model review regressions (ADR 0006): the HOOK-ROUTING boundary, not
 //     just the decision function, must cover the mutators; corrupt tickets fail closed. ---
 
-test('(matcher) the shipped preToolUse matcher routes every mutation tool to the guard', () => {
-  // Build the regex the way Cursor would interpret the matcher string (strip the
-  // inline (?i) flag, apply case-insensitively) and confirm it MATCHES the tools
-  // the classifier treats as mutating — otherwise the guard is never invoked and
-  // decide()'s deny is dead code in production (the F1 finding).
-  const re = new RegExp(MUTATING_MATCHER.replace('(?i)', ''), 'i');
-  for (const tool of ['Write', 'Edit', 'MultiEdit', 'search_replace', 'str_replace', 'reapply', 'delete_file', 'create_file', 'rename_file', 'apply_patch']) {
+test('(matcher) the shipped preToolUse matcher is catch-all so EVERY tool reaches the guard', () => {
+  // A narrow allowlist matcher would let a novel mutator name (modify_file,
+  // save_file) bypass the guard before the fail-closed classifier runs. Route all.
+  assert.equal(PRETOOL_MATCHER, '.*');
+  const re = new RegExp(PRETOOL_MATCHER, 'i');
+  for (const tool of ['Write', 'str_replace', 'modify_file', 'save_file', 'frobnicate', 'Read']) {
     assert.ok(re.test(tool), `matcher must route "${tool}" to the guard`);
   }
-  // Drift guard: the committed hooks.json matcher must equal the derived one.
+  // Drift guard: the committed hooks.json matcher must equal PRETOOL_MATCHER.
   const hooksJson = JSON.parse(readFileSync(join(HERE, '..', 'hooks.json'), 'utf8'));
-  assert.equal(hooksJson.hooks.preToolUse[0].matcher, MUTATING_MATCHER, 'hooks.json matcher drifted from MUTATING_MATCHER');
+  assert.equal(hooksJson.hooks.preToolUse[0].matcher, PRETOOL_MATCHER, 'hooks.json matcher drifted from PRETOOL_MATCHER');
 });
 
-test('(F2) a corrupt/invalid tickets.json fails CLOSED under active enforcement', () => {
-  const root = mkdtempSync(join(tmpdir(), 'adlc-cursor-'));
+test('(matcher-e2e) a novel mutator name routed to the guard fails CLOSED on a rail', () => {
+  const root = fixture({ tickets: RAILED });
   try {
-    mkdirSync(join(root, '.adlc'), { recursive: true });
-    writeFileSync(join(root, '.adlc', 'tickets.json'), '{ this is not valid json');
-    const v = decide(payload('Write', 'src/anything.js'), { root, env: env() });
-    assert.equal(v.permission, 'deny', 'corrupt tickets.json must not silently drop declared rails');
-    assert.match(v.user_message, /failing closed/);
+    for (const tool of ['modify_file', 'save_file', 'update_file']) {
+      const v = decide(payload(tool, 'src/frozen.js'), { root, env: env() });
+      assert.equal(v.permission, 'deny', `unknown mutator "${tool}" on a rail must fail closed`);
+    }
   } finally { cleanup(root); }
+});
+
+test('(F2) corrupt tickets.json fails CLOSED — invalid JSON, throwing schema, and missing tickets', () => {
+  for (const content of ['{ this is not valid json', '{"tickets":{}}', '{"tickets":"x"}', '{"nope":1}']) {
+    const root = mkdtempSync(join(tmpdir(), 'adlc-cursor-'));
+    try {
+      mkdirSync(join(root, '.adlc'), { recursive: true });
+      writeFileSync(join(root, '.adlc', 'tickets.json'), content);
+      const v = decide(payload('Write', 'src/anything.js'), { root, env: env() });
+      assert.equal(v.permission, 'deny', `tickets.json=${content} must fail closed, not drop declared rails`);
+      assert.match(v.user_message, /failing closed|not found/);
+    } finally { cleanup(root); }
+  }
+});
+
+test('(multi-root) the guard checks the workspace root that OWNS the edited path', () => {
+  // repo-a (first root, no ADLC) + repo-b (ADLC-initialized, has the rail).
+  const repoA = mkdtempSync(join(tmpdir(), 'adlc-a-'));
+  const repoB = fixture({ tickets: RAILED });
+  try {
+    const abs = join(repoB, 'src', 'frozen.js'); // absolute path under repo-b (the rail)
+    const p = { tool_name: 'Edit', tool_input: { file_path: abs }, workspace_roots: [repoA, repoB] };
+    // No explicit root: the adapter must pick repo-b (owns the path), not repo-a.
+    const v = decide(p, { env: env() });
+    assert.equal(v.permission, 'deny', 'edit to repo-b rail must be denied even when repo-a is listed first');
+  } finally { cleanup(repoA); cleanup(repoB); }
 });
 
 test('wire format: the real script reads stdin JSON and writes a {permission} verdict', () => {

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -236,6 +236,28 @@ test('(batch) MultiEdit/batch payloads with nested edits[]/files[] are rail-chec
   } finally { cleanup(root); }
 });
 
+test('(patch) apply_patch command string naming a rail is denied; a non-rail patch allows', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    const railPatch = '*** Begin Patch\n*** Update File: src/frozen.js\n@@\n-a\n+b\n*** End Patch';
+    assert.equal(decide({ tool_name: 'apply_patch', tool_input: { command: railPatch } }, { root, env: env() }).permission, 'deny');
+    const freePatch = '*** Begin Patch\n*** Add File: src/new.js\n+x\n*** End Patch';
+    assert.equal(decide({ tool_name: 'apply_patch', tool_input: { command: freePatch } }, { root, env: env() }).permission, 'allow');
+  } finally { cleanup(root); }
+});
+
+test('(no-path) a MUTATING tool with no extractable path fails CLOSED under enforcement, OPEN otherwise; reads allow', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    // mutating tool, nothing to inspect, enforcement on -> deny (opaque, can't verify)
+    assert.equal(decide({ tool_name: 'edit_file', tool_input: {} }, { root, env: env() }).permission, 'deny');
+    // same, enforcement off -> allow (guard is a no-op)
+    assert.equal(decide({ tool_name: 'edit_file', tool_input: {} }, { root, env: { ADLC_P4_ENFORCEMENT: '0' } }).permission, 'allow');
+    // read-only tool with no path -> always allow
+    assert.equal(decide({ tool_name: 'codebase_search', tool_input: { query: 'x' } }, { root, env: env() }).permission, 'allow');
+  } finally { cleanup(root); }
+});
+
 test('(fail-safe) an unexpected throw in the deny path fails CLOSED under active enforcement, OPEN when off', () => {
   // Force checkRail to throw (a non-string root makes path.join throw) to exercise
   // the categorical catch: under active enforcement an error must NOT become a

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -270,6 +270,24 @@ test('(no-path) a MUTATING tool with no extractable path fails CLOSED under enfo
   } finally { cleanup(root); }
 });
 
+test('(no-path multi-root) a pathless opaque tool fails CLOSED if ANY workspace root is actively enforcing', () => {
+  // A pathless tool gives no ownership signal; if any root (even a later one) is
+  // active, an opaque mutator must deny rather than slip via roots[0].
+  const bare = mkdtempSync(join(tmpdir(), 'adlc-bare-'));
+  const active = fixture({ tickets: RAILED }); // initialized + has a rail
+  try {
+    const op = { tool_name: 'edit_file', tool_input: {}, workspace_roots: [bare, active] };
+    assert.equal(decide(op, { env: env() }).permission, 'deny', 'opaque mutator must deny when a later root is active');
+    // shell tools stay exempt even with an active root
+    const sh = { tool_name: 'Bash', tool_input: { command: 'npm test' }, workspace_roots: [bare, active] };
+    assert.equal(decide(sh, { env: env() }).permission, 'allow', 'shell stays allowed in multi-root');
+    // all-inactive roots -> allow
+    const bare2 = mkdtempSync(join(tmpdir(), 'adlc-bare2-'));
+    assert.equal(decide({ ...op, workspace_roots: [bare, bare2] }, { env: env() }).permission, 'allow', 'all-inactive must allow');
+    cleanup(bare2);
+  } finally { cleanup(bare); cleanup(active); }
+});
+
 test('(no-path preconditions) a pathless opaque tool NO-OPs when uninitialized / no active ticket', () => {
   const op = { tool_name: 'edit_file', tool_input: {} };
   // uninitialized repo (enforcement on, no tickets.json) -> allow (no-op)

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -1,0 +1,178 @@
+// rails-guard.test.mjs — enforcement proof for the Cursor preToolUse adapter and
+// the afterFileEdit audit hook. Drives the REAL exported handlers (no Cursor
+// binary) and also spawns the actual hook script to prove the stdin→stdout wire
+// format. Covers AC3 (a)-(h) of .adlc/cursor-spec.md.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { decide, extractToolName, extractFilePath } from '../hooks/adlc-rails-guard.mjs';
+import { audit } from '../hooks/adlc-audit.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GUARD_SCRIPT = join(HERE, '..', 'hooks', 'adlc-rails-guard.mjs');
+
+/** Build a fixture repo with the given tickets; returns its root. */
+function fixture({ tickets = null, currentTicket = undefined } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-cursor-'));
+  if (tickets) {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'tickets.json'), JSON.stringify({ tickets }));
+    if (currentTicket !== undefined) {
+      writeFileSync(join(root, '.adlc', 'current-ticket.json'), JSON.stringify({ id: currentTicket }));
+    }
+  }
+  return root;
+}
+const cleanup = (root) => rmSync(root, { recursive: true, force: true });
+
+/** A Cursor preToolUse payload. */
+const payload = (tool, filePath) => ({ tool_name: tool, tool_input: { file_path: filePath } });
+const env = (over = {}) => ({ ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1', ...over });
+
+const RAILED = [{ id: 'T1', title: 'one', rails: ['src/frozen.js', 'src/contracts/**'] },
+                { id: 'T2', title: 'two', rails: ['src/other.js'] }];
+
+test('extractors pull tool name and path from the Cursor shape', () => {
+  assert.equal(extractToolName(payload('Edit', 'a.js')), 'Edit');
+  assert.equal(extractFilePath(payload('Edit', 'src/a.js')), 'src/a.js');
+});
+
+test('(a) allow when .adlc/tickets.json is absent', () => {
+  const root = fixture();
+  try {
+    assert.deepEqual(decide(payload('Write', 'src/frozen.js'), { root, env: env() }), { permission: 'allow' });
+  } finally { cleanup(root); }
+});
+
+test('(b) allow when ADLC_P4_ENFORCEMENT !== "1"', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    const v = decide(payload('Write', 'src/frozen.js'), { root, env: env({ ADLC_P4_ENFORCEMENT: '0' }) });
+    assert.deepEqual(v, { permission: 'allow' });
+  } finally { cleanup(root); }
+});
+
+test('(c) allow when no active ticket is resolved', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    const v = decide(payload('Write', 'src/frozen.js'), { root, env: { ADLC_P4_ENFORCEMENT: '1' } });
+    assert.deepEqual(v, { permission: 'allow' });
+  } finally { cleanup(root); }
+});
+
+test('(d) deny a Write AND an Edit to the active ticket rail', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    for (const tool of ['Write', 'Edit']) {
+      const v = decide(payload(tool, 'src/frozen.js'), { root, env: env() });
+      assert.equal(v.permission, 'deny', `${tool} should be denied`);
+      assert.match(v.user_message, /frozen rail/);
+      assert.match(v.agent_message, /FROZEN ADLC rail/);
+    }
+    // glob rail also denies
+    const g = decide(payload('Write', 'src/contracts/export.schema.json'), { root, env: env() });
+    assert.equal(g.permission, 'deny');
+  } finally { cleanup(root); }
+});
+
+test('(e) deny an edit to .adlc/tickets.json (trust-root rail)', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    const v = decide(payload('Edit', '.adlc/tickets.json'), { root, env: env() });
+    assert.equal(v.permission, 'deny');
+  } finally { cleanup(root); }
+});
+
+test('(f) a DIFFERENT ticket rail does not deny under the active ticket', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    // src/other.js is T2's rail; active ticket is T1 → allow (not a union).
+    const v = decide(payload('Write', 'src/other.js'), { root, env: env() });
+    assert.deepEqual(v, { permission: 'allow' });
+  } finally { cleanup(root); }
+});
+
+test('(g) conflicting ADLC_TICKET vs current-ticket.json denies (fail closed)', () => {
+  const root = fixture({ tickets: RAILED, currentTicket: 'T2' });
+  try {
+    const v = decide(payload('Write', 'src/anything.js'), { root, env: env({ ADLC_TICKET: 'T1' }) });
+    assert.equal(v.permission, 'deny');
+    assert.match(v.user_message, /conflicting active-ticket/);
+  } finally { cleanup(root); }
+});
+
+test('(h) afterFileEdit audit NEVER blocks, even on a rail path', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    const res = audit({ file_path: 'src/frozen.js' }, { root, env: env() });
+    // It observes the rail touch but returns no permission/deny channel.
+    assert.equal(res.rail, true);
+    assert.ok(!('permission' in res));
+    // A non-rail path is simply not flagged.
+    assert.deepEqual(audit({ file_path: 'src/free.js' }, { root, env: env() }), { rail: false });
+  } finally { cleanup(root); }
+});
+
+test('read-only tools are never gated', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    assert.deepEqual(decide(payload('Read', 'src/frozen.js'), { root, env: env() }), { permission: 'allow' });
+    assert.deepEqual(decide(payload('codebase_search', 'src/frozen.js'), { root, env: env() }), { permission: 'allow' });
+  } finally { cleanup(root); }
+});
+
+// --- P5 prosecution regressions (ADR 0006): the in-session deny must cover
+//     Cursor's in-place edit tool, unrecognized tools, and symlink aliases. ---
+
+test('(d2) search_replace / str_replace edits to a rail are denied (not waved through as a read)', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    for (const tool of ['search_replace', 'SearchReplace', 'str_replace', 'reapply']) {
+      const v = decide(payload(tool, 'src/frozen.js'), { root, env: env() });
+      assert.equal(v.permission, 'deny', `${tool} editing a rail must be denied`);
+    }
+  } finally { cleanup(root); }
+});
+
+test('(d3) an UNRECOGNIZED structured tool carrying a rail path fails closed (denied)', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    // "frobnicate" is unknown — it must not be classified read-only and waved through.
+    const v = decide(payload('frobnicate', 'src/frozen.js'), { root, env: env() });
+    assert.equal(v.permission, 'deny', 'unknown tool on a rail must fail closed');
+  } finally { cleanup(root); }
+});
+
+test('(d4) a symlink whose real target is a frozen rail is denied', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    // Create src/frozen.js (the rail) and an alias symlink pointing at it.
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'frozen.js'), '// rail');
+    let linked = false;
+    try { symlinkSync(join(root, 'src', 'frozen.js'), join(root, 'alias.js')); linked = true; } catch { /* FS without symlink perms */ }
+    if (!linked) return; // skip on platforms that can't symlink
+    const v = decide(payload('Edit', 'alias.js'), { root, env: env() });
+    assert.equal(v.permission, 'deny', 'editing a symlink aliasing a rail must be denied');
+  } finally { cleanup(root); }
+});
+
+test('wire format: the real script reads stdin JSON and writes a {permission} verdict', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    const out = execFileSync(process.execPath, [GUARD_SCRIPT], {
+      input: JSON.stringify(payload('Write', 'src/frozen.js')),
+      cwd: root,
+      env: { ...process.env, ...env() },
+    }).toString();
+    const verdict = JSON.parse(out);
+    assert.equal(verdict.permission, 'deny');
+    assert.match(verdict.user_message, /frozen rail/);
+  } finally { cleanup(root); }
+});

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -288,6 +288,20 @@ test('(no-path multi-root) a pathless opaque tool fails CLOSED if ANY workspace 
   } finally { cleanup(bare); cleanup(active); }
 });
 
+test('(no-path multi-root) shell/read-only tools stay exempt even when a candidate root is conflicted/corrupt', () => {
+  // A bad ticket state in ONE root must not block a pathless shell command or a
+  // read-only search — classification is checked before strict precondition denial.
+  const bare = mkdtempSync(join(tmpdir(), 'adlc-bare-'));
+  const conflicted = fixture({ tickets: RAILED, currentTicket: 'T2' }); // ADLC_TICKET=T1 vs file T2 -> conflict
+  try {
+    const roots = [bare, conflicted];
+    assert.equal(decide({ tool_name: 'Bash', tool_input: { command: 'npm test' }, workspace_roots: roots }, { env: env() }).permission, 'allow', 'shell must run despite a conflicted root');
+    assert.equal(decide({ tool_name: 'codebase_search', tool_input: { query: 'x' }, workspace_roots: roots }, { env: env() }).permission, 'allow', 'read-only must run despite a conflicted root');
+    // but an opaque mutator with a conflicted root still fails closed
+    assert.equal(decide({ tool_name: 'edit_file', tool_input: {}, workspace_roots: roots }, { env: env() }).permission, 'deny', 'opaque mutator must fail closed on a conflicted root');
+  } finally { cleanup(bare); cleanup(conflicted); }
+});
+
 test('(no-path preconditions) a pathless opaque tool NO-OPs when uninitialized / no active ticket', () => {
   const op = { tool_name: 'edit_file', tool_input: {} };
   // uninitialized repo (enforcement on, no tickets.json) -> allow (no-op)

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -270,6 +270,24 @@ test('(no-path) a MUTATING tool with no extractable path fails CLOSED under enfo
   } finally { cleanup(root); }
 });
 
+test('(no-path preconditions) a pathless opaque tool NO-OPs when uninitialized / no active ticket', () => {
+  const op = { tool_name: 'edit_file', tool_input: {} };
+  // uninitialized repo (enforcement on, no tickets.json) -> allow (no-op)
+  const bare = mkdtempSync(join(tmpdir(), 'adlc-cursor-'));
+  try {
+    assert.equal(decide(op, { root: bare, env: env() }).permission, 'allow', 'uninitialized must no-op, not deny');
+  } finally { cleanup(bare); }
+  // initialized but NO active ticket -> allow (no-op), matching a path-bearing edit
+  const r = fixture({ tickets: RAILED });
+  try {
+    assert.equal(decide(op, { root: r, env: { ADLC_P4_ENFORCEMENT: '1' } }).permission, 'allow', 'no active ticket must no-op');
+    // but a conflict still fails closed even with no path
+    mkdirSync(join(r, '.adlc'), { recursive: true });
+    writeFileSync(join(r, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T2' }));
+    assert.equal(decide(op, { root: r, env: env() }).permission, 'deny', 'conflict must fail closed');
+  } finally { cleanup(r); }
+});
+
 test('(shell) shell/terminal commands with no file path are NOT denied under enforcement (npm test must run)', () => {
   const root = fixture({ tickets: RAILED });
   try {

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -236,6 +236,18 @@ test('(batch) MultiEdit/batch payloads with nested edits[]/files[] are rail-chec
   } finally { cleanup(root); }
 });
 
+test('(rename) a rename/move with a frozen rail in EITHER slot (path or target_path) is denied', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    // frozen destination behind a non-rail source
+    assert.equal(decide({ tool_name: 'rename_file', tool_input: { path: 'src/free.js', target_path: 'src/frozen.js' } }, { root, env: env() }).permission, 'deny');
+    // frozen source moved to a non-rail destination
+    assert.equal(decide({ tool_name: 'move_file', tool_input: { path: 'src/frozen.js', target_path: 'src/free.js' } }, { root, env: env() }).permission, 'deny');
+    // neither slot is a rail -> allow
+    assert.equal(decide({ tool_name: 'rename_file', tool_input: { path: 'src/a.js', target_path: 'src/b.js' } }, { root, env: env() }).permission, 'allow');
+  } finally { cleanup(root); }
+});
+
 test('(patch) apply_patch command string naming a rail is denied; a non-rail patch allows', () => {
   const root = fixture({ tickets: RAILED });
   try {

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { decide, extractToolName, extractFilePath } from '../hooks/adlc-rails-guard.mjs';
@@ -213,6 +213,20 @@ test('(multi-root) the guard checks the workspace root that OWNS the edited path
     // No explicit root: the adapter must pick repo-b (owns the path), not repo-a.
     const v = decide(p, { env: env() });
     assert.equal(v.permission, 'deny', 'edit to repo-b rail must be denied even when repo-a is listed first');
+  } finally { cleanup(repoA); cleanup(repoB); }
+});
+
+test('(multi-root ..) a non-normalized path is attributed to the repo it RESOLVES into', () => {
+  // repoB (uninitialized, listed first) and repoA (has the rail). The payload path
+  // lexically prefixes repoB but ../-resolves into repoA — raw prefix matching would
+  // pick repoB (uninitialized -> allow); normalized ownership must pick repoA -> deny.
+  const repoA = fixture({ tickets: RAILED });
+  const repoB = mkdtempSync(join(tmpdir(), 'adlc-b-'));
+  try {
+    const sneaky = join(repoB, '..', basename(repoA), 'src', 'frozen.js'); // resolves to repoA/src/frozen.js
+    const p = { tool_name: 'Write', tool_input: { file_path: sneaky }, workspace_roots: [repoB, repoA] };
+    const v = decide(p, { env: env() });
+    assert.equal(v.permission, 'deny', 'non-normalized path resolving into repoA rail must be denied');
   } finally { cleanup(repoA); cleanup(repoB); }
 });
 

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -216,6 +216,29 @@ test('(multi-root) the guard checks the workspace root that OWNS the edited path
   } finally { cleanup(repoA); cleanup(repoB); }
 });
 
+test('(fail-safe) an unexpected throw in the deny path fails CLOSED under active enforcement, OPEN when off', () => {
+  // Force checkRail to throw (a non-string root makes path.join throw) to exercise
+  // the categorical catch: under active enforcement an error must NOT become a
+  // silent allow; with enforcement off the guard is a no-op so it fails open.
+  const p = payload('Write', 'src/x.js');
+  assert.equal(decide(p, { root: 42, env: { ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' } }).permission, 'deny');
+  assert.equal(decide(p, { root: 42, env: { ADLC_P4_ENFORCEMENT: '0' } }).permission, 'allow');
+});
+
+test('(F2-rails) a malformed rail entry (non-string) fails CLOSED, not open', () => {
+  // @adlc/core only checks rails is an array, not its element types. A non-string
+  // rail makes globMatch throw; without a guard the adapter catch fails open.
+  const root = mkdtempSync(join(tmpdir(), 'adlc-cursor-'));
+  try {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'tickets.json'),
+      JSON.stringify({ tickets: [{ id: 'T1', title: 'x', rails: [123, 'src/frozen.js'] }] }));
+    const v = decide(payload('Write', 'src/frozen.js'), { root, env: env() });
+    assert.equal(v.permission, 'deny', 'a malformed rail entry must fail closed');
+    assert.match(v.user_message, /malformed rail|failing closed/);
+  } finally { cleanup(root); }
+});
+
 test('(multi-root ..) a non-normalized path is attributed to the repo it RESOLVES into', () => {
   // repoB (uninitialized, listed first) and repoA (has the rail). The payload path
   // lexically prefixes repoB but ../-resolves into repoA — raw prefix matching would

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -281,6 +281,19 @@ test('(shell) shell/terminal commands with no file path are NOT denied under enf
   } finally { cleanup(root); }
 });
 
+test('(shell-masquerade) a structured mutator named like a shell tool still fails CLOSED', () => {
+  // The shell exemption must not let a pathless structured mutator whose name merely
+  // contains "shell"/"terminal"/"powershell" bypass the fail-closed branch.
+  const root = fixture({ tickets: RAILED });
+  try {
+    for (const t of ['terminal_edit', 'shell_edit', 'powershell_write', 'shell_replace']) {
+      assert.equal(decide({ tool_name: t, tool_input: {} }, { root, env: env() }).permission, 'deny', `${t} (a mutator) must not masquerade as shell`);
+    }
+    // real shell tools still allowed (regression guard for over-correction)
+    assert.equal(decide({ tool_name: 'run_terminal_cmd', tool_input: { command: 'npm test' } }, { root, env: env() }).permission, 'allow');
+  } finally { cleanup(root); }
+});
+
 test('(fail-safe) an unexpected throw in the deny path fails CLOSED under active enforcement, OPEN when off', () => {
   // Force checkRail to throw (a non-string root makes path.join throw) to exercise
   // the categorical catch: under active enforcement an error must NOT become a

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -6,13 +6,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { decide, extractToolName, extractFilePath } from '../hooks/adlc-rails-guard.mjs';
 import { audit } from '../hooks/adlc-audit.mjs';
+import { MUTATING_MATCHER } from '../rails-checker.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GUARD_SCRIPT = join(HERE, '..', 'hooks', 'adlc-rails-guard.mjs');
@@ -160,6 +161,34 @@ test('(d4) a symlink whose real target is a frozen rail is denied', () => {
     if (!linked) return; // skip on platforms that can't symlink
     const v = decide(payload('Edit', 'alias.js'), { root, env: env() });
     assert.equal(v.permission, 'deny', 'editing a symlink aliasing a rail must be denied');
+  } finally { cleanup(root); }
+});
+
+// --- Cross-model review regressions (ADR 0006): the HOOK-ROUTING boundary, not
+//     just the decision function, must cover the mutators; corrupt tickets fail closed. ---
+
+test('(matcher) the shipped preToolUse matcher routes every mutation tool to the guard', () => {
+  // Build the regex the way Cursor would interpret the matcher string (strip the
+  // inline (?i) flag, apply case-insensitively) and confirm it MATCHES the tools
+  // the classifier treats as mutating — otherwise the guard is never invoked and
+  // decide()'s deny is dead code in production (the F1 finding).
+  const re = new RegExp(MUTATING_MATCHER.replace('(?i)', ''), 'i');
+  for (const tool of ['Write', 'Edit', 'MultiEdit', 'search_replace', 'str_replace', 'reapply', 'delete_file', 'create_file', 'rename_file', 'apply_patch']) {
+    assert.ok(re.test(tool), `matcher must route "${tool}" to the guard`);
+  }
+  // Drift guard: the committed hooks.json matcher must equal the derived one.
+  const hooksJson = JSON.parse(readFileSync(join(HERE, '..', 'hooks.json'), 'utf8'));
+  assert.equal(hooksJson.hooks.preToolUse[0].matcher, MUTATING_MATCHER, 'hooks.json matcher drifted from MUTATING_MATCHER');
+});
+
+test('(F2) a corrupt/invalid tickets.json fails CLOSED under active enforcement', () => {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-cursor-'));
+  try {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'tickets.json'), '{ this is not valid json');
+    const v = decide(payload('Write', 'src/anything.js'), { root, env: env() });
+    assert.equal(v.permission, 'deny', 'corrupt tickets.json must not silently drop declared rails');
+    assert.match(v.user_message, /failing closed/);
   } finally { cleanup(root); }
 });
 

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -216,6 +216,26 @@ test('(multi-root) the guard checks the workspace root that OWNS the edited path
   } finally { cleanup(repoA); cleanup(repoB); }
 });
 
+test('(batch) MultiEdit/batch payloads with nested edits[]/files[] are rail-checked, not waved through', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    // edits[] (MultiEdit): a rail among the items must deny.
+    const multi = { tool_name: 'MultiEdit', tool_input: { edits: [
+      { file_path: 'src/free.js', old_string: 'a', new_string: 'b' },
+      { file_path: 'src/frozen.js', old_string: 'a', new_string: 'b' },
+    ] } };
+    assert.equal(decide(multi, { root, env: env() }).permission, 'deny', 'edits[] rail must deny');
+
+    // files[] string array.
+    const files = { tool_name: 'apply_patch', tool_input: { files: ['src/free.js', 'src/frozen.js'] } };
+    assert.equal(decide(files, { root, env: env() }).permission, 'deny', 'files[] rail must deny');
+
+    // All-non-rail batch must allow.
+    const clean = { tool_name: 'MultiEdit', tool_input: { edits: [{ file_path: 'src/free.js' }, { file_path: 'lib/ok.js' }] } };
+    assert.equal(decide(clean, { root, env: env() }).permission, 'allow', 'non-rail batch must allow');
+  } finally { cleanup(root); }
+});
+
 test('(fail-safe) an unexpected throw in the deny path fails CLOSED under active enforcement, OPEN when off', () => {
   // Force checkRail to throw (a non-string root makes path.join throw) to exercise
   // the categorical catch: under active enforcement an error must NOT become a

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -391,6 +391,35 @@ test('(multi-root symlink) a NEW file under a symlinked root, in a frozen glob, 
   } finally { cleanup(repoA); cleanup(repoB); }
 });
 
+test('(multi-root relative) a RELATIVE ../ traversal into a sibling root rail is denied', () => {
+  // Gemini caught this: resolveRoot skipped ownership for relative paths, so a
+  // relative ../sibling/rail edit was checked against roots[0] (wrong root) -> allow.
+  const tmp = mkdtempSync(join(tmpdir(), 'adlc-ws-'));
+  const fe = join(tmp, 'frontend'); // roots[0], uninitialized
+  const be = join(tmp, 'backend');  // has the active rail
+  mkdirSync(fe, { recursive: true });
+  mkdirSync(join(be, '.adlc'), { recursive: true });
+  writeFileSync(join(be, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'x', rails: ['src/auth.js'] }] }));
+  try {
+    const w = (fp) => ({ tool_name: 'Write', tool_input: { file_path: fp }, workspace_roots: [fe, be] });
+    assert.equal(decide(w('../backend/src/auth.js'), { env: env() }).permission, 'deny', 'relative traversal into a sibling rail must deny');
+    assert.equal(decide(w('../backend/src/ok.js'), { env: env() }).permission, 'allow', 'relative non-rail must allow');
+    assert.equal(decide(w('src/app.js'), { env: env() }).permission, 'allow', 'frontend-local edit (inactive root) must allow');
+  } finally { rmSync(tmp, { recursive: true, force: true }); }
+});
+
+test('(malformed payload) the hook script fails CLOSED on unparseable JSON under enforcement, OPEN otherwise', () => {
+  const root = fixture({ tickets: RAILED });
+  const run = (env) => {
+    const out = execFileSync(process.execPath, [GUARD_SCRIPT], { input: '{ this is : not json', cwd: root, env: { ...process.env, ...env } }).toString();
+    return JSON.parse(out).permission;
+  };
+  try {
+    assert.equal(run({ ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' }), 'deny', 'malformed payload must fail closed under enforcement');
+    assert.equal(run({ ADLC_P4_ENFORCEMENT: '0' }), 'allow', 'malformed payload no-ops (allow) when enforcement is off');
+  } finally { cleanup(root); }
+});
+
 test('(multi-root ..) a non-normalized path is attributed to the repo it RESOLVES into', () => {
   // repoB (uninitialized, listed first) and repoA (has the rail). The payload path
   // lexically prefixes repoB but ../-resolves into repoA — raw prefix matching would

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -286,11 +286,16 @@ test('(shell-masquerade) a structured mutator named like a shell tool still fail
   // contains "shell"/"terminal"/"powershell" bypass the fail-closed branch.
   const root = fixture({ tickets: RAILED });
   try {
-    for (const t of ['terminal_edit', 'shell_edit', 'powershell_write', 'shell_replace']) {
-      assert.equal(decide({ tool_name: t, tool_input: {} }, { root, env: env() }).permission, 'deny', `${t} (a mutator) must not masquerade as shell`);
+    // (a) names with a mutating hint (edit/write/replace) — denied by precedence
+    // (b) names with NO mutating hint but a shell token (modify/set) — denied because
+    //     the shell exemption matches EXACT known shell names only, not tokens
+    for (const t of ['terminal_edit', 'shell_edit', 'powershell_write', 'shell_replace', 'terminal_modify', 'shell_modify', 'terminal_set', 'powershell_morph']) {
+      assert.equal(decide({ tool_name: t, tool_input: {} }, { root, env: env() }).permission, 'deny', `${t} must not masquerade as shell`);
     }
     // real shell tools still allowed (regression guard for over-correction)
-    assert.equal(decide({ tool_name: 'run_terminal_cmd', tool_input: { command: 'npm test' } }, { root, env: env() }).permission, 'allow');
+    for (const t of ['Bash', 'run_terminal_cmd', 'terminal', 'shell', 'pwsh', 'run_command']) {
+      assert.equal(decide({ tool_name: t, tool_input: { command: 'npm test' } }, { root, env: env() }).permission, 'allow', `${t} must run during P4`);
+    }
   } finally { cleanup(root); }
 });
 

--- a/plugins/adlc-cursor/test/rails-guard.test.mjs
+++ b/plugins/adlc-cursor/test/rails-guard.test.mjs
@@ -270,6 +270,17 @@ test('(no-path) a MUTATING tool with no extractable path fails CLOSED under enfo
   } finally { cleanup(root); }
 });
 
+test('(shell) shell/terminal commands with no file path are NOT denied under enforcement (npm test must run)', () => {
+  const root = fixture({ tickets: RAILED });
+  try {
+    for (const t of ['Bash', 'run_terminal_cmd', 'terminal', 'shell', 'powershell']) {
+      assert.equal(decide({ tool_name: t, tool_input: { command: 'npm test && npm run build' } }, { root, env: env() }).permission, 'allow', `${t} must run during P4`);
+    }
+    // but a shell payload that DOES expose a rail target (patch envelope) is still checked
+    assert.equal(decide({ tool_name: 'Bash', tool_input: { command: '*** Update File: src/frozen.js' } }, { root, env: env() }).permission, 'deny');
+  } finally { cleanup(root); }
+});
+
 test('(fail-safe) an unexpected throw in the deny path fails CLOSED under active enforcement, OPEN when off', () => {
   // Force checkRail to throw (a non-string root makes path.join throw) to exercise
   // the categorical catch: under active enforcement an error must NOT become a

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -46,11 +46,16 @@ test('mergeHooks preserves a user existing hook and does not duplicate ADLC entr
   assert.equal(adlcCount, 1);
 });
 
-test('ensureCursorHooks recovers from an unparseable existing hooks.json', () => {
+test('ensureCursorHooks BACKS UP an unparseable existing hooks.json instead of dropping it', () => {
   const root = mkRepo();
   mkdirSync(join(root, '.cursor'), { recursive: true });
-  writeFileSync(join(root, '.cursor', 'hooks.json'), '{ not json');
-  ensureCursorHooks(root);
+  const original = '{ not json — a company hook lived here';
+  writeFileSync(join(root, '.cursor', 'hooks.json'), original);
+  const res = ensureCursorHooks(root);
+  // ADLC hook is installed...
   const hooks = readJson(join(root, '.cursor', 'hooks.json'));
   assert.match(hooks.hooks.preToolUse[0].command, /adlc-rails-guard/);
+  // ...but the original content is preserved verbatim in a backup, not lost.
+  assert.ok(res.backedUp, 'a backup path must be reported');
+  assert.equal(readFileSync(res.backedUp, 'utf8'), original, 'backup must hold the original bytes');
 });

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -1,0 +1,56 @@
+// scaffold.test.mjs — the scaffolder writes valid Cursor config, merges hooks
+// without clobbering the user's other hooks, and is idempotent.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { scaffold, mergeHooks, ensureCursorHooks } from '../lib/scaffold.mjs';
+
+const mkRepo = () => mkdtempSync(join(tmpdir(), 'adlc-cursor-scaffold-'));
+const readJson = (p) => JSON.parse(readFileSync(p, 'utf8'));
+
+test('scaffold creates config, hooks.json (rails-guard + audit) and the rule', () => {
+  const root = mkRepo();
+  const res = scaffold(root);
+  assert.ok(existsSync(join(root, '.adlc', 'config.json')));
+  assert.ok(existsSync(join(root, '.cursor', 'rules', 'adlc.mdc')));
+
+  const hooks = readJson(join(root, '.cursor', 'hooks.json'));
+  assert.equal(hooks.version, 1);
+  assert.match(hooks.hooks.preToolUse[0].command, /adlc-rails-guard\.mjs/);
+  assert.equal(hooks.hooks.preToolUse[0].failClosed, false);
+  assert.match(hooks.hooks.afterFileEdit[0].command, /adlc-audit\.mjs/);
+  assert.ok(res.config.created && res.rule.created);
+});
+
+test('mergeHooks preserves a user existing hook and does not duplicate ADLC entries', () => {
+  const userHooks = {
+    version: 1,
+    hooks: {
+      preToolUse: [{ command: './scripts/my-guard.sh', matcher: 'curl' }],
+      beforeShellExecution: [{ command: './scripts/net.sh' }],
+    },
+  };
+  const once = mergeHooks(userHooks);
+  // user's entries survive
+  assert.ok(once.hooks.preToolUse.some((e) => e.command === './scripts/my-guard.sh'));
+  assert.ok(once.hooks.beforeShellExecution.some((e) => e.command === './scripts/net.sh'));
+  // ours added
+  assert.ok(once.hooks.preToolUse.some((e) => /adlc-rails-guard/.test(e.command)));
+  // idempotent: merging again does not add a second ADLC entry
+  const twice = mergeHooks(once);
+  const adlcCount = twice.hooks.preToolUse.filter((e) => /adlc-rails-guard/.test(e.command)).length;
+  assert.equal(adlcCount, 1);
+});
+
+test('ensureCursorHooks recovers from an unparseable existing hooks.json', () => {
+  const root = mkRepo();
+  mkdirSync(join(root, '.cursor'), { recursive: true });
+  writeFileSync(join(root, '.cursor', 'hooks.json'), '{ not json');
+  ensureCursorHooks(root);
+  const hooks = readJson(join(root, '.cursor', 'hooks.json'));
+  assert.match(hooks.hooks.preToolUse[0].command, /adlc-rails-guard/);
+});

--- a/scripts/cursor-install-smoke.mjs
+++ b/scripts/cursor-install-smoke.mjs
@@ -45,13 +45,14 @@ else {
   // advisory: failClosed must be false so a hook bug cannot brick the editor
   if (pre[0]?.failClosed !== false) fail('preToolUse failClosed is not false (advisory layer must not brick the editor)');
   else ok('preToolUse is advisory (failClosed:false)');
-  // F1: the matcher must actually ROUTE the mutation tools to the guard, else the
-  // deny decision is dead code in production. Check str_replace / search_replace.
+  // F1: the matcher must ROUTE every tool to the guard (catch-all) so a novel
+  // mutator name can't bypass the fail-closed classifier. Anything narrower is an
+  // allowlist with a hole.
   const matcher = pre.find((e) => /adlc-rails-guard/.test(e.command ?? ''))?.matcher ?? '';
-  const re = new RegExp(matcher.replace('(?i)', ''), 'i');
-  const routed = ['Write', 'Edit', 'str_replace', 'search_replace'].every((t) => re.test(t));
-  if (!routed) fail(`preToolUse matcher does not route all mutation tools to the guard (matcher="${matcher}")`);
-  else ok('preToolUse matcher routes str_replace/search_replace/Write/Edit to the guard');
+  const re = new RegExp(matcher, 'i');
+  const routed = ['Write', 'str_replace', 'modify_file', 'frobnicate', 'Read'].every((t) => re.test(t));
+  if (!routed) fail(`preToolUse matcher is an allowlist, not catch-all (matcher="${matcher}") — novel mutators bypass the guard`);
+  else ok('preToolUse matcher is catch-all (every tool reaches the guard; classifier decides)');
 }
 
 // ---- AC1: hook scripts present + contract ----

--- a/scripts/cursor-install-smoke.mjs
+++ b/scripts/cursor-install-smoke.mjs
@@ -45,6 +45,13 @@ else {
   // advisory: failClosed must be false so a hook bug cannot brick the editor
   if (pre[0]?.failClosed !== false) fail('preToolUse failClosed is not false (advisory layer must not brick the editor)');
   else ok('preToolUse is advisory (failClosed:false)');
+  // F1: the matcher must actually ROUTE the mutation tools to the guard, else the
+  // deny decision is dead code in production. Check str_replace / search_replace.
+  const matcher = pre.find((e) => /adlc-rails-guard/.test(e.command ?? ''))?.matcher ?? '';
+  const re = new RegExp(matcher.replace('(?i)', ''), 'i');
+  const routed = ['Write', 'Edit', 'str_replace', 'search_replace'].every((t) => re.test(t));
+  if (!routed) fail(`preToolUse matcher does not route all mutation tools to the guard (matcher="${matcher}")`);
+  else ok('preToolUse matcher routes str_replace/search_replace/Write/Edit to the guard');
 }
 
 // ---- AC1: hook scripts present + contract ----

--- a/scripts/cursor-install-smoke.mjs
+++ b/scripts/cursor-install-smoke.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// cursor-install-smoke.mjs — local verification for the ADLC Cursor integration
+// MVP. Mirrors scripts/opencode-install-smoke.mjs: validates the package shape,
+// the hooks.json wiring (preToolUse + afterFileEdit), the rule registration, the
+// @adlc/core delegation (no inlined rail engine), and runs the real enforcement
+// unit tests. Does NOT require the Cursor binary and does not mutate the user
+// environment. Exit 0 = all checks pass; exit 2 = a check failed.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), '..'));
+const PLUGIN = join(ROOT, 'plugins', 'adlc-cursor');
+let failures = 0;
+const fail = (m) => { console.error(`cursor-install-smoke: FAIL — ${m}`); failures++; };
+const ok = (m) => console.log(`  ok — ${m}`);
+const read = (p) => readFileSync(p, 'utf8');
+
+// ---- AC1: package + manifest shape ----
+const pkgPath = join(PLUGIN, 'package.json');
+if (!existsSync(pkgPath)) fail('plugins/adlc-cursor/package.json missing');
+else {
+  const pkg = JSON.parse(read(pkgPath));
+  if (pkg.name !== '@adlc/cursor-package') fail(`package name is ${pkg.name}`); else ok('package name');
+  if (pkg.type !== 'module') fail('package is not type:module'); else ok('type:module');
+  if (!pkg.dependencies?.['@adlc/core']) fail('missing @adlc/core dependency'); else ok('dependency @adlc/core');
+  if (!pkg.cursor?.hooks) fail('package.json cursor.hooks entry missing'); else ok('cursor.hooks manifest entry');
+  if (!pkg.cursor?.rules) fail('package.json cursor.rules entry missing'); else ok('cursor.rules manifest entry');
+}
+
+// ---- AC1: hooks.json wiring (preToolUse rails-guard + afterFileEdit audit) ----
+const hooksJsonPath = join(PLUGIN, 'hooks.json');
+if (!existsSync(hooksJsonPath)) fail('hooks.json missing');
+else {
+  const hj = JSON.parse(read(hooksJsonPath));
+  if (hj.version !== 1) fail('hooks.json version is not 1'); else ok('hooks.json version 1');
+  const pre = hj.hooks?.preToolUse ?? [];
+  if (!pre.some((e) => /adlc-rails-guard\.mjs/.test(e.command ?? ''))) fail('preToolUse does not wire adlc-rails-guard.mjs');
+  else ok('preToolUse wires the rails-guard adapter');
+  const after = hj.hooks?.afterFileEdit ?? [];
+  if (!after.some((e) => /adlc-audit\.mjs/.test(e.command ?? ''))) fail('afterFileEdit does not wire adlc-audit.mjs');
+  else ok('afterFileEdit wires the observational audit hook');
+  // advisory: failClosed must be false so a hook bug cannot brick the editor
+  if (pre[0]?.failClosed !== false) fail('preToolUse failClosed is not false (advisory layer must not brick the editor)');
+  else ok('preToolUse is advisory (failClosed:false)');
+}
+
+// ---- AC1: hook scripts present + contract ----
+const guardPath = join(PLUGIN, 'hooks', 'adlc-rails-guard.mjs');
+const auditPath = join(PLUGIN, 'hooks', 'adlc-audit.mjs');
+if (!existsSync(guardPath)) fail('hooks/adlc-rails-guard.mjs missing');
+else {
+  const g = read(guardPath);
+  if (!/permission/.test(g)) fail('rails-guard does not emit a Cursor {permission} verdict'); else ok('rails-guard emits {permission} verdict');
+  if (!/export function decide\b/.test(g)) fail('rails-guard does not export decide()'); else ok('rails-guard exports decide()');
+}
+if (!existsSync(auditPath)) fail('hooks/adlc-audit.mjs missing');
+else {
+  const a = read(auditPath);
+  if (/permission['"]?\s*:\s*['"]deny/.test(a)) fail('afterFileEdit audit must NOT emit a deny (it cannot block)');
+  else ok('afterFileEdit audit never denies (observational only)');
+}
+
+// ---- AC1: rule registration ----
+if (!existsSync(join(PLUGIN, 'rules', 'adlc.mdc'))) fail('rules/adlc.mdc missing');
+else {
+  const r = read(join(PLUGIN, 'rules', 'adlc.mdc'));
+  if (!/^---\n[\s\S]*?description:[\s\S]*?\n---/.test(r)) fail('rules/adlc.mdc lacks frontmatter'); else ok('rules/adlc.mdc has frontmatter');
+}
+
+// ---- AC2: delegate to @adlc/core, do NOT re-implement the rail engine ----
+const checkerPath = join(PLUGIN, 'rails-checker.mjs');
+if (!existsSync(checkerPath)) fail('rails-checker.mjs missing');
+else {
+  const chk = read(checkerPath);
+  if (!/from '@adlc\/core'/.test(chk)) fail('rails-checker does not import @adlc/core'); else ok('rails-checker imports @adlc/core');
+  if (!/globMatch/.test(chk) || !/loadTickets/.test(chk)) fail('rails-checker does not use globMatch+loadTickets from core'); else ok('delegates globMatch+loadTickets to core');
+  if (/function\s+globMatch\s*\(/.test(chk)) fail('rails-checker RE-IMPLEMENTS globMatch (must delegate to @adlc/core)'); else ok('no inlined globMatch (engine delegated)');
+  // deny-path source must not pull a third-party runtime dependency
+  const imports = [...chk.matchAll(/from '([^']+)'/g), ...read(guardPath).matchAll(/from '([^']+)'/g)].map((m) => m[1]);
+  const thirdParty = imports.filter((s) => !s.startsWith('node:') && !s.startsWith('.') && s !== '@adlc/core');
+  if (thirdParty.length) fail(`deny path imports third-party deps: ${thirdParty.join(', ')}`); else ok('deny path: only node: builtins + @adlc/core');
+}
+
+// ---- AC1: scaffolder registers the integration ----
+const scaffoldPath = join(PLUGIN, 'lib', 'scaffold.mjs');
+if (!existsSync(scaffoldPath)) fail('lib/scaffold.mjs missing');
+else {
+  const sc = read(scaffoldPath);
+  if (!/export function ensurePluginRegistered\b/.test(sc)) fail('scaffold does not register the integration (hooks would not wire)');
+  else ok('scaffold registers the integration (.cursor/hooks.json + rule)');
+}
+if (!existsSync(join(PLUGIN, 'lib', 'scaffold-cli.mjs'))) fail('lib/scaffold-cli.mjs missing'); else ok('scaffold-cli present');
+if (!existsSync(join(PLUGIN, 'command', 'adlc-init.md'))) fail('command/adlc-init.md missing'); else ok('command/adlc-init.md present');
+
+// ---- AC3: run the real enforcement unit tests (always-on proof) ----
+try {
+  execFileSync(process.execPath, ['--test', ...globTests(join(PLUGIN, 'test'))], { cwd: ROOT, stdio: 'pipe' });
+  ok('plugin unit tests pass (rails-guard adapter + audit + scaffold)');
+} catch (e) {
+  fail(`enforcement unit test failed:\n${e.stdout?.toString() ?? e.message}`);
+}
+
+// ---- AC4: two-layer framing in the doc; no competing CI workflow ----
+const docPath = join(ROOT, 'docs', 'integrations', 'cursor.md');
+if (!existsSync(docPath)) fail('docs/integrations/cursor.md missing');
+else {
+  const doc = read(docPath);
+  if (!/ci\/rails-guard\.yml/.test(doc)) fail('cursor.md does not point at the mandatory CI gate (docs/ci/rails-guard.yml)'); else ok('links the unbypassable CI gate');
+  if (!/advisor/i.test(doc)) fail('cursor.md does not frame the in-session hook as advisory'); else ok('frames in-session hook as advisory');
+  if (!/Formal ADLC Coverage/.test(doc)) fail('cursor.md missing the Formal ADLC Coverage table'); else ok('has Formal ADLC Coverage table');
+}
+
+// ---- AC5: ADR exists and pins the Cursor hook facts ----
+const adrPath = join(ROOT, 'docs', 'adr', '0006-adlc-cursor-integration.md');
+if (!existsSync(adrPath)) fail('docs/adr/0006-adlc-cursor-integration.md missing');
+else {
+  const adr = read(adrPath);
+  for (const needle of ['preToolUse', 'afterFileEdit', '## Threat Model']) {
+    if (!adr.includes(needle)) fail(`ADR 0006 does not pin "${needle}"`); else ok(`ADR pins ${needle}`);
+  }
+}
+
+if (failures) { console.error(`\ncursor-install-smoke: ${failures} failure(s)`); process.exit(2); }
+console.log('\ncursor-install-smoke: PASS');
+
+function globTests(dir) {
+  return existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith('.test.mjs')).map((f) => join(dir, f)) : [];
+}


### PR DESCRIPTION
## Summary

Adds a **Cursor native integration** for ADLC, joining the existing Claude Code, OpenCode, and Codex integrations. Cursor has no plugin marketplace, so this wires rail enforcement into Cursor's native surfaces: **hooks** (`.cursor/hooks.json`), **rules** (`.cursor/rules/*.mdc`), and a scaffolder that bootstraps them into a user repo.

Built via the ADLC itself (P0 ticket → P1 spec-lint/premortem → P3 rail freeze → P4 build → P5 prosecution).

## What's included

- **`plugins/adlc-cursor/`**
  - `hooks/adlc-rails-guard.mjs` — Cursor `preToolUse` adapter: reads the stdin payload, maps it to `checkRail`, emits `{ permission: "allow" | "deny" }`.
  - `hooks/adlc-audit.mjs` — `afterFileEdit` observational audit (Cursor's `afterFileEdit` fires post-write and **cannot block**, so this only surfaces a notice).
  - `rails-checker.mjs` — the rail decision, **delegating glob/ticket primitives to `@adlc/core`** (no re-implemented engine), faithful to `adlc-opencode`.
  - `hooks.json` template, `rules/adlc.mdc` gate-router, `lib/scaffold{,-cli}.mjs` (idempotent, merges into existing hooks), `command/adlc-init.md`.
  - `test/` — enforcement + scaffold tests.
- **`scripts/cursor-install-smoke.mjs`** — validates package shape, hook wiring, `@adlc/core` delegation, and runs the unit tests. No Cursor binary required.
- **`docs/integrations/cursor.md`** + **`docs/adr/0006-adlc-cursor-integration.md`** — adoption guide and design record.

## Design: two-layer enforcement (honest about Cursor's limits)

Cursor's in-session deny is **best-effort**: `permission: "deny"` has open reliability reports, and `afterFileEdit` can't block. So the hook is **advisory** (`failClosed: false` so a hook bug can't brick the editor), and the **unbypassable control is the existing CI `rails-guard` gate** (`docs/ci/rails-guard.yml`). This mirrors the ADR-0004 model, made explicit in ADR-0006. No competing CI workflow is added.

## Prosecution (P5)

An adversarial pre-merge pass caught a **critical defect**: `classifyTool("search_replace")` returned `readonly` (the normalized name contains the substring `search`), which would have **allowed editing a frozen rail** via Cursor's primary in-place edit tool. Fixed — mutating hints (incl. `replace`) are checked first, reads are a whole-token set, and unknown tools default to fail-closed. Re-prosecution verdict: **SHIP**, with the fix and two latent gaps (unrecognized-tool fail-closed, symlink alias) **mutation-proven load-bearing**.

## Test plan

- [x] `node scripts/cursor-install-smoke.mjs .` exits 0
- [x] `node --test plugins/adlc-cursor/test/rails-guard.test.mjs plugins/adlc-cursor/test/scaffold.test.mjs` — all pass
- [x] No sibling regression: opencode / codex / claude-code smoke scripts all exit 0
- [x] No inlined `globMatch` in `plugins/adlc-cursor` (delegation to `@adlc/core` enforced by smoke)
- [x] Mutation tests: search_replace bypass, unrecognized-tool fail-open, and symlink-neuter mutants are all caught
- [ ] **Follow-up (not in this MVP):** live deny-proof against a real Cursor binary; pin exact `preToolUse` payload field names; phase command suite + prosecutor subagents

## Notes

- `.adlc/tickets.json` is intentionally **not** in this diff (kept as a local working file). Related hygiene gap tracked in #39.