### PR TITLE
docs(adr-0007): accept risk-tiered multi-model adversarial review

### DIFF
--- a/docs/adr/0007-multimodel-adversarial-review.md
+++ b/docs/adr/0007-multimodel-adversarial-review.md
@@ -1,6 +1,7 @@
 # ADR: Risk-tiered multi-model adversarial review
 
-**Status:** **Proposed.** Adopt reviewer **diversity** as a risk-gated P5 practice: for
+**Status:** **Accepted — recommended practice (mechanical enforcement deferred).**
+(Superseded `Proposed` on 2026-06-27.) Adopt reviewer **diversity** as a risk-gated P5 practice: for
 high-blast-radius changes, require an independent verdict from **≥2 distinct providers**
 and treat a single provider's clean `approve` as **advisory, not a gate-pass**. Ship the
 `--providers` multi-provider mode in the `adversarial-review` skill as the mechanism. Do
@@ -132,10 +133,9 @@ surfaced **only** when an independent provider with different priors was added.
 
 ## Adoption / next steps
 
-1. Accept this ADR (P6 human gate) → status `Accepted`.
+1. ~~Accept this ADR (P6 human gate)~~ — **Accepted 2026-06-27.**
 2. Build the `--providers` mode in the `voodootikigod/adversarial-review` repo per the
    spec's AC4–AC7 (follow-on ticket).
-3. Document the risk-tier policy in `docs/toolkit.md` alongside the existing review
-   guidance.
+3. ~~Document the risk-tier policy in `docs/toolkit.md`~~ — **done** (Typical flow, step 6).
 4. Revisit mechanical enforcement once trust-boundary features are built often enough
    that operator invocation proves insufficient — the same trigger ADR-0005 set.

--- a/docs/adr/0007-multimodel-adversarial-review.md
+++ b/docs/adr/0007-multimodel-adversarial-review.md
@@ -1,0 +1,141 @@
+# ADR: Risk-tiered multi-model adversarial review
+
+**Status:** **Proposed.** Adopt reviewer **diversity** as a risk-gated P5 practice: for
+high-blast-radius changes, require an independent verdict from **≥2 distinct providers**
+and treat a single provider's clean `approve` as **advisory, not a gate-pass**. Ship the
+`--providers` multi-provider mode in the `adversarial-review` skill as the mechanism. Do
+**not** yet build mechanical enforcement into `coldstart`/the router (defer, exactly as
+[ADR-0005](./0005-adversarial-design-review-gate.md) deferred its P2-entry enforcement).
+The full design is the [multi-model review spec](../specs/multimodel-review.md).
+
+**Date:** 2026-06-27
+**Deciders:** Chris Williams (with three independent models — Claude, Codex/GPT, and
+Gemini — acting as the counter-models for the case study below).
+
+> Related: [ADR-0005](./0005-adversarial-design-review-gate.md) adds an adversarial
+> gate for the *design* (P1→P2); the P5 prosecution surface ([ADR-0001](./0001-codex-native-adlc-integration.md),
+> the `prosecutor` subagent in [ADR-0003](./0003-adlc-claude-code-plugin.md)) is the
+> adversarial gate for *built code*. This ADR is orthogonal to both: it governs **how
+> many, and how diverse, the reviewing models must be** for either gate to be trusted.
+
+---
+
+## Context
+
+The `adversarial-review` skill is already model-agnostic and, inside Claude Code or
+Cursor, **prefers a single provider different from the builder** — a model reviewing its
+own output is a weak critic. That is correct but insufficient. Its `--passes <n>` flag
+samples **one** model N times: it raises recall on that model's blind spots but adds **no
+provider diversity**. Nothing in the toolkit says *how many distinct providers* a review
+needs, or that a single clean `approve` is not proof.
+
+The cost of that gap is concrete and was observed directly (see Validation): different
+providers have **different blind spots**, and a security-critical deny path can earn a
+zero-finding approve from one strong model while a second strong model finds a
+high-severity bypass in a single pass.
+
+## Decision
+
+### 1. Risk gate (when ≥2 distinct providers are required)
+
+Reuse the `model-router` (D1) risk tiers. A change is **high-blast-radius** — and so
+requires an independent verdict from **≥2 distinct-family providers** — when it touches
+any of: authentication / authorization / **trust boundary**; a security control or
+**deny path** (rail guards, validators, sandboxes); secrets handling; data-loss /
+destructive / irreversible operations; schema or migration changes; CI/CD or
+supply-chain config. For those changes a single provider's `approve` is **advisory**,
+never a gate-pass. Everything else defaults to **single cross-model** review (today's
+behavior); trivial / non-security changes may skip review entirely.
+
+### 2. Mechanism — `adversarial-review --providers`
+
+A new multi-provider mode, distinct from `--passes`:
+
+- `--providers <a,b[,c]>` runs the same review prompt against each named provider
+  independently (API key or local CLI; e.g. `gpt`, `gemini`, `claude`).
+- **Merge + dedup** all findings into one report, keyed by `(file, line range,
+  category)`; a finding raised by multiple providers is tagged with its corroborators
+  (corroboration is signal — it raises confidence).
+- **Quorum-aware verdict:** `needs-attention` if **any** provider returns a material
+  finding at/above `--fail-on`; `approve` only if **all** selected providers approve.
+  `--quorum <n>` may relax this deliberately.
+- **Distinct-family auto-selection** when `--providers` is omitted but the risk tier (or
+  the operator) requests multi-model: pick ≥2 providers from *different* families, never
+  the builder's family twice.
+- **No silent downgrade:** if fewer than the requested providers are reachable, run what
+  is available and emit a loud notice that multi-provider was under-satisfied — a
+  degraded run must not masquerade as a full one.
+
+### 3. Evidence-driven escalation via `review-calibration`
+
+Diversity should be applied where it demonstrably helps, not as blanket ceremony. Tie
+the requirement to `review-calibration` (P5, "who reviews the reviewer"), which measures
+a reviewer's injected-mutant recall on *this* repo: a **measured low single-model recall**
+is the principled trigger for adding the second provider. This keeps the practice
+honest — escalate on evidence of missed defects, not on a fixed model count.
+
+### 4. Placement in the phase model
+
+This is a **P5 (Prosecute)** practice for built code and applies equally to the
+[ADR-0005](./0005-adversarial-design-review-gate.md) P1 design-review gate. Like
+ADR-0005, adoption is by **operator invocation** (run the skill with `--providers` on
+qualifying changes); mechanical enforcement in the gate path is **deferred** until the
+manual practice proves insufficient.
+
+## Consequences
+
+**Positive.** Security-critical changes get genuinely independent scrutiny; corroborated
+findings carry visible confidence; a single model's approve can no longer be mistaken for
+proof; the escalation is evidence-driven via `review-calibration`.
+
+**Negative / cost.** Each added provider is real tokens and wall-clock, and findings must
+be triaged across reports. This is acceptable **only** because it is risk-gated — applied
+to high-blast-radius code, not everywhere.
+
+**Diminishing returns (explicit caveat).** Value comes from provider **diversity, not
+count**: a third model from a family already represented adds little, and beyond ~2–3
+distinct providers the marginal yield shows sharply diminishing returns. The Cursor case study's long
+single-provider loop also shows that most late-round findings were narrow edges already
+covered by the unbypassable CI backstop — multi-model is highest-value on the load-bearing
+security logic, not on every diff. Do not prescribe a fixed N; prescribe *diversity on the
+changes that warrant it*.
+
+## Alternatives considered
+
+- **Status quo (one different-from-builder provider).** Rejected for high-blast-radius
+  code: the Validation shows one strong model's approve is not proof.
+- **Always run N≥3 models on every change.** Rejected: cost without commensurate value on
+  low-risk diffs; conflates count with diversity.
+- **More `--passes` on a single model.** Rejected: raises recall on one model's blind
+  spots but never crosses a provider boundary, so it cannot catch a cross-provider blind
+  spot — exactly the failure mode observed.
+- **Mechanical P5-entry enforcement now.** Deferred, mirroring ADR-0005: prove the manual
+  practice first.
+
+## Validation (the Cursor build, 2026-06-27)
+
+On the ADLC Cursor rails-guard integration (PR #40 — a security control whose entire job
+is to deny edits):
+
+1. A same-model (**Claude**) P5 prosecution passed after catching one classifier bug.
+2. A cross-model **Codex/GPT** `adversarial-review` loop ran **18 rounds** to a
+   **zero-finding `approve`**, hardening many real in-session bypasses along the way.
+3. A third model, **Gemini 3.1 Pro**, then found a **high-severity** multi-root
+   relative-path rail bypass GPT had missed across all 18 rounds — and, after the fix,
+   correctly flagged that the fix was *incomplete* (a path-mangling on different-depth
+   roots) plus a `JSON.parse` fail-open. It converged to its own clean `approve` two
+   rounds later.
+
+A single model's clean approve was demonstrably **not proof**. The high-severity finding
+surfaced **only** when an independent provider with different priors was added.
+**Diversity, not count, was the load-bearing variable.**
+
+## Adoption / next steps
+
+1. Accept this ADR (P6 human gate) → status `Accepted`.
+2. Build the `--providers` mode in the `voodootikigod/adversarial-review` repo per the
+   spec's AC4–AC7 (follow-on ticket).
+3. Document the risk-tier policy in `docs/toolkit.md` alongside the existing review
+   guidance.
+4. Revisit mechanical enforcement once trust-boundary features are built often enough
+   that operator invocation proves insufficient — the same trigger ADR-0005 set.

--- a/docs/specs/multimodel-review.md
+++ b/docs/specs/multimodel-review.md
@@ -66,8 +66,8 @@ auto-provisioning of provider keys.
 
 ## Acceptance criteria (each has a concrete verification method)
 
-- **AC1** — ADR-0007 exists, is `Status: Proposed`, references the Cursor case study and
-  `review-calibration`, and includes a cost / diminishing-returns caveat. *Verify:* run `grep -nE 'Proposed|review-calibration|Cursor|diminishing' docs/adr/0007-multimodel-adversarial-review.md` and confirm all four appear.
+- **AC1** — ADR-0007 exists with a `Status` line (Accepted), references the Cursor case
+  study and `review-calibration`, and includes a cost / diminishing-returns caveat. *Verify:* run `grep -nE 'Status|review-calibration|Cursor|diminishing' docs/adr/0007-multimodel-adversarial-review.md` and confirm all four appear.
 
 - **AC2** — ADR-0007 defines the risk tiers (`trust boundary`, `deny path`, auth, data-loss, CI/CD) requiring ≥2 distinct providers and states a single approve is advisory for those tiers. *Verify:* `grep -nE 'trust boundary|deny path|advisory' docs/adr/0007-multimodel-adversarial-review.md` and confirm the tiers + "advisory" appear.
 

--- a/docs/specs/multimodel-review.md
+++ b/docs/specs/multimodel-review.md
@@ -1,0 +1,86 @@
+# Spec — Risk-tiered multi-model adversarial review (ADLC P5)
+
+**Phase:** P1 working spec for ADR-0007. Deliverable of this ticket is the **design**
+(this spec + ADR-0007). The `adversarial-review` skill enhancement it specifies is a
+follow-on build (separate repo: `voodootikigod/adversarial-review`); its acceptance
+criteria are captured here so the build is executable without re-deriving the design.
+
+## Goal
+
+Make **reviewer diversity** a first-class, risk-gated part of the ADLC's adversarial
+review surface. Today the `adversarial-review` skill already prefers a *single*
+provider different from the builder. This spec elevates that to: for high-blast-radius
+changes, require an independent verdict from **≥2 distinct providers**, and treat a
+single clean approve as **advisory, not a gate-pass** — because providers have
+different blind spots.
+
+## Motivating evidence (the Cursor case study)
+
+On the ADLC Cursor integration (PR #40), a same-model (Claude) P5 prosecution passed;
+a cross-model **Codex/GPT** `adversarial-review` loop then ran **18 rounds** to a
+zero-finding `approve`; a third model, **Gemini 3.1 Pro**, then found a **high-severity**
+multi-root relative-path rail bypass GPT had missed, plus a follow-on flaw in the fix.
+A single model's clean approve was demonstrably **not proof**. Diversity — not count —
+was the load-bearing variable.
+
+## Scope of the policy (when ≥2 providers are REQUIRED)
+
+Mirror the `model-router` (D1) risk tiers. A change qualifies as **high-blast-radius**
+(needs ≥2 distinct providers) if it touches any of: authentication / authorization /
+trust boundaries; a security control or deny path (rail guards, validators); secrets
+handling; data-loss / destructive / irreversible operations; schema or migration
+changes; CI/CD or supply-chain config. Everything else defaults to **single
+cross-model** review (today's behavior). Trivial / non-security changes may skip.
+
+## The `adversarial-review` enhancement (`--providers`)
+
+A new multi-provider mode, distinct from the existing `--passes` (which samples ONE
+model N times and so adds no provider diversity):
+
+1. `--providers <a,b[,c]>` — run the same review prompt against each named provider
+   (API key or local CLI), independently.
+2. **Merge + dedup** all providers' findings into one report, keyed by
+   (file, line range, category/title); a finding raised by multiple providers is
+   marked with its corroborating providers.
+3. **Quorum-aware verdict** — `needs-attention` if ANY provider returns a material
+   finding (at/above the `--fail-on` threshold); `approve` only if ALL selected
+   providers approve. `--quorum <n>` may relax this deliberately.
+4. **Distinct-family auto-selection** — when `--providers` is omitted but multi-model
+   is requested (or the risk tier demands it), auto-select ≥2 providers from
+   *different* families (never the builder's family twice).
+5. **No silent downgrade** — if fewer than the requested providers are reachable, run
+   what is available AND emit a loud notice that multi-provider was requested but
+   under-satisfied (so a degraded run can't masquerade as a full one).
+
+## Evidence-driven, not dogmatic
+
+Tie the requirement to `review-calibration` (P5, "who reviews the reviewer"): a
+*measured* low single-model mutant-catch recall on the repo is what should trigger the
+second provider, so multi-model is applied where it demonstrably adds recall rather
+than as blanket ceremony. The ADR records this as the principled escalation lever.
+
+## Out of scope (note in ADR)
+Building the skill enhancement (separate repo); a mechanical P5-entry enforcement in
+`coldstart`/router (defer, exactly as ADR-0005 deferred its P2 enforcement); paid
+auto-provisioning of provider keys.
+
+## Acceptance criteria (each has a concrete verification method)
+
+- **AC1** — ADR-0007 exists, is `Status: Proposed`, references the Cursor case study and
+  `review-calibration`, and includes a cost / diminishing-returns caveat. *Verify:* run `grep -nE 'Proposed|review-calibration|Cursor|diminishing' docs/adr/0007-multimodel-adversarial-review.md` and confirm all four appear.
+
+- **AC2** — ADR-0007 defines the risk tiers (`trust boundary`, `deny path`, auth, data-loss, CI/CD) requiring ≥2 distinct providers and states a single approve is advisory for those tiers. *Verify:* `grep -nE 'trust boundary|deny path|advisory' docs/adr/0007-multimodel-adversarial-review.md` and confirm the tiers + "advisory" appear.
+
+- **AC3** — This spec passes spec-lint with zero wishes. *Verify:* run `adlc spec-lint docs/specs/multimodel-review.md` and assert exit 0.
+
+- **AC4** (follow-on build) — `adversarial-review --providers gpt,gemini` runs the
+  prompt against BOTH providers independently. *Verify:* a unit test stubs two providers and asserts each is invoked once with the same prompt; assert exit 0.
+
+- **AC5** (follow-on build) — findings from multiple providers are merged and deduped by `(file, line, category)` with corroboration recorded. *Verify:* a unit test feeds two provider outputs sharing one finding and each having one unique finding, and asserts the merged report has exactly three findings with the shared one tagged by both providers.
+
+- **AC6** (follow-on build) — the verdict is quorum-aware: one `approve` + one
+  `needs-attention` yields exit 2 by default. *Verify:* a unit test with those two stubbed verdicts asserts the merged exit code is 2 unless `--quorum` overrides.
+
+- **AC7** (follow-on build) — requesting multi-provider with only one reachable provider runs single-provider AND emits an under-satisfied `notice` (no silent downgrade). *Verify:* a unit test with one available provider asserts a warning line is emitted and exit reflects the single-provider result.
+
+Suppressions are denied.

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -34,7 +34,12 @@ through the stable `adlc <tool>` dispatcher.
    and select a gated consensus winner.
 6. Before review, use [`adlc hollow-test`](./tools/hollow-test.md), [`adlc prosecute`](./tools/prosecute.md), [`adlc behavior-diff`](./tools/behavior-diff.md), and [`adlc gate-manifest`](./tools/gate-manifest.md)
    to prove that tests are load-bearing, prosecution reached two dry passes, behavior
-   changes are visible, and gate evidence is recorded.
+   changes are visible, and gate evidence is recorded. For **high-blast-radius** changes
+   (trust boundary, deny path, auth, secrets, data-loss, schema/migration, CI/CD), run the
+   adversarial review against **≥2 distinct-family providers** and treat a single
+   provider's clean approve as advisory, not a gate-pass — different models have different
+   blind spots (see [ADR-0007](./adr/0007-multimodel-adversarial-review.md)). Use
+   [`adlc review-calibration`](./tools/review-calibration.md) to decide, on evidence, when one model's recall is too low to trust alone.
 7. After review, use [`adlc lesson-foundry`](./tools/lesson-foundry.md) and [`adlc rejection-mining`](./tools/rejection-mining.md) to convert repeated review
    findings into deterministic lint checks, skills, or spec-gap templates.
 8. On a schedule or after model changes, use [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md),


### PR DESCRIPTION
## Summary

Adds **ADR-0007 (Accepted)** + a P1 spec making reviewer **diversity** a first-class, risk-gated part of the ADLC's adversarial-review surface, and wires the policy into `docs/toolkit.md`.

**Policy:** for **high-blast-radius** changes (trust boundary / deny path / auth / secrets / data-loss / schema-migration / CI-CD), require an independent verdict from **≥2 distinct-family providers**, and treat a single provider's clean `approve` as **advisory, not a gate-pass**. Everything else stays single-cross-model; trivial work may skip.

## Why (the evidence)

On the Cursor rails-guard build (#40), a same-model Claude prosecution passed, a cross-model **Codex/GPT** `adversarial-review` loop ran **18 rounds** to a zero-finding approve — and then **Gemini 3.1 Pro found a high-severity multi-root relative-path rail bypass GPT had missed**, plus a follow-on flaw in the fix. A single model's clean approve was demonstrably not proof. **Diversity, not count, was the load-bearing variable.**

## What's included

- `docs/adr/0007-multimodel-adversarial-review.md` — the decision: risk gate, the `--providers` mechanism (fan-out + merge/dedup + quorum verdict + distinct-family auto-select + no silent downgrade, distinct from `--passes` which adds no diversity), evidence-driven escalation via `review-calibration`, P5 placement (peer to ADR-0005's P1 design gate), alternatives, and explicit cost / diminishing-returns caveats. Mechanical enforcement **deferred**, mirroring ADR-0005.
- `docs/specs/multimodel-review.md` — P1 spec with 7 testable ACs (AC1–AC3 in-scope/done; AC4–AC7 = the follow-on skill build).
- `docs/toolkit.md` — Typical flow step 6 now states the multi-model policy.

## ADLC trail

P0 ticket → P1 `spec-lint` (7/7, zero wishes) → `premortem` (5 failure modes, mitigated/noted) → ADR drafted → **Accepted**. `.adlc/tickets.json` kept out of the diff (local working file).

## Follow-on (not in this PR)

Build the `--providers` multi-provider mode in `voodootikigod/adversarial-review` per spec AC4–AC7 — tracked as a separate issue.