### PR TITLE
fix(core): handle --help / -h centrally in parseArgs to prevent stack trace (closes #72)

### DIFF
--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -11,13 +11,24 @@ Native ADLC integration for the Antigravity CLI. Two layers:
 
 ## Install
 
+**Local Checkout (Recommended/Verified).** Currently, the most reliable way to install the plugin is directly from a local checkout:
+
 ```sh
-agy plugin install adlc-antigravity@adlc     # via the .agents marketplace
-# or, from a local checkout:
-agy plugin install /abs/path/plugins/adlc-antigravity
+agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
 ```
 
-Then `/adlc-init`. Enforcement: `export ADLC_P4_ENFORCEMENT=1` with an active ticket.
+Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
+
+**Universal Installer (Planned — Not yet supported).** Support for Google Antigravity inside the vendor-neutral `plugins` installer is currently in development and **not yet present**. Once implemented, you will be able to install it via:
+
+```sh
+npx plugins add voodootikigod/adlc
+```
+
+
+**Note on native marketplace:** The native `.agents` marketplace registration command (`agy plugin install adlc-antigravity@adlc`) is currently subject to a CLI limitation where the CLI rejects unregistered third-party marketplaces with `unknown marketplace: adlc`. Local installation is the recommended path.
+
+Then `/adlc-init` (or manual bootstrap). Enforcement: `export ADLC_P4_ENFORCEMENT=1` with an active ticket.
 
 ## Formal ADLC Coverage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "apps/docs/node_modules/typescript": {

--- a/packages/coldstart/bin/coldstart.mjs
+++ b/packages/coldstart/bin/coldstart.mjs
@@ -15,7 +15,10 @@ import { buildPrompt, SYSTEM_PROMPT } from '../lib/prompt.mjs';
 import { checkAll } from '../lib/gate.mjs';
 import { renderReport, buildJsonOutput, allPass } from '../lib/report.mjs';
 
+const USAGE = 'usage: coldstart <ticket-id> [--tickets path] [--all] [--tier cheap|mid|frontier] [--prompt-only] [--json]';
+
 const { values, positionals } = parseArgs({
+  usage: USAGE,
   options: {
     tickets: { type: 'string', default: '.adlc/tickets.json' },
     all: { type: 'boolean', default: false },
@@ -56,9 +59,7 @@ if (runAll) {
 } else {
   const ticketId = positionals[0];
   if (!ticketId) {
-    opError(
-      'usage: coldstart <ticket-id> [--tickets path] [--all] [--tier cheap|mid|frontier] [--prompt-only] [--json]'
-    );
+    opError(USAGE);
   }
   const ticket = tickets.find((t) => t.id === ticketId);
   if (!ticket) {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -7,7 +7,7 @@ export type ParsedArgs = {
   readonly values: Record<string, string | boolean | string[] | boolean[] | undefined>;
   readonly positionals: string[];
 };
-export function parseArgs(config?: ParseArgsConfig): ParsedArgs;
+export function parseArgs(config?: ParseArgsConfig & { usage?: string | (() => void) }): ParsedArgs;
 export function pass(message?: string): never;
 export function gateFail(message?: string, details?: unknown): never;
 export function opError(message?: string): never;

--- a/packages/core/lib/cli.mjs
+++ b/packages/core/lib/cli.mjs
@@ -4,6 +4,21 @@
 import { parseArgs as nodeParseArgs } from 'node:util';
 
 export function parseArgs(config) {
+  const args = config?.args ?? process.argv.slice(2);
+  const hasHelp = args.includes('--help') || args.includes('-h');
+  if (hasHelp) {
+    const declaresHelp = config?.options && ('help' in config.options || 'h' in config.options);
+    if (!declaresHelp) {
+      if (config?.usage) {
+        if (typeof config.usage === 'function') {
+          config.usage();
+        } else {
+          console.log(config.usage);
+        }
+        process.exit(0);
+      }
+    }
+  }
   return nodeParseArgs({ allowPositionals: true, ...config });
 }
 

--- a/packages/core/test/core.test.mjs
+++ b/packages/core/test/core.test.mjs
@@ -453,3 +453,76 @@ test('agy provider: ADLC_AGY=false/0 do NOT enable the provider', () => {
   assert.equal(detectProvider({ ADLC_AGY: '1' })?.name, 'agy');
   assert.equal(detectProvider({ ADLC_AGY: '/usr/local/bin/agy' })?.apiKey, '/usr/local/bin/agy');
 });
+
+test('parseArgs: pre-scans for --help and prints usage', () => {
+  const originalExit = process.exit;
+  const originalLog = console.log;
+  let exitCode = null;
+  let loggedMsg = null;
+  
+  process.exit = (code) => {
+    exitCode = code;
+    throw new Error('exited');
+  };
+  console.log = (msg) => {
+    loggedMsg = msg;
+  };
+  
+  try {
+    assert.throws(() => {
+      corePublic.parseArgs({
+        args: ['--help'],
+        usage: 'my custom usage text',
+        options: {
+          foo: { type: 'boolean' }
+        }
+      });
+    }, /exited/);
+    
+    assert.equal(exitCode, 0);
+    assert.equal(loggedMsg, 'my custom usage text');
+  } finally {
+    process.exit = originalExit;
+    console.log = originalLog;
+  }
+});
+
+test('parseArgs: calls callback usage if it is a function', () => {
+  const originalExit = process.exit;
+  let exitCode = null;
+  let called = false;
+  
+  process.exit = (code) => {
+    exitCode = code;
+    throw new Error('exited');
+  };
+  
+  try {
+    assert.throws(() => {
+      corePublic.parseArgs({
+        args: ['-h'],
+        usage: () => {
+          called = true;
+        },
+        options: {
+          foo: { type: 'boolean' }
+        }
+      });
+    }, /exited/);
+    
+    assert.equal(exitCode, 0);
+    assert.equal(called, true);
+  } finally {
+    process.exit = originalExit;
+  }
+});
+
+test('parseArgs: does not intercept help if options explicitly declares it', () => {
+  const parsed = corePublic.parseArgs({
+    args: ['--help'],
+    options: {
+      help: { type: 'boolean' }
+    }
+  });
+  assert.equal(parsed.values.help, true);
+});

--- a/packages/gate-manifest/bin/gate-manifest.mjs
+++ b/packages/gate-manifest/bin/gate-manifest.mjs
@@ -9,7 +9,15 @@ import { loadFiltered, renderEntries } from '../lib/show.mjs';
 import { buildAttest } from '../lib/attest.mjs';
 import { ADLC_DIR } from '@adlc/core';
 
+const USAGE =
+  'usage: gate-manifest <verb> [options]\n' +
+  'verbs: record <gate-name> [--ticket id] [--data \'{json}\'] [--files a,b,c]\n' +
+  '       verify [--json]\n' +
+  '       show   [--ticket id] [--json]\n' +
+  '       attest [--ticket id]';
+
 const { values: flags, positionals } = parseArgs({
+  usage: USAGE,
   options: {
     ticket: { type: 'string' },
     data:   { type: 'string' },
@@ -22,13 +30,7 @@ const { values: flags, positionals } = parseArgs({
 const verb = positionals[0];
 
 if (!verb) {
-  opError(
-    'usage: gate-manifest <verb> [options]\n' +
-    'verbs: record <gate-name> [--ticket id] [--data \'{json}\'] [--files a,b,c]\n' +
-    '       verify [--json]\n' +
-    '       show   [--ticket id] [--json]\n' +
-    '       attest [--ticket id]'
-  );
+  opError(USAGE);
 }
 
 // ── record ──────────────────────────────────────────────────────────────────

--- a/packages/parallax/bin/parallax.mjs
+++ b/packages/parallax/bin/parallax.mjs
@@ -23,7 +23,28 @@ import {
 import { renderReport, renderRouteConflict } from '../lib/scoring.mjs';
 import { runSpecMode, runEdgeMode, runRouteMode } from '../lib/modes.mjs';
 
+const USAGE = `parallax — measured-ambiguity interrogation (ADLC D3)
+
+Usage:
+  parallax --request "feature request text"
+  parallax --file req.md
+  echo "request" | parallax
+  parallax --edge T1 T2 [--tickets path]
+  parallax --route "question" [--context file ...]
+
+Flags:
+  --n <int>           fan width (default 3)
+  --threshold <0-1>   ambiguity gate threshold (default 0.25)
+  --tier cheap|mid|frontier  override LLM tier
+  --json              machine-readable output
+  --prompt-only       print prompts and exit 0 (no API key needed)
+  --tickets <path>    tickets file (default .adlc/tickets.json)
+  --context <file>    context file(s) for --route mode (repeatable)
+
+Exit codes: 0 = gate passes, 1 = operational error, 2 = gate fails`;
+
 const { values, positionals } = parseArgs({
+  usage: USAGE,
   options: {
     // SPEC MODE
     request: { type: 'string', short: 'r' },
@@ -186,26 +207,7 @@ if (!request) {
 
 if (!request) {
   // Print usage to stderr and exit 1
-  process.stderr.write(`parallax — measured-ambiguity interrogation (ADLC D3)
-
-Usage:
-  parallax --request "feature request text"
-  parallax --file req.md
-  echo "request" | parallax
-  parallax --edge T1 T2 [--tickets path]
-  parallax --route "question" [--context file ...]
-
-Flags:
-  --n <int>           fan width (default 3)
-  --threshold <0-1>   ambiguity gate threshold (default 0.25)
-  --tier cheap|mid|frontier  override LLM tier
-  --json              machine-readable output
-  --prompt-only       print prompts and exit 0 (no API key needed)
-  --tickets <path>    tickets file (default .adlc/tickets.json)
-  --context <file>    context file(s) for --route mode (repeatable)
-
-Exit codes: 0 = gate passes, 1 = operational error, 2 = gate fails
-`);
+  process.stderr.write(USAGE + '\n');
   process.exit(1);
 }
 

--- a/packages/spec-lint/bin/spec-lint.mjs
+++ b/packages/spec-lint/bin/spec-lint.mjs
@@ -9,7 +9,10 @@ import { classifyAll, applyLlmDemotion } from '../lib/classify.mjs';
 import { buildJsonResult, buildHumanReport } from '../lib/report.mjs';
 import { buildVacuousPrompt, detectVacuous } from '../lib/llm.mjs';
 
+const USAGE = 'usage: spec-lint <spec.md> [--llm] [--tier cheap|mid|frontier] [--json] [--prompt-only]';
+
 const { values: flags, positionals } = parseArgs({
+  usage: USAGE,
   options: {
     llm: { type: 'boolean', default: false },
     tier: { type: 'string', default: 'cheap' },
@@ -21,7 +24,7 @@ const { values: flags, positionals } = parseArgs({
 const specPath = positionals[0];
 
 if (!specPath) {
-  opError('usage: spec-lint <spec.md> [--llm] [--tier cheap|mid|frontier] [--json] [--prompt-only]');
+  opError(USAGE);
 }
 
 const VALID_TIERS = ['cheap', 'mid', 'frontier'];

--- a/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { readFileSync, realpathSync } from 'node:fs';
+import { isAbsolute, relative, resolve, dirname, basename } from 'node:path';
 
 function fail(message) {
   console.error(`adlc-rails-guard: ${message}`);
@@ -306,10 +306,25 @@ function resolveActiveTicketId() {
   return envTicket ?? fileTicket;
 }
 
+function safeRealpath(fp) {
+  try {
+    return realpathSync(fp);
+  } catch {
+    const parent = dirname(fp);
+    if (parent === fp) return fp;
+    try {
+      return resolve(safeRealpath(parent), basename(fp));
+    } catch {
+      return fp;
+    }
+  }
+}
+
 function normalizePath(path, baseCwd = process.cwd()) {
   const normalized = path.replaceAll('\\', '/');
-  const absolute = isAbsolute(normalized) ? normalized : resolve(baseCwd, normalized);
-  const projectRelative = relative(process.cwd(), absolute).replaceAll('\\', '/');
+  const absolute = safeRealpath(isAbsolute(normalized) ? normalized : resolve(baseCwd, normalized));
+  const projectRoot = safeRealpath(process.cwd());
+  const projectRelative = relative(projectRoot, absolute).replaceAll('\\', '/');
   return projectRelative.startsWith('..') ? normalized : projectRelative;
 }
 


### PR DESCRIPTION
This PR fixes issue #72 by pre-scanning incoming arguments for --help or -h centrally in the shared parseArgs helper, and short-circuiting to the usage text if not explicitly declared in options. Also fixes a macOS-specific temp directory real path resolution bug in the rails guard.