### PR TITLE
docs(adlc-antigravity): foreground fail-open risk in install docs

### DIFF
--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -11,6 +11,14 @@ Native ADLC integration for the Antigravity CLI. Two layers:
 
 ## Install
 
+> **⚠️ Fail-open, CI is the real backstop.** The in-session `PreToolUse` rail hook
+> installed below is **advisory only** — `agy` fails **OPEN** on a non-zero hook
+> exit (crash, timeout, unsupported platform), so a frozen-rail write can slip
+> through. Do not treat the hook as a hard block. The unbypassable control is the
+> CI diff gate (`scripts/rails-guard-ci.mjs`, wired via
+> [`docs/ci/rails-guard.yml`](../ci/rails-guard.yml)) — **make it a required
+> check** before relying on this integration for enforcement.
+
 **Local Checkout (Recommended/Verified).** Currently, the most reliable way to install the plugin is directly from a local checkout:
 
 ```sh

--- a/docs/specs/antigravity-fail-open-visibility.md
+++ b/docs/specs/antigravity-fail-open-visibility.md
@@ -1,0 +1,40 @@
+# Spec — Antigravity fail-open visibility (issue #62)
+
+## What this addresses
+
+Issue #62 has two parts:
+
+- **(a) Router omits adversarial-review.** Already resolved on `main` by the T13/T14
+  router-consolidation work (commits `6d3d6cc`, `d5cb96e`, `0175d7d`). Verified here:
+  `plugins/adlc-antigravity/skills/adlc/SKILL.md` references `adversarial-review` at
+  P1 (line 27), P3 (line 29), and P5 (line 32) of the phase table. No changes needed;
+  this spec does not redo that work.
+- **(b) Fail-open hook risk isn't surfaced prominently enough.** The in-session
+  `PreToolUse` hook (`plugins/adlc-antigravity/hooks/adlc-rails-guard.cjs`) fails
+  **open** on a non-zero exit — documented in SKILL.md, but `docs/integrations/antigravity.md`'s
+  **Install** section (the first thing an operator reads) said nothing about it, and
+  the plugin has no README linking `scripts/rails-guard-ci.mjs` as the actual
+  required-check control.
+
+## Acceptance criteria
+
+1. `docs/integrations/antigravity.md`'s `## Install` section contains a fail-open /
+   CI-is-the-backstop callout, and that callout appears **before** the first install
+   command (i.e., near the top of the section, not buried after the steps).
+2. `plugins/adlc-antigravity` has no README (consistent with every other plugin in
+   `plugins/`), so the closest equivalent doc — `commands/adlc-init.md`, the plugin's
+   own bootstrap instructions — names `scripts/rails-guard-ci.mjs` explicitly and
+   frames it as a required check in branch protection.
+3. No regression in the existing antigravity plugin test suite or install smoke test.
+
+## Verification commands
+
+```sh
+node --test plugins/adlc-antigravity/test/docs-visibility.test.mjs   # new tests for (b), RED before fix
+node --test plugins/adlc-antigravity/test/*.test.mjs                 # full plugin suite, no regressions
+node scripts/antigravity-install-smoke.mjs .                          # existing install smoke, no regressions
+npm test                                                              # full repo suite
+```
+
+All four passed after the fix (`node --test plugins/adlc-antigravity/test/*.test.mjs`:
+52/52 pass including the 3 new tests; `npm test`: full suite green).

--- a/plugins/adlc-antigravity/commands/adlc-init.md
+++ b/plugins/adlc-antigravity/commands/adlc-init.md
@@ -22,6 +22,9 @@ Bootstrap the ADLC runtime for use with `agy`.
    !.adlc/tickets.json
    ```
 4. **Wire the CI gate** (the real guarantee): copy `docs/ci/rails-guard.yml` into your
-   pipeline and make it a required check. The in-session hook is advisory.
+   pipeline and make it a required check. The in-session hook is advisory — `agy`
+   fails **open** on a non-zero hook exit, so it cannot substitute for CI. The
+   workflow template runs `scripts/rails-guard-ci.mjs` directly; treat that script
+   as a required check in branch protection, not just an informational job.
 5. **Activate enforcement** for a build: `export ADLC_P4_ENFORCEMENT=1` with an active
    ticket whose `rails[]` are frozen.

--- a/plugins/adlc-antigravity/test/docs-visibility.test.mjs
+++ b/plugins/adlc-antigravity/test/docs-visibility.test.mjs
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+// Issue #62(b): the in-session PreToolUse hook fails OPEN on a non-zero exit.
+// This is already documented in SKILL.md and the hook shim, but wasn't surfaced
+// anywhere more visible -- an operator skimming install docs could assume the
+// hook is a hard block. These tests pin that visibility so it can't silently
+// regress back to "buried SKILL.md line only".
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..');
+
+function section(markdown, heading) {
+  // Extract the body of a level-2 (##) markdown section up to the next ## heading.
+  const lines = markdown.split('\n');
+  const startIdx = lines.findIndex((l) => l.trim() === heading);
+  assert.ok(startIdx !== -1, `heading "${heading}" not found`);
+  const rest = lines.slice(startIdx + 1);
+  const endIdx = rest.findIndex((l) => /^## /.test(l));
+  return (endIdx === -1 ? rest : rest.slice(0, endIdx)).join('\n');
+}
+
+test('antigravity.md Install section foregrounds the fail-open risk near the top', () => {
+  const doc = readFileSync(
+    join(REPO_ROOT, 'docs', 'integrations', 'antigravity.md'),
+    'utf8'
+  );
+  const install = section(doc, '## Install');
+  assert.match(
+    install,
+    /fail(s)?\s*\*{0,2}open/i,
+    'Install section should state the hook fails OPEN'
+  );
+  assert.match(
+    install,
+    /CI\b.*(backstop|real (guarantee|control))|(backstop|real (guarantee|control)).*CI\b/is,
+    'Install section should name CI as the real backstop'
+  );
+});
+
+test('antigravity.md Install section callout appears before the install commands, not buried after them', () => {
+  const doc = readFileSync(
+    join(REPO_ROOT, 'docs', 'integrations', 'antigravity.md'),
+    'utf8'
+  );
+  const install = section(doc, '## Install');
+  const calloutIdx = install.search(/fail(s)?\s*\*{0,2}open/i);
+  const firstCommandIdx = install.indexOf('agy plugin install');
+  assert.ok(calloutIdx !== -1, 'callout not found');
+  assert.ok(firstCommandIdx !== -1, 'install command not found');
+  assert.ok(
+    calloutIdx < firstCommandIdx,
+    'fail-open callout should appear before the first install command, i.e. near the top'
+  );
+});
+
+test('the Antigravity plugin points at scripts/rails-guard-ci.mjs as a required-check recommendation', () => {
+  // plugins/adlc-antigravity has no README.md (matches the rest of the plugins/
+  // directory, none of which have one) -- commands/adlc-init.md is the closest
+  // equivalent (it is the plugin's own install/bootstrap doc).
+  const initDoc = readFileSync(
+    join(REPO_ROOT, 'plugins', 'adlc-antigravity', 'commands', 'adlc-init.md'),
+    'utf8'
+  );
+  assert.match(
+    initDoc,
+    /scripts\/rails-guard-ci\.mjs/,
+    'adlc-init.md should link scripts/rails-guard-ci.mjs by path'
+  );
+  assert.match(
+    initDoc,
+    /required check/i,
+    'the rails-guard-ci.mjs reference should be framed as a required-check recommendation'
+  );
+});


### PR DESCRIPTION
## Summary

Part (b) of #62 — the Antigravity (`agy`) in-session `PreToolUse` rail hook is
documented as failing **open** on a non-zero exit (crash, timeout, unsupported
platform), meaning a frozen-rail write can slip through a hook failure. That
risk was previously only mentioned deep in `SKILL.md`/the hook shim itself —
an operator skimming the install docs could easily assume the hook is a hard
block. This PR surfaces the fail-open trade-off and the CI backstop
prominently at the top of the install flow instead.

- Adds a `⚠️ Fail-open, CI is the real backstop` callout to
  `docs/integrations/antigravity.md`'s Install section, placed before the
  install commands, pointing at `scripts/rails-guard-ci.mjs` /
  `docs/ci/rails-guard.yml` as the required-check recommendation.
- Strengthens the "Wire the CI gate" step in
  `plugins/adlc-antigravity/commands/adlc-init.md` to spell out *why* the
  in-session hook can't substitute for CI, and to call out that
  `rails-guard-ci.mjs` itself should be the required branch-protection check.
- Adds `docs/specs/antigravity-fail-open-visibility.md` documenting the
  scoped fix.
- Adds `plugins/adlc-antigravity/test/docs-visibility.test.mjs` asserting the
  callout exists, appears before the install commands (not buried after),
  and that the plugin points at `scripts/rails-guard-ci.mjs` as the
  required-check recommendation.

Part (a) of #62 (router adversarial-review discoverability) is tracked
separately and closed by the router-consolidation work (T13/T14, #74) — this
PR only addresses part (b), the fail-open visibility gap.

Fixes #62

## Review

Adversarial review: SHIPPED — 2 consecutive clean rounds (0 findings each).

## Test plan

- [x] `node --test plugins/adlc-antigravity/test/*.test.mjs` — 52/52 pass
- [x] `node --test apps/docs/test/*.test.mjs` — 12/12 pass (docs theory-link tests unaffected)
- [x] `node scripts/antigravity-install-smoke.mjs .` — PASS (includes doc-frames-hook-as-advisory / doc-names-CI-gate checks)