### PR TITLE
feat(cli): register adlc review dispatcher verb, make prosecute recorder seam explicit

### DIFF
--- a/docs/specs/prosecute-recorder-seam.md
+++ b/docs/specs/prosecute-recorder-seam.md
@@ -1,0 +1,44 @@
+# Spec — Make the prosecute recorder/reviewer seam explicit (closes #65)
+
+**Phase:** P1 lightweight record for a docs + small-dispatcher-addition ticket.
+
+## Issue
+
+`packages/prosecute` (bin `adlc-prosecute`) makes zero model calls — it is a P5
+evidence recorder/ledger, not a reviewer. The actual adversarial engine is the separate
+`adversarial-review` CLI (`npx adversarial-review`), which was not registered as a verb
+in `packages/cli/lib/registry.mjs`. This is a defensible design (control flow is code,
+judgment is models) but was previously a surprise: nothing in the dispatcher, the
+toolkit guide, or the top of the prosecute README said so up front.
+
+## Acceptance criteria
+
+1. `adlc review` is registered as a dispatcher verb in `packages/cli/lib/registry.mjs`
+   and shells out to `npx adversarial-review` with full argument passthrough, following
+   the existing thin-passthrough pattern used by other registered verbs.
+2. A test exists that confirms the verb is registered and that dispatching it passes
+   arguments through to the underlying command, using a mocked/injected child-process
+   spawn function — no real process is spawned and no network call is made.
+3. `docs/toolkit.md`'s P5 material states, as a headline design decision (not a buried
+   caveat), that `adlc prosecute` records evidence and does not itself review, and that
+   `adlc review` / `npx adversarial-review` is the tool that actually judges code.
+4. `packages/prosecute/README.md`'s top-level summary leads with the same design
+   decision, ahead of the mechanical description of what the tool records.
+5. The full `@adlc/cli` test suite passes after the change, with no regressions.
+
+## Verification
+
+```sh
+cd packages/cli
+node --test test/*.test.mjs
+```
+
+All 20 tests pass, including the 5 new tests in `test/review-dispatch.test.mjs` that
+cover verb registration, help-text listing, argument passthrough, exit-code
+propagation, and spawn-error surfacing for `adlc review`.
+
+```sh
+node -e "import('./packages/cli/lib/registry.mjs').then(m => console.log(m.getTool('review')))"
+```
+
+confirms the registered tool shape: `{ name: 'review', packageName: 'adversarial-review', external: true, ... }`.

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -15,10 +15,25 @@ through the stable `adlc <tool>` dispatcher.
 | P2 / C3 | Can an agent execute this ticket without guessing? | [`adlc coldstart`](./tools/coldstart.md), [`adlc merge-forecast`](./tools/merge-forecast.md), [`adlc model-router`](./tools/model-router.md) |
 | P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | [`adlc rails-guard`](./tools/rails-guard.md), [`adlc flail-detector`](./tools/flail-detector.md) |
 | P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | [`adlc consensus-fix`](./tools/consensus-fix.md) |
-| P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | [`adlc prosecute`](./tools/prosecute.md), [`adlc behavior-diff`](./tools/behavior-diff.md), [`adlc gate-manifest`](./tools/gate-manifest.md), [`adlc hollow-test`](./tools/hollow-test.md) |
+| P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | `adlc review` (runs the model review — see [seam note](#p5-recorder-vs-reviewer-seam)), [`adlc prosecute`](./tools/prosecute.md) (records its evidence — it runs no model review itself), [`adlc behavior-diff`](./tools/behavior-diff.md), [`adlc gate-manifest`](./tools/gate-manifest.md), [`adlc hollow-test`](./tools/hollow-test.md) |
 | C12 / maintenance | What must be re-prosecuted after model or repo drift? | [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md), [`adlc skill-rot`](./tools/skill-rot.md) |
 | P7 | Which repeated findings should become deterministic defenses? | [`adlc lesson-foundry`](./tools/lesson-foundry.md), [`adlc rejection-mining`](./tools/rejection-mining.md) |
 | Continuous calibration | Can hostile candidates defeat the gates? | [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) |
+
+## P5: recorder vs. reviewer seam
+
+**This is a deliberate design decision, not a gap:** `adlc prosecute` makes zero model
+calls. It is a P5 evidence ledger — it validates input, hashes and verifies artifact
+paths, and appends normalized reviewer-produced pass records to `.adlc/manifest.jsonl`.
+It never judges code itself. The actual model-judged adversarial review is a separate
+tool, reachable from the dispatcher as `adlc review`, which passes its arguments
+straight through to `npx adversarial-review` (or the Codex/OpenCode
+multi-lens loop — see [ADR-0007](./adr/0007-multimodel-adversarial-review.md)). Run the
+reviewer first, then feed its normalized output into `adlc prosecute --input` as the
+evidence to record. Control flow (gating, dry-pass convergence, manifest evidence) is
+code; judgment (finding bugs) is models — see the package summary in
+[`packages/prosecute/README.md`](../packages/prosecute/README.md) for the full seam
+statement.
 
 ## Typical flow
 
@@ -32,9 +47,12 @@ through the stable `adlc <tool>` dispatcher.
    [`adlc flail-detector`](./tools/flail-detector.md) to catch repeated error loops, scope drift, churn, or oversized logs.
 5. For hard failing tests, use [`adlc consensus-fix`](./tools/consensus-fix.md) to fan out independent candidate repairs
    and select a gated consensus winner.
-6. Before review, use [`adlc hollow-test`](./tools/hollow-test.md), [`adlc prosecute`](./tools/prosecute.md), [`adlc behavior-diff`](./tools/behavior-diff.md), and [`adlc gate-manifest`](./tools/gate-manifest.md)
-   to prove that tests are load-bearing, prosecution reached two dry passes, behavior
-   changes are visible, and gate evidence is recorded. For **high-blast-radius** changes
+6. Before review, use [`adlc hollow-test`](./tools/hollow-test.md) to prove tests are load-bearing. Run the actual
+   model-judged review with [`adlc review`](#p5-recorder-vs-reviewer-seam) (passthrough to `npx adversarial-review`), then
+   record its normalized output with [`adlc prosecute`](./tools/prosecute.md) — prosecute runs no model review of its
+   own, it only records that one already happened and reached two dry passes. Use [`adlc behavior-diff`](./tools/behavior-diff.md)
+   and [`adlc gate-manifest`](./tools/gate-manifest.md) so behavior changes are visible and gate evidence is recorded.
+   For **high-blast-radius** changes
    (trust boundary, deny path, auth, secrets, data-loss, schema/migration, CI/CD), run the
    adversarial review against **≥2 distinct-family providers** and treat a single
    provider's clean approve as advisory, not a gate-pass — different models have different
@@ -56,7 +74,9 @@ Several tools use `.adlc/` as the shared workspace for machine-readable state:
 
 ### Recording an adversarial-review verdict (P6)
 
-The adversarial-review loop emits NDJSON events (`loop_start` / `review` / `fix` /
+Run the review itself via `adlc review` (dispatcher passthrough to `npx
+adversarial-review`) or invoke `npx adversarial-review` directly. The adversarial-review
+loop emits NDJSON events (`loop_start` / `review` / `fix` /
 `loop_end`); `loop_end.exitReason === "clean"` is the SHIP signal. Record the verdict as
 first-class human-gate evidence:
 

--- a/docs/tools/prosecute.md
+++ b/docs/tools/prosecute.md
@@ -19,10 +19,17 @@ flowchart TD
 
 
 
-P5 review-evidence recorder. It does not run a model review by itself. It consumes
-normalized reviewer-produced pass evidence, records ticket- and revision-scoped P5
-evidence to `.adlc/manifest.jsonl`, and passes only after two consecutive dry passes
-with at least three distinct dry lenses.
+> **Design decision: this is a recorder, not a reviewer.** `@adlc/prosecute` makes zero
+> model calls and runs no adversarial review of its own. It is a P5 evidence ledger: it
+> validates, hashes, and appends normalized reviewer-produced pass records to
+> `.adlc/manifest.jsonl`. The actual model-judged review is a separate tool -- run
+> `npx adversarial-review` (or `adlc review`, which passes args through to it) -- and feed
+> **its** output into `prosecute` as the `--input` evidence. If you run `adlc prosecute`
+> expecting it to find bugs, it will not; it only proves that a real review already did.
+
+P5 review-evidence recorder. It consumes normalized reviewer-produced pass evidence,
+records ticket- and revision-scoped P5 evidence to `.adlc/manifest.jsonl`, and passes
+only after two consecutive dry passes with at least three distinct dry lenses.
 
 ## Usage
 

--- a/packages/cli/lib/dispatch.mjs
+++ b/packages/cli/lib/dispatch.mjs
@@ -47,7 +47,7 @@ export function resolveRunnerBin() {
   return binPathFromPackage(pkgJsonPath, pkg, 'adlc-runner') ?? binPathFromPackage(pkgJsonPath, pkg);
 }
 
-function runBin(label, bin, args) {
+function runBin(label, bin, args, spawnFn) {
   if (!bin) {
     return {
       code: 1,
@@ -55,16 +55,33 @@ function runBin(label, bin, args) {
     };
   }
 
-  const result = spawnSync(process.execPath, [bin, ...args], { stdio: 'inherit' });
+  const result = spawnFn(process.execPath, [bin, ...args], { stdio: 'inherit' });
   if (result.error) return { code: 1, error: `failed to run ${label}: ${result.error.message}` };
   if (result.signal) return { code: 1, error: `${label} terminated by signal ${result.signal}` };
   return { code: typeof result.status === 'number' ? result.status : 1 };
 }
 
-export function dispatch(toolName, args) {
-  return runBin(`@adlc/${toolName}`, resolveBin(toolName), args);
+// External verbs (registry.mjs `external: true`) are not workspace packages, so there is
+// no local bin to resolve. They shell out to `npx <packageName>` with full argument
+// passthrough instead -- this is how `adlc review` reaches the separate
+// `adversarial-review` CLI without vendoring it into this monorepo (issue #65).
+function runExternal(packageName, args, spawnFn) {
+  const result = spawnFn('npx', [packageName, ...args], { stdio: 'inherit' });
+  if (result.error) return { code: 1, error: `failed to run npx ${packageName}: ${result.error.message}` };
+  if (result.signal) return { code: 1, error: `${packageName} terminated by signal ${result.signal}` };
+  return { code: typeof result.status === 'number' ? result.status : 1 };
 }
 
-export function dispatchRunner(args) {
-  return runBin('@adlc/runner', resolveRunnerBin(), args);
+export function dispatch(toolName, args, opts = {}) {
+  const spawnFn = opts.spawnFn ?? spawnSync;
+  const tool = getTool(toolName);
+  if (tool?.external) {
+    return runExternal(tool.packageName, args, spawnFn);
+  }
+  return runBin(`@adlc/${toolName}`, resolveBin(toolName), args, spawnFn);
+}
+
+export function dispatchRunner(args, opts = {}) {
+  const spawnFn = opts.spawnFn ?? spawnSync;
+  return runBin('@adlc/runner', resolveRunnerBin(), args, spawnFn);
 }

--- a/packages/cli/lib/help.mjs
+++ b/packages/cli/lib/help.mjs
@@ -27,6 +27,9 @@ export function renderHelp(version) {
   lines.push('');
   lines.push('Note: "ticket" is the dispatcher shorthand for the @adlc/ticket-sync package');
   lines.push('      (adlc ticket ... routes to ticket-sync\'s bin).');
+  lines.push('Note: "review" is a passthrough to `npx adversarial-review`, an external');
+  lines.push('      package (not a workspace tool). `prosecute` only records the P5');
+  lines.push('      evidence a review like this one produces -- it does not review.');
 
   return lines.join('\n');
 }

--- a/packages/cli/lib/registry.mjs
+++ b/packages/cli/lib/registry.mjs
@@ -1,7 +1,12 @@
 /**
- * @typedef {{ name: string, packageName: string, binName?: string, summary: string }} Tool
+ * @typedef {{ name: string, packageName: string, binName?: string, summary: string, external?: boolean }} Tool
  * @typedef {{ title: string, tools: Tool[] }} Group
  */
+// `external: true` marks a verb that is not one of this monorepo's @adlc/* workspace
+// packages. It dispatches via `npx <packageName>` instead of resolving a local bin
+// (see runExternal in dispatch.mjs). `review` is the one example today: it routes to
+// the separate `adversarial-review` CLI -- the actual model-judged reviewer that
+// `@adlc/prosecute` records evidence *for* but never runs itself (see issue #65).
 
 /** @type {Group[]} */
 export const GROUPS = [
@@ -35,6 +40,7 @@ export const GROUPS = [
       { name: 'review-calibration', packageName: '@adlc/review-calibration', summary: 'Measure reviewer recall by scoring whether review catches mutants.' },
       { name: 'model-ratchet', packageName: '@adlc/model-ratchet', summary: 'Identify hot files for re-prosecution after model or repo drift.' },
       { name: 'gate-fuzzing', packageName: '@adlc/gate-fuzzing', summary: 'Run hostile candidates against gate suites to find defeats.' },
+      { name: 'review', packageName: 'adversarial-review', external: true, summary: 'Run the model-judged adversarial review (via `npx adversarial-review`) that `prosecute` records evidence for.' },
     ],
   },
   {

--- a/packages/cli/test/dispatch.test.mjs
+++ b/packages/cli/test/dispatch.test.mjs
@@ -40,10 +40,11 @@ function withTempSpec(contents, fn) {
 }
 
 test('registry exposes the suite tools and omits internal packages', () => {
-  assert.equal(TOOLS.length, 21);
+  assert.equal(TOOLS.length, 22);
   assert.equal(isTool('spec-lint'), true);
   assert.equal(isTool('prosecute'), true);
   assert.equal(isTool('ticket'), true);
+  assert.equal(isTool('review'), true);
   assert.equal(isTool('core'), false);
   assert.equal(isTool('runner'), false);
 });
@@ -61,6 +62,10 @@ test('resolves package-local tool bins without PATH lookup', () => {
   assert.equal(resolveBin('definitely-not-real'), null);
 });
 
+test('external verbs like "review" have no local bin to resolve (they are npx passthroughs)', () => {
+  assert.equal(resolveBin('review'), null);
+});
+
 test('resolves runner bin for run and accept verbs', () => {
   assert.match(resolveRunnerBin() ?? '', /packages\/runner\/bin\/adlc\.mjs$/);
 });
@@ -74,7 +79,7 @@ test('help lists every routed tool and exits 0', () => {
 test('renderHelp embeds version and tool count', () => {
   const output = renderHelp('9.9.9');
   assert.match(output, /adlc 9\.9\.9/);
-  assert.match(output, /Tools \(21\)/);
+  assert.match(output, /Tools \(22\)/);
 });
 
 test('version prints a semver-shaped string', () => {

--- a/packages/cli/test/review-dispatch.test.mjs
+++ b/packages/cli/test/review-dispatch.test.mjs
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dispatch } from '../lib/dispatch.mjs';
+import { getTool, isTool } from '../lib/registry.mjs';
+import { renderHelp } from '../lib/help.mjs';
+
+// Issue #65: packages/prosecute is a P5 evidence recorder, not the model reviewer.
+// The actual adversarial engine lives in the separate `adversarial-review` CLI
+// (`npx adversarial-review`), which was previously unreachable from the `adlc`
+// dispatcher. These tests confirm `adlc review` routes to it via npx passthrough,
+// without ever spawning a real child process (the spawn call is injected/mocked).
+
+test('registry registers "review" as an external npx-routed verb, not a workspace package', () => {
+  assert.equal(isTool('review'), true);
+  const tool = getTool('review');
+  assert.ok(tool);
+  assert.equal(tool.external, true);
+  assert.equal(tool.packageName, 'adversarial-review');
+  assert.equal(tool.name, 'review');
+});
+
+test('help output lists the review verb', () => {
+  const output = renderHelp('1.0.0');
+  assert.match(output, /\breview\b/);
+  assert.match(output, /adversarial-review/);
+});
+
+test('dispatching "review" shells out to `npx adversarial-review` with full argument passthrough', () => {
+  const calls = [];
+  const spawnFn = (cmd, args, options) => {
+    calls.push({ cmd, args, options });
+    return { status: 0, error: null, signal: null };
+  };
+
+  const { code, error } = dispatch('review', ['--scope', 'working-tree', '--include-files'], { spawnFn });
+
+  assert.equal(error, undefined);
+  assert.equal(code, 0);
+  assert.equal(calls.length, 1, 'expected exactly one spawn call (no network access)');
+  assert.equal(calls[0].cmd, 'npx');
+  assert.deepEqual(calls[0].args, ['adversarial-review', '--scope', 'working-tree', '--include-files']);
+  assert.equal(calls[0].options.stdio, 'inherit');
+});
+
+test('dispatching "review" propagates the underlying tool\'s exit code', () => {
+  const spawnFn = () => ({ status: 2, error: null, signal: null });
+  const { code } = dispatch('review', [], { spawnFn });
+  assert.equal(code, 2);
+});
+
+test('dispatching "review" surfaces a spawn error instead of throwing', () => {
+  const spawnFn = () => ({ status: null, error: new Error('npx not found'), signal: null });
+  const { code, error } = dispatch('review', [], { spawnFn });
+  assert.equal(code, 1);
+  assert.match(error, /npx not found/);
+});

--- a/packages/prosecute/README.md
+++ b/packages/prosecute/README.md
@@ -1,9 +1,16 @@
 # @adlc/prosecute
 
-P5 review-evidence recorder. It does not run a model review by itself. It consumes
-normalized reviewer-produced pass evidence, records ticket- and revision-scoped P5
-evidence to `.adlc/manifest.jsonl`, and passes only after two consecutive dry passes
-with at least three distinct dry lenses.
+> **Design decision: this is a recorder, not a reviewer.** `@adlc/prosecute` makes zero
+> model calls and runs no adversarial review of its own. It is a P5 evidence ledger: it
+> validates, hashes, and appends normalized reviewer-produced pass records to
+> `.adlc/manifest.jsonl`. The actual model-judged review is a separate tool -- run
+> `npx adversarial-review` (or `adlc review`, which passes args through to it) -- and feed
+> **its** output into `prosecute` as the `--input` evidence. If you run `adlc prosecute`
+> expecting it to find bugs, it will not; it only proves that a real review already did.
+
+P5 review-evidence recorder. It consumes normalized reviewer-produced pass evidence,
+records ticket- and revision-scoped P5 evidence to `.adlc/manifest.jsonl`, and passes
+only after two consecutive dry passes with at least three distinct dry lenses.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

`packages/prosecute` makes zero model calls — it's a P5 evidence recorder/ledger, not a reviewer. The actual adversarial engine (`npx adversarial-review`) was unreachable from the `adlc` dispatcher, and the "does not run a model review by itself" caveat was buried deep in the prosecute README instead of being a visible design decision.

This PR:
- Registers `adlc review` in `packages/cli/lib/registry.mjs` as an external `npx` passthrough verb, wired through `dispatch.mjs` and listed in `help.mjs`.
- Promotes the recorder-vs-reviewer distinction to a headline design decision in `docs/toolkit.md`'s P5 material and in `packages/prosecute/README.md`.
- Adds `docs/specs/prosecute-recorder-seam.md` documenting the seam and its rationale.
- Updates `docs/tools/prosecute.md` to point at `adlc review` for the actual adversarial pass.
- Adds `packages/cli/test/review-dispatch.test.mjs` covering registry registration, help output, argument passthrough, exit-code propagation, and spawn-error surfacing for the new verb.

Fixes #65

## Test plan

- [x] `npm test` in `packages/cli` — 20/20 tests passing (includes 5 new tests for the `review` verb: registry registration, help listing, npx passthrough with full args, exit-code propagation, spawn-error surfacing)
- [x] Adversarial review: 2 consecutive clean rounds (0 findings each) — SHIPPED
- [ ] Manual smoke test: `adlc review --help` routes to `npx adversarial-review --help` in a real checkout