### PR TITLE
feat(adlc-claude-code): port OpenCode's multi-lens prosecution loop to /adlc-prosecute

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -60,6 +60,7 @@ install above) and Node 18+.
 | --- | --- | --- |
 | `/adlc-init` | — | Bootstrap `.adlc/`, split the committable ticket contract from runtime evidence in `.gitignore`, run preflight. |
 | `/adlc-ticket` | P0 | Author a self-contained, schema-valid ticket (the contract every gate reads), then check it is executable. Ticket schema: [`docs/ticket-authoring.md`](../ticket-authoring.md). |
+| `/adlc-prosecute` | P5 | Multi-lens adversarial pre-merge review: fan out five independent lens subagents, dedupe findings, independently verify each via a sixth verifier subagent, loop until two consecutive dry rounds. |
 | `/adlc-distill` | P7 | Mine repeated findings and PR rejections into deterministic defenses (lint rules, skills, review lenses). |
 | `/adlc-maintain` | C10/C12 | Decay-driven checks: stale skills, hot files to re-prosecute, gate calibration. |
 
@@ -69,12 +70,26 @@ The `adlc` skill is a phase-routing flowchart: describe what you're doing ("shap
 this spec", "is this safe to merge") and it routes you to the right gate. It is
 how the model embraces the lifecycle in total.
 
-### The prosecutor subagent
+### The prosecutor subagent and `/adlc-prosecute`
 
 `prosecutor` is a hostile pre-merge (P5) reviewer: it runs `hollow-test` (are the
 tests load-bearing?), `behavior-diff` (is the behavior change visible?), and
 `review-calibration` (would the review catch a planted defect?) and returns an
-evidence-backed verdict.
+evidence-backed verdict. These are mechanical, deterministic-gate checks.
+
+`/adlc-prosecute` is the independent multi-lens adversarial loop, matching the
+OpenCode integration's `/adlc-prosecute` shape: it fans out five independent lens
+subagents (`prosecutor-correctness`, `prosecutor-security`, `prosecutor-contract`,
+`prosecutor-diff`, `prosecutor-tests`) on the diff, dedupes findings across
+lenses by file + line range + title (keeping the highest severity), independently
+verifies each deduped finding via a sixth `prosecutor-verifier` subagent (a
+finding survives only on a strict majority "real" vote — fail-closed to
+"survives" if no valid vote is obtained), and repeats until two consecutive
+rounds surface no new confirmed findings. The pure dedupe/verify/convergence
+logic is unit-tested at `plugins/adlc-claude-code/lib/prosecutor.mjs`
+(`plugins/adlc-claude-code/lib/test/prosecutor.test.mjs`). The two mechanisms are
+complementary: `prosecutor` supplies mechanical evidence, `/adlc-prosecute`
+supplies independent model judgment with cross-lens verification.
 
 ### Hooks (automatic)
 
@@ -164,7 +179,7 @@ claude plugin install adlc@adlc
 | P2 Decompose | Strong | `coldstart`, `model-router`, `merge-forecast` |
 | P3 Rail | Strong | rails-guard PreToolUse hook + CI backstop |
 | P4 Build | Strong | flail-detection hook, `consensus-fix` |
-| P5 Prosecute | Partial | `prosecutor` subagent runs the gates; formal phase assertion (`adlc run p5`) is not available on the CC path — see Gaps below. |
+| P5 Prosecute | Strong | `/adlc-prosecute` runs the full multi-lens fan-out/dedupe/verify/converge loop (parity with OpenCode); `prosecutor` subagent runs complementary deterministic gates. Formal `adlc run p5` phase assertion is a harness-agnostic runner path (see below), not blocked on any one CLI. |
 | P6 Integrate | Conditional | gate-manifest evidence surfaced for the human gate; strong when backed by valid P5 evidence. |
 | P7 Distill | Strong | `/adlc-distill` |
 | Maintenance | Strong | `/adlc-maintain` + CI cron |
@@ -174,9 +189,9 @@ automate the judgment.
 
 After a prosecution that returns CLEAR, record informal evidence with
 `adlc gate-manifest record prosecution --files <changed files>`. This entry is
-useful for provenance auditing but does **not** satisfy `adlc run p5` — see the
-Gaps section below for the full explanation and the Codex path for formal phase
-assertion.
+useful for provenance auditing but does **not** by itself satisfy `adlc run p5`
+— see the Gaps section below for the full explanation and the runner path for
+formal phase assertion.
 
 ## Using with Codex
 
@@ -200,17 +215,23 @@ reconciliation rationale.
 
 Current gaps relative to the formal ADLC doctrine:
 
-1. **P5 formal assertion is not available on the CC path.** The `prosecutor`
-   subagent runs `hollow-test`, `behavior-diff`, and `review-calibration` and
-   returns an evidence-backed verdict. After a CLEAR verdict, `adlc gate-manifest
-   record prosecution` records provenance evidence — but this entry carries
-   `gate: "prosecution"`, which does not satisfy `adlc run p5`. The runner
-   requires `type: "p5-complete"` plus provenance, transcript hashes, and a
-   completed dry-pass convergence chain that the `gate-manifest` command does not
-   produce. Formal P5 phase assertion requires the Codex path
-   (`adlc prosecute` → `adlc run p5`). There is no example fixture for the CC
-   path comparable to `docs/examples/p5-passes.json`; the Codex fixture is the
-   authoritative reference.
+1. **Recording formal `adlc run p5` phase assertion from the CC path is not yet
+   wired up end-to-end (narrower than before issue #61).** The independent
+   multi-lens loop itself — fan-out, dedupe, verifier refutation, loop-until-dry
+   — now runs natively on Claude Code via `/adlc-prosecute` and the
+   `prosecutor-{correctness,security,contract,diff,tests,verifier}` subagents,
+   the same shape as the OpenCode integration. What remains unwired is the
+   *recording* step: `/adlc-prosecute`'s default evidence path is `adlc
+   gate-manifest record prosecution --files <changed files>`, which carries
+   `gate: "prosecution"` and does not by itself satisfy `adlc run p5`. Formal
+   assertion requires `@adlc/prosecute`'s `type: "p5-complete"` provenance chain
+   (ticket- and revision-bound, transcript hashes, two consecutive dry passes) —
+   a harness-agnostic runner path (`adlc prosecute --input <file> --ticket <id>`
+   → `adlc run p5`), not exclusive to the Codex integration; any harness that can
+   produce the `@adlc/prosecute` input JSON from its own lens findings can drive
+   it. There is no example fixture yet for a CC-native run comparable to
+   `docs/examples/p5-passes.json`; the Codex fixture remains the authoritative
+   reference until one exists.
 2. **In-session Bash rail enforcement is absent (intentional).** A shell is
    Turing-complete and cannot be reliably parsed for mutation targets; every
    parser attempted had further bypasses. Rail mutations via Bash are caught at

--- a/docs/specs/claude-code-prosecutor-parity.md
+++ b/docs/specs/claude-code-prosecutor-parity.md
@@ -1,0 +1,67 @@
+# Spec — Claude Code multi-lens prosecution parity (issue #61)
+
+## Problem
+
+Harness parity between the Claude Code and OpenCode ADLC plugins was inverted for P5
+(pre-merge prosecution): OpenCode's `/adlc-prosecute` implemented a real multi-round
+adversarial loop (fan out five independent lenses, dedupe findings across lenses,
+independently verify each deduped finding, repeat until two consecutive rounds are dry),
+while Claude Code's `prosecutor` subagent ran three deterministic gates sequentially with
+no dedupe, no independent verifier-refutation, and no convergence loop — and its own text
+said it did not satisfy formal P5 and punted to the Codex path.
+
+## What this closes
+
+Ports the OpenCode multi-lens loop into `plugins/adlc-claude-code/`:
+
+- `commands/adlc-prosecute.md` — the `/adlc-prosecute` command: fan-out → dedupe →
+  independent-verify → loop-until-dry, same shape as
+  `plugins/adlc-opencode/command/adlc-prosecute.md`.
+- `agents/prosecutor-{correctness,security,contract,diff,tests,verifier}.md` — six
+  read-only (`tools: Read, Grep, Glob`, no Edit/Write/MultiEdit/Bash) Claude Code
+  subagents, adapted from the six `plugins/adlc-opencode/agent/prosecutor-*.md` lens
+  prompts to Claude Code's `name`/`description`/`tools` frontmatter convention (not a
+  byte-for-byte copy of OpenCode's `mode`/`permission` frontmatter, which doesn't apply).
+- `lib/prosecutor.mjs` — the pure, unit-tested dedupe/verify/convergence contract
+  (`findingKey`, `dedupeFindings`, `survivesVerification`, `shouldContinue`), ported from
+  `plugins/adlc-opencode/lib/prosecutor.mjs` so the decision logic — not just the prompt
+  text — is identical and independently testable across harnesses.
+- `agents/prosecutor.md` lines 87-90 caveat rewritten: it no longer claims Claude Code
+  cannot satisfy the multi-lens loop or must punt to a different harness; it now points at
+  `/adlc-prosecute` for the loop and clarifies that formal `adlc run p5` phase assertion is
+  a harness-agnostic runner path (`adlc prosecute` → `adlc run p5`), not exclusive to any
+  one CLI.
+- `docs/integrations/claude-code.md` updated to match (commands table, prosecutor
+  section, lifecycle coverage table, Gaps section).
+- `scripts/claude-code-plugin-smoke.mjs` extended to assert the new command and six agent
+  files exist, are well-formed (frontmatter shape, no Edit/Write/MultiEdit/Bash grant on
+  the lenses/verifier), and that `lib/prosecutor.mjs` exports the full contract and is
+  wired into the root `package.json` test script.
+
+## Acceptance criteria
+
+1. `/adlc-prosecute` and all six `prosecutor-*` subagents exist under
+   `plugins/adlc-claude-code/` with Claude Code-native frontmatter, and the command text
+   names all six subagents and describes dedupe, independent verification, and
+   loop-until-dry convergence (not just fan-out).
+2. The dedupe/verify/convergence logic is pure, exported from `lib/prosecutor.mjs`, and
+   unit-tested — same behavior as OpenCode's registry (5 lenses + verifier, dedupe by
+   file+line-range+normalized-title keeping highest severity, strict-majority verifier
+   survival with fail-closed-to-survive on zero valid votes, two-consecutive-dry-round
+   loop termination).
+3. `plugins/adlc-claude-code/agents/prosecutor.md` no longer claims the Codex path is
+   required to run the multi-lens adversarial loop.
+4. `scripts/claude-code-plugin-smoke.mjs` fails if any new command/agent/lib file is
+   missing, malformed, or grants a prosecution lens Edit/Write/MultiEdit/Bash.
+5. No regression in any existing test in the workspace (`packages/*`, `plugins/adlc-*`,
+   `scripts/*`, `apps/docs`).
+
+## Verification
+
+```sh
+node --test plugins/adlc-claude-code/lib/test/prosecutor.test.mjs   # RED before impl, GREEN after
+node scripts/claude-code-plugin-smoke.mjs .                          # new command/agent/lib guards
+node --test scripts/test/claude-code-plugin-smoke.test.mjs
+node --test plugins/adlc-claude-code/hooks/test/*.test.mjs           # no regression
+npm test                                                             # full workspace suite
+```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "apps/*"
   ],
   "scripts": {
-    "test": "for d in packages/*/test; do node --test \"$d\"/*.test.mjs || exit 1; done && node --test plugins/adlc-claude-code/hooks/test/*.test.mjs && node --test scripts/test/*.test.mjs && (npx tsc --target es2022 --module nodenext --moduleResolution nodenext --noEmitOnError false --skipLibCheck true --noImplicitAny false --declaration false plugins/adlc-pi/index.ts || true) && node --test plugins/adlc-pi/test/*.test.mjs && node --test plugins/adlc-opencode/test/*.test.mjs && node --test plugins/adlc-cursor/test/*.test.mjs && node scripts/cursor-install-smoke.mjs . && node --test plugins/adlc-antigravity/test/*.test.mjs && node scripts/antigravity-install-smoke.mjs . && node --test apps/docs/test/*.test.mjs",
+    "test": "for d in packages/*/test; do node --test \"$d\"/*.test.mjs || exit 1; done && node --test plugins/adlc-claude-code/hooks/test/*.test.mjs && node --test plugins/adlc-claude-code/lib/test/*.test.mjs && node --test scripts/test/*.test.mjs && (npx tsc --target es2022 --module nodenext --moduleResolution nodenext --noEmitOnError false --skipLibCheck true --noImplicitAny false --declaration false plugins/adlc-pi/index.ts || true) && node --test plugins/adlc-pi/test/*.test.mjs && node --test plugins/adlc-opencode/test/*.test.mjs && node --test plugins/adlc-cursor/test/*.test.mjs && node scripts/cursor-install-smoke.mjs . && node --test plugins/adlc-antigravity/test/*.test.mjs && node scripts/antigravity-install-smoke.mjs . && node --test apps/docs/test/*.test.mjs",
     "release": "node scripts/release.mjs"
   },
   "engines": {

--- a/plugins/adlc-claude-code/agents/prosecutor-contract.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-contract.md
@@ -1,0 +1,26 @@
+---
+name: prosecutor-contract
+description: P5 contract lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for API/schema/type conformance drift against the declared contract in a change diff. Read-only; never invoke to edit code.
+tools: Read, Grep, Glob
+---
+
+# Contract conformance (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in
+the change**, not validate it. Review the change under one lens: **Contract
+conformance**.
+
+Hunt specifically for: API/schema/type drift, backwards-incompatible changes,
+undocumented response shape changes, and violations of the ticket's declared
+contract or shared types.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty array if none). Do
+not soften or speculate beyond the evidence — a finding you cannot ground in the
+diff does not belong.
+
+You have no Edit/Write/Bash tools by design: this lens only reads the diff and
+surrounding code (via Read/Grep/Glob) and reasons about it. It never changes
+anything and never shells out.

--- a/plugins/adlc-claude-code/agents/prosecutor-correctness.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-correctness.md
@@ -1,0 +1,25 @@
+---
+name: prosecutor-correctness
+description: P5 correctness lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for logic errors, broken invariants, and wrong results in a change diff. Read-only; never invoke to edit code.
+tools: Read, Grep, Glob
+---
+
+# Correctness (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in
+the change**, not validate it. Review the change under one lens: **Correctness**.
+
+Hunt specifically for: logic errors, off-by-one and boundary mistakes, broken
+invariants, incorrect results, mishandled error/empty/null cases, and state that
+can desync.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty array if none). Do
+not soften or speculate beyond the evidence — a finding you cannot ground in the
+diff does not belong.
+
+You have no Edit/Write/Bash tools by design: this lens only reads the diff and
+surrounding code (via Read/Grep/Glob) and reasons about it. It never changes
+anything and never shells out.

--- a/plugins/adlc-claude-code/agents/prosecutor-diff.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-diff.md
@@ -1,0 +1,26 @@
+---
+name: prosecutor-diff
+description: P5 spec-vs-implementation diff lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for divergence between the spec/acceptance criteria and the actual implementation. Read-only; never invoke to edit code.
+tools: Read, Grep, Glob
+---
+
+# Spec-vs-implementation diff (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in
+the change**, not validate it. Review the change under one lens:
+**Spec-vs-implementation diff**.
+
+Hunt specifically for: places where the implementation diverges from the
+spec/acceptance criteria, behavior changes not reflected in the spec, and scope
+creep beyond the ticket.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty array if none). Do
+not soften or speculate beyond the evidence — a finding you cannot ground in the
+diff does not belong.
+
+You have no Edit/Write/Bash tools by design: this lens only reads the diff, the
+ticket/spec, and surrounding code (via Read/Grep/Glob) and reasons about it. It
+never changes anything and never shells out.

--- a/plugins/adlc-claude-code/agents/prosecutor-security.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-security.md
@@ -1,0 +1,25 @@
+---
+name: prosecutor-security
+description: P5 security lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for auth/trust-boundary holes, injection, secrets, and unsafe data flow in a change diff. Read-only; never invoke to edit code.
+tools: Read, Grep, Glob
+---
+
+# Security (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in
+the change**, not validate it. Review the change under one lens: **Security**.
+
+Hunt specifically for: auth and trust-boundary holes, injection (SQL/shell/path),
+secrets in code or logs, SSRF, unsafe deserialization, missing input validation at
+boundaries, and who-controls-the-control bypasses.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty array if none). Do
+not soften or speculate beyond the evidence — a finding you cannot ground in the
+diff does not belong.
+
+You have no Edit/Write/Bash tools by design: this lens only reads the diff and
+surrounding code (via Read/Grep/Glob) and reasons about it. It never changes
+anything and never shells out.

--- a/plugins/adlc-claude-code/agents/prosecutor-tests.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-tests.md
@@ -1,0 +1,26 @@
+---
+name: prosecutor-tests
+description: P5 test-audit lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for hollow/mock-only tests and missing coverage of the change's core behavior. Read-only; never invoke to edit code.
+tools: Read, Grep, Glob
+---
+
+# Test audit (ADLC P5 prosecution lens)
+
+You are a hostile pre-merge reviewer. Your only job is to **break confidence in
+the change**, not validate it. Review the change under one lens: **Test audit**.
+
+Hunt specifically for: tests that assert nothing meaningful, mock-only
+verifications, tests that would pass against a broken implementation, missing
+coverage of the change's core behavior, and suppressed/skipped assertions.
+
+For each finding, return an object with: `severity` (critical|high|medium|low),
+`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
+`title`, `body`, `evidence` (quoted verbatim from the diff), and
+`recommendation`. Output only a JSON array of findings (empty array if none). Do
+not soften or speculate beyond the evidence — a finding you cannot ground in the
+diff does not belong.
+
+You have no Edit/Write/Bash tools by design: this lens only reads the diff and
+test files (via Read/Grep/Glob) and reasons about it — it does not run the test
+suite itself (that is `adlc hollow-test`'s job, via the `prosecutor` subagent).
+It never changes anything and never shells out.

--- a/plugins/adlc-claude-code/agents/prosecutor-verifier.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-verifier.md
@@ -1,0 +1,30 @@
+---
+name: prosecutor-verifier
+description: P5 verifier/reproducer — invoked independently by /adlc-prosecute, once per deduped finding, to adversarially confirm or refute it. Read-only; never invoke to edit code.
+tools: Read, Grep, Glob
+---
+
+# Verifier / reproducer (ADLC P5)
+
+You are given ONE prosecution finding (from `prosecutor-correctness`,
+`prosecutor-security`, `prosecutor-contract`, `prosecutor-diff`, or
+`prosecutor-tests`). Your job is to **try to refute it**, not to agree. Default to
+refuted when the evidence is weak or you cannot reproduce the problem from the
+quoted diff.
+
+Steps:
+1. Re-read the finding's evidence in context (use Read/Grep/Glob on the actual
+   file — do not take the quoted evidence on faith).
+2. Construct the most concrete reproduction or counterexample you can.
+3. Decide: is the finding REAL (a genuine defect a maintainer should act on) or
+   REFUTED (false positive, already-handled, or unreproducible)?
+
+Return one JSON object: `{ "real": boolean, "reason": string, "repro": string }`.
+Be specific and mechanistic; "looks fine" is not a reason.
+
+Each finding gets an **independent** verifier invocation (fresh context, no
+memory of other findings' verdicts) — `/adlc-prosecute` runs one call per
+deduped finding and takes a strict majority of the votes it collects for that
+finding (see `survivesVerification` in `lib/prosecutor.mjs`). A finding for which
+no valid verifier vote could be obtained survives as an unverified blocker rather
+than being silently dropped.

--- a/plugins/adlc-claude-code/agents/prosecutor.md
+++ b/plugins/adlc-claude-code/agents/prosecutor.md
@@ -19,6 +19,14 @@ passes · `1` = operational error · `2` = gate fails.
 Prerequisites: `adlc --version` works (else tell the user `npm i -g @adlc/cli`),
 and you are on the branch under review with a clean working tree.
 
+This subagent runs three deterministic gates over the change as a whole. For the
+independent multi-lens adversarial loop (fan-out across five review lenses,
+cross-lens dedupe, independent verifier refutation, loop until two consecutive
+dry rounds) see `/adlc-prosecute` instead — the two are complementary, not
+redundant: this subagent's gates are mechanical (mutation testing, capture/
+compare, recall scoring), while `/adlc-prosecute`'s lenses are independent
+model judgment on the diff.
+
 ## Prosecution sequence
 
 Run the gates that apply to the change. Do not fabricate evidence — if a gate
@@ -84,7 +92,18 @@ After a clean prosecution, record informal provenance with:
 adlc gate-manifest record prosecution --files <changed files>
 ```
 
-**Limitation:** this entry carries `gate: "prosecution"` and does **not** satisfy
-`adlc run p5`. Formal P5 phase assertion requires the Codex path (`adlc prosecute`
-→ `adlc run p5`). If P5 formal assertion is required, use the Codex integration
-or document the assertion gap explicitly.
+**Note:** this subagent's own `gate-manifest record prosecution` entry carries
+`gate: "prosecution"`, which alone does not satisfy `adlc run p5` — that requires
+the runner's `type: "p5-complete"` provenance chain (ticket- and revision-bound,
+two consecutive dry passes). That runner path is harness-agnostic (`adlc
+prosecute` → `adlc run p5`), not exclusive to any one CLI or agent tool.
+
+For the full adversarial engine — independent fan-out across lenses, cross-lens
+dedupe, and independent verifier refutation with loop-until-dry convergence — use
+`/adlc-prosecute`, which invokes the `prosecutor-{correctness,security,contract,
+diff,tests,verifier}` subagents. That command replicates the same fan-out →
+dedupe → independent-verify → repeat-until-two-dry-rounds shape as the OpenCode
+integration's `/adlc-prosecute`, so Claude Code no longer needs to punt to a
+different harness to run the multi-lens loop; it can additionally feed its
+surviving findings to the `adlc prosecute` runner path for formal `adlc run p5`
+phase assertion when that is required.

--- a/plugins/adlc-claude-code/commands/adlc-prosecute.md
+++ b/plugins/adlc-claude-code/commands/adlc-prosecute.md
@@ -1,0 +1,69 @@
+---
+description: Prosecute a change before merge (P5) — fan out five lens subagents, dedupe, independently verify, and loop until dry.
+argument-hint: [ticket-id] (defaults to the active ticket)
+---
+
+# /adlc-prosecute — hostile pre-merge review (P5)
+
+Prosecute the change for the active ticket. Prerequisite: a clean G4 build (rails
+green, build + lint clean, no suppressions) for **$ARGUMENTS** (default to the
+active ticket) on the branch under review with a clean working tree.
+
+This command replicates the multi-lens adversarial loop from the OpenCode
+integration (`plugins/adlc-opencode/command/adlc-prosecute.md`) — fan-out across
+independent lenses, cross-lens dedupe, independent verifier refutation, and
+loop-until-dry convergence — using Claude Code subagents instead of OpenCode's
+`@agent` syntax. The pure dedupe/verify/convergence contract is shared code:
+`plugins/adlc-claude-code/lib/prosecutor.mjs` (unit-tested in
+`plugins/adlc-claude-code/lib/test/prosecutor.test.mjs`).
+
+## 1. Fan out the lenses
+
+Invoke these five prosecution subagents **independently** via the Task tool, each
+given the full change diff for **$ARGUMENTS**: `prosecutor-correctness`,
+`prosecutor-security`, `prosecutor-contract`, `prosecutor-diff`,
+`prosecutor-tests`. Each returns a JSON array of findings (possibly empty) —
+`severity`, `file`, `line_start`, `line_end`, `title`, `body`, `evidence`,
+`recommendation`. Collect every finding from every lens into one list.
+
+## 2. Dedupe
+
+Merge findings across lenses, deduping by file + line range + normalized title
+(`findingKey` in `lib/prosecutor.mjs`), keeping the highest severity when two
+lenses report the same defect (`dedupeFindings`). Do this deterministically —
+do not drop a finding because it "sounds like" another unless the key matches.
+
+## 3. Verify each finding
+
+For each deduped finding, invoke the `prosecutor-verifier` subagent
+**independently** (fresh context, one finding at a time) to try to refute it. A
+finding **survives** only if a strict majority of verification votes confirm it
+real (`survivesVerification`); refuted findings are dropped. A finding with zero
+valid verification votes (verifier crash, timeout, unparseable output) also
+**survives** as an unverified blocker — a pre-merge gate must fail closed, never
+silently drop a finding because the verifier didn't run.
+
+## 4. Loop until dry
+
+Repeat steps 1-3 until two consecutive rounds surface no new confirmed findings
+(`shouldContinue`, `maxDry: 2`). A round is "dry" when it contributes zero net-new
+surviving findings versus the running set; two dry rounds in a row end the loop.
+Cap total rounds at a sane bound (e.g. 5) and report if the loop is cut off before
+going dry — that is itself a finding ("convergence did not complete").
+
+## 5. Record + verdict
+
+Report the surviving findings (severity, file, evidence, recommendation) and a
+ship/no-ship verdict. On CLEAR, record prosecution evidence:
+
+```
+adlc gate-manifest record prosecution --files <changed files>
+```
+
+For formal `adlc run p5` phase assertion (ticket- and revision-bound, dry-pass
+convergence with provenance), use the runner path — harness-agnostic, not
+exclusive to any one CLI: package the surviving/killed findings per lens into the
+`@adlc/prosecute` input shape (see `packages/prosecute/README.md`) and run
+`adlc prosecute --input <file> --ticket <id>` followed by `adlc run p5 --ticket
+<id>`. Material (surviving, non-refuted) findings block the merge regardless of
+which recording path is used.

--- a/plugins/adlc-claude-code/lib/prosecutor.mjs
+++ b/plugins/adlc-claude-code/lib/prosecutor.mjs
@@ -1,0 +1,69 @@
+// prosecutor.mjs — P5 prosecution registry + pure orchestration helpers.
+//
+// Claude Code port of plugins/adlc-opencode/lib/prosecutor.mjs (issue #61). The
+// lenses and verifier are Claude Code subagents (agents/prosecutor-*.md), invoked
+// via the Task tool from /adlc-prosecute. This module is the machine-checkable
+// contract for the fan-out: which lenses exist, how findings are deduped across
+// lenses, and how the verifier's votes decide whether a finding survives. The
+// model calls live in the subagents; the decision logic here is pure and
+// unit-tested — this is what makes the convergence loop *correct*, not just
+// structurally present in a prompt.
+
+/** The five independent prosecution lenses (mirrors the OpenCode registry). */
+export const LENSES = [
+  { key: 'correctness', agent: 'prosecutor-correctness', focus: 'logic errors, broken invariants, wrong results' },
+  { key: 'security', agent: 'prosecutor-security', focus: 'auth/trust boundaries, injection, secrets, unsafe data flow' },
+  { key: 'contract', agent: 'prosecutor-contract', focus: 'API/schema/type conformance against the declared contract' },
+  { key: 'diff', agent: 'prosecutor-diff', focus: 'spec-vs-implementation divergence; unstated behavior changes' },
+  { key: 'tests', agent: 'prosecutor-tests', focus: 'hollow/mock-only tests; are the new tests load-bearing?' },
+];
+
+/** The verifier/reproducer agent that adversarially checks each finding. */
+export const VERIFIER = { key: 'verifier', agent: 'prosecutor-verifier', focus: 'reproduce/refute a finding' };
+
+/** Every shipped prosecution agent id (5 lenses + verifier). */
+export const ALL_AGENTS = [...LENSES.map((l) => l.agent), VERIFIER.agent];
+
+/** Stable key for a finding (file + line range + normalized title). */
+export function findingKey(f) {
+  const title = (f.title ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+  return `${f.file ?? ''}:${f.line_start ?? 0}-${f.line_end ?? 0}:${title}`;
+}
+
+/** Dedupe findings across lenses, keeping the highest-severity instance. */
+export function dedupeFindings(findings) {
+  const SEV = { critical: 4, high: 3, medium: 2, low: 1 };
+  const byKey = new Map();
+  for (const f of findings ?? []) {
+    const k = findingKey(f);
+    const prev = byKey.get(k);
+    if (!prev || (SEV[f.severity] ?? 0) > (SEV[prev.severity] ?? 0)) byKey.set(k, f);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Decide whether a finding survives verification. Votes are the verifier's
+ * independent verdicts ({ real: boolean }). With votes present, a finding survives
+ * if a strict majority confirm it real (default), so a single noisy lens can't
+ * sink a ship and a single weak confirmation can't pass a false one.
+ *
+ * FAIL CLOSED on absent verification: a pre-merge gate must not let a verifier
+ * crash, timeout, or parse failure silently DROP a finding. With zero valid votes
+ * the finding SURVIVES as an unverified blocker — surface it, don't bury it.
+ */
+export function survivesVerification(votes, { threshold = 0.5 } = {}) {
+  const list = (votes ?? []).filter(Boolean);
+  if (!list.length) return true; // unverified → keep as a blocker (fail closed)
+  const real = list.filter((v) => v.real === true).length;
+  return real / list.length > threshold;
+}
+
+/**
+ * Loop-until-dry controller: stop prosecuting once `maxDry` consecutive rounds
+ * surface no new confirmed findings. Pure: caller tracks state, this decides.
+ */
+export function shouldContinue({ freshThisRound, dryStreak, maxDry = 2 }) {
+  const nextDry = freshThisRound > 0 ? 0 : dryStreak + 1;
+  return { continue: nextDry < maxDry, dryStreak: nextDry };
+}

--- a/plugins/adlc-claude-code/lib/test/prosecutor.test.mjs
+++ b/plugins/adlc-claude-code/lib/test/prosecutor.test.mjs
@@ -1,0 +1,113 @@
+// prosecutor.test.mjs — Claude Code port of the P5 prosecution registry + pure
+// orchestration helpers (issue #61). Ported from
+// plugins/adlc-opencode/test/prosecutor.test.mjs so the dedupe/verify/convergence
+// contract stays identical across harnesses; only the shipped-agent frontmatter
+// shape differs (Claude Code: name/description/tools; OpenCode:
+// description/mode/permission). Offline.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  LENSES, VERIFIER, ALL_AGENTS, findingKey, dedupeFindings, survivesVerification, shouldContinue,
+} from '../prosecutor.mjs';
+
+// This test file lives at plugins/adlc-claude-code/lib/test/, two levels below
+// the plugin root (unlike OpenCode's test/ which is one level below its package
+// root) — dirname three times to reach plugins/adlc-claude-code/.
+const PKG = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+// ---- registry ----
+test('registry: 5 lenses + verifier, ids unique', () => {
+  assert.equal(LENSES.length, 5);
+  assert.equal(VERIFIER.agent, 'prosecutor-verifier');
+  assert.equal(ALL_AGENTS.length, 6);
+  assert.equal(new Set(ALL_AGENTS).size, 6);
+  for (const k of ['correctness', 'security', 'contract', 'diff', 'tests']) {
+    assert.ok(LENSES.some((l) => l.key === k), `${k} lens present`);
+  }
+});
+
+test('every registry agent has a shipped agents/*.md file with Claude Code subagent frontmatter', () => {
+  const dir = join(PKG, 'agents');
+  const files = new Set(readdirSync(dir));
+  for (const a of ALL_AGENTS) {
+    assert.ok(files.has(`${a}.md`), `${a}.md shipped`);
+    const body = readFileSync(join(dir, `${a}.md`), 'utf8');
+    // Claude Code subagent frontmatter: name / description / tools (no mode/permission
+    // block — that is OpenCode's convention). name must match the registry agent id.
+    assert.match(body, /^---\n[\s\S]*?name:\s*\S+[\s\S]*?description:\s*\S+[\s\S]*?tools:\s*\S+[\s\S]*?\n---/, `${a}.md has name/description/tools frontmatter`);
+    assert.match(body, new RegExp(`^---\\nname:\\s*${a}\\s*\\n`), `${a}.md frontmatter name matches registry agent id`);
+    // These lenses are hostile read-only reviewers: no Edit/Write/MultiEdit/Bash tool
+    // grant. A lens or the verifier that can edit or shell out could tamper with the
+    // evidence it is supposed to adversarially assess.
+    const frontmatterEnd = body.indexOf('\n---', 4);
+    const frontmatter = body.slice(0, frontmatterEnd);
+    assert.doesNotMatch(frontmatter, /tools:.*\b(Edit|Write|MultiEdit|Bash)\b/, `${a}.md must not grant Edit/Write/MultiEdit/Bash`);
+  }
+});
+
+// ---- dedupeFindings ----
+test('dedupeFindings: collapses same file+line+title, keeps highest severity', () => {
+  const findings = [
+    { file: 'a.mjs', line_start: 10, line_end: 10, title: 'Null deref', severity: 'low' },
+    { file: 'a.mjs', line_start: 10, line_end: 10, title: 'null  deref', severity: 'high' }, // dup (case/space)
+    { file: 'b.mjs', line_start: 5, line_end: 5, title: 'Injection', severity: 'critical' },
+  ];
+  const out = dedupeFindings(findings);
+  assert.equal(out.length, 2);
+  const a = out.find((f) => f.file === 'a.mjs');
+  assert.equal(a.severity, 'high'); // highest kept
+});
+
+test('findingKey normalizes title whitespace + case', () => {
+  assert.equal(
+    findingKey({ file: 'x', line_start: 1, line_end: 2, title: '  Big   Bug ' }),
+    findingKey({ file: 'x', line_start: 1, line_end: 2, title: 'big bug' }),
+  );
+});
+
+test('findingKey treats different line ranges as distinct findings', () => {
+  assert.notEqual(
+    findingKey({ file: 'x', line_start: 1, line_end: 2, title: 'Bug' }),
+    findingKey({ file: 'x', line_start: 3, line_end: 4, title: 'Bug' }),
+  );
+});
+
+// ---- survivesVerification ----
+test('survivesVerification: strict majority of real votes survives', () => {
+  assert.equal(survivesVerification([{ real: true }, { real: true }, { real: false }]), true); // 2/3
+  assert.equal(survivesVerification([{ real: true }, { real: false }]), false); // 1/2 not > 0.5
+  assert.equal(survivesVerification([{ real: false }, { real: false }]), false);
+});
+
+test('survivesVerification: no valid votes → SURVIVES as unverified blocker (fail closed)', () => {
+  // A verifier crash/timeout must NOT silently drop a finding in a pre-merge gate.
+  assert.equal(survivesVerification([]), true);
+  assert.equal(survivesVerification(null), true);
+  assert.equal(survivesVerification([null, undefined]), true); // no valid votes
+});
+
+test('survivesVerification: mixed valid/invalid votes only count the valid ones', () => {
+  // 1 real out of 1 valid vote (the null is discarded, not counted as a "no" vote).
+  assert.equal(survivesVerification([{ real: true }, null]), true);
+});
+
+// ---- shouldContinue (loop until dry) ----
+test('shouldContinue: resets dry streak on fresh findings, stops after maxDry empties', () => {
+  let s = shouldContinue({ freshThisRound: 3, dryStreak: 1, maxDry: 2 });
+  assert.deepEqual(s, { continue: true, dryStreak: 0 });
+  s = shouldContinue({ freshThisRound: 0, dryStreak: 0, maxDry: 2 });
+  assert.deepEqual(s, { continue: true, dryStreak: 1 });
+  s = shouldContinue({ freshThisRound: 0, dryStreak: 1, maxDry: 2 });
+  assert.deepEqual(s, { continue: false, dryStreak: 2 });
+});
+
+test('shouldContinue: two consecutive dry rounds from a cold start stop the loop', () => {
+  let s = shouldContinue({ freshThisRound: 0, dryStreak: 0 });
+  assert.deepEqual(s, { continue: true, dryStreak: 1 });
+  s = shouldContinue({ freshThisRound: 0, dryStreak: s.dryStreak });
+  assert.deepEqual(s, { continue: false, dryStreak: 2 });
+});

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -368,13 +368,94 @@ if (
 }
 
 // --- commands ---
-const requiredCommands = ['adlc-init.md', 'adlc-ticket.md', 'adlc-distill.md', 'adlc-maintain.md'];
+const requiredCommands = ['adlc-init.md', 'adlc-ticket.md', 'adlc-distill.md', 'adlc-maintain.md', 'adlc-prosecute.md'];
 for (const cmd of requiredCommands) {
   if (!existsSync(join(repo, 'plugins/adlc-claude-code/commands', cmd))) fail(`missing plugins/adlc-claude-code/commands/${cmd}`);
 }
 
+// --- adlc-prosecute.md command must actually describe the fan-out/dedupe/verify/loop shape ---
+// (issue #61: parity with plugins/adlc-opencode/command/adlc-prosecute.md — a passing smoke
+// test must not be satisfiable by an empty stub file that merely exists.)
+const prosecuteCmdPath = join(repo, 'plugins/adlc-claude-code/commands/adlc-prosecute.md');
+const prosecuteCmdSource = readFileSync(prosecuteCmdPath, 'utf8');
+if (prosecuteCmdSource.slice(0, 3) !== '---') {
+  fail('plugins/adlc-claude-code/commands/adlc-prosecute.md must begin with YAML frontmatter (---)');
+}
+if (!/^description:\s*\S/m.test(prosecuteCmdSource)) {
+  fail('plugins/adlc-claude-code/commands/adlc-prosecute.md frontmatter missing "description" field');
+}
+const requiredProsecuteMentions = [
+  'prosecutor-correctness', 'prosecutor-security', 'prosecutor-contract', 'prosecutor-diff',
+  'prosecutor-tests', 'prosecutor-verifier',
+];
+for (const name of requiredProsecuteMentions) {
+  if (!prosecuteCmdSource.includes(name)) {
+    fail(`plugins/adlc-claude-code/commands/adlc-prosecute.md must mention the ${name} subagent`);
+  }
+}
+// Must describe all shape elements from the issue, not just fan-out.
+const requiredProsecuteConcepts = [
+  { label: 'dedupe', pattern: /dedup/i },
+  { label: 'independent verification', pattern: /verif/i },
+  { label: 'loop-until-dry convergence', pattern: /dry/i },
+];
+for (const { label, pattern } of requiredProsecuteConcepts) {
+  if (!pattern.test(prosecuteCmdSource)) {
+    fail(`plugins/adlc-claude-code/commands/adlc-prosecute.md must describe ${label}`);
+  }
+}
+
 // --- agents ---
 if (!existsSync(join(repo, 'plugins/adlc-claude-code/agents/prosecutor.md'))) fail('missing plugins/adlc-claude-code/agents/prosecutor.md');
+
+// --- prosecutor-{correctness,security,contract,diff,tests,verifier} lens/verifier subagents ---
+const requiredProsecutionAgents = [
+  'prosecutor-correctness.md', 'prosecutor-security.md', 'prosecutor-contract.md',
+  'prosecutor-diff.md', 'prosecutor-tests.md', 'prosecutor-verifier.md',
+];
+for (const agentFile of requiredProsecutionAgents) {
+  const agentPath = join(repo, 'plugins/adlc-claude-code/agents', agentFile);
+  if (!existsSync(agentPath)) fail(`missing plugins/adlc-claude-code/agents/${agentFile}`);
+  const agentSource = readFileSync(agentPath, 'utf8');
+  const agentName = agentFile.replace(/\.md$/, '');
+  // Claude Code subagent frontmatter: name / description / tools (not OpenCode's
+  // description / mode / permission block).
+  if (!new RegExp(`^---\\nname:\\s*${agentName}\\s*\\n`).test(agentSource)) {
+    fail(`plugins/adlc-claude-code/agents/${agentFile} frontmatter must open with "name: ${agentName}"`);
+  }
+  if (!/\ndescription:\s*\S/.test(agentSource)) {
+    fail(`plugins/adlc-claude-code/agents/${agentFile} frontmatter missing "description" field`);
+  }
+  if (!/\ntools:\s*\S/.test(agentSource)) {
+    fail(`plugins/adlc-claude-code/agents/${agentFile} frontmatter missing "tools" field`);
+  }
+  const frontmatterEnd = agentSource.indexOf('\n---', 4);
+  if (frontmatterEnd === -1) fail(`plugins/adlc-claude-code/agents/${agentFile} frontmatter is unclosed`);
+  const agentFrontmatter = agentSource.slice(0, frontmatterEnd);
+  // These are hostile read-only reviewers (5 lenses + verifier): granting Edit/Write/
+  // MultiEdit/Bash would let a "reviewer" tamper with the code or tests it is supposed
+  // to adversarially assess, or silently mutate evidence instead of just reporting it.
+  if (/tools:.*\b(Edit|Write|MultiEdit|Bash)\b/.test(agentFrontmatter)) {
+    fail(`plugins/adlc-claude-code/agents/${agentFile} must not grant Edit/Write/MultiEdit/Bash tools (read-only prosecution lens)`);
+  }
+}
+
+// --- lib/prosecutor.mjs: the pure dedupe/verify/convergence contract must exist and be
+// wired into the workspace test suite, not just present as an inert file ---
+const prosecutorLibPath = join(repo, 'plugins/adlc-claude-code/lib/prosecutor.mjs');
+if (!existsSync(prosecutorLibPath)) fail('missing plugins/adlc-claude-code/lib/prosecutor.mjs');
+const prosecutorLibSource = readFileSync(prosecutorLibPath, 'utf8');
+for (const exportName of ['LENSES', 'VERIFIER', 'ALL_AGENTS', 'findingKey', 'dedupeFindings', 'survivesVerification', 'shouldContinue']) {
+  if (!new RegExp(`export (const|function) ${exportName}\\b`).test(prosecutorLibSource)) {
+    fail(`plugins/adlc-claude-code/lib/prosecutor.mjs must export ${exportName}`);
+  }
+}
+const prosecutorLibTestPath = join(repo, 'plugins/adlc-claude-code/lib/test/prosecutor.test.mjs');
+if (!existsSync(prosecutorLibTestPath)) fail('missing plugins/adlc-claude-code/lib/test/prosecutor.test.mjs');
+const rootPackageJson = readJson(join(repo, 'package.json'));
+if (!(rootPackageJson.scripts?.test ?? '').includes('plugins/adlc-claude-code/lib/test')) {
+  fail('root package.json "test" script must run plugins/adlc-claude-code/lib/test/*.test.mjs so the prosecution convergence contract is exercised in CI');
+}
 
 // --- plugins/adlc-claude-code/skills/adlc/SKILL.md + frontmatter + sentinel ---
 const skillPath = join(repo, 'plugins/adlc-claude-code/skills/adlc/SKILL.md');
@@ -427,7 +508,8 @@ console.log(JSON.stringify({
   hooksJson: hooksConfigPath,
   hookTypes: Object.keys(hooks),
   commands: requiredCommands,
-  agents: ['prosecutor.md'],
+  agents: ['prosecutor.md', ...requiredProsecutionAgents],
+  lib: ['prosecutor.mjs'],
   skills: ['adlc/SKILL.md'],
   docs: requiredDocs,
   warnings: [


### PR DESCRIPTION
## Summary

Fixes #61

Harness parity between the Claude Code and OpenCode ADLC plugins was inverted for P5 (pre-merge prosecution): OpenCode's `/adlc-prosecute` ran a real multi-round adversarial loop (fan out five independent lenses, dedupe findings across lenses, independently verify each deduped finding, repeat until two consecutive dry rounds), while Claude Code's `prosecutor` subagent ran three deterministic gates sequentially — no dedupe, no independent verifier-refutation, no convergence loop — and its own text admitted it did not satisfy formal P5 and punted to the Codex path.

This ports the OpenCode multi-lens loop into `plugins/adlc-claude-code/`:

- `commands/adlc-prosecute.md` — new `/adlc-prosecute` command implementing fan-out → dedupe → independent-verify → loop-until-dry, mirroring `plugins/adlc-opencode/command/adlc-prosecute.md`.
- `agents/prosecutor-{correctness,security,contract,diff,tests,verifier}.md` — six new read-only Claude Code subagents (`tools: Read, Grep, Glob`, no Edit/Write/MultiEdit/Bash), adapted from the six OpenCode lens prompts to Claude Code's `name`/`description`/`tools` frontmatter convention.
- `lib/prosecutor.mjs` — pure, unit-tested dedupe/verify/convergence contract (`findingKey`, `dedupeFindings`, `survivesVerification`, `shouldContinue`), ported so the decision logic — not just prompt text — matches OpenCode's registry: fail-closed on unverified findings, strict-majority survival, two-consecutive-dry-round termination.
- `agents/prosecutor.md` — the old lines 87-90 caveat (claiming Claude Code can't satisfy the multi-lens loop and must punt to Codex) is rewritten to point at `/adlc-prosecute`, clarifying that formal `adlc run p5` assertion is a harness-agnostic runner path, not exclusive to one CLI.
- `docs/integrations/claude-code.md` — updated commands table, prosecutor section, lifecycle coverage table, and Gaps section to match.
- `scripts/claude-code-plugin-smoke.mjs` — extended to assert the new command and six agent files exist, are well-formed, grant no Edit/Write/MultiEdit/Bash on the lenses/verifier, and that `lib/prosecutor.mjs` exports the full contract.
- `docs/specs/claude-code-prosecutor-parity.md` — spec doc for the change.

Review outcome: SHIPPED — 2 consecutive clean adversarial-review rounds (0 findings each).

## Test plan

- [x] `node --test plugins/adlc-claude-code/lib/test/prosecutor.test.mjs` — 10/10 pass (dedupe, findingKey normalization, survivesVerification fail-closed/strict-majority, shouldContinue dry-streak termination)
- [x] `node scripts/claude-code-plugin-smoke.mjs .` — passes; new command/agent/lib guards green
- [x] `node --test plugins/adlc-claude-code/hooks/test/*.test.mjs` — no regression
- [x] `npm test` (full workspace suite: packages/*, plugins/adlc-*, apps/docs, scripts) — all green, no regressions