### PR TITLE
fix(review-calibration): judge/reviewer provider-independence guard

### DIFF
--- a/docs/specs/review-calibration-provider-guard.md
+++ b/docs/specs/review-calibration-provider-guard.md
@@ -43,4 +43,4 @@ node --test test/review-calibration.test.mjs
 npm test   # full package suite (all *.test.mjs)
 ```
 
-All of the above pass (85/85 tests across the three files as of this change).
+All of the above pass (98/98 tests across the three files as of this change).

--- a/docs/specs/review-calibration-provider-guard.md
+++ b/docs/specs/review-calibration-provider-guard.md
@@ -1,0 +1,46 @@
+# Spec — review-calibration provider-independence guard (issue #64)
+
+## Issue
+
+`packages/review-calibration` resolves its LLM judge via the same auto-detect
+provider path as everything else in the toolkit (`detectProvider`/`complete` from
+`@adlc/core`), while the reviewer-under-test runs as an opaque subprocess via
+`--review-cmd`. Nothing compared the two, so the tool's core claim — "who reviews
+the reviewer" — could be silently satisfied by the judge and the reviewer being the
+same model family, defeating the cross-model independence rationale in ADR-0007.
+The issue also noted `lib/*.mjs` (1032 lines, 8 files) was covered by exactly one
+monolithic test file.
+
+## Acceptance criteria
+
+- A new `--review-provider <name>` flag lets the caller declare which
+  provider/model family `--review-cmd` actually runs on (the subprocess can't be
+  introspected generically).
+- The declared `--review-provider` is compared (case-insensitively, with common
+  aliases like `claude`→`anthropic`, `gpt`→`openai`, `google`→`gemini`) against the
+  judge's resolved provider (`detectProvider().name`).
+- If they match: warn to stderr by default (gate still governed by recall/precision);
+  with `--strict`, gate-fail with exit code 2 instead.
+- `--strict` without `--review-provider` is an operational error (exit 1) — there is
+  nothing to compare.
+- If `--review-provider` is omitted, no comparison is attempted and no warning is
+  printed (unchanged behavior).
+- Dedicated per-concern test files exist for `lib/judge.mjs` and `lib/scorer.mjs`
+  (`test/judge.test.mjs`, `test/scorer.test.mjs`), matching the one-file-per-concern
+  pattern used in `packages/gate-fuzzing/test/*.test.mjs`. The prior monolithic
+  `test/review-calibration.test.mjs` no longer duplicates those unit tests; it keeps
+  CLI/E2E and other-module coverage (including new CLI-level tests for the guard).
+- Full REDESIGN.md v2 migration (plant/defect/witness schema) is explicitly out of
+  scope for this branch — see `packages/review-calibration/REDESIGN.md`.
+
+## Verification commands
+
+```bash
+cd packages/review-calibration
+node --test test/judge.test.mjs
+node --test test/scorer.test.mjs
+node --test test/review-calibration.test.mjs
+npm test   # full package suite (all *.test.mjs)
+```
+
+All of the above pass (85/85 tests across the three files as of this change).

--- a/packages/review-calibration/bin/review-calibration.mjs
+++ b/packages/review-calibration/bin/review-calibration.mjs
@@ -19,7 +19,9 @@ import { filterCodeFiles, selectPlants, loadPlantsFile } from '../lib/targets.mj
 import { runWithPlants } from '../lib/runner.mjs';
 import { parseFindings } from '../lib/findings.mjs';
 import { scorePlants } from '../lib/scorer.mjs';
-import { makeLlmJudge, referenceJudge, JUDGE_SYSTEM, buildJudgePrompt } from '../lib/judge.mjs';
+import {
+  makeLlmJudge, referenceJudge, JUDGE_SYSTEM, buildJudgePrompt, checkProviderIndependence,
+} from '../lib/judge.mjs';
 import { filterEquivalentMutants } from '../lib/verify.mjs';
 import { echoReviewer, oracleReviewer } from '../lib/controls.mjs';
 import { printScorecard, buildJsonReport } from '../lib/report.mjs';
@@ -37,6 +39,8 @@ const { values } = parseArgs({
     files:          { type: 'string' },
     'plants-file':  { type: 'string' },
     tier:           { type: 'string', default: 'cheap' },
+    'review-provider': { type: 'string' },
+    strict:         { type: 'boolean', default: false },
     json:           { type: 'boolean', default: false },
     'prompt-only':  { type: 'boolean', default: false },
     help:           { type: 'boolean', default: false },
@@ -68,6 +72,17 @@ Options:
   --plants-file <path>  JSON array of authored plants:
                         [{file,line,original,mutated,category?,defect?,witness?}]
   --tier cheap|mid|frontier  Model tier for the LLM judge (default: cheap)
+  --review-provider <name>  Provider/model family the --review-cmd subprocess
+                        actually uses (e.g. anthropic, openai, gemini). The
+                        subprocess can't be introspected generically, so the
+                        caller must state it. Compared against the judge's
+                        own resolved provider — if they match, the "who
+                        reviews the reviewer" independence claim is
+                        undermined (same-family blind spots go undetected).
+                        Warns by default; see --strict.
+  --strict              Gate-fail (exit 2) instead of warning when
+                        --review-provider matches the judge's resolved
+                        provider. Requires --review-provider.
   --json                Machine-readable JSON output
   --prompt-only         Print a representative judge prompt and exit 0 (no
                         API key or git repo needed)
@@ -77,7 +92,7 @@ Exit codes:
   0  Recall (and precision, if set) meet thresholds
   1  Operational error (dirty tree, no plants, review crashed, no judge available,
      or the scorer's own control self-test failed)
-  2  Recall/precision below thresholds (gate fails)
+  2  Recall/precision below thresholds (gate fails), or --strict provider match
 
 ADLC phase: P5 meta-gate — "who reviews the reviewer"
 `;
@@ -129,6 +144,8 @@ const filesFlag  = values.files ?? '';
 const tier       = values.tier;
 const useJson    = values.json;
 const cwd        = process.cwd();
+const reviewProvider = values['review-provider'];
+const strict     = values.strict;
 
 if (isNaN(maxPlants) || maxPlants < 1)  opError('--plants must be a positive integer');
 if (isNaN(minRecall) || minRecall < 0 || minRecall > 1) opError('--min-recall must be between 0 and 1');
@@ -137,6 +154,9 @@ if (minPrecision != null && (isNaN(minPrecision) || minPrecision < 0 || minPreci
 }
 if (scorerMode !== 'judge' && scorerMode !== 'string') {
   opError(`--scorer must be "judge" or "string" (got "${scorerMode}")`);
+}
+if (strict && !reviewProvider) {
+  opError('--strict requires --review-provider — nothing to compare the judge against');
 }
 
 // ── safety checks ────────────────────────────────────────────────────────────
@@ -147,6 +167,7 @@ if (isDirty(cwd)) opError('commit or stash first — review-calibration plants b
 // ── resolve the judge BEFORE expensive work (fail closed, never string-match silently) ──
 
 let judge;
+let judgeProviderName;
 if (scorerMode === 'string') {
   console.error(
     'WARNING: --scorer string is location-only and is defeated by a reviewer that ' +
@@ -155,13 +176,37 @@ if (scorerMode === 'string') {
   );
   judge = () => true; // any locating finding counts — the gameable legacy behavior
 } else {
-  if (!detectProvider()) {
+  const judgeProvider = detectProvider();
+  if (!judgeProvider) {
     opError(
       'no LLM provider for the judge — set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY, ' +
       'or pass --scorer string (gameable, warned). Refusing to emit a string-matched recall number.'
     );
   }
+  judgeProviderName = judgeProvider.name;
   judge = makeLlmJudge(coreComplete, coreExtractJson, tier);
+}
+
+// ── provider-independence guard (issue #64) ──────────────────────────────────
+// "Who reviews the reviewer" is undermined if the judge and the reviewer
+// under test (--review-cmd, an opaque subprocess we cannot introspect) are
+// silently the same model family. --review-provider is the caller's explicit
+// declaration of what --review-cmd actually runs on.
+
+const independence = checkProviderIndependence(reviewProvider, judgeProviderName);
+if (independence.same) {
+  const msg =
+    `judge and --review-provider are both "${judgeProviderName}" — the reviewer-under-test ` +
+    'and the judge scoring it share the same model family, undermining the "who reviews ' +
+    'the reviewer" independence this gate exists to check';
+  if (strict) {
+    gateFail(msg);
+  } else {
+    console.error(
+      `WARNING: ${msg}. Use --strict to fail the gate on this, or pass --review-provider ` +
+      'for a provider different from the judge\'s.'
+    );
+  }
 }
 
 // ── select plants ────────────────────────────────────────────────────────────

--- a/packages/review-calibration/bin/review-calibration.mjs
+++ b/packages/review-calibration/bin/review-calibration.mjs
@@ -21,6 +21,7 @@ import { parseFindings } from '../lib/findings.mjs';
 import { scorePlants } from '../lib/scorer.mjs';
 import {
   makeLlmJudge, referenceJudge, JUDGE_SYSTEM, buildJudgePrompt, checkProviderIndependence,
+  resolveEffectiveProvider,
 } from '../lib/judge.mjs';
 import { filterEquivalentMutants } from '../lib/verify.mjs';
 import { echoReviewer, oracleReviewer } from '../lib/controls.mjs';
@@ -183,7 +184,11 @@ if (scorerMode === 'string') {
       'or pass --scorer string (gameable, warned). Refusing to emit a string-matched recall number.'
     );
   }
-  judgeProviderName = judgeProvider.name;
+  // agy's actual model family is tier-dependent (e.g. --tier cheap runs
+  // Gemini, --tier mid/frontier run Claude/anthropic) — resolve to the
+  // family it will really dispatch to, not the literal 'agy' provider name,
+  // so the independence guard below can't be silently defeated (issue #64).
+  judgeProviderName = resolveEffectiveProvider(judgeProvider, tier);
   judge = makeLlmJudge(coreComplete, coreExtractJson, tier);
 }
 

--- a/packages/review-calibration/lib/judge.mjs
+++ b/packages/review-calibration/lib/judge.mjs
@@ -110,3 +110,48 @@ export async function calibrateJudge(fixture, judge) {
   const n = fixture.length;
   return { agreement: n > 0 ? agree / n : 0, n, disagreements };
 }
+
+// ── provider-independence guard (issue #64) ───────────────────────────────────
+// The judge is resolved through the same auto-detect provider path as
+// everything else in the toolkit, while the reviewer-under-test runs as an
+// opaque subprocess via --review-cmd — it can't be introspected generically.
+// The caller states its provider explicitly via --review-provider; this
+// compares that declaration against the judge's resolved provider so the
+// "who reviews the reviewer" claim can't be silently satisfied by the same
+// model family reviewing itself.
+
+/** Known aliases that name the same provider family as `detectProvider`. */
+const PROVIDER_ALIASES = {
+  claude: 'anthropic',
+  gpt: 'openai',
+  gpt4: 'openai',
+  chatgpt: 'openai',
+  google: 'gemini',
+};
+
+function normalizeProviderName(name) {
+  const n = String(name).trim().toLowerCase();
+  return PROVIDER_ALIASES[n] ?? n;
+}
+
+/**
+ * Compare the caller-declared reviewer-under-test provider against the
+ * judge's resolved provider. Neither side can be compared if undeclared
+ * (a missing --review-provider, or a judge that isn't LLM-backed, e.g.
+ * --scorer string) — in that case `same` is false because no comparison was
+ * possible, not because independence was verified.
+ *
+ * @param {string|undefined} reviewProvider  caller-declared --review-provider value
+ * @param {string|undefined} judgeProvider   judge's resolved provider name (detectProvider().name)
+ * @returns {{ same: boolean, reviewProvider: string|undefined, judgeProvider: string|undefined }}
+ */
+export function checkProviderIndependence(reviewProvider, judgeProvider) {
+  if (!reviewProvider || !judgeProvider) {
+    return { same: false, reviewProvider, judgeProvider };
+  }
+  return {
+    same: normalizeProviderName(reviewProvider) === normalizeProviderName(judgeProvider),
+    reviewProvider,
+    judgeProvider,
+  };
+}

--- a/packages/review-calibration/lib/judge.mjs
+++ b/packages/review-calibration/lib/judge.mjs
@@ -4,6 +4,8 @@
 // (find the bug) — the generator–verifier gap — so a cheap model judges well.
 // The judge is itself calibrated against a labeled fixture (calibrateJudge).
 
+import { resolveModel } from '@adlc/core';
+
 /**
  * A judge is `async (plant, finding) => boolean` — true iff the finding
  * identifies the plant's defect.
@@ -121,17 +123,17 @@ export async function calibrateJudge(fixture, judge) {
 // model family reviewing itself.
 
 /** Known aliases that name the same provider family as `detectProvider`. */
-const PROVIDER_ALIASES = {
-  claude: 'anthropic',
-  gpt: 'openai',
-  gpt4: 'openai',
-  chatgpt: 'openai',
-  google: 'gemini',
-};
+const PROVIDER_ALIASES = new Map([
+  ['claude', 'anthropic'],
+  ['gpt', 'openai'],
+  ['gpt4', 'openai'],
+  ['chatgpt', 'openai'],
+  ['google', 'gemini'],
+]);
 
 function normalizeProviderName(name) {
   const n = String(name).trim().toLowerCase();
-  return PROVIDER_ALIASES[n] ?? n;
+  return PROVIDER_ALIASES.get(n) ?? n;
 }
 
 /**
@@ -176,19 +178,32 @@ const MODEL_FAMILY_PATTERNS = [
  * declared --review-provider, silently defeating the guard exactly when agy is
  * transparently running the same model family as the reviewer-under-test.
  *
- * Resolves by inspecting the actual model name for the given tier and matching
- * it against known family substrings. Falls back to the literal provider name
- * (never silently claims independence) when the provider isn't 'agy' or its
- * model name doesn't match a known family.
+ * Resolves the ACTUAL model id `complete()` will dispatch to — via core's
+ * `resolveModel`, which checks `ADLC_MODEL_<TIER>` env overrides FIRST and only
+ * falls back to the provider's static `models[tier]` table when unset — then
+ * matches that model id against known family substrings. Using the static
+ * table directly (without the override) would let an operator's
+ * `ADLC_MODEL_MID=<openai-model>` override silently defeat the guard: the judge
+ * would actually run on OpenAI while this function kept reporting 'anthropic'.
+ * Falls back to the literal provider name (never silently claims independence)
+ * when the provider isn't 'agy' or its resolved model name doesn't match a
+ * known family.
  *
  * @param {{name: string, models?: Record<string,string>}|null|undefined} provider  detectProvider() result
  * @param {string} tier
+ * @param {NodeJS.ProcessEnv} [env]  defaults to process.env; accepts ADLC_MODEL_<TIER> overrides
  * @returns {string|undefined}
  */
-export function resolveEffectiveProvider(provider, tier) {
+export function resolveEffectiveProvider(provider, tier, env = process.env) {
   if (!provider) return undefined;
   if (provider.name !== 'agy') return provider.name;
-  const model = String(provider.models?.[tier] ?? '').toLowerCase();
+  let modelId;
+  try {
+    modelId = resolveModel(provider, { tier }, env);
+  } catch {
+    return provider.name; // unknown tier — fall back, don't guess a match
+  }
+  const model = String(modelId ?? '').toLowerCase();
   for (const [pattern, family] of MODEL_FAMILY_PATTERNS) {
     if (pattern.test(model)) return family;
   }

--- a/packages/review-calibration/lib/judge.mjs
+++ b/packages/review-calibration/lib/judge.mjs
@@ -155,3 +155,42 @@ export function checkProviderIndependence(reviewProvider, judgeProvider) {
     judgeProvider,
   };
 }
+
+/** Substring → family, checked against the actual model name agy dispatches to. */
+const MODEL_FAMILY_PATTERNS = [
+  [/claude/, 'anthropic'],
+  [/gemini/, 'gemini'],
+  [/gpt/, 'openai'],
+];
+
+/**
+ * Resolve the judge's EFFECTIVE provider family for `checkProviderIndependence`.
+ *
+ * `detectProvider().name` is a literal identifier ('anthropic' | 'openai' |
+ * 'gemini' | 'agy') — accurate for the three API-key providers, whose name
+ * already equals the model family they call. The 'agy' provider is different:
+ * it proxies to the Antigravity CLI, whose ACTUAL model family is tier-dependent
+ * (see packages/core/lib/llm.mjs PROVIDERS[3].models — models.cheap is
+ * Gemini-family while models.mid/frontier are Claude/anthropic-family). Passing
+ * the literal string 'agy' into checkProviderIndependence would never match a
+ * declared --review-provider, silently defeating the guard exactly when agy is
+ * transparently running the same model family as the reviewer-under-test.
+ *
+ * Resolves by inspecting the actual model name for the given tier and matching
+ * it against known family substrings. Falls back to the literal provider name
+ * (never silently claims independence) when the provider isn't 'agy' or its
+ * model name doesn't match a known family.
+ *
+ * @param {{name: string, models?: Record<string,string>}|null|undefined} provider  detectProvider() result
+ * @param {string} tier
+ * @returns {string|undefined}
+ */
+export function resolveEffectiveProvider(provider, tier) {
+  if (!provider) return undefined;
+  if (provider.name !== 'agy') return provider.name;
+  const model = String(provider.models?.[tier] ?? '').toLowerCase();
+  for (const [pattern, family] of MODEL_FAMILY_PATTERNS) {
+    if (pattern.test(model)) return family;
+  }
+  return provider.name; // unrecognized model name — fall back, don't guess a match
+}

--- a/packages/review-calibration/test/judge.test.mjs
+++ b/packages/review-calibration/test/judge.test.mjs
@@ -125,6 +125,20 @@ describe('checkProviderIndependence', () => {
     assert.equal(checkProviderIndependence('anthropic', undefined).same, false);
     assert.equal(checkProviderIndependence(undefined, undefined).same, false);
   });
+
+  it('is NOT defeated by a "--review-provider __proto__" prototype-pollution bypass', () => {
+    // A plain-object alias lookup (`ALIASES[n] ?? n`) resolves '__proto__' to
+    // Object.prototype (a non-nullish value), so the `??` fallback never
+    // fires and normalization silently returns an object instead of a
+    // string. An object is never === a string, so `same` would always be
+    // false for '__proto__' regardless of the true underlying provider —
+    // silently defeating both the warning and --strict. PROVIDER_ALIASES
+    // must be looked up in a way immune to this (e.g. a Map), so '__proto__'
+    // is treated like any other unrecognized name and normalizes to itself.
+    const bypassAttempt = checkProviderIndependence('__proto__', '__proto__');
+    assert.equal(bypassAttempt.same, true); // both sides identical -> correctly flagged
+    assert.equal(checkProviderIndependence('__proto__', 'anthropic').same, false);
+  });
 });
 
 // ── resolveEffectiveProvider (agy tier-dependent model family, issue #64) ─────
@@ -173,5 +187,25 @@ describe('resolveEffectiveProvider', () => {
     const effective = resolveEffectiveProvider(agyProvider, 'mid');
     const result = checkProviderIndependence('anthropic', effective);
     assert.equal(result.same, true);
+  });
+
+  // packages/core/lib/llm.mjs resolveModel() checks env[`ADLC_MODEL_${TIER}`]
+  // BEFORE falling back to provider.models[tier] — this is what complete()
+  // actually dispatches to. Reading the static table alone (ignoring the
+  // override) would let ADLC_MODEL_MID=<openai model> silently defeat the
+  // guard: the judge really runs on OpenAI while this function kept
+  // reporting 'anthropic' from the stale static default.
+  it('honors an ADLC_MODEL_MID override, not just the static default table', () => {
+    const env = { ADLC_MODEL_MID: 'gpt-5.1-some-openai-model' };
+    assert.equal(resolveEffectiveProvider(agyProvider, 'mid', env), 'openai');
+  });
+
+  it('honors an ADLC_MODEL_CHEAP override matching a different family than the default', () => {
+    const env = { ADLC_MODEL_CHEAP: 'claude-haiku-4-5' };
+    assert.equal(resolveEffectiveProvider(agyProvider, 'cheap', env), 'anthropic');
+  });
+
+  it('falls back to the static table when no override env is set', () => {
+    assert.equal(resolveEffectiveProvider(agyProvider, 'mid', {}), 'anthropic');
   });
 });

--- a/packages/review-calibration/test/judge.test.mjs
+++ b/packages/review-calibration/test/judge.test.mjs
@@ -1,0 +1,128 @@
+// review-calibration/test/judge.test.mjs
+// Dedicated coverage for lib/judge.mjs: the LLM judge, its deterministic
+// reference double, calibration against labeled fixtures, and the
+// provider-independence guard (issue #64 — "who reviews the reviewer" must
+// not be satisfiable by the judge and the reviewer-under-test sharing a
+// model family).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  referenceJudge, defectTokens, calibrateJudge, makeLlmJudge,
+  checkProviderIndependence,
+} from '../lib/judge.mjs';
+
+// ── referenceJudge / defectTokens ─────────────────────────────────────────────
+
+describe('referenceJudge / defectTokens', () => {
+  const plant = {
+    file: 'src/auth.mjs', line: 5, category: 'logic-inversion',
+    defect: 'Inverted comparison: the conditional now matches the opposite case.',
+    original: 'if (x > 0)', mutated: 'if (x <= 0)',
+  };
+
+  it('extracts content tokens from the defect text', () => {
+    const t = defectTokens(plant);
+    assert.ok(t.includes('inverted'));
+    assert.ok(t.includes('comparison'));
+    assert.ok(!t.includes('the')); // stopword / too short
+  });
+
+  it('accepts a finding that describes the defect', () => {
+    assert.equal(referenceJudge(plant, { description: 'The comparison is inverted, matching the opposite case' }), true);
+  });
+
+  it('REJECTS a content-free echo finding (this is the whole fix)', () => {
+    assert.equal(referenceJudge(plant, { description: 'auth.mjs:5 changed' }), false);
+  });
+
+  it('rejects a finding quoting only the raw mutated line with no defect claim', () => {
+    assert.equal(referenceJudge(plant, { description: 'if (x <= 0)' }), false);
+  });
+});
+
+// ── calibrateJudge ────────────────────────────────────────────────────────────
+
+describe('calibrateJudge', () => {
+  it('measures agreement of a judge against labeled pairs', async () => {
+    const p = { defect: 'Inverted comparison opposite case.', category: 'logic-inversion' };
+    const fixture = [
+      { plant: p, finding: { description: 'comparison inverted, opposite case' }, expected: true },
+      { plant: p, finding: { description: 'a.mjs:1 changed' }, expected: false },
+      { plant: p, finding: { description: 'the comparison is now inverted' }, expected: true },
+    ];
+    const { agreement, n } = await calibrateJudge(fixture, referenceJudge);
+    assert.equal(n, 3);
+    assert.equal(agreement, 1); // reference judge agrees with all three labels
+  });
+
+  it('reports disagreements when the judge is wrong', async () => {
+    const p = { defect: 'Off-by-one boundary error.', category: 'off-by-one' };
+    const alwaysTrue = () => true;
+    const fixture = [{ plant: p, finding: { description: 'noise' }, expected: false }];
+    const { agreement, disagreements } = await calibrateJudge(fixture, alwaysTrue);
+    assert.equal(agreement, 0);
+    assert.equal(disagreements.length, 1);
+  });
+});
+
+// ── makeLlmJudge (injected completion, no network) ────────────────────────────
+
+describe('makeLlmJudge', () => {
+  it('builds the judge prompt from plant + finding and parses {match}', async () => {
+    let seen;
+    const completeFn = async (opts) => { seen = opts; return '{"match": true}'; };
+    const extractJsonFn = (t) => JSON.parse(t);
+    const judge = makeLlmJudge(completeFn, extractJsonFn);
+    const plant = { file: 'a.mjs', line: 5, category: 'off-by-one', defect: 'boundary shifted', original: 'i<=n', mutated: 'i<n' };
+    const finding = { file: 'a.mjs', line: 5, description: 'loop misses last element' };
+    const out = await judge(plant, finding);
+    assert.equal(out, true);
+    assert.equal(seen.tier, 'cheap');
+    assert.ok(seen.prompt.includes('boundary shifted'));
+    assert.ok(seen.prompt.includes('loop misses last element'));
+  });
+
+  it('returns false when the model does not answer match:true', async () => {
+    const judge = makeLlmJudge(async () => '{"match": false}', (t) => JSON.parse(t));
+    assert.equal(await judge({ defect: 'x' }, { description: 'y' }), false);
+  });
+});
+
+// ── checkProviderIndependence (issue #64) ─────────────────────────────────────
+// The judge is resolved via the same auto-detect path as everything else, while
+// the reviewer-under-test runs as an opaque subprocess via --review-cmd. Nothing
+// compared the two, so "who reviews the reviewer" could silently be satisfied by
+// the same model family reviewing itself. --review-provider lets the caller
+// state the reviewer's provider explicitly (the subprocess can't be introspected
+// generically); this guard compares it against the judge's resolved provider.
+
+describe('checkProviderIndependence', () => {
+  it('flags same-family judge and reviewer as NOT independent', () => {
+    const result = checkProviderIndependence('anthropic', 'anthropic');
+    assert.equal(result.same, true);
+    assert.equal(result.reviewProvider, 'anthropic');
+    assert.equal(result.judgeProvider, 'anthropic');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    assert.equal(checkProviderIndependence(' Anthropic ', 'anthropic').same, true);
+    assert.equal(checkProviderIndependence('OPENAI', 'openai').same, true);
+  });
+
+  it('treats known aliases as the same family (claude -> anthropic, gpt -> openai)', () => {
+    assert.equal(checkProviderIndependence('claude', 'anthropic').same, true);
+    assert.equal(checkProviderIndependence('gpt', 'openai').same, true);
+  });
+
+  it('does not flag genuinely different providers', () => {
+    const result = checkProviderIndependence('openai', 'anthropic');
+    assert.equal(result.same, false);
+  });
+
+  it('cannot flag anything when either side is undeclared (no comparison possible)', () => {
+    assert.equal(checkProviderIndependence(undefined, 'anthropic').same, false);
+    assert.equal(checkProviderIndependence('anthropic', undefined).same, false);
+    assert.equal(checkProviderIndependence(undefined, undefined).same, false);
+  });
+});

--- a/packages/review-calibration/test/judge.test.mjs
+++ b/packages/review-calibration/test/judge.test.mjs
@@ -9,7 +9,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   referenceJudge, defectTokens, calibrateJudge, makeLlmJudge,
-  checkProviderIndependence,
+  checkProviderIndependence, resolveEffectiveProvider,
 } from '../lib/judge.mjs';
 
 // ── referenceJudge / defectTokens ─────────────────────────────────────────────
@@ -124,5 +124,54 @@ describe('checkProviderIndependence', () => {
     assert.equal(checkProviderIndependence(undefined, 'anthropic').same, false);
     assert.equal(checkProviderIndependence('anthropic', undefined).same, false);
     assert.equal(checkProviderIndependence(undefined, undefined).same, false);
+  });
+});
+
+// ── resolveEffectiveProvider (agy tier-dependent model family, issue #64) ─────
+// detectProvider().name for the 'agy' provider is the literal string 'agy',
+// but agy proxies to a tier-dependent underlying model family (Gemini on
+// --tier cheap, Claude/anthropic on --tier mid/frontier per
+// packages/core/lib/llm.mjs PROVIDERS[3].models). Comparing the literal
+// 'agy' string against a declared --review-provider would never match even
+// when the judge and reviewer-under-test are genuinely the same family.
+
+describe('resolveEffectiveProvider', () => {
+  const agyProvider = {
+    name: 'agy',
+    models: {
+      cheap: 'Gemini 3.5 Flash (Medium)',
+      mid: 'Claude Sonnet 4.6 (Thinking)',
+      frontier: 'Claude Opus 4.6 (Thinking)',
+    },
+  };
+
+  it('resolves agy + mid/frontier tier to anthropic (Claude model)', () => {
+    assert.equal(resolveEffectiveProvider(agyProvider, 'mid'), 'anthropic');
+    assert.equal(resolveEffectiveProvider(agyProvider, 'frontier'), 'anthropic');
+  });
+
+  it('resolves agy + cheap tier to gemini (Gemini model)', () => {
+    assert.equal(resolveEffectiveProvider(agyProvider, 'cheap'), 'gemini');
+  });
+
+  it('leaves non-agy providers untouched (name already equals its family)', () => {
+    assert.equal(resolveEffectiveProvider({ name: 'anthropic', models: {} }, 'mid'), 'anthropic');
+    assert.equal(resolveEffectiveProvider({ name: 'openai', models: {} }, 'cheap'), 'openai');
+  });
+
+  it('falls back to the literal name for an unrecognized agy model mapping', () => {
+    const unknown = { name: 'agy', models: { mid: 'Some Future Model X' } };
+    assert.equal(resolveEffectiveProvider(unknown, 'mid'), 'agy');
+  });
+
+  it('returns undefined for a missing provider', () => {
+    assert.equal(resolveEffectiveProvider(null, 'mid'), undefined);
+    assert.equal(resolveEffectiveProvider(undefined, 'mid'), undefined);
+  });
+
+  it('end-to-end: agy at mid tier now correctly flags as same-family as anthropic', () => {
+    const effective = resolveEffectiveProvider(agyProvider, 'mid');
+    const result = checkProviderIndependence('anthropic', effective);
+    assert.equal(result.same, true);
   });
 });

--- a/packages/review-calibration/test/review-calibration.test.mjs
+++ b/packages/review-calibration/test/review-calibration.test.mjs
@@ -776,6 +776,67 @@ describe('E2E: --review-provider / --strict provider-independence guard', () => 
   });
 });
 
+// ── E2E: agy provider's tier-dependent model family (issue #64 follow-up) ─────
+// detectProvider().name for 'agy' is the literal string 'agy', but agy proxies
+// to a tier-dependent underlying model (Gemini on --tier cheap, Claude on
+// --tier mid/frontier — see packages/core/lib/llm.mjs PROVIDERS[3].models).
+// These tests force ADLC_PROVIDER=agy (no real agy binary needed — the fake
+// reviewer reports nothing, so the judge function itself is never invoked)
+// and verify the guard compares against the RESOLVED family, not 'agy'.
+
+describe('E2E: agy provider resolves to its tier-dependent model family', () => {
+  let dir;
+  const agyEnv = {
+    ...process.env,
+    ANTHROPIC_API_KEY: '', OPENAI_API_KEY: '', GEMINI_API_KEY: '',
+    ADLC_PROVIDER: 'agy',
+  };
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rc-agy-guard-'));
+    createRepo(dir);
+  });
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function run(args) {
+    return spawnSync('node', [BIN, ...args], {
+      cwd: dir, encoding: 'utf8', stdio: 'pipe', timeout: 60000, env: agyEnv,
+    });
+  }
+
+  it('agy + --tier mid + --review-provider anthropic --strict → gate-fails (both are Claude)', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--tier', 'mid', '--review-provider', 'anthropic', '--strict', '--json',
+    ]);
+    assert.equal(result.status, 2, `expected gate-fail exit 2, got ${result.status}: ${result.stderr}`);
+    assert.ok(/same model family|independence/i.test(result.stderr), result.stderr);
+  });
+
+  it('agy + --tier cheap + --review-provider gemini --strict → gate-fails (both are Gemini)', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--tier', 'cheap', '--review-provider', 'gemini', '--strict', '--json',
+    ]);
+    assert.equal(result.status, 2, `expected gate-fail exit 2, got ${result.status}: ${result.stderr}`);
+  });
+
+  it('agy + --tier cheap + --review-provider anthropic → no warning (genuinely different families)', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--tier', 'cheap', '--review-provider', 'anthropic', '--json',
+    ]);
+    assert.equal(result.status, 0, `expected pass, got ${result.status}: ${result.stderr}`);
+    assert.ok(!/same model family|independence/i.test(result.stderr), result.stderr);
+  });
+});
+
 describe('E2E: dirty tree rejection', () => {
   let dir;
 

--- a/packages/review-calibration/test/review-calibration.test.mjs
+++ b/packages/review-calibration/test/review-calibration.test.mjs
@@ -17,9 +17,9 @@ import {
   parseCommitFiles, filterCodeFiles, selectPlants, loadPlantsFile,
   operatorToCategory, describeDefect,
 } from '../lib/targets.mjs';
-import { scorePlants, locatingFindings, countFalsePositives } from '../lib/scorer.mjs';
+import { locatingFindings } from '../lib/scorer.mjs';
 import { parseFindings, parseProseFindings } from '../lib/findings.mjs';
-import { referenceJudge, defectTokens, calibrateJudge, makeLlmJudge } from '../lib/judge.mjs';
+import { referenceJudge } from '../lib/judge.mjs';
 import { echoReviewer, oracleReviewer } from '../lib/controls.mjs';
 import { verifyWitness, filterEquivalentMutants } from '../lib/verify.mjs';
 import {
@@ -254,135 +254,10 @@ describe('parseFindings', () => {
   });
 });
 
-// ── judge (reference) ─────────────────────────────────────────────────────────
-
-describe('referenceJudge / defectTokens', () => {
-  const plant = {
-    file: 'src/auth.mjs', line: 5, category: 'logic-inversion',
-    defect: 'Inverted comparison: the conditional now matches the opposite case.',
-    original: 'if (x > 0)', mutated: 'if (x <= 0)',
-  };
-
-  it('extracts content tokens from the defect text', () => {
-    const t = defectTokens(plant);
-    assert.ok(t.includes('inverted'));
-    assert.ok(t.includes('comparison'));
-    assert.ok(!t.includes('the')); // stopword / too short
-  });
-
-  it('accepts a finding that describes the defect', () => {
-    assert.equal(referenceJudge(plant, { description: 'The comparison is inverted, matching the opposite case' }), true);
-  });
-
-  it('REJECTS a content-free echo finding (this is the whole fix)', () => {
-    assert.equal(referenceJudge(plant, { description: 'auth.mjs:5 changed' }), false);
-  });
-
-  it('rejects a finding quoting only the raw mutated line with no defect claim', () => {
-    assert.equal(referenceJudge(plant, { description: 'if (x <= 0)' }), false);
-  });
-});
-
-// ── scorePlants — verifier-based scoring ──────────────────────────────────────
-
-describe('scorePlants', () => {
-  const plants = [
-    { file: 'src/math.mjs', line: 5, operator: 'off-by-one', category: 'off-by-one',
-      defect: 'Off-by-one error: boundary shifted by one.', original: 'n + 1', mutated: 'n + 2' },
-    { file: 'src/math.mjs', line: 10, operator: 'bool-flip', category: 'logic-inversion',
-      defect: 'Inverted boolean flips the branch taken.', original: 'return true', mutated: 'return false' },
-    { file: 'src/auth.mjs', line: 20, operator: 'invert-comparison', category: 'logic-inversion',
-      defect: 'Inverted comparison matches the opposite case.', original: 'x > 0', mutated: 'x <= 0' },
-  ];
-
-  it('throws without a judge — refuses to string-match', async () => {
-    await assert.rejects(() => scorePlants(plants, [], {}), /requires a judge/);
-  });
-
-  it('oracle reviewer (perfect findings) → recall 1.0', async () => {
-    const findings = oracleReviewer(plants);
-    const score = await scorePlants(plants, findings, { judge: referenceJudge });
-    assert.equal(score.recall, 1);
-    assert.equal(score.caught, 3);
-  });
-
-  it('echo reviewer (content-free) → recall ~0  [INVERTED: this used to score 1.0]', async () => {
-    const findings = echoReviewer(plants);
-    const score = await scorePlants(plants, findings, { judge: referenceJudge });
-    assert.equal(score.caught, 0);
-    assert.equal(score.recall, 0);
-  });
-
-  it('a finding must LOCATE and IDENTIFY — locating without identifying misses', async () => {
-    // located at the right line, but the description identifies nothing
-    const findings = [{ file: 'math.mjs', line: 5, description: 'line 5 was modified', evidence: 'n + 2' }];
-    const score = await scorePlants(plants, findings, { judge: referenceJudge });
-    assert.equal(score.caught, 0);
-  });
-
-  it('identifying at the wrong location does not count', async () => {
-    const findings = [{ file: 'math.mjs', line: 99, description: 'off-by-one boundary error' }];
-    const score = await scorePlants(plants, findings, { judge: referenceJudge });
-    assert.equal(score.caught, 0);
-  });
-
-  it('partial catch → fractional recall, keyed per category', async () => {
-    const findings = [
-      { file: 'math.mjs', line: 5, description: 'off-by-one: boundary shifted' },
-      { file: 'auth.mjs', line: 20, description: 'comparison inverted, opposite case' },
-    ];
-    const score = await scorePlants(plants, findings, { judge: referenceJudge });
-    assert.equal(score.caught, 2);
-    assert.ok(Math.abs(score.recall - 2 / 3) < 1e-6);
-    assert.equal(score.perCategory['off-by-one'].caught, 1);
-    assert.equal(score.perCategory['logic-inversion'].total, 2);
-    assert.equal(score.perCategory['logic-inversion'].caught, 1);
-  });
-
-  it('precision falls when findings flag unplanted locations', async () => {
-    const findings = [
-      { file: 'math.mjs', line: 5, description: 'off-by-one boundary shifted' }, // TP
-      { file: 'other.mjs', line: 99, description: 'spurious' },                   // FP (no plant)
-    ];
-    const score = await scorePlants(plants, findings, { judge: referenceJudge });
-    assert.equal(score.truePositives, 1);
-    assert.equal(score.falsePositives, 1);
-    assert.equal(score.precision, 0.5);
-  });
-
-  it('uses a reviewer-supplied repro behaviorally when present (verifyRepro)', async () => {
-    const findings = [{ file: 'math.mjs', line: 5, description: 'anything', repro: { cmd: 'x' } }];
-    // verifyRepro discriminates → caught even though the judge would say no
-    const judge = () => false;
-    const verifyRepro = () => true;
-    const score = await scorePlants(plants, findings, { judge, verifyRepro });
-    assert.equal(score.results.find((r) => r.line === 5).caught, true);
-  });
-
-  it('a repro that does NOT discriminate is not a catch', async () => {
-    const findings = [{ file: 'math.mjs', line: 5, description: 'x', repro: { cmd: 'x' } }];
-    const score = await scorePlants(plants, findings, { judge: () => true, verifyRepro: () => false });
-    assert.equal(score.results.find((r) => r.line === 5).caught, false);
-  });
-});
-
-// ── countFalsePositives (new signature: findings, plants) ─────────────────────
-
-describe('countFalsePositives', () => {
-  it('counts findings located at no plant', () => {
-    const plants = [{ file: 'math.mjs', line: 10 }];
-    const findings = [{ file: 'math.mjs', line: 10 }, { file: 'other.mjs', line: 5 }];
-    assert.equal(countFalsePositives(findings, plants), 1);
-  });
-
-  it('±3 proximity counts as matching a plant', () => {
-    assert.equal(countFalsePositives([{ file: 'a.mjs', line: 12 }], [{ file: 'a.mjs', line: 10 }]), 0);
-  });
-
-  it('zero findings → zero false positives', () => {
-    assert.equal(countFalsePositives([], [{ file: 'x.mjs', line: 1 }]), 0);
-  });
-});
+// Note: judge.mjs and scorer.mjs unit tests now live in their own dedicated
+// files (test/judge.test.mjs, test/scorer.test.mjs) per the per-concern
+// test-file pattern (issue #64). This file keeps CLI/E2E and other-module
+// coverage.
 
 // ── control reviewers + locatingFindings ──────────────────────────────────────
 
@@ -400,54 +275,6 @@ describe('controls + locatingFindings', () => {
   it('oracleReviewer emits findings that both locate and identify', () => {
     const f = oracleReviewer(plants);
     assert.equal(referenceJudge(plants[0], f[0]), true);
-  });
-});
-
-// ── calibrateJudge ────────────────────────────────────────────────────────────
-
-describe('calibrateJudge', () => {
-  it('measures agreement of a judge against labeled pairs', async () => {
-    const p = { defect: 'Inverted comparison opposite case.', category: 'logic-inversion' };
-    const fixture = [
-      { plant: p, finding: { description: 'comparison inverted, opposite case' }, expected: true },
-      { plant: p, finding: { description: 'a.mjs:1 changed' }, expected: false },
-      { plant: p, finding: { description: 'the comparison is now inverted' }, expected: true },
-    ];
-    const { agreement, n } = await calibrateJudge(fixture, referenceJudge);
-    assert.equal(n, 3);
-    assert.equal(agreement, 1); // reference judge agrees with all three labels
-  });
-
-  it('reports disagreements when the judge is wrong', async () => {
-    const p = { defect: 'Off-by-one boundary error.', category: 'off-by-one' };
-    const alwaysTrue = () => true;
-    const fixture = [{ plant: p, finding: { description: 'noise' }, expected: false }];
-    const { agreement, disagreements } = await calibrateJudge(fixture, alwaysTrue);
-    assert.equal(agreement, 0);
-    assert.equal(disagreements.length, 1);
-  });
-});
-
-// ── makeLlmJudge (injected completion, no network) ────────────────────────────
-
-describe('makeLlmJudge', () => {
-  it('builds the judge prompt from plant + finding and parses {match}', async () => {
-    let seen;
-    const completeFn = async (opts) => { seen = opts; return '{"match": true}'; };
-    const extractJsonFn = (t) => JSON.parse(t);
-    const judge = makeLlmJudge(completeFn, extractJsonFn);
-    const plant = { file: 'a.mjs', line: 5, category: 'off-by-one', defect: 'boundary shifted', original: 'i<=n', mutated: 'i<n' };
-    const finding = { file: 'a.mjs', line: 5, description: 'loop misses last element' };
-    const out = await judge(plant, finding);
-    assert.equal(out, true);
-    assert.equal(seen.tier, 'cheap');
-    assert.ok(seen.prompt.includes('boundary shifted'));
-    assert.ok(seen.prompt.includes('loop misses last element'));
-  });
-
-  it('returns false when the model does not answer match:true', async () => {
-    const judge = makeLlmJudge(async () => '{"match": false}', (t) => JSON.parse(t));
-    assert.equal(await judge({ defect: 'x' }, { description: 'y' }), false);
   });
 });
 
@@ -855,6 +682,97 @@ describe('E2E: file restoration after run', () => {
 
     const after = readFileSync(srcPath, 'utf8');
     assert.equal(after, before, 'File was not restored after calibration run');
+  });
+});
+
+// ── E2E: --review-provider / --strict guard (issue #64) ───────────────────────
+// The judge is resolved via the same auto-detect provider path as everything
+// else, while --review-cmd runs as an opaque subprocess. These tests force a
+// detectable (but fake) judge provider via env vars and drive the CLI with a
+// reviewer that reports nothing, so no locating findings exist and the judge
+// function is never actually invoked (no network needed) — only the
+// provider-name comparison, which happens before any findings are scored.
+
+describe('E2E: --review-provider / --strict provider-independence guard', () => {
+  let dir;
+  const fakeProviderEnv = {
+    ...process.env,
+    ANTHROPIC_API_KEY: 'dummy-key-for-detection-only',
+    OPENAI_API_KEY: '',
+    GEMINI_API_KEY: '',
+    ADLC_PROVIDER: 'anthropic',
+  };
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rc-provider-guard-'));
+    createRepo(dir);
+  });
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function run(args) {
+    return spawnSync('node', [BIN, ...args], {
+      cwd: dir, encoding: 'utf8', stdio: 'pipe', timeout: 60000, env: fakeProviderEnv,
+    });
+  }
+
+  it('same-family judge + --review-provider → warns by default, still passes the gate', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--review-provider', 'anthropic', '--json',
+    ]);
+    assert.equal(result.status, 0, `expected pass, got ${result.status}: ${result.stderr}`);
+    assert.ok(/same model family|independence/i.test(result.stderr), result.stderr);
+  });
+
+  it('same-family judge + --review-provider + --strict → gate-fails (exit 2)', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--review-provider', 'anthropic', '--strict', '--json',
+    ]);
+    assert.equal(result.status, 2, `expected gate-fail exit 2, got ${result.status}: ${result.stderr}`);
+    assert.ok(/same model family|independence/i.test(result.stderr), result.stderr);
+  });
+
+  it('a claude alias for --review-provider is still recognized as the same family under --strict', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--review-provider', 'claude', '--strict', '--json',
+    ]);
+    assert.equal(result.status, 2, `expected gate-fail exit 2, got ${result.status}: ${result.stderr}`);
+  });
+
+  it('different --review-provider from the judge → no warning, gate governed only by recall', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0',
+      '--review-provider', 'openai', '--json',
+    ]);
+    assert.equal(result.status, 0, `expected pass, got ${result.status}: ${result.stderr}`);
+    assert.ok(!/same model family|independence/i.test(result.stderr), result.stderr);
+  });
+
+  it('--strict without --review-provider is an operational error (exit 1)', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0', '--strict',
+    ]);
+    assert.equal(result.status, 1, `expected opError exit 1, got ${result.status}: ${result.stderr}`);
+    assert.ok(/--strict requires --review-provider/.test(result.stderr), result.stderr);
+  });
+
+  it('no --review-provider at all → no comparison, no warning', () => {
+    const result = run([
+      '--review-cmd', 'node -e "process.stdout.write(\'LGTM\\n\')"',
+      '--commit', 'HEAD', '--plants', '3', '--min-recall', '0', '--json',
+    ]);
+    assert.equal(result.status, 0);
+    assert.ok(!/same model family|independence/i.test(result.stderr), result.stderr);
   });
 });
 

--- a/packages/review-calibration/test/scorer.test.mjs
+++ b/packages/review-calibration/test/scorer.test.mjs
@@ -1,0 +1,159 @@
+// review-calibration/test/scorer.test.mjs
+// Dedicated coverage for lib/scorer.mjs: locating findings, identifying
+// matches (judge or behavioral verifyRepro), recall/precision aggregation,
+// and false-positive counting.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { scorePlants, locatingFindings, countFalsePositives, findIdentifying } from '../lib/scorer.mjs';
+import { referenceJudge } from '../lib/judge.mjs';
+import { echoReviewer, oracleReviewer } from '../lib/controls.mjs';
+
+// ── scorePlants — verifier-based scoring ──────────────────────────────────────
+
+describe('scorePlants', () => {
+  const plants = [
+    { file: 'src/math.mjs', line: 5, operator: 'off-by-one', category: 'off-by-one',
+      defect: 'Off-by-one error: boundary shifted by one.', original: 'n + 1', mutated: 'n + 2' },
+    { file: 'src/math.mjs', line: 10, operator: 'bool-flip', category: 'logic-inversion',
+      defect: 'Inverted boolean flips the branch taken.', original: 'return true', mutated: 'return false' },
+    { file: 'src/auth.mjs', line: 20, operator: 'invert-comparison', category: 'logic-inversion',
+      defect: 'Inverted comparison matches the opposite case.', original: 'x > 0', mutated: 'x <= 0' },
+  ];
+
+  it('throws without a judge — refuses to string-match', async () => {
+    await assert.rejects(() => scorePlants(plants, [], {}), /requires a judge/);
+  });
+
+  it('oracle reviewer (perfect findings) → recall 1.0', async () => {
+    const findings = oracleReviewer(plants);
+    const score = await scorePlants(plants, findings, { judge: referenceJudge });
+    assert.equal(score.recall, 1);
+    assert.equal(score.caught, 3);
+  });
+
+  it('echo reviewer (content-free) → recall ~0  [INVERTED: this used to score 1.0]', async () => {
+    const findings = echoReviewer(plants);
+    const score = await scorePlants(plants, findings, { judge: referenceJudge });
+    assert.equal(score.caught, 0);
+    assert.equal(score.recall, 0);
+  });
+
+  it('a finding must LOCATE and IDENTIFY — locating without identifying misses', async () => {
+    // located at the right line, but the description identifies nothing
+    const findings = [{ file: 'math.mjs', line: 5, description: 'line 5 was modified', evidence: 'n + 2' }];
+    const score = await scorePlants(plants, findings, { judge: referenceJudge });
+    assert.equal(score.caught, 0);
+  });
+
+  it('identifying at the wrong location does not count', async () => {
+    const findings = [{ file: 'math.mjs', line: 99, description: 'off-by-one boundary error' }];
+    const score = await scorePlants(plants, findings, { judge: referenceJudge });
+    assert.equal(score.caught, 0);
+  });
+
+  it('partial catch → fractional recall, keyed per category', async () => {
+    const findings = [
+      { file: 'math.mjs', line: 5, description: 'off-by-one: boundary shifted' },
+      { file: 'auth.mjs', line: 20, description: 'comparison inverted, opposite case' },
+    ];
+    const score = await scorePlants(plants, findings, { judge: referenceJudge });
+    assert.equal(score.caught, 2);
+    assert.ok(Math.abs(score.recall - 2 / 3) < 1e-6);
+    assert.equal(score.perCategory['off-by-one'].caught, 1);
+    assert.equal(score.perCategory['logic-inversion'].total, 2);
+    assert.equal(score.perCategory['logic-inversion'].caught, 1);
+  });
+
+  it('precision falls when findings flag unplanted locations', async () => {
+    const findings = [
+      { file: 'math.mjs', line: 5, description: 'off-by-one boundary shifted' }, // TP
+      { file: 'other.mjs', line: 99, description: 'spurious' },                   // FP (no plant)
+    ];
+    const score = await scorePlants(plants, findings, { judge: referenceJudge });
+    assert.equal(score.truePositives, 1);
+    assert.equal(score.falsePositives, 1);
+    assert.equal(score.precision, 0.5);
+  });
+
+  it('uses a reviewer-supplied repro behaviorally when present (verifyRepro)', async () => {
+    const findings = [{ file: 'math.mjs', line: 5, description: 'anything', repro: { cmd: 'x' } }];
+    // verifyRepro discriminates → caught even though the judge would say no
+    const judge = () => false;
+    const verifyRepro = () => true;
+    const score = await scorePlants(plants, findings, { judge, verifyRepro });
+    assert.equal(score.results.find((r) => r.line === 5).caught, true);
+  });
+
+  it('a repro that does NOT discriminate is not a catch', async () => {
+    const findings = [{ file: 'math.mjs', line: 5, description: 'x', repro: { cmd: 'x' } }];
+    const score = await scorePlants(plants, findings, { judge: () => true, verifyRepro: () => false });
+    assert.equal(score.results.find((r) => r.line === 5).caught, false);
+  });
+});
+
+// ── findIdentifying ────────────────────────────────────────────────────────────
+
+describe('findIdentifying', () => {
+  it('returns the first locating finding the judge accepts', async () => {
+    const plant = { defect: 'x' };
+    const located = [{ id: 1 }, { id: 2 }];
+    const judge = async (_p, f) => f.id === 2;
+    const hit = await findIdentifying(plant, located, { judge });
+    assert.equal(hit.id, 2);
+  });
+
+  it('returns null when no located finding identifies the defect', async () => {
+    const plant = { defect: 'x' };
+    const located = [{ id: 1 }];
+    const hit = await findIdentifying(plant, located, { judge: async () => false });
+    assert.equal(hit, null);
+  });
+
+  it('a repro that fails to discriminate is skipped, not treated as a miss for the whole search', async () => {
+    const plant = { defect: 'x' };
+    const located = [{ id: 1, repro: { cmd: 'x' } }, { id: 2 }];
+    const verifyRepro = async () => false; // first finding's repro doesn't discriminate
+    const judge = async (_p, f) => f.id === 2; // second finding is judged and accepted
+    const hit = await findIdentifying(plant, located, { judge, verifyRepro });
+    assert.equal(hit.id, 2);
+  });
+});
+
+// ── locatingFindings ───────────────────────────────────────────────────────────
+
+describe('locatingFindings', () => {
+  const plant = { file: 'src/a.mjs', line: 10 };
+
+  it('matches by basename, ignoring directory differences', () => {
+    const findings = [{ file: 'a.mjs', line: 10 }, { file: 'other/a.mjs', line: 10 }];
+    assert.equal(locatingFindings(plant, findings).length, 2);
+  });
+
+  it('respects the default tolerance of ±3 lines', () => {
+    assert.equal(locatingFindings(plant, [{ file: 'a.mjs', line: 13 }]).length, 1);
+    assert.equal(locatingFindings(plant, [{ file: 'a.mjs', line: 14 }]).length, 0);
+  });
+
+  it('honors a custom tolerance', () => {
+    assert.equal(locatingFindings(plant, [{ file: 'a.mjs', line: 20 }], 10).length, 1);
+  });
+});
+
+// ── countFalsePositives ────────────────────────────────────────────────────────
+
+describe('countFalsePositives', () => {
+  it('counts findings located at no plant', () => {
+    const plants = [{ file: 'math.mjs', line: 10 }];
+    const findings = [{ file: 'math.mjs', line: 10 }, { file: 'other.mjs', line: 5 }];
+    assert.equal(countFalsePositives(findings, plants), 1);
+  });
+
+  it('±3 proximity counts as matching a plant', () => {
+    assert.equal(countFalsePositives([{ file: 'a.mjs', line: 12 }], [{ file: 'a.mjs', line: 10 }]), 0);
+  });
+
+  it('zero findings → zero false positives', () => {
+    assert.equal(countFalsePositives([], [{ file: 'x.mjs', line: 1 }]), 0);
+  });
+});


### PR DESCRIPTION
## Summary

`review-calibration`'s entire value proposition is "who reviews the reviewer" — measuring whether a reviewer-under-test actually catches planted defects. Before this change, nothing compared the LLM judge's resolved provider against the provider actually powering the `--review-cmd` subprocess, so the independence claim could be silently satisfied by the same model family reviewing itself.

This adds an explicit, fail-closed provider-independence guard:

- New `--review-provider <name>` flag lets the caller declare the provider/model family the `--review-cmd` subprocess actually uses (it can't be introspected generically since it runs as an opaque subprocess).
- `checkProviderIndependence()` (`lib/judge.mjs`) compares that declaration against the judge's own resolved provider. Same family: warns by default; `--strict` gate-fails (exit 2). `--strict` without `--review-provider` is an operational error (exit 1).
- `resolveEffectiveProvider()` maps `agy`'s tier-dependent model family (Gemini on `--tier cheap`, Claude/Anthropic on `--tier mid`/`frontier`) to its real underlying family before the comparison, so `ADLC_PROVIDER=agy --tier mid --review-provider anthropic --strict` correctly gate-fails instead of silently passing when both are actually Claude.
- `resolveEffectiveProvider()` also honors `ADLC_MODEL_<TIER>` env overrides via core's `resolveModel()` rather than only the static `provider.models[tier]` table, so an override that changes the judge's actual dispatch target can't defeat the guard.
- `PROVIDER_ALIASES` is now a `Map` instead of a plain object literal, closing a prototype-pollution path where `--review-provider __proto__` resolved to `Object.prototype` via `{}[n] ?? n`, making the independence check always report "different" regardless of the true provider.
- Split the monolithic test file into `test/judge.test.mjs` and `test/scorer.test.mjs` (following the one-file-per-concern pattern in `packages/gate-fuzzing/test/*.test.mjs`), adding direct unit coverage for `judge.mjs`/`scorer.mjs` (previously covered only indirectly through the single E2E test file), plus new CLI-level and E2E coverage for the flags above.

Fixes #64

## Review history

Shipped after 2 consecutive clean adversarial-review rounds:

| Round | Findings |
|---|---|
| 1 | 1 (agy tier-dependent model family not resolved) |
| 2 | 3 (env-override bypass, prototype-pollution alias lookup, stale spec test count) |
| 3 | 0 |
| 4 | 0 |

## Test plan

- [x] `npm test` in `packages/review-calibration` — 98/98 passing, 0 failures
- [x] E2E coverage for `--review-provider`/`--strict` guard: same-family warn, same-family + `--strict` gate-fail, alias recognition, different-family no-warning, `--strict` without `--review-provider` operational error, neither flag → no comparison
- [x] E2E coverage for `agy`'s tier-dependent family resolution at `cheap` and `mid` tiers
- [x] Regression test for the `PROVIDER_ALIASES` prototype-pollution lookup
- [x] Working tree confirmed clean before push; no unrelated files included