### PR TITLE
docs(site): add Antigravity integration page and real integrations landing page

### DIFF
--- a/apps/docs/content/docs/integrations/antigravity.mdx
+++ b/apps/docs/content/docs/integrations/antigravity.mdx
@@ -1,0 +1,114 @@
+---
+title: Antigravity
+description: Native ADLC integration for Google Antigravity (agy) — an in-session rails-guard hook plus the unbypassable CI diff gate that is the real enforcement layer.
+---
+
+# ADLC × Google Antigravity (`agy`)
+
+Native ADLC integration for the Antigravity CLI. Two layers:
+
+1. **In-session rails-guard (advisory).** A `PreToolUse` plugin hook denies edits to
+   frozen rails. It is best-effort: agy fails **open** on a non-zero hook exit, so a
+   hook crash/timeout/Windows-path failure can let a rail write through.
+2. **CI diff gate (the guarantee).** `scripts/rails-guard-ci.mjs` is the unbypassable,
+   cross-platform control. Make it a required check.
+
+## Install
+
+**Local checkout (recommended/verified).** Currently, the most reliable way to install the plugin is directly from a local checkout:
+
+```sh
+agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
+```
+
+Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
+
+**Universal installer (planned — not yet supported).** Support for Google Antigravity inside the vendor-neutral `plugins` installer is currently in development and **not yet present**. Once implemented, you will be able to install it via:
+
+```sh
+npx plugins add voodootikigod/adlc
+```
+
+**Note on native marketplace:** the native `.agents` marketplace registration command (`agy plugin install adlc-antigravity@adlc`) is currently subject to a CLI limitation where the CLI rejects unregistered third-party marketplaces with `unknown marketplace: adlc`. Local installation is the recommended path.
+
+Then `/adlc-init` (or manual bootstrap). Enforcement: `export ADLC_P4_ENFORCEMENT=1` with an active ticket.
+
+## Formal ADLC coverage
+
+| Phase | Antigravity surface |
+| --- | --- |
+| P0 Triage | `/adlc-init`, `adlc-ticket` skill → `.adlc/tickets.json` |
+| P1 Interrogate | `adlc spec-lint/premortem/parallax` via the `adlc` CLI |
+| P2 Decompose | `adlc coldstart/model-router/merge-forecast` |
+| P3 Rail | **PreToolUse rails-guard hook** (advisory) + CI gate (guarantee) |
+| P4 Build | doctrine skill; `adlc flail-detector/consensus-fix` |
+| P5 Prosecute | `adlc-prosecutor` skill + `prosecutor` agent; `adlc hollow-test/behavior-diff` |
+| P6 Integrate | human gate — `adlc gate-manifest` |
+| P7 Distill | `adlc lesson-foundry/rejection-mining` |
+
+## Rail enforcement — two layers
+
+Antigravity's hooks are a **best-effort, in-session** layer, not the control:
+
+1. **In-session (advisory).** The `PreToolUse` hook returns
+   `{ "allow_tool": false, "deny_reason": "..." }` on a frozen-rail edit. Antigravity
+   *should* block it, but the hook is subject to several fail-open conditions (see
+   "Platform notes" below). The hook is configured to fail **open** so a hook
+   bug/timeout/incompatibility can never brick your session. Bash/shell writes are
+   **not** gated in-session (a Turing-complete shell can't be reliably parsed).
+
+2. **Commit-time (unbypassable).** The real control is the CI rail-freeze gate
+   (`scripts/rails-guard-ci.mjs`). It reads the frozen rail set **from the trusted base
+   ref** and rejects any PR that edits a path frozen there, regardless of how the edit
+   was made. **Make it a required check.**
+
+   **Scope limit:** because the rail set is read from the base ref, the gate protects
+   rails **already frozen on the base branch**. A PR that *introduces* a new rail
+   **and** edits that path in the same PR is **not** caught — first-time rails are
+   enforced only once they land on the base branch. Freeze rails in a separate,
+   merged commit before the build PR if you need same-PR protection.
+
+## Rail contract
+
+Enforcement is identical to the sibling integrations (the engine is `@adlc/core`,
+not re-implemented here):
+
+- Active ticket via `ADLC_TICKET` **or** `.adlc/current-ticket.json`; a conflict
+  between the two fails closed (denied).
+- Enforcement is phase-scoped to `ADLC_P4_ENFORCEMENT=1`; otherwise no-op.
+- Rails in force = the **single** active ticket's `rails` plus the trust-root rails
+  `.adlc/tickets.json` and `.adlc/current-ticket.json` (not a union across tickets).
+- No-op when the repo is not ADLC-initialized, enforcement is off, or no active
+  ticket resolves.
+- Symlink aliases whose real target is a frozen rail are resolved and denied.
+
+## Platform notes / limitations
+
+- **POSIX only in-session** (`$HOME` command path); Windows in-session is unsupported —
+  the CI gate protects Windows users regardless.
+- Shell (`run_command`) writes are not gated in-session (CI gate catches them).
+
+## Appendix: verified `agy` hook contract (agy 1.0.13)
+
+This appendix documents the native hook contract verified by direct probing. These
+facts are the foundation for the in-session rails-guard implementation and belong in
+any document describing the integration's enforcement surface.
+
+| # | Fact |
+| --- | --- |
+| V1 | agy has a **native plugin system**: `agy plugin install <path>` installs into `~/.gemini/config/plugins/<name>/`. Manifest is Claude-Code-shaped: root `plugin.json` (name, version) + `skills/`, `agents/`, `commands/` (auto-converted to skills), root `hooks.json`. `agy plugin import claude` even ingests Claude Code plugins. |
+| V2 | `agy plugin validate` checks component **presence only**, not deep hook schema — it passed a `hooks.json` the runtime later refused to parse. **Validation is not sufficient; runtime load must be tested.** |
+| V3 | **hooks.json schema (agy-native)** — verified working: `{ "<hook-name>": { "PreToolUse": [ { "matcher": ".*", "hooks": [ { "type":"command", "command":"<cmd>", "timeout":15 } ] } ] } }`. Top level is keyed by **hook name**, then event, then an **array** of `{matcher, hooks:[handler]}`. |
+| V4 | `matcher` is a **regex on the tool name**. `.*` matches all. `write` did **not** match tool `write_to_file` — so use `.*` or exact names. |
+| V5 | **Deny contract (inverted from Claude Code/Codex):** a hook denies by writing stdout `{"allow_tool": false, "deny_reason": "..."}` and **exiting 0**. `{"allow_tool": true}` allows. **Non-zero exit = hook FAILURE = FAIL-OPEN (tool proceeds).** |
+| V6 | Hooks **fire in `agy --print` (headless) mode** — a write to a rail was actually blocked. So rails-guard protects both interactive sessions and the headless fleet path. |
+| V7 | **stdin payload** (verbatim): `{"toolCall":{"name":"write_to_file","args":{"TargetFile":"/abs","CodeContent":"…","Overwrite":true}},"workspacePaths":[],"conversationId":…,"transcriptPath":…,"stepIdx":3}`. The path field varies per tool: `write_to_file`→`TargetFile`, `view_file`→`AbsolutePath`, `run_command`→`CommandLine`. Observed target paths were **absolute**. |
+| V8 | Hook **cwd is the plugin dir** (`~/.gemini/config/plugins/<name>/`), **not the repo**. In `--print` mode `workspacePaths` was observed **empty (`[]`)**. There is **no workspace-root env var** (env exposes `ANTIGRAVITY_CONVERSATION_ID`, not a workspace path). |
+| V9 | agy **expands `$HOME`** (and shell env vars) in the `command` string; there is **no** `${CLAUDE_PLUGIN_ROOT}`/`${AGY_PLUGIN_ROOT}`. Because plugins always install to `$HOME/.gemini/config/plugins/<name>/`, `node $HOME/.gemini/config/plugins/adlc-antigravity/hooks/adlc-rails-guard.mjs` is portable across users with no install-time rewrite. |
+
+## Go deeper
+
+Source: [`plugins/adlc-antigravity/`](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-antigravity).
+
+The rail-freeze gate this integration automates:
+[Tests Are the Spec](https://voodootikigod.com/adlc-3-tests-are-the-spec).

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -1,8 +1,25 @@
 ---
 title: Integrations
-description: Integrations documentation (coming soon).
+description: Native ADLC integrations for six agentic coding harnesses — Claude Code, Codex, Cursor, opencode, pi, and Antigravity.
 ---
 
 # Integrations
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+ADLC gates are implemented once in [`@adlc/core`](/docs/lifecycle) and wired into each
+harness through its own native mechanism — skills, hooks, plugins, or agents. Pick your
+harness below.
+
+- **[Claude Code](/docs/integrations/claude-code)** — phase-routing skill, gate
+  commands, a `prosecutor` subagent, and hooks that fire the gates automatically.
+- **[Codex](/docs/integrations/codex)** — the OpenAI Codex CLI integration for the
+  ADLC toolkit.
+- **[Cursor](/docs/integrations/cursor)** — the Cursor editor integration for the
+  ADLC toolkit.
+- **[opencode](/docs/integrations/opencode)** — the opencode CLI integration for the
+  ADLC toolkit.
+- **[pi](/docs/integrations/pi)** — the pi CLI integration for the ADLC toolkit.
+- **[Antigravity](/docs/integrations/antigravity)** — native `agy` plugin with an
+  in-session rails-guard hook, backed by the unbypassable CI rail-freeze gate.
+
+See the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory) for
+the gates these integrations wire up.

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -12,12 +12,13 @@ harness below.
 - **[Claude Code](/docs/integrations/claude-code)** — phase-routing skill, gate
   commands, a `prosecutor` subagent, and hooks that fire the gates automatically.
 - **[Codex](/docs/integrations/codex)** — the OpenAI Codex CLI integration for the
-  ADLC toolkit.
+  ADLC toolkit; full walkthrough still being written.
 - **[Cursor](/docs/integrations/cursor)** — the Cursor editor integration for the
-  ADLC toolkit.
+  ADLC toolkit; full walkthrough still being written.
 - **[opencode](/docs/integrations/opencode)** — the opencode CLI integration for the
-  ADLC toolkit.
-- **[pi](/docs/integrations/pi)** — the pi CLI integration for the ADLC toolkit.
+  ADLC toolkit; full walkthrough still being written.
+- **[pi](/docs/integrations/pi)** — the pi CLI integration for the ADLC toolkit;
+  full walkthrough still being written.
 - **[Antigravity](/docs/integrations/antigravity)** — native `agy` plugin with an
   in-session rails-guard hook, backed by the unbypassable CI rail-freeze gate.
 

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -1,1 +1,1 @@
-{ "title": "Integrations", "pages": ["index", "claude-code", "codex", "cursor", "opencode", "pi"] }
+{ "title": "Integrations", "pages": ["index", "claude-code", "codex", "cursor", "opencode", "pi", "antigravity"] }

--- a/apps/docs/test/integrations-antigravity.test.mjs
+++ b/apps/docs/test/integrations-antigravity.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const integrationsDir = path.join(__dirname, '..', 'content', 'docs', 'integrations');
+
+const HARNESSES = ['claude-code', 'codex', 'cursor', 'opencode', 'pi', 'antigravity'];
+
+test('antigravity.mdx exists in the integrations directory', () => {
+  const p = path.join(integrationsDir, 'antigravity.mdx');
+  assert.ok(existsSync(p), 'apps/docs/content/docs/integrations/antigravity.mdx should exist');
+});
+
+test('antigravity.mdx has real frontmatter (title + description) and is not a stub', () => {
+  const p = path.join(integrationsDir, 'antigravity.mdx');
+  const content = readFileSync(p, 'utf8');
+
+  assert.match(content, /^---\n/, 'file should start with frontmatter');
+  assert.match(content, /^title:\s*.+$/m, 'frontmatter should declare a title');
+  assert.match(content, /^description:\s*.+$/m, 'frontmatter should declare a description');
+
+  assert.doesNotMatch(
+    content,
+    /coming soon/i,
+    'antigravity.mdx should be real content, not the "coming soon" stub'
+  );
+  assert.doesNotMatch(
+    content,
+    /This page is being written/i,
+    'antigravity.mdx should be real content, not the stub body'
+  );
+
+  // Spot-check a couple of facts that must survive the port from docs/integrations/antigravity.md
+  assert.match(content, /rails-guard-ci\.mjs/, 'should mention the CI rail-freeze gate script');
+  assert.match(content, /ADLC_P4_ENFORCEMENT/, 'should mention the enforcement env var');
+});
+
+test("meta.json's pages array includes antigravity alongside the other five harnesses", () => {
+  const p = path.join(integrationsDir, 'meta.json');
+  const meta = JSON.parse(readFileSync(p, 'utf8'));
+
+  assert.ok(Array.isArray(meta.pages), 'meta.json should have a pages array');
+  assert.ok(meta.pages.includes('antigravity'), 'pages array should include "antigravity"');
+
+  for (const harness of HARNESSES) {
+    assert.ok(meta.pages.includes(harness), `pages array should include "${harness}"`);
+  }
+});
+
+test('index.mdx is a real landing page (no "coming soon" stub) enumerating all six harnesses', () => {
+  const p = path.join(integrationsDir, 'index.mdx');
+  const content = readFileSync(p, 'utf8');
+
+  assert.doesNotMatch(content, /coming soon/i, 'index.mdx should no longer be the stub');
+  assert.doesNotMatch(content, /This page is being written/i, 'index.mdx should no longer be the stub body');
+
+  for (const harness of HARNESSES) {
+    assert.match(
+      content,
+      new RegExp(`\\(/docs/integrations/${harness}\\)`),
+      `index.mdx should link to /docs/integrations/${harness}`
+    );
+  }
+});

--- a/apps/docs/test/integrations-antigravity.test.mjs
+++ b/apps/docs/test/integrations-antigravity.test.mjs
@@ -65,3 +65,37 @@ test('index.mdx is a real landing page (no "coming soon" stub) enumerating all s
     );
   }
 });
+
+test('index.mdx discloses that the stub harness pages (codex, cursor, opencode, pi) are still being written', () => {
+  const p = path.join(integrationsDir, 'index.mdx');
+  const content = readFileSync(p, 'utf8');
+
+  const STUB_HARNESSES = ['codex', 'cursor', 'opencode', 'pi'];
+  const WRITTEN_HARNESSES = ['claude-code', 'antigravity'];
+
+  for (const harness of STUB_HARNESSES) {
+    const bulletMatch = content.match(
+      new RegExp(`- \\*\\*\\[[^\\]]+\\]\\(/docs/integrations/${harness}\\)\\*\\*[\\s\\S]*?(?=\\n- \\*\\*|\\n\\nSee)`)
+    );
+    assert.ok(bulletMatch, `index.mdx should have a bullet for ${harness}`);
+    assert.match(
+      bulletMatch[0],
+      /full walkthrough still being written/,
+      `the ${harness} bullet should disclose that its full walkthrough is still being written`
+    );
+  }
+
+  // The two harnesses with real, complete pages must NOT carry the disclosure —
+  // otherwise it would misleadingly undersell finished documentation.
+  for (const harness of WRITTEN_HARNESSES) {
+    const bulletMatch = content.match(
+      new RegExp(`- \\*\\*\\[[^\\]]+\\]\\(/docs/integrations/${harness}\\)\\*\\*[\\s\\S]*?(?=\\n- \\*\\*|\\n\\nSee)`)
+    );
+    assert.ok(bulletMatch, `index.mdx should have a bullet for ${harness}`);
+    assert.doesNotMatch(
+      bulletMatch[0],
+      /still being written/,
+      `the ${harness} bullet documents a finished page and should not claim it is still being written`
+    );
+  }
+});

--- a/docs/specs/antigravity-site-page.md
+++ b/docs/specs/antigravity-site-page.md
@@ -1,0 +1,27 @@
+# Spec — Antigravity docs-site page (closes #66)
+
+**Issue:** `apps/docs/content/docs/integrations/` had pages for claude-code, codex, cursor,
+opencode, and pi, but nothing for Antigravity (`agy`), and `index.mdx` was a literal
+"coming soon" stub. Real prose already existed at `docs/integrations/antigravity.md` but was
+never ported onto the public Fumadocs site.
+
+## Acceptance criteria
+
+- **AC1** — `apps/docs/content/docs/integrations/antigravity.mdx` exists, carries the same
+  frontmatter shape (`title` + `description`) as the other five integration pages, and is not
+  a "coming soon" stub — it carries the real two-layer rails-guard content ported from
+  `docs/integrations/antigravity.md`.
+- **AC2** — `apps/docs/content/docs/integrations/meta.json`'s `pages` array includes
+  `"antigravity"` alongside the existing five harnesses.
+- **AC3** — `apps/docs/content/docs/integrations/index.mdx` is a real landing page (no
+  "coming soon" stub) that enumerates and links to all six harness pages (claude-code, codex,
+  cursor, opencode, pi, antigravity).
+- **AC4** — the docs site still typechecks and builds (Fumadocs MDX + `next build`) with the
+  new page and updated nav.
+
+## Verify
+
+```sh
+node --test apps/docs/test/*.test.mjs
+cd apps/docs && npm run types:check && npm run build
+```


### PR DESCRIPTION
## Summary

Fixes #66

The Fumadocs site's `integrations/` section had pages for `claude-code`, `codex`, `cursor`, `opencode`, and `pi` but nothing for `antigravity`, and the section's own index page was a literal "coming soon" stub. This closed the sequencing gap between the docs-site scaffold (#52) and the Antigravity plugin (#53) — a shipped, documented harness integration was invisible on the public docs site.

- Ports `docs/integrations/antigravity.md` into `apps/docs/content/docs/integrations/antigravity.mdx`, matching the front-matter/content conventions of the other five harness pages (two-layer enforcement model, `agy plugin install`, `ADLC_P4_ENFORCEMENT`).
- Adds `"antigravity"` to `meta.json`'s `pages` array so it appears in the site nav.
- Replaces `index.mdx`'s stub with a real landing page enumerating all six harnesses.
- Landing page explicitly discloses which harness pages (codex, cursor, opencode, pi) are still stubs, so the page doesn't silently imply more finished content than exists (added in review round 1; regression-tested in round 2).

Went through 5 rounds of adversarial review (2 rounds surfaced findings and were fixed, 3 rounds clean) before being marked SHIPPED.

## Test plan

- [x] `node --test 'test/**/*.test.mjs'` in `apps/docs` — 17/17 passing, including the two new antigravity-specific tests (page exists + isn't a stub) and the stub-honesty regression test added in review round 2
- [x] `npm run build` in `apps/docs` — Next.js/Fumadocs production build compiles cleanly, all 126 static pages generate with no errors
- [x] Manual read-through confirming `meta.json` nav includes `antigravity` and `index.mdx` lists all six harnesses with accurate stub/complete status