### PR TITLE
feat(core): add per-invocation --provider/--providers selection (closes #63)

### DIFF
--- a/docs/specs/core-provider-selection.md
+++ b/docs/specs/core-provider-selection.md
@@ -1,0 +1,65 @@
+# Spec — Per-invocation provider selection for model-calling tools (closes #63)
+
+**Phase:** P1 lightweight record for a small, additive core+two-package build.
+
+## Problem
+
+Every model-calling `@adlc` package used `packages/core/lib/llm.mjs`'s single-provider
+auto-detect, with per-invocation selection available only via env overrides
+(`ADLC_PROVIDER`). `consensus-fix` and `gate-fuzzing` in particular fan **N samples of
+the same auto-detected provider** (`fan(opts, n)` / `fanAdversary`), which is strictly
+weaker than N candidates drawn from N distinct model families for the diversity reasons
+ADR-0007 documents for `adversarial-review`.
+
+## What changed
+
+- `packages/core/lib/llm.mjs`: `detectProvider(env, forceProvider)` gained an optional
+  per-invocation override (takes precedence over `ADLC_PROVIDER`, additive only);
+  `complete(opts, env)` accepts `opts.provider`; new `fanProviders(opts, providerNames, env)`
+  issues one `complete()` call per named provider instead of N resamples of one; new
+  `PROVIDER_NAMES` export for CLI validation.
+- `packages/consensus-fix`: `bin/consensus-fix.mjs` gained `--provider <name>` and
+  `--providers <a,b,c>` (mutually exclusive); `lib/runner.mjs`'s `runConsensusFix` accepts
+  `providerNames` and, when set, draws one candidate per named provider (fan width =
+  `providerNames.length`, overriding `--n`) instead of N samples of one provider.
+- `packages/gate-fuzzing`: `bin/gate-fuzzing.mjs` gained the same `--provider`/`--providers`
+  flags; `lib/fan.mjs`'s `fanAdversary` accepts `provider` (force one provider for all
+  resamples) and `providerNames` (one mutation-strategy instance per distinct provider).
+
+Single-provider auto-detect remains the default in all three packages — this is additive
+only, not a default-behavior change (ADR-0007's cost/latency default is untouched).
+
+## Acceptance criteria
+
+- **AC1** — `detectProvider(env, 'openai')` selects `openai` even when `ADLC_PROVIDER`/env
+  order would otherwise pick a different provider; an unavailable or unknown override
+  name returns `null` (fails closed), never throws or silently falls back.
+- **AC2** — `fanProviders(opts, ['anthropic','openai','gemini'])` issues exactly one
+  completion per named provider (never resamples one), and a provider missing its API key
+  surfaces as a per-entry `{ ok: false }` result without aborting the others.
+- **AC3** — `consensus-fix --providers a,b,c` draws one candidate per named provider
+  (fan width = 3, `--n` ignored) and each survivor records which provider produced it;
+  `--provider`/`--providers` are mutually exclusive and validated against known provider
+  names before any LLM call; a missing API key for a requested provider fails closed with
+  a clear operational error (exit 1), not a network attempt.
+- **AC4** — `gate-fuzzing --providers a,b` fans mutation-strategy instances across the
+  named providers (fan width = number of providers, `--n` ignored for width purposes);
+  same validation/fail-closed behavior as AC3.
+- **AC5** — Omitting `--provider`/`--providers` entirely is behavior-identical to before
+  this change (single auto-detected provider, `--n` resamples) — verified by the existing
+  test suites for all three packages passing unchanged.
+
+## Verification commands
+
+```bash
+node --test packages/core/test/core.test.mjs
+node --test packages/consensus-fix/test/runner.test.mjs packages/consensus-fix/test/bin.test.mjs
+node --test packages/gate-fuzzing/test/fan.test.mjs packages/gate-fuzzing/test/bin.test.mjs
+
+# full regression sweep for the three touched packages
+node --test packages/core/test/*.test.mjs packages/consensus-fix/test/*.test.mjs packages/gate-fuzzing/test/*.test.mjs
+```
+
+All of the above pass with zero real API keys configured — provider-selection and
+fan-across-providers behavior is exercised with an injected/mocked `completeFn`/`fetch`,
+and the fail-closed paths are exercised by deliberately clearing provider API keys.

--- a/docs/tools/consensus-fix.md
+++ b/docs/tools/consensus-fix.md
@@ -43,8 +43,10 @@ consensus-fix --test-cmd "..." --files a.mjs,b.mjs [options]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--rails <cmd>` | _(none)_ | The **regression gate**: a command that runs the FULL frozen rail suite (all tests + types). A candidate survives only if BOTH `--test-cmd` and `--rails` exit 0. A candidate that fixes the repro but reddens the rails is **rejected**, not ranked. If omitted, candidates are checked only against `--test-cmd` and a **WARNING** is printed (no silent caps). |
-| `--n <int>` | `3` | Number of independent fix candidates to generate. |
+| `--n <int>` | `3` | Number of independent fix candidates to generate. Ignored when `--providers` is given (fan width becomes the number of providers named). |
 | `--tier cheap\|mid\|frontier` | `mid` | LLM tier to use for completions. |
+| `--provider <name>` | _(auto-detect)_ | Force a single provider (`anthropic\|openai\|gemini\|agy`) for the whole run, overriding `ADLC_PROVIDER` for this invocation only. Additive — omit it and single-provider auto-detect is unchanged. Mutually exclusive with `--providers`. |
+| `--providers <a,b,c>` | _(none)_ | Draw **one** candidate fix per named provider family instead of `--n` resamples of one auto-detected provider — cross-family diversity per [ADR-0007](../../docs/adr/0007-multimodel-adversarial-review.md). Each survivor records which provider produced it. Mutually exclusive with `--provider`. |
 | `--apply` | off | Write the winning fix. Default is dry-run (report only). |
 | `--allow-dirty` | off | Skip dirty-tree check. Useful in CI with staged-only changes. |
 | `--json` | off | Machine-readable output (JSON to stdout). |
@@ -118,6 +120,18 @@ consensus-fix --test-cmd "pytest tests/test_core.py::test_sum" \
 consensus-fix --test-cmd "node --test test/*.test.mjs" \
               --files lib/broken.mjs \
               --allow-dirty --n 3
+
+# Draw one candidate fix per distinct provider family instead of 3 samples
+# of one auto-detected model (requires an API key for each named provider).
+consensus-fix --test-cmd "node --test test/math.test.mjs" \
+              --rails    "node --test test/*.test.mjs" \
+              --files src/math.mjs \
+              --providers anthropic,openai,gemini
+
+# Force a single non-default provider for the whole run
+consensus-fix --test-cmd "node --test test/math.test.mjs" \
+              --files src/math.mjs \
+              --provider gemini --n 3
 ```
 
 ---
@@ -162,7 +176,9 @@ consensus-fix --test-cmd "node --test test/*.test.mjs" \
 
 ## LLM provider detection
 
-Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`. Force a provider with `ADLC_PROVIDER`. Override the model per tier via `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, `ADLC_MODEL_FRONTIER`.
+Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` (then `agy` if `ADLC_AGY` is set). Force a provider with `ADLC_PROVIDER` (env, whole shell) or `--provider <name>` (per-invocation, overrides `ADLC_PROVIDER`). Override the model per tier via `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, `ADLC_MODEL_FRONTIER`.
+
+Single-provider auto-detect remains the default (cost/latency per ADR-0007) — `--provider`/`--providers` are additive, not a default-behavior change. Use `--providers <a,b,c>` when you want N candidate fixes drawn from N distinct model families instead of N samples of one model; each requested provider must have its own API key configured, or the run fails closed before any LLM call with a list of the missing ones.
 
 ---
 
@@ -177,4 +193,4 @@ Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_
 
 ## Core gaps
 
-None. `fan`, `complete`, `extractJson`, `detectProvider`, `resolveModel`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`, `promptOnly`, and `isDirty` are all provided by `@adlc/core`.
+None. `fan`, `complete`, `extractJson`, `detectProvider`, `resolveModel`, `PROVIDER_NAMES`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`, `promptOnly`, and `isDirty` are all provided by `@adlc/core`.

--- a/docs/tools/core.md
+++ b/docs/tools/core.md
@@ -31,7 +31,7 @@ the gap in your README — do not edit core.
 Import surface (from a tool at `packages/<name>/`):
 
 ```js
-import { complete, fan, extractJson, detectProvider, resolveModel } from '../../core/index.mjs';
+import { complete, fan, fanProviders, extractJson, detectProvider, resolveModel, PROVIDER_NAMES } from '../../core/index.mjs';
 import { git, gitDiff, changedFiles, isDirty, isGitRepo, coChange, pairKey, churn } from '../../core/index.mjs';
 import { parseArgs, pass, gateFail, opError, printJson, readStdin, promptOnly } from '../../core/index.mjs';
 import { ADLC_DIR, appendEntry, readEntries, ledgerPath, sha256, hashFiles } from '../../core/index.mjs';
@@ -41,10 +41,12 @@ import { mutate } from '../../core/index.mjs'; // mutate.generateMutants / apply
 
 ## llm
 
-- `detectProvider(env?)` → `{ name, apiKey, models } | null`. Order: anthropic, openai, gemini. Force with `ADLC_PROVIDER`.
+- `detectProvider(env?, forceProvider?)` → `{ name, apiKey, models } | null`. Order: anthropic, openai, gemini, agy. Force with `ADLC_PROVIDER` (env) or the `forceProvider` arg (per-invocation, e.g. a CLI `--provider` flag — takes precedence over `ADLC_PROVIDER`).
+- `PROVIDER_NAMES` → `['anthropic', 'openai', 'gemini', 'agy']`, for CLI validation of `--provider`/`--providers`.
 - `resolveModel(provider, { tier, model }, env?)` → model id. Tiers: `cheap | mid | frontier`. Override via `ADLC_MODEL_CHEAP/MID/FRONTIER`.
-- `complete({ tier, model, system, prompt, maxTokens })` → `Promise<string>`. Throws if no provider (tools must catch and offer `--prompt-only`).
-- `fan(opts, n)` → `Promise<[{ ok, value | error }]>` — n independent stateless completions.
+- `complete({ tier, model, system, prompt, maxTokens, provider? }, env?)` → `Promise<string>`. Throws if no provider (tools must catch and offer `--prompt-only`). `provider` is a per-invocation override, additive only — omit it and single-provider auto-detect remains the default (cost/latency per ADR-0007).
+- `fan(opts, n, env?)` → `Promise<[{ ok, value | error }]>` — n independent stateless completions of the SAME (auto-detected or `opts.provider`-forced) provider.
+- `fanProviders(opts, providerNames, env?)` → `Promise<[{ ok, value | error, provider }]>` — one completion per DISTINCT named provider (e.g. `['anthropic', 'openai', 'gemini']`), instead of N resamples of one provider. A named provider missing its API key surfaces as `{ ok: false }` for that entry only.
 - `extractJson(text)` → parsed JSON value from messy model output. Throws if none.
 
 ## git

--- a/docs/tools/gate-fuzzing.md
+++ b/docs/tools/gate-fuzzing.md
@@ -30,6 +30,7 @@ This turns "we found 11 bypasses once" into "finding bypasses is a CI gate."
 
 ```
 gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid]
+             [--provider <name> | --providers <a,b,c>]
              [--max-rounds <int>] [--dry-rounds <int>] [--token-budget <int>]
              [--witness-trials <int>] [--max-fail-rate <float>] [--canary-budget <int>]
              [--behavioral-witness] [--allow-cmd <name>...] [--unsafe-no-sandbox]
@@ -50,8 +51,10 @@ gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid]
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--suite <path>` | `.adlc/gate-suite.json` | Gate suite descriptor (refuses if absent) |
-| `--n <int>` | `6` | Fan width per round |
+| `--n <int>` | `6` | Fan width per round. Ignored when `--providers` is given (fan width becomes the number of providers named). |
 | `--tier cheap\|mid` | `mid` | Adversary tier (frontier rejected) |
+| `--provider <name>` | _(auto-detect)_ | Force a single provider (`anthropic\|openai\|gemini\|agy`) for every fan instance, overriding `ADLC_PROVIDER` for this invocation only. Additive — omit it and single-provider auto-detect is unchanged. Mutually exclusive with `--providers`. |
+| `--providers <a,b,c>` | _(none)_ | Fan mutation strategies across **distinct** named providers (one instance per provider) instead of `--n` resamples of one auto-detected provider — cross-family diversity per [ADR-0007](../../docs/adr/0007-multimodel-adversarial-review.md). Mutually exclusive with `--provider`. |
 | `--max-rounds <int>` | `10` | Hard round ceiling |
 | `--dry-rounds <int>` | `3` | K consecutive dry rounds to stop |
 | `--token-budget <int>` | `200000` | Estimated token ceiling (chars/4) |

--- a/packages/consensus-fix/README.md
+++ b/packages/consensus-fix/README.md
@@ -24,8 +24,10 @@ consensus-fix --test-cmd "..." --files a.mjs,b.mjs [options]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--rails <cmd>` | _(none)_ | The **regression gate**: a command that runs the FULL frozen rail suite (all tests + types). A candidate survives only if BOTH `--test-cmd` and `--rails` exit 0. A candidate that fixes the repro but reddens the rails is **rejected**, not ranked. If omitted, candidates are checked only against `--test-cmd` and a **WARNING** is printed (no silent caps). |
-| `--n <int>` | `3` | Number of independent fix candidates to generate. |
+| `--n <int>` | `3` | Number of independent fix candidates to generate. Ignored when `--providers` is given (fan width becomes the number of providers named). |
 | `--tier cheap\|mid\|frontier` | `mid` | LLM tier to use for completions. |
+| `--provider <name>` | _(auto-detect)_ | Force a single provider (`anthropic\|openai\|gemini\|agy`) for the whole run, overriding `ADLC_PROVIDER` for this invocation only. Additive — omit it and single-provider auto-detect is unchanged. Mutually exclusive with `--providers`. |
+| `--providers <a,b,c>` | _(none)_ | Draw **one** candidate fix per named provider family instead of `--n` resamples of one auto-detected provider — cross-family diversity per [ADR-0007](../../docs/adr/0007-multimodel-adversarial-review.md). Each survivor records which provider produced it. Mutually exclusive with `--provider`. |
 | `--apply` | off | Write the winning fix. Default is dry-run (report only). |
 | `--allow-dirty` | off | Skip dirty-tree check. Useful in CI with staged-only changes. |
 | `--json` | off | Machine-readable output (JSON to stdout). |
@@ -99,6 +101,18 @@ consensus-fix --test-cmd "pytest tests/test_core.py::test_sum" \
 consensus-fix --test-cmd "node --test test/*.test.mjs" \
               --files lib/broken.mjs \
               --allow-dirty --n 3
+
+# Draw one candidate fix per distinct provider family instead of 3 samples
+# of one auto-detected model (requires an API key for each named provider).
+consensus-fix --test-cmd "node --test test/math.test.mjs" \
+              --rails    "node --test test/*.test.mjs" \
+              --files src/math.mjs \
+              --providers anthropic,openai,gemini
+
+# Force a single non-default provider for the whole run
+consensus-fix --test-cmd "node --test test/math.test.mjs" \
+              --files src/math.mjs \
+              --provider gemini --n 3
 ```
 
 ---
@@ -143,7 +157,9 @@ consensus-fix --test-cmd "node --test test/*.test.mjs" \
 
 ## LLM provider detection
 
-Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`. Force a provider with `ADLC_PROVIDER`. Override the model per tier via `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, `ADLC_MODEL_FRONTIER`.
+Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` (then `agy` if `ADLC_AGY` is set). Force a provider with `ADLC_PROVIDER` (env, whole shell) or `--provider <name>` (per-invocation, overrides `ADLC_PROVIDER`). Override the model per tier via `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, `ADLC_MODEL_FRONTIER`.
+
+Single-provider auto-detect remains the default (cost/latency per ADR-0007) — `--provider`/`--providers` are additive, not a default-behavior change. Use `--providers <a,b,c>` when you want N candidate fixes drawn from N distinct model families instead of N samples of one model; each requested provider must have its own API key configured, or the run fails closed before any LLM call with a list of the missing ones.
 
 ---
 
@@ -158,4 +174,4 @@ Inherits from `@adlc/core`. Checks (in order): `ANTHROPIC_API_KEY`, `OPENAI_API_
 
 ## Core gaps
 
-None. `fan`, `complete`, `extractJson`, `detectProvider`, `resolveModel`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`, `promptOnly`, and `isDirty` are all provided by `@adlc/core`.
+None. `fan`, `complete`, `extractJson`, `detectProvider`, `resolveModel`, `PROVIDER_NAMES`, `parseArgs`, `pass`, `gateFail`, `opError`, `printJson`, `promptOnly`, and `isDirty` are all provided by `@adlc/core`.

--- a/packages/consensus-fix/bin/consensus-fix.mjs
+++ b/packages/consensus-fix/bin/consensus-fix.mjs
@@ -5,12 +5,21 @@
  * Usage:
  *   consensus-fix --test-cmd "npm test" --files src/foo.mjs,src/bar.mjs
  *                 [--rails "npm test"] [--n 3] [--tier mid] [--apply]
+ *                 [--provider <name> | --providers <a,b,c>]
  *                 [--allow-dirty] [--json] [--prompt-only]
  *
  *   --test-cmd is the repro gate (the specific failing test).
  *   --rails    is the regression gate (the FULL frozen rail suite). A candidate
  *              survives only if BOTH gates pass. Without --rails, candidates are
  *              not checked against the rails and a WARNING is printed.
+ *   --provider forces a single provider for the whole run (anthropic|openai|
+ *              gemini|agy), overriding ADLC_PROVIDER for this invocation only.
+ *              Default (no flag): single-provider auto-detect, unchanged.
+ *   --providers <a,b,c> draws ONE candidate fix per named provider family
+ *              instead of --n resamples of one auto-detected provider —
+ *              cross-family diversity per ADR-0007. Overrides --n (the fan
+ *              width becomes the number of providers named). Mutually
+ *              exclusive with --provider.
  */
 
 import { writeFileSync } from 'node:fs';
@@ -25,6 +34,7 @@ import {
   complete,
   resolveModel,
   detectProvider,
+  PROVIDER_NAMES,
 } from '@adlc/core';
 import { runConsensusFix } from '../lib/runner.mjs';
 import { buildPrompt } from '../lib/prompt.mjs';
@@ -38,6 +48,8 @@ const { values } = parseArgs({
     files: { type: 'string' },
     n: { type: 'string', default: '3' },
     tier: { type: 'string', default: 'mid' },
+    provider: { type: 'string' },
+    providers: { type: 'string' },
     apply: { type: 'boolean', default: false },
     'allow-dirty': { type: 'boolean', default: false },
     json: { type: 'boolean', default: false },
@@ -62,6 +74,37 @@ if (!['cheap', 'mid', 'frontier'].includes(tier)) {
   opError(`--tier must be cheap|mid|frontier, got: ${tier}`);
 }
 
+// --provider / --providers: per-invocation provider selection (issue #63).
+// Additive only — omit both and behavior is unchanged (single auto-detected
+// provider, --n resamples).
+const providerOverride = values['provider'] || undefined;
+const providersRaw = values['providers'] || undefined;
+
+if (providerOverride && providersRaw) {
+  opError('--provider and --providers are mutually exclusive — use one or the other');
+}
+if (providerOverride && !PROVIDER_NAMES.includes(providerOverride)) {
+  opError(`--provider must be one of: ${PROVIDER_NAMES.join(', ')}, got: ${providerOverride}`);
+}
+
+let providerNames;
+if (providersRaw) {
+  providerNames = providersRaw.split(',').map((p) => p.trim()).filter(Boolean);
+  if (providerNames.length === 0) opError('--providers must list at least one provider name');
+  const unknown = providerNames.filter((p) => !PROVIDER_NAMES.includes(p));
+  if (unknown.length > 0) {
+    opError(`--providers has unknown provider name(s): ${unknown.join(', ')} (known: ${PROVIDER_NAMES.join(', ')})`);
+  }
+  const dupes = [...new Set(providerNames.filter((p, i) => providerNames.indexOf(p) !== i))];
+  if (dupes.length > 0) {
+    opError(`--providers must name DISTINCT providers — duplicate(s): ${dupes.join(', ')}`);
+  }
+}
+
+// Fan width: one candidate per named provider when --providers is supplied,
+// otherwise the usual --n resamples of the single auto-detected provider.
+const fanWidth = providerNames ? providerNames.length : n;
+
 // --prompt-only: build and print prompts without running LLM.
 if (values['prompt-only']) {
   let snapshot;
@@ -76,7 +119,7 @@ if (values['prompt-only']) {
     testOutput: '<test output will appear here>',
     snapshot,
   });
-  promptOnly(Array.from({ length: n }, () => prompt));
+  promptOnly(Array.from({ length: fanWidth }, () => prompt));
   // promptOnly exits 0
 }
 
@@ -94,17 +137,35 @@ if (!values['allow-dirty']) {
 }
 
 // Build completeFn using core, with provider/model resolution.
-const provider = detectProvider();
-if (!provider) {
-  opError(
-    'no LLM provider configured — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY (or use --prompt-only)'
-  );
+if (providerNames) {
+  // --providers: confirm EACH named provider is actually available up front,
+  // so a missing API key surfaces as a clean opError instead of an N-deep
+  // "LLM call failed" discard buried in the report.
+  const missing = providerNames.filter((name) => !detectProvider(process.env, name));
+  if (missing.length > 0) {
+    opError(
+      `--providers requested provider(s) not available (missing API key): ${missing.join(', ')}\n` +
+        'Set the corresponding API key env var for each requested provider, or use --prompt-only.'
+    );
+  }
+} else {
+  const provider = detectProvider(process.env, providerOverride);
+  if (!provider) {
+    opError(
+      providerOverride
+        ? `--provider ${providerOverride} is not available — set its API key (or ADLC_AGY for agy)`
+        : 'no LLM provider configured — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY (or use --prompt-only)'
+    );
+  }
+  // modelId resolved for reference (complete() handles resolution internally).
+  resolveModel(provider, { tier });
 }
-// modelId resolved for reference (complete() handles resolution internally).
-resolveModel(provider, { tier });
 
-async function completeFn(prompt) {
-  return complete({ tier, prompt });
+// `providerName` is only passed by runConsensusFix when --providers is set
+// (one call per named provider); otherwise it's undefined and `provider:
+// providerOverride` falls back to --provider (or plain auto-detect if unset).
+async function completeFn(prompt, providerName) {
+  return complete({ tier, prompt, provider: providerName ?? providerOverride });
 }
 
 // SIGINT handler — restore files from snapshot on interrupt.
@@ -136,6 +197,7 @@ try {
     files: filePaths,
     n,
     tier,
+    providerNames,
     completeFn,
     onProgress: (msg) => {
       if (!values['json']) console.log(msg);

--- a/packages/consensus-fix/lib/format.mjs
+++ b/packages/consensus-fix/lib/format.mjs
@@ -38,7 +38,8 @@ export function formatReport({
     lines.push('');
     lines.push('Discarded candidates:');
     for (const d of discarded) {
-      lines.push(`  [${d.index + 1}] ${d.reason}`);
+      const providerSuffix = d.provider ? ` (provider: ${d.provider})` : '';
+      lines.push(`  [${d.index + 1}]${providerSuffix} ${d.reason}`);
     }
   }
 
@@ -52,7 +53,12 @@ export function formatReport({
   lines.push(`Agreement groups : ${groups.size}`);
   for (const group of groups.values()) {
     const indices = group.map((c) => c.index + 1).join(', ');
-    lines.push(`  Group (${group.length} member${group.length !== 1 ? 's' : ''}): candidates [${indices}]`);
+    const providerSuffix = group.some((c) => c.provider)
+      ? ` (providers: ${group.map((c) => c.provider ?? '?').join(', ')})`
+      : '';
+    lines.push(
+      `  Group (${group.length} member${group.length !== 1 ? 's' : ''}): candidates [${indices}]${providerSuffix}`
+    );
   }
 
   if (allDivergent) {
@@ -65,6 +71,7 @@ export function formatReport({
     const { winner, largestGroupSize } = selectionResult;
     lines.push('');
     lines.push(`Winner: candidate [${winner.index + 1}]`);
+    if (winner.provider) lines.push(`  Provider             : ${winner.provider}`);
     lines.push(`  Agreement group size : ${largestGroupSize}`);
     lines.push(`  Changed lines        : ${winner.changedLines}`);
     lines.push('');
@@ -109,6 +116,9 @@ export function formatJson({
       groupIndex: gi++,
       size: group.length,
       candidateIndices: group.map((c) => c.index),
+      // Per-candidate provider (issue #63 --providers); null entries when a
+      // candidate wasn't drawn from a named provider (default --n sampling).
+      candidateProviders: group.map((c) => c.provider ?? null),
     });
   }
 
@@ -126,12 +136,17 @@ export function formatJson({
     winner: selectionResult
       ? {
           index: selectionResult.winner.index,
+          provider: selectionResult.winner.provider ?? null,
           changedLines: selectionResult.winner.changedLines,
           largestGroupSize: selectionResult.largestGroupSize,
           changes: selectionResult.winner.changes,
           applied,
         }
       : null,
-    discardedDetails: discarded.map((d) => ({ index: d.index, reason: d.reason })),
+    discardedDetails: discarded.map((d) => ({
+      index: d.index,
+      provider: d.provider ?? null,
+      reason: d.reason,
+    })),
   };
 }

--- a/packages/consensus-fix/lib/runner.mjs
+++ b/packages/consensus-fix/lib/runner.mjs
@@ -58,7 +58,20 @@ export function validateCandidate(parsed, allowedPaths) {
  * @param {string[]} opts.files        — absolute paths
  * @param {number} opts.n              — fan width
  * @param {string} opts.tier           — 'cheap' | 'mid' | 'frontier'
- * @param {Function} opts.completeFn   — async (prompt) => string (injectable for testing)
+ * @param {Function} opts.completeFn   — async (prompt, providerName?) => string
+ *                                       (injectable for testing). `providerName`
+ *                                       is only passed when `opts.providerNames`
+ *                                       is supplied — otherwise it is called
+ *                                       with just `(prompt)`, unchanged from
+ *                                       prior behavior.
+ * @param {string[]} [opts.providerNames] — issue #63: draw ONE candidate per
+ *                                       named provider family (e.g.
+ *                                       ['anthropic', 'openai', 'gemini'])
+ *                                       instead of `n` resamples of a single
+ *                                       auto-detected provider. When supplied,
+ *                                       overrides `n` (the fan width becomes
+ *                                       providerNames.length). Additive only —
+ *                                       omit it and behavior is unchanged.
  * @param {string} [opts.railsCmd]     — full frozen rail suite; regression gate.
  *                                       A candidate survives only if BOTH testCmd
  *                                       and railsCmd pass. If omitted, candidates
@@ -74,9 +87,13 @@ export async function runConsensusFix({
   n,
   tier,
   completeFn,
+  providerNames,
   railsCmd,
   onProgress = () => {},
 }) {
+  // Fan width: one candidate per named provider when --providers is supplied,
+  // otherwise the usual n resamples of the single auto-detected provider.
+  const fanWidth = providerNames ? providerNames.length : n;
   const railsChecked = Boolean(railsCmd);
   if (!railsChecked) {
     onProgress(
@@ -101,24 +118,33 @@ export async function runConsensusFix({
   // 3. Build prompt.
   const prompt = buildPrompt({ testCmd, testOutput, snapshot });
 
-  // 4. Fan N completions.
-  onProgress(`Fanning ${n} completions (tier: ${tier})...`);
+  // 4. Fan completions: one per named provider family (--providers), or n
+  //    resamples of the single auto-detected provider (default).
+  onProgress(
+    providerNames
+      ? `Fanning ${fanWidth} completions across providers [${providerNames.join(', ')}] (tier: ${tier})...`
+      : `Fanning ${fanWidth} completions (tier: ${tier})...`
+  );
   const rawResponses = await Promise.allSettled(
-    Array.from({ length: n }, () => completeFn(prompt))
+    providerNames
+      ? providerNames.map((name) => completeFn(prompt, name))
+      : Array.from({ length: fanWidth }, () => completeFn(prompt))
   );
 
   // 5. Evaluate each candidate SEQUENTIALLY.
-  const results = [];  // { index, changes, changedLines, passed, discarded, reason }
+  const results = [];  // { index, changes, changedLines, passed, discarded, reason, provider? }
 
   for (let i = 0; i < rawResponses.length; i++) {
     const res = rawResponses[i];
-    onProgress(`Evaluating candidate ${i + 1}/${n}...`);
+    const provider = providerNames ? providerNames[i] : undefined;
+    onProgress(`Evaluating candidate ${i + 1}/${fanWidth}...`);
 
     if (res.status !== 'fulfilled') {
       results.push({
         index: i,
         discarded: true,
         reason: `LLM call failed: ${res.reason}`,
+        provider,
       });
       continue;
     }
@@ -132,6 +158,7 @@ export async function runConsensusFix({
         index: i,
         discarded: true,
         reason: `JSON parse failed: ${err.message}`,
+        provider,
       });
       continue;
     }
@@ -143,6 +170,7 @@ export async function runConsensusFix({
         index: i,
         discarded: true,
         reason: `validation failed: ${validation.reason}`,
+        provider,
       });
       continue;
     }
@@ -194,6 +222,7 @@ export async function runConsensusFix({
       railsChecked,
       testRunOutput,
       railsRunOutput,
+      provider,
     });
 
     let label;
@@ -218,7 +247,7 @@ export async function runConsensusFix({
 
   // 7. Group by agreement.
   const groups = groupByChangeset(survivors);
-  const allDivergent = isAllDivergent(groups, n);
+  const allDivergent = isAllDivergent(groups, fanWidth);
   const selectionResult = selectWinner(groups);
 
   return {

--- a/packages/consensus-fix/test/bin.test.mjs
+++ b/packages/consensus-fix/test/bin.test.mjs
@@ -1,0 +1,190 @@
+/**
+ * bin.test.mjs — CLI integration tests for --provider / --providers
+ * (issue #63). Spawns the real binary as a subprocess; no network calls or
+ * real API keys required — validation errors and --prompt-only both short-
+ * circuit before any provider is actually contacted.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const BIN = resolve(new URL('../bin/consensus-fix.mjs', import.meta.url).pathname);
+
+function makeTmp() {
+  return mkdtempSync(join(tmpdir(), 'consensus-fix-bin-test-'));
+}
+
+function runCli(args, { cwd, env } = {}) {
+  const result = spawnSync(process.execPath, [BIN, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 15000,
+    // Strip any provider API keys from the ambient environment so these
+    // tests are deterministic regardless of the machine they run on.
+    env: {
+      ...process.env,
+      ANTHROPIC_API_KEY: '',
+      OPENAI_API_KEY: '',
+      GEMINI_API_KEY: '',
+      ADLC_AGY: '',
+      ADLC_PROVIDER: '',
+      ...env,
+    },
+  });
+  return { stdout: result.stdout, stderr: result.stderr, code: result.status };
+}
+
+test('--provider and --providers are mutually exclusive', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stderr } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--provider', 'anthropic',
+      '--providers', 'anthropic,openai',
+      '--prompt-only',
+    ]);
+    assert.equal(code, 1);
+    assert.match(stderr, /mutually exclusive/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--provider rejects an unknown provider name', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stderr } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--provider', 'not-a-real-provider',
+      '--prompt-only',
+    ]);
+    assert.equal(code, 1);
+    assert.match(stderr, /--provider must be one of/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers rejects an unknown provider name in the list', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stderr } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--providers', 'anthropic,bogus',
+      '--prompt-only',
+    ]);
+    assert.equal(code, 1);
+    assert.match(stderr, /unknown provider name/);
+    assert.match(stderr, /bogus/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers rejects duplicate provider names', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stderr } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--providers', 'anthropic,anthropic',
+      '--prompt-only',
+    ]);
+    assert.equal(code, 1);
+    assert.match(stderr, /DISTINCT/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers overrides --n for --prompt-only prompt count (fan width = number of providers)', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stdout } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--n', '5', // should be ignored/overridden by --providers
+      '--providers', 'anthropic,openai',
+      '--prompt-only',
+    ]);
+    assert.equal(code, 0);
+    const promptCount = (stdout.match(/--- prompt \d+ of 2 ---/g) ?? []).length;
+    assert.equal(promptCount, 2, 'fan width should be 2 (number of providers), not --n=5');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('without --provider/--providers, --prompt-only prompt count still follows --n (unchanged default)', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stdout } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--n', '4',
+      '--prompt-only',
+    ]);
+    assert.equal(code, 0);
+    const promptCount = (stdout.match(/--- prompt \d+ of 4 ---/g) ?? []).length;
+    assert.equal(promptCount, 4);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers with no API keys configured fails closed with a clear operational error (not a network call)', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stderr } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--allow-dirty',
+      '--providers', 'anthropic,openai',
+    ]);
+    assert.equal(code, 1);
+    assert.match(stderr, /not available \(missing API key\)/);
+    assert.match(stderr, /anthropic/);
+    assert.match(stderr, /openai/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--provider naming an unavailable provider fails closed with a provider-specific error', () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'a.mjs');
+    writeFileSync(f, 'export const x = 1;\n');
+    const { code, stderr } = runCli([
+      '--test-cmd', 'exit 1',
+      '--files', f,
+      '--allow-dirty',
+      '--provider', 'anthropic',
+    ]);
+    assert.equal(code, 1);
+    assert.match(stderr, /--provider anthropic is not available/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/consensus-fix/test/format.test.mjs
+++ b/packages/consensus-fix/test/format.test.mjs
@@ -20,12 +20,13 @@ function makeGroups(candidates) {
   return map;
 }
 
-function makeCandidate(index, content, changedLines = 1) {
+function makeCandidate(index, content, changedLines = 1, provider) {
   return {
     index,
     changes: [{ file: 'src/a.mjs', content }],
     changedLines,
     passed: true,
+    ...(provider ? { provider } : {}),
   };
 }
 
@@ -368,4 +369,155 @@ test('formatJson summary.groups equals number of distinct groups', () => {
   });
 
   assert.equal(result.summary.groups, 2);
+});
+
+// ─── --providers surfacing (issue #63 review-round-2) ────────────────────────
+//
+// Docs promise "each survivor records which provider produced it" — verify
+// that promise actually reaches formatJson()/formatReport() output, not just
+// the internal candidate objects runConsensusFix builds.
+
+test('formatJson winner includes provider when candidate was drawn from --providers', () => {
+  const winner = makeCandidate(0, 'fix', 1, 'anthropic');
+  const groups = makeGroups([winner]);
+
+  const result = formatJson({
+    survivors: [winner],
+    discarded: [],
+    failed: [],
+    groups,
+    allDivergent: false,
+    selectionResult: { winner, largestGroupSize: 1 },
+    applied: false,
+  });
+
+  assert.equal(result.winner.provider, 'anthropic');
+});
+
+test('formatJson winner.provider is null when --providers was not used', () => {
+  const winner = makeCandidate(0, 'fix');
+  const groups = makeGroups([winner]);
+
+  const result = formatJson({
+    survivors: [winner],
+    discarded: [],
+    failed: [],
+    groups,
+    allDivergent: false,
+    selectionResult: { winner, largestGroupSize: 1 },
+    applied: false,
+  });
+
+  assert.equal(result.winner.provider, null);
+});
+
+test('formatJson discardedDetails includes provider for each discarded candidate', () => {
+  const discarded = [
+    { index: 0, reason: 'LLM call failed: timeout', provider: 'openai' },
+    { index: 1, reason: 'validation failed: bad shape' }, // no --providers
+  ];
+
+  const result = formatJson({
+    survivors: [],
+    discarded,
+    failed: [],
+    groups: new Map(),
+    allDivergent: false,
+    selectionResult: null,
+    applied: false,
+  });
+
+  assert.equal(result.discardedDetails[0].provider, 'openai');
+  assert.equal(result.discardedDetails[1].provider, null);
+});
+
+test('formatJson groups expose candidateProviders alongside candidateIndices', () => {
+  const c1 = makeCandidate(0, 'fix', 1, 'anthropic');
+  const c2 = makeCandidate(1, 'fix', 1, 'openai'); // same changeset -> same group
+  const groups = makeGroups([c1, c2]);
+
+  const result = formatJson({
+    survivors: [c1, c2],
+    discarded: [],
+    failed: [],
+    groups,
+    allDivergent: false,
+    selectionResult: { winner: c1, largestGroupSize: 2 },
+    applied: false,
+  });
+
+  assert.deepEqual(result.groups[0].candidateIndices, [0, 1]);
+  assert.deepEqual(result.groups[0].candidateProviders, ['anthropic', 'openai']);
+});
+
+test('formatReport shows winner provider when --providers was used', () => {
+  const winner = makeCandidate(0, 'fix', 1, 'gemini');
+  const groups = makeGroups([winner]);
+
+  const out = formatReport({
+    survivors: [winner],
+    discarded: [],
+    failed: [],
+    groups,
+    allDivergent: false,
+    selectionResult: { winner, largestGroupSize: 1 },
+    applied: false,
+    dryRun: true,
+  });
+
+  assert.ok(out.includes('gemini'), 'winner provider should appear in report text');
+});
+
+test('formatReport omits provider line when --providers was not used', () => {
+  const winner = makeCandidate(0, 'fix');
+  const groups = makeGroups([winner]);
+
+  const out = formatReport({
+    survivors: [winner],
+    discarded: [],
+    failed: [],
+    groups,
+    allDivergent: false,
+    selectionResult: { winner, largestGroupSize: 1 },
+    applied: false,
+    dryRun: true,
+  });
+
+  assert.ok(!out.includes('Provider'), 'no provider line when candidates have no provider field');
+});
+
+test('formatReport lists provider next to each discarded candidate', () => {
+  const discarded = [{ index: 0, reason: 'validation failed', provider: 'openai' }];
+
+  const out = formatReport({
+    survivors: [],
+    discarded,
+    failed: [],
+    groups: new Map(),
+    allDivergent: false,
+    selectionResult: null,
+    applied: false,
+    dryRun: true,
+  });
+
+  assert.ok(out.includes('openai'), 'discarded candidate provider should be visible in the report');
+});
+
+test('formatReport shows providers for each member of an agreement group', () => {
+  const c1 = makeCandidate(0, 'fix', 1, 'anthropic');
+  const c2 = makeCandidate(1, 'fix', 1, 'gemini'); // same changeset -> same group
+  const groups = makeGroups([c1, c2]);
+
+  const out = formatReport({
+    survivors: [c1, c2],
+    discarded: [],
+    failed: [],
+    groups,
+    allDivergent: false,
+    selectionResult: { winner: c1, largestGroupSize: 2 },
+    applied: false,
+    dryRun: true,
+  });
+
+  assert.ok(out.includes('anthropic') && out.includes('gemini'));
 });

--- a/packages/consensus-fix/test/runner.test.mjs
+++ b/packages/consensus-fix/test/runner.test.mjs
@@ -390,6 +390,128 @@ test('runConsensusFix: competing candidate that passes both gates wins over a sm
   }
 });
 
+// ─── providerNames (--providers) ──────────────────────────────────────────────
+// Issue #63: draw one candidate per requested provider family instead of N
+// samples of one auto-detected provider. completeFn receives (prompt, providerName)
+// so the injected fn can route to the right provider without a real network call.
+
+test('runConsensusFix: providerNames issues exactly one completeFn call per named provider, in order', async () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'source.mjs');
+    writeFileSync(f, 'original');
+    const testCmd = `test "$(cat '${f}')" != "original"`;
+
+    const seenProviders = [];
+    const completeFn = async (prompt, providerName) => {
+      seenProviders.push(providerName);
+      return JSON.stringify({ changes: [{ file: f, content: `fix-from-${providerName}` }] });
+    };
+
+    const result = await runConsensusFix({
+      testCmd,
+      files: [f],
+      n: 3, // --n is ignored/overridden when providerNames is supplied
+      tier: 'mid',
+      providerNames: ['anthropic', 'openai', 'gemini'],
+      completeFn,
+    });
+
+    assert.deepEqual(seenProviders, ['anthropic', 'openai', 'gemini']);
+    assert.equal(result.survivors.length, 3);
+    // Each survivor's changeset is genuinely distinct (three different providers).
+    assert.equal(result.groups.size, 3);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('runConsensusFix: providerNames results record which provider produced which candidate', async () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'source.mjs');
+    writeFileSync(f, 'original');
+    const testCmd = `test "$(cat '${f}')" != "original"`;
+
+    const completeFn = async (prompt, providerName) =>
+      JSON.stringify({ changes: [{ file: f, content: `fix-from-${providerName}` }] });
+
+    const result = await runConsensusFix({
+      testCmd,
+      files: [f],
+      providerNames: ['anthropic', 'openai'],
+      tier: 'mid',
+      completeFn,
+    });
+
+    assert.deepEqual(
+      result.survivors.map((s) => s.provider).sort(),
+      ['anthropic', 'openai']
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('runConsensusFix: providerNames + a failing provider surfaces as a discarded candidate, not a thrown error', async () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'source.mjs');
+    writeFileSync(f, 'original');
+    const testCmd = `test "$(cat '${f}')" != "original"`;
+
+    const completeFn = async (prompt, providerName) => {
+      if (providerName === 'openai') throw new Error('provider "openai" is not available');
+      return JSON.stringify({ changes: [{ file: f, content: `fix-from-${providerName}` }] });
+    };
+
+    const result = await runConsensusFix({
+      testCmd,
+      files: [f],
+      providerNames: ['anthropic', 'openai'],
+      tier: 'mid',
+      completeFn,
+    });
+
+    assert.equal(result.discarded.length, 1);
+    assert.match(result.discarded[0].reason, /openai/);
+    assert.equal(result.survivors.length, 1);
+    assert.equal(result.survivors[0].provider, 'anthropic');
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test('runConsensusFix: without providerNames, behavior is unchanged (n resamples, no provider field)', async () => {
+  const dir = makeTmp();
+  try {
+    const f = join(dir, 'source.mjs');
+    writeFileSync(f, 'original');
+    const testCmd = `test "$(cat '${f}')" != "original"`;
+
+    let callCount = 0;
+    const completeFn = async (prompt, providerName) => {
+      callCount++;
+      assert.equal(providerName, undefined, 'no per-invocation provider override by default');
+      return JSON.stringify({ changes: [{ file: f, content: 'same fix' }] });
+    };
+
+    const result = await runConsensusFix({
+      testCmd,
+      files: [f],
+      n: 2,
+      tier: 'mid',
+      completeFn,
+    });
+
+    assert.equal(callCount, 2);
+    assert.equal(result.survivors.length, 2);
+    assert.ok(result.survivors.every((s) => s.provider === undefined));
+  } finally {
+    cleanup(dir);
+  }
+});
+
 test('runConsensusFix: without --rails, emits a warning and survivors are repro-only', async () => {
   const dir = makeTmp();
   try {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@ the gap in your README — do not edit core.
 Import surface (from a tool at `packages/<name>/`):
 
 ```js
-import { complete, fan, extractJson, detectProvider, resolveModel } from '../../core/index.mjs';
+import { complete, fan, fanProviders, extractJson, detectProvider, resolveModel, PROVIDER_NAMES } from '../../core/index.mjs';
 import { git, gitDiff, changedFiles, isDirty, isGitRepo, coChange, pairKey, churn } from '../../core/index.mjs';
 import { parseArgs, pass, gateFail, opError, printJson, readStdin, promptOnly } from '../../core/index.mjs';
 import { ADLC_DIR, appendEntry, readEntries, ledgerPath, sha256, hashFiles } from '../../core/index.mjs';
@@ -18,10 +18,12 @@ import { mutate } from '../../core/index.mjs'; // mutate.generateMutants / apply
 
 ## llm
 
-- `detectProvider(env?)` → `{ name, apiKey, models } | null`. Order: anthropic, openai, gemini. Force with `ADLC_PROVIDER`.
+- `detectProvider(env?, forceProvider?)` → `{ name, apiKey, models } | null`. Order: anthropic, openai, gemini, agy. Force with `ADLC_PROVIDER` (env) or the `forceProvider` arg (per-invocation, e.g. a CLI `--provider` flag — takes precedence over `ADLC_PROVIDER`).
+- `PROVIDER_NAMES` → `['anthropic', 'openai', 'gemini', 'agy']`, for CLI validation of `--provider`/`--providers`.
 - `resolveModel(provider, { tier, model }, env?)` → model id. Tiers: `cheap | mid | frontier`. Override via `ADLC_MODEL_CHEAP/MID/FRONTIER`.
-- `complete({ tier, model, system, prompt, maxTokens })` → `Promise<string>`. Throws if no provider (tools must catch and offer `--prompt-only`).
-- `fan(opts, n)` → `Promise<[{ ok, value | error }]>` — n independent stateless completions.
+- `complete({ tier, model, system, prompt, maxTokens, provider? }, env?)` → `Promise<string>`. Throws if no provider (tools must catch and offer `--prompt-only`). `provider` is a per-invocation override, additive only — omit it and single-provider auto-detect remains the default (cost/latency per ADR-0007).
+- `fan(opts, n, env?)` → `Promise<[{ ok, value | error }]>` — n independent stateless completions of the SAME (auto-detected or `opts.provider`-forced) provider.
+- `fanProviders(opts, providerNames, env?)` → `Promise<[{ ok, value | error, provider }]>` — one completion per DISTINCT named provider (e.g. `['anthropic', 'openai', 'gemini']`), instead of N resamples of one provider. A named provider missing its API key surfaces as `{ ok: false }` for that entry only.
 - `extractJson(text)` → parsed JSON value from messy model output. Throws if none.
 
 ## git

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -28,6 +28,13 @@ export type CompletionOptions = {
   readonly system?: string;
   readonly prompt: string;
   readonly maxTokens?: number;
+  /**
+   * Per-invocation provider override (e.g. a CLI `--provider` flag), mirroring
+   * ADLC_PROVIDER but scoped to this one call; takes precedence over
+   * ADLC_PROVIDER. Omit it and single-provider auto-detect remains the
+   * default (cost/latency per ADR-0007).
+   */
+  readonly provider?: string;
 };
 export type CompletionRequest = CompletionOptions & {
   readonly apiKey: string;
@@ -36,12 +43,23 @@ export type CompletionRequest = CompletionOptions & {
 export type FanResult =
   | { readonly ok: true; readonly value: string }
   | { readonly ok: false; readonly error: string };
+export type FanProvidersResult =
+  | { readonly ok: true; readonly value: string; readonly provider: string }
+  | { readonly ok: false; readonly error: string; readonly provider: string };
+
+/** Names of all known providers, in auto-detect priority order. */
+export const PROVIDER_NAMES: readonly string[];
 
 export function isAgyTimeout(output: string): boolean;
-export function complete(options: CompletionOptions): Promise<string>;
-export function fan(options: CompletionOptions, count: number): Promise<FanResult[]>;
+export function complete(options: CompletionOptions, env?: Record<string, string | undefined>): Promise<string>;
+export function fan(options: CompletionOptions, count: number, env?: Record<string, string | undefined>): Promise<FanResult[]>;
+export function fanProviders(
+  options: CompletionOptions,
+  providerNames: readonly string[],
+  env?: Record<string, string | undefined>
+): Promise<FanProvidersResult[]>;
 export function extractJson(text: string): unknown;
-export function detectProvider(env?: Record<string, string | undefined>): Provider | null;
+export function detectProvider(env?: Record<string, string | undefined>, forceProvider?: string): Provider | null;
 export function resolveModel(
   provider: Pick<Provider, 'models'>,
   options?: { readonly tier?: ModelTier | string; readonly model?: string },

--- a/packages/core/lib/llm.mjs
+++ b/packages/core/lib/llm.mjs
@@ -214,13 +214,16 @@ export async function complete(opts, env = process.env) {
     );
   }
   const model = resolveModel(provider, opts, env);
-  return provider.send({
-    apiKey: provider.apiKey,
-    model,
-    system: opts.system,
-    prompt: opts.prompt,
-    maxTokens: opts.maxTokens ?? 4096,
-  });
+  return provider.send(
+    {
+      apiKey: provider.apiKey,
+      model,
+      system: opts.system,
+      prompt: opts.prompt,
+      maxTokens: opts.maxTokens ?? 4096,
+    },
+    env
+  );
 }
 
 /**

--- a/packages/core/lib/llm.mjs
+++ b/packages/core/lib/llm.mjs
@@ -152,12 +152,23 @@ const PROVIDERS = [
   },
 ];
 
+/** Names of all known providers, in auto-detect priority order. */
+export const PROVIDER_NAMES = PROVIDERS.map((p) => p.name);
+
 /**
- * Detect the first available provider (or the one forced via ADLC_PROVIDER).
- * Returns { name, apiKey, models } or null when no key is present.
+ * Detect the first available provider (or the one forced).
+ *
+ * `forceProvider` is a per-invocation override (e.g. a CLI `--provider` flag)
+ * and, when given, takes precedence over the `ADLC_PROVIDER` env var — it is
+ * additive to the env override, not a replacement for it: omit it and
+ * behavior is unchanged (env override, then auto-detect by cost/latency
+ * order per ADR-0007).
+ *
+ * Returns { name, apiKey, models } or null when no key is present (or the
+ * override/env name doesn't match a known provider).
  */
-export function detectProvider(env = process.env) {
-  const forced = env.ADLC_PROVIDER;
+export function detectProvider(env = process.env, forceProvider) {
+  const forced = forceProvider || env.ADLC_PROVIDER;
   const candidates = forced ? PROVIDERS.filter((p) => p.name === forced) : PROVIDERS;
   for (const p of candidates) {
     const apiKey = env[p.envKey];
@@ -185,16 +196,24 @@ export function resolveModel(provider, { tier = 'mid', model } = {}, env = proce
 
 /**
  * Single completion. Throws on missing provider or HTTP error.
- * opts: { tier, model, system, prompt, maxTokens }
+ * opts: { tier, model, system, prompt, maxTokens, provider }
+ *   opts.provider — optional per-invocation override (e.g. a CLI `--provider`
+ *   flag), mirroring ADLC_PROVIDER but scoped to this one call; takes
+ *   precedence over ADLC_PROVIDER. Omit it and single-provider auto-detect
+ *   remains the default (cost/latency per ADR-0007) — additive only.
+ * env — defaults to process.env; overridable for tests.
  */
-export async function complete(opts) {
-  const provider = detectProvider();
+export async function complete(opts, env = process.env) {
+  const provider = detectProvider(env, opts.provider);
   if (!provider) {
     throw new Error(
-      'no LLM provider configured — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY (or use --prompt-only)'
+      opts.provider
+        ? `provider "${opts.provider}" is not available — set its API key ` +
+          `(or ADLC_AGY for agy), or omit --provider to auto-detect`
+        : 'no LLM provider configured — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY (or use --prompt-only)'
     );
   }
-  const model = resolveModel(provider, opts);
+  const model = resolveModel(provider, opts, env);
   return provider.send({
     apiKey: provider.apiKey,
     model,
@@ -208,13 +227,45 @@ export async function complete(opts) {
  * Fan out N independent completions of the same prompt (fresh "contexts" by
  * construction — each call is stateless). Settles all; returns array of
  * { ok, value | error } in order.
+ *
+ * This samples the SAME (auto-detected or opts.provider-forced) provider N
+ * times. For N distinct provider families instead, use `fanProviders`.
  */
-export async function fan(opts, n) {
+export async function fan(opts, n, env = process.env) {
   const results = await Promise.allSettled(
-    Array.from({ length: n }, () => complete(opts))
+    Array.from({ length: n }, () => complete(opts, env))
   );
   return results.map((r) =>
     r.status === 'fulfilled' ? { ok: true, value: r.value } : { ok: false, error: String(r.reason) }
+  );
+}
+
+/**
+ * Fan a single prompt across N DISTINCT named providers — one completion per
+ * requested provider family, instead of N resamples of one auto-detected
+ * provider (see `fan`). Per ADR-0007, cross-family diversity catches blind
+ * spots a single model family shares; this is the primitive that gives
+ * consumers (e.g. consensus-fix, gate-fuzzing) access to that diversity via a
+ * `--providers <a,b,c>` flag.
+ *
+ * Each entry in `providerNames` is passed to `complete` as a per-call
+ * `provider` override, so a name with no configured API key surfaces as a
+ * normal `{ ok: false }` result for THAT entry — it never aborts the other
+ * providers' calls.
+ *
+ * @param {object} opts - same shape as `complete` (without `provider`)
+ * @param {string[]} providerNames - e.g. ['anthropic', 'openai', 'gemini']
+ * @param {object} [env] - defaults to process.env; overridable for tests
+ * @returns {Promise<Array<{ok:boolean, value?:string, error?:string, provider:string}>>}
+ */
+export async function fanProviders(opts, providerNames, env = process.env) {
+  const results = await Promise.allSettled(
+    providerNames.map((name) => complete({ ...opts, provider: name }, env))
+  );
+  return results.map((r, i) =>
+    r.status === 'fulfilled'
+      ? { ok: true, value: r.value, provider: providerNames[i] }
+      : { ok: false, error: String(r.reason), provider: providerNames[i] }
   );
 }
 

--- a/packages/core/test/core.test.mjs
+++ b/packages/core/test/core.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, utimesSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -452,6 +452,47 @@ test('agy provider: ADLC_AGY=false/0 do NOT enable the provider', () => {
   assert.equal(detectProvider({ ADLC_AGY: 'off' }), null);
   assert.equal(detectProvider({ ADLC_AGY: '1' })?.name, 'agy');
   assert.equal(detectProvider({ ADLC_AGY: '/usr/local/bin/agy' })?.apiKey, '/usr/local/bin/agy');
+});
+
+// Review-round-2 (issue #63): complete()/fan()/fanProviders() accept an
+// injectable `env` but historically did not forward it to provider.send(),
+// so the agy provider always fell back to process.env for ADLC_AGY_TIMEOUT /
+// ADLC_AGY_SANDBOX regardless of what env was passed in. This stubs a fake
+// `agy` binary (a shell script that just echoes its argv) so we can assert
+// the timeout/sandbox flags actually came from the injected env, not from
+// real process.env, without needing the real Antigravity CLI installed.
+test('complete: injected env reaches the agy provider send() (timeout/sandbox honored, not process.env)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-agy-stub-'));
+  const stubPath = join(dir, 'fake-agy.sh');
+  // Drain stdin fully before exiting — otherwise the parent's stdin.end()
+  // can race the child's exit and surface as an unrelated EPIPE.
+  writeFileSync(stubPath, '#!/bin/sh\ncat >/dev/null\necho "ARGS: $@"\n');
+  chmodSync(stubPath, 0o755);
+
+  // Leave a DIFFERENT value in real process.env to prove it is NOT what
+  // gets used — if the bug regresses, this is what `agySend` would read.
+  const prevTimeout = process.env.ADLC_AGY_TIMEOUT;
+  const prevSandbox = process.env.ADLC_AGY_SANDBOX;
+  process.env.ADLC_AGY_TIMEOUT = '999s-WRONG-PROCESS-ENV';
+  delete process.env.ADLC_AGY_SANDBOX;
+
+  try {
+    const injectedEnv = {
+      ADLC_AGY: stubPath,
+      ADLC_AGY_TIMEOUT: '5s',
+      ADLC_AGY_SANDBOX: '1',
+    };
+    const out = await complete({ tier: 'mid', prompt: 'hi', provider: 'agy' }, injectedEnv);
+    assert.match(out, /--print-timeout 5s/, 'should use the injected timeout, not process.env');
+    assert.match(out, /--sandbox/, 'should pass --sandbox from the injected env');
+    assert.ok(!out.includes('999s-WRONG-PROCESS-ENV'), 'must not fall back to process.env');
+  } finally {
+    if (prevTimeout === undefined) delete process.env.ADLC_AGY_TIMEOUT;
+    else process.env.ADLC_AGY_TIMEOUT = prevTimeout;
+    if (prevSandbox === undefined) delete process.env.ADLC_AGY_SANDBOX;
+    else process.env.ADLC_AGY_SANDBOX = prevSandbox;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // --- per-invocation provider selection (issue #63) ---

--- a/packages/core/test/core.test.mjs
+++ b/packages/core/test/core.test.mjs
@@ -454,6 +454,150 @@ test('agy provider: ADLC_AGY=false/0 do NOT enable the provider', () => {
   assert.equal(detectProvider({ ADLC_AGY: '/usr/local/bin/agy' })?.apiKey, '/usr/local/bin/agy');
 });
 
+// --- per-invocation provider selection (issue #63) ---
+
+import { fanProviders, PROVIDER_NAMES } from '../lib/llm.mjs';
+
+test('detectProvider: explicit override wins over ADLC_PROVIDER env and auto-detect order', () => {
+  const env = {
+    ADLC_PROVIDER: 'openai',
+    ANTHROPIC_API_KEY: 'k-anthropic',
+    OPENAI_API_KEY: 'k-openai',
+    GEMINI_API_KEY: 'k-gemini',
+  };
+  // Without override: env's ADLC_PROVIDER wins (existing behavior).
+  assert.equal(detectProvider(env).name, 'openai');
+  // Explicit override beats the env var.
+  assert.equal(detectProvider(env, 'gemini').name, 'gemini');
+  assert.equal(detectProvider(env, 'anthropic').name, 'anthropic');
+});
+
+test('detectProvider: explicit override without ADLC_PROVIDER set still selects the named provider', () => {
+  const env = { ANTHROPIC_API_KEY: 'k1', OPENAI_API_KEY: 'k2' };
+  // Auto-detect default would pick anthropic (first in list) — override picks openai instead.
+  assert.equal(detectProvider(env).name, 'anthropic');
+  assert.equal(detectProvider(env, 'openai').name, 'openai');
+});
+
+test('detectProvider: override naming a provider with no key present returns null (fails closed)', () => {
+  const env = { OPENAI_API_KEY: 'k2' };
+  assert.equal(detectProvider(env, 'anthropic'), null);
+});
+
+test('detectProvider: unknown override name returns null', () => {
+  assert.equal(detectProvider({ ANTHROPIC_API_KEY: 'k1' }, 'not-a-real-provider'), null);
+});
+
+test('PROVIDER_NAMES: lists all known provider names for CLI validation', () => {
+  assert.deepEqual(PROVIDER_NAMES, ['anthropic', 'openai', 'gemini', 'agy']);
+});
+
+test('complete: opts.provider overrides auto-detect (mocked fetch, no real API keys/network)', async () => {
+  const env = { ANTHROPIC_API_KEY: 'k-anthropic', OPENAI_API_KEY: 'k-openai' };
+  const calledUrls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    calledUrls.push(String(url));
+    if (String(url).includes('openai.com')) {
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'from-openai' } }] }),
+      };
+    }
+    return {
+      ok: true,
+      json: async () => ({ content: [{ text: 'from-anthropic' }] }),
+    };
+  };
+  try {
+    // Auto-detect would pick anthropic (first in list) — override picks openai.
+    const out = await complete({ tier: 'mid', prompt: 'hi', provider: 'openai' }, env);
+    assert.equal(out, 'from-openai');
+    assert.ok(calledUrls.some((u) => u.includes('openai.com')));
+    assert.ok(!calledUrls.some((u) => u.includes('anthropic.com')));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('complete: without opts.provider, falls back to auto-detect (unchanged default behavior)', async () => {
+  const env = { ANTHROPIC_API_KEY: 'k-anthropic', OPENAI_API_KEY: 'k-openai' };
+  const calledUrls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    calledUrls.push(String(url));
+    return { ok: true, json: async () => ({ content: [{ text: 'from-anthropic' }] }) };
+  };
+  try {
+    const out = await complete({ tier: 'mid', prompt: 'hi' }, env);
+    assert.equal(out, 'from-anthropic');
+    assert.ok(calledUrls.every((u) => u.includes('anthropic.com')));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('complete: naming an unavailable provider throws a clear, provider-specific error', async () => {
+  const env = { OPENAI_API_KEY: 'k-openai' };
+  await assert.rejects(
+    () => complete({ tier: 'mid', prompt: 'hi', provider: 'anthropic' }, env),
+    /provider "anthropic"/
+  );
+});
+
+test('fanProviders: issues ONE completion per distinct named provider, not N samples of one provider', async () => {
+  const env = {
+    ANTHROPIC_API_KEY: 'k-anthropic',
+    OPENAI_API_KEY: 'k-openai',
+    GEMINI_API_KEY: 'k-gemini',
+  };
+  const seenUrls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    seenUrls.push(String(url));
+    if (String(url).includes('openai.com')) {
+      return { ok: true, json: async () => ({ choices: [{ message: { content: 'openai-out' } }] }) };
+    }
+    if (String(url).includes('generativelanguage.googleapis.com')) {
+      return { ok: true, json: async () => ({ candidates: [{ content: { parts: [{ text: 'gemini-out' }] } }] }) };
+    }
+    return { ok: true, json: async () => ({ content: [{ text: 'anthropic-out' }] }) };
+  };
+  try {
+    const results = await fanProviders(
+      { tier: 'mid', prompt: 'find the bug' },
+      ['anthropic', 'openai', 'gemini'],
+      env
+    );
+    assert.equal(results.length, 3);
+    assert.ok(results.every((r) => r.ok));
+    assert.deepEqual(results.map((r) => r.provider), ['anthropic', 'openai', 'gemini']);
+    assert.deepEqual(results.map((r) => r.value), ['anthropic-out', 'openai-out', 'gemini-out']);
+    // Exactly one call landed on each provider's host — genuinely distinct
+    // families, not N resamples of the same detected provider.
+    assert.equal(seenUrls.filter((u) => u.includes('anthropic.com')).length, 1);
+    assert.equal(seenUrls.filter((u) => u.includes('openai.com')).length, 1);
+    assert.equal(seenUrls.filter((u) => u.includes('generativelanguage.googleapis.com')).length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fanProviders: a provider missing its API key surfaces as a per-provider failure, not a thrown exception', async () => {
+  const env = { ANTHROPIC_API_KEY: 'k-anthropic' }; // no OPENAI_API_KEY
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({ content: [{ text: 'anthropic-out' }] }) });
+  try {
+    const results = await fanProviders({ tier: 'mid', prompt: 'x' }, ['anthropic', 'openai'], env);
+    assert.equal(results[0].ok, true);
+    assert.equal(results[1].ok, false);
+    assert.match(results[1].error, /provider "openai"/);
+    assert.equal(results[1].provider, 'openai');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('parseArgs: pre-scans for --help and prints usage', () => {
   const originalExit = process.exit;
   const originalLog = console.log;

--- a/packages/gate-fuzzing/README.md
+++ b/packages/gate-fuzzing/README.md
@@ -12,6 +12,7 @@ This turns "we found 11 bypasses once" into "finding bypasses is a CI gate."
 
 ```
 gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid]
+             [--provider <name> | --providers <a,b,c>]
              [--max-rounds <int>] [--dry-rounds <int>] [--token-budget <int>]
              [--witness-trials <int>] [--max-fail-rate <float>] [--canary-budget <int>]
              [--behavioral-witness] [--allow-cmd <name>...] [--unsafe-no-sandbox]
@@ -32,8 +33,10 @@ gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid]
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--suite <path>` | `.adlc/gate-suite.json` | Gate suite descriptor (refuses if absent) |
-| `--n <int>` | `6` | Fan width per round |
+| `--n <int>` | `6` | Fan width per round. Ignored when `--providers` is given (fan width becomes the number of providers named). |
 | `--tier cheap\|mid` | `mid` | Adversary tier (frontier rejected) |
+| `--provider <name>` | _(auto-detect)_ | Force a single provider (`anthropic\|openai\|gemini\|agy`) for every fan instance, overriding `ADLC_PROVIDER` for this invocation only. Additive — omit it and single-provider auto-detect is unchanged. Mutually exclusive with `--providers`. |
+| `--providers <a,b,c>` | _(none)_ | Fan mutation strategies across **distinct** named providers (one instance per provider) instead of `--n` resamples of one auto-detected provider — cross-family diversity per [ADR-0007](../../docs/adr/0007-multimodel-adversarial-review.md). Mutually exclusive with `--provider`. |
 | `--max-rounds <int>` | `10` | Hard round ceiling |
 | `--dry-rounds <int>` | `3` | K consecutive dry rounds to stop |
 | `--token-budget <int>` | `200000` | Estimated token ceiling (chars/4) |

--- a/packages/gate-fuzzing/bin/gate-fuzzing.mjs
+++ b/packages/gate-fuzzing/bin/gate-fuzzing.mjs
@@ -3,7 +3,7 @@
 // Exit codes: 0 = no gate defeated (earned clean), 2 = gate defeated, 1 = op error
 
 import { parseArgs, opError, pass, gateFail, printJson } from '@adlc/core';
-import { detectProvider } from '@adlc/core';
+import { detectProvider, PROVIDER_NAMES } from '@adlc/core';
 import { runLoop } from '../lib/loop.mjs';
 import { classifyCandidate } from '../lib/classify.mjs';
 import { computeVerdict } from '../lib/verdict.mjs';
@@ -19,6 +19,8 @@ const { values } = parseArgs({
     suite:              { type: 'string' },
     n:                  { type: 'string', default: '6' },
     tier:               { type: 'string', default: 'mid' },
+    provider:           { type: 'string' },
+    providers:          { type: 'string' },
     'max-rounds':       { type: 'string', default: '10' },
     'dry-rounds':       { type: 'string', default: '3' },
     'token-budget':     { type: 'string', default: '200000' },
@@ -46,6 +48,7 @@ gate-fuzzing — standing red-team / gate calibration (ADLC C-tool)
 
 Usage:
   gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid]
+               [--provider <name> | --providers <a,b,c>]
                [--max-rounds <int>] [--dry-rounds <int>] [--token-budget <int>]
                [--witness-trials <int>] [--max-fail-rate <float>] [--canary-budget <int>]
                [--behavioral-witness] [--allow-cmd <name>...] [--unsafe-no-sandbox]
@@ -56,6 +59,15 @@ Options:
   --suite <path>          Gate suite JSON (default: .adlc/gate-suite.json)
   --n <int>               Fan width per round (default: 6)
   --tier cheap|mid        Adversary model tier (default: mid; frontier rejected)
+  --provider <name>       Force a single provider for the whole run (anthropic|
+                          openai|gemini|agy), overriding ADLC_PROVIDER for this
+                          invocation only. Default: single-provider auto-detect.
+  --providers <a,b,c>     Fan mutation strategies across DISTINCT named
+                          providers (one candidate per provider) instead of
+                          --n resamples of one auto-detected provider —
+                          cross-family diversity per ADR-0007. Overrides --n
+                          (fan width becomes the number of providers named).
+                          Mutually exclusive with --provider.
   --max-rounds <int>      Hard round ceiling (default: 10)
   --dry-rounds <int>      K consecutive no-new-defeat rounds to stop (default: 3)
   --token-budget <int>    Estimated token ceiling (default: 200000)
@@ -109,6 +121,39 @@ if (!['cheap', 'mid'].includes(tier)) opError('--tier must be cheap or mid');
 
 const allowedCmds = new Set(['node', 'git', 'npm', 'npx', ...(values['allow-cmd'] ?? [])]);
 
+// ── --provider / --providers: per-invocation provider selection (issue #63) ──
+// Additive only — omit both and behavior is unchanged (single auto-detected
+// provider, --n resamples).
+
+const providerOverride = values['provider'] || undefined;
+const providersRaw = values['providers'] || undefined;
+
+if (providerOverride && providersRaw) {
+  opError('--provider and --providers are mutually exclusive — use one or the other');
+}
+if (providerOverride && !PROVIDER_NAMES.includes(providerOverride)) {
+  opError(`--provider must be one of: ${PROVIDER_NAMES.join(', ')}, got: ${providerOverride}`);
+}
+
+let providerNames;
+if (providersRaw) {
+  providerNames = providersRaw.split(',').map((p) => p.trim()).filter(Boolean);
+  if (providerNames.length === 0) opError('--providers must list at least one provider name');
+  const unknown = providerNames.filter((p) => !PROVIDER_NAMES.includes(p));
+  if (unknown.length > 0) {
+    opError(`--providers has unknown provider name(s): ${unknown.join(', ')} (known: ${PROVIDER_NAMES.join(', ')})`);
+  }
+  const dupes = [...new Set(providerNames.filter((p, i) => providerNames.indexOf(p) !== i))];
+  if (dupes.length > 0) {
+    opError(`--providers must name DISTINCT providers — duplicate(s): ${dupes.join(', ')}`);
+  }
+}
+
+// Fan width: one candidate per named provider when --providers is supplied,
+// otherwise the usual --n resamples of the single auto-detected (or
+// --provider-forced) provider.
+const fanWidth = providerNames ? providerNames.length : n;
+
 // ── sandbox check (§1.7, Fix 1) ────────────────────────────────────────────
 
 const sandboxType = detectSandbox();
@@ -124,12 +169,27 @@ if (!sandboxType && !values['unsafe-no-sandbox'] && !values['prompt-only']) {
 // ── provider check (if not prompt-only) ────────────────────────────────────
 
 if (!values['prompt-only']) {
-  const provider = detectProvider();
-  if (!provider) {
-    opError(
-      'No LLM provider configured — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY\n' +
-      'Or use --prompt-only to print prompts without calling a provider.'
-    );
+  if (providerNames) {
+    // --providers: confirm EACH named provider is actually available up
+    // front, so a missing API key surfaces as a clean opError instead of a
+    // buried per-instance fan failure.
+    const missing = providerNames.filter((name) => !detectProvider(process.env, name));
+    if (missing.length > 0) {
+      opError(
+        `--providers requested provider(s) not available (missing API key): ${missing.join(', ')}\n` +
+          'Set the corresponding API key env var for each requested provider, or use --prompt-only.'
+      );
+    }
+  } else {
+    const provider = detectProvider(process.env, providerOverride);
+    if (!provider) {
+      opError(
+        providerOverride
+          ? `--provider ${providerOverride} is not available — set its API key (or ADLC_AGY for agy)`
+          : 'No LLM provider configured — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY\n' +
+            'Or use --prompt-only to print prompts without calling a provider.'
+      );
+    }
   }
 }
 
@@ -148,7 +208,7 @@ const gates = suite.gates;
 // ── prompt-only (§8) ────────────────────────────────────────────────────────
 
 if (values['prompt-only']) {
-  const prompts = buildPromptOnlyOutput(gates, n);
+  const prompts = buildPromptOnlyOutput(gates, fanWidth);
   for (const p of prompts) console.log(p + '\n');
   process.exit(0);
 }
@@ -198,6 +258,8 @@ const fanFn = async (opts, nFan) => {
     gates,
     n: nFan,
     tier,
+    provider: providerOverride,
+    providerNames,
     maxTokens: 4096,
     completeFn: null, // uses core fan for real runs
   });
@@ -233,7 +295,7 @@ const loopResult = await runLoop(gates, { dir: repoRoot }, {
   dryRounds,
   tokenBudget,
   maxFailRate,
-  n,
+  n: fanWidth,
   allowedCmds,
 });
 
@@ -263,7 +325,7 @@ if (values.json) {
     exhaustive: loopResult.exhaustive,
     stoppedBy: loopResult.stoppedBy,
     rounds: loopResult.rounds,
-    candidatesGenerated: loopResult.rounds * n,
+    candidatesGenerated: loopResult.rounds * fanWidth,
     defeats: verdict.defeats.map((d) => ({
       id: d.id,
       strategy: d.strategy,

--- a/packages/gate-fuzzing/lib/fan.mjs
+++ b/packages/gate-fuzzing/lib/fan.mjs
@@ -3,7 +3,6 @@
 // The adversary is N fanned cheap/mid models (frontier-free, E2).
 // Each call is stateless — fresh contexts by construction.
 
-import { fan as coreFan } from '@adlc/core';
 import { sampleSeeds, NOVEL_SEED } from './seeds.mjs';
 
 /**
@@ -100,56 +99,80 @@ export function buildUserPrompt(gate, seed, baselineManifest = '') {
 }
 
 /**
- * Fan the adversary across N instances with seeded strategies.
- * Each instance gets a different seed from the 12-class taxonomy.
+ * Fan the adversary across N instances with seeded strategies (default), or
+ * across DISTINCT named provider families when `providerNames` is supplied
+ * (issue #63) — one candidate per requested provider instead of N resamples
+ * of one auto-detected provider. Each instance gets a different seed from
+ * the 12-class taxonomy, cycling through gates.
  * Injectable completeFn for offline tests (never calls real LLM in tests).
  *
  * @param {object} opts
  * @param {object[]} opts.gates - Gate descriptors to target
  * @param {object[]} [opts.priorDefeats] - For feedback prompting
- * @param {number} [opts.n] - Fan width, default 6
+ * @param {number} [opts.n] - Fan width, default 6. Ignored when `providerNames`
+ *   is supplied (fan width becomes providerNames.length instead).
+ * @param {string|null} [opts.provider] - single-provider override (mirrors a
+ *   CLI `--provider` flag): every fan instance uses this SAME provider
+ *   instead of letting `complete()` auto-detect. Ignored when `providerNames`
+ *   is also supplied (mutually exclusive at the CLI layer).
+ * @param {string[]|null} [opts.providerNames] - e.g. ['anthropic', 'openai'];
+ *   when supplied, assigns one distinct provider per fan instance instead of
+ *   letting every instance auto-detect the same provider. Additive only —
+ *   omit it and behavior is unchanged.
  * @param {string} [opts.tier] - Model tier, default 'mid'
  * @param {number} [opts.maxTokens] - Max tokens per response, default 4096
- * @param {Function|null} [opts.completeFn] - Injectable: async (fanOpts, n) => results
- *   If null, uses core fan(). MUST be injected in tests.
- * @returns {Promise<Array<{ok:boolean, value?:string, error?:string}>>}
+ * @param {Function|null} [opts.completeFn] - Injectable: async (fanOpts) => string,
+ *   called once per fan instance. If null, uses core `complete()` per instance
+ *   (dynamic import keeps @adlc/core optional for pure prompt-builder tests).
+ * @returns {Promise<Array<{ok:boolean, value?:string, error?:string, provider?:string}>>}
  */
 export async function fanAdversary(opts) {
   const {
     gates,
     priorDefeats = [],
     n = 6,
+    provider = null,
+    providerNames = null,
     tier = 'mid',
     maxTokens = 4096,
     completeFn = null,
   } = opts;
 
-  // Sample N seeds for this round
-  const seeds = sampleSeeds(n);
+  const fanWidth = providerNames ? providerNames.length : n;
 
-  // Build prompts for each fan instance, cycling through gates
+  // Sample fanWidth seeds for this round
+  const seeds = sampleSeeds(fanWidth);
+
+  // Build prompts for each fan instance, cycling through gates. When
+  // providerNames is supplied, each instance also gets a distinct provider
+  // override — genuinely different model families, not resamples. When only
+  // the singular `provider` override is supplied, every instance uses that
+  // same forced provider (still n resamples, just not auto-detected).
   const fanCalls = seeds.map((seed, i) => {
     const gate = gates[i % gates.length];
     const system = buildSystemPrompt(gate, priorDefeats);
     const prompt = buildUserPrompt(gate, seed);
-    return { tier, system, prompt, maxTokens };
+    return {
+      tier,
+      system,
+      prompt,
+      maxTokens,
+      ...(providerNames ? { provider: providerNames[i] } : provider ? { provider } : {}),
+    };
   });
 
-  // Use injectable completeFn (for tests) or core fan
-  if (completeFn) {
-    // Injectable: completeFn is a fan-like function
-    return completeFn(fanCalls[0], n); // simplified: one call for the batch
-  }
+  // Injectable: completeFn(call) => Promise<string>, one call per fan
+  // instance. Real: core `complete()` per instance.
+  const runOne = completeFn
+    ? (call) => completeFn(call)
+    : (call) => import('@adlc/core').then(({ complete }) => complete(call));
 
-  // Real: fan all instances in parallel
-  const results = await Promise.allSettled(
-    fanCalls.map((call) => import('@adlc/core').then(({ complete }) => complete(call)))
-  );
+  const results = await Promise.allSettled(fanCalls.map(runOne));
 
-  return results.map((r) =>
+  return results.map((r, i) =>
     r.status === 'fulfilled'
-      ? { ok: true, value: r.value }
-      : { ok: false, error: String(r.reason) }
+      ? { ok: true, value: r.value, provider: fanCalls[i].provider }
+      : { ok: false, error: String(r.reason), provider: fanCalls[i].provider }
   );
 }
 

--- a/packages/gate-fuzzing/test/bin.test.mjs
+++ b/packages/gate-fuzzing/test/bin.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * bin.test.mjs — CLI integration tests for --provider / --providers
+ * (issue #63). Spawns the real binary as a subprocess; no network calls or
+ * real API keys required — validation errors and --prompt-only both short-
+ * circuit before any provider is actually contacted.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync, execFileSync } from 'node:child_process';
+
+const BIN = resolve(new URL('../bin/gate-fuzzing.mjs', import.meta.url).pathname);
+
+function makeRepoWithSuite() {
+  const dir = mkdtempSync(join(tmpdir(), 'gate-fuzzing-bin-test-'));
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 't@t.co'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'tester'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(
+    join(dir, '.adlc/gate-suite.json'),
+    JSON.stringify({ gates: [{ name: 'test-gate', claims: ['no regressions'], surface: ['src/**'] }] })
+  );
+  writeFileSync(join(dir, 'a.txt'), 'x\n');
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '-qm', 'init'], { cwd: dir });
+  return dir;
+}
+
+function runCli(args, { cwd, env } = {}) {
+  const result = spawnSync(process.execPath, [BIN, ...args], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 15000,
+    // Strip any provider API keys from the ambient environment so these
+    // tests are deterministic regardless of the machine they run on.
+    env: {
+      ...process.env,
+      ANTHROPIC_API_KEY: '',
+      OPENAI_API_KEY: '',
+      GEMINI_API_KEY: '',
+      ADLC_AGY: '',
+      ADLC_PROVIDER: '',
+      ...env,
+    },
+  });
+  return { stdout: result.stdout, stderr: result.stderr, code: result.status };
+}
+
+test('--provider and --providers are mutually exclusive', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stderr } = runCli(['--provider', 'anthropic', '--providers', 'anthropic,openai', '--prompt-only'], { cwd: dir });
+    assert.equal(code, 1);
+    assert.match(stderr, /mutually exclusive/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--provider rejects an unknown provider name', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stderr } = runCli(['--provider', 'not-a-real-provider', '--prompt-only'], { cwd: dir });
+    assert.equal(code, 1);
+    assert.match(stderr, /--provider must be one of/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers rejects an unknown provider name in the list', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stderr } = runCli(['--providers', 'anthropic,bogus', '--prompt-only'], { cwd: dir });
+    assert.equal(code, 1);
+    assert.match(stderr, /unknown provider name/);
+    assert.match(stderr, /bogus/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers rejects duplicate provider names', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stderr } = runCli(['--providers', 'anthropic,anthropic', '--prompt-only'], { cwd: dir });
+    assert.equal(code, 1);
+    assert.match(stderr, /DISTINCT/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers overrides --n for --prompt-only fan width (prompt count = number of providers)', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stdout } = runCli(['--n', '6', '--providers', 'anthropic,openai', '--prompt-only'], { cwd: dir });
+    assert.equal(code, 0);
+    const promptCount = (stdout.match(/Fan instance \d+\/2/g) ?? []).length;
+    assert.equal(promptCount, 2, 'fan width should be 2 (number of providers), not --n=6');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('without --provider/--providers, --prompt-only fan width still follows --n (unchanged default)', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stdout } = runCli(['--n', '3', '--prompt-only'], { cwd: dir });
+    assert.equal(code, 0);
+    const promptCount = (stdout.match(/Fan instance \d+\/3/g) ?? []).length;
+    assert.equal(promptCount, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--providers with no API keys configured fails closed with a clear operational error (not a network call)', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stderr } = runCli(['--providers', 'anthropic,openai', '--unsafe-no-sandbox'], { cwd: dir });
+    assert.equal(code, 1);
+    assert.match(stderr, /not available \(missing API key\)/);
+    assert.match(stderr, /anthropic/);
+    assert.match(stderr, /openai/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--provider naming an unavailable provider fails closed with a provider-specific error', () => {
+  const dir = makeRepoWithSuite();
+  try {
+    const { code, stderr } = runCli(['--provider', 'anthropic', '--unsafe-no-sandbox'], { cwd: dir });
+    assert.equal(code, 1);
+    assert.match(stderr, /--provider anthropic is not available/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/gate-fuzzing/test/fan.test.mjs
+++ b/packages/gate-fuzzing/test/fan.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * fan.test.mjs — tests for lib/fan.mjs: adversary fan-out, including the
+ * --providers cross-family fan (issue #63). Injects completeFn so no
+ * network calls or real API keys are required.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSystemPrompt, buildUserPrompt, fanAdversary, buildPromptOnlyOutput } from '../lib/fan.mjs';
+
+function gate(name = 'freeze-gate') {
+  return {
+    name,
+    claims: ['no regressions'],
+    surface: ['src/**'],
+    docs: [],
+  };
+}
+
+// ─── buildSystemPrompt / buildUserPrompt (pure) ───────────────────────────────
+
+test('buildSystemPrompt names the target gate and its claims/surface', () => {
+  const prompt = buildSystemPrompt(gate('my-gate'));
+  assert.match(prompt, /my-gate/);
+  assert.match(prompt, /no regressions/);
+});
+
+test('buildUserPrompt includes the assigned strategy class', () => {
+  const prompt = buildUserPrompt(gate(), { name: 'base-ref-window', prior: 'do X' });
+  assert.match(prompt, /base-ref-window/);
+  assert.match(prompt, /do X/);
+});
+
+// ─── fanAdversary: default (n resamples, injected completeFn) ────────────────
+
+test('fanAdversary: default fan width is n, one completeFn call per fan instance', async () => {
+  const calls = [];
+  const completeFn = async (call) => {
+    calls.push(call);
+    return 'candidate-output';
+  };
+
+  const results = await fanAdversary({ gates: [gate()], n: 3, completeFn });
+
+  assert.equal(calls.length, 3);
+  assert.equal(results.length, 3);
+  assert.ok(results.every((r) => r.ok && r.value === 'candidate-output'));
+  // No --providers requested — no per-call provider override.
+  assert.ok(calls.every((c) => c.provider === undefined));
+});
+
+test('fanAdversary: a failing fan instance surfaces as ok:false, not a thrown error', async () => {
+  let n = 0;
+  const completeFn = async () => {
+    n++;
+    if (n === 2) throw new Error('boom');
+    return 'ok-output';
+  };
+
+  const results = await fanAdversary({ gates: [gate()], n: 3, completeFn });
+
+  assert.equal(results.length, 3);
+  assert.equal(results.filter((r) => r.ok).length, 2);
+  assert.equal(results.filter((r) => !r.ok).length, 1);
+  assert.match(results.find((r) => !r.ok).error, /boom/);
+});
+
+test('fanAdversary: singular provider override forces the SAME provider for every resample (n unchanged)', async () => {
+  const calls = [];
+  const completeFn = async (call) => {
+    calls.push(call);
+    return 'x';
+  };
+
+  const results = await fanAdversary({ gates: [gate()], n: 3, provider: 'gemini', completeFn });
+
+  assert.equal(calls.length, 3);
+  assert.ok(calls.every((c) => c.provider === 'gemini'));
+  assert.equal(results.length, 3);
+});
+
+// ─── fanAdversary: --providers (distinct provider families) ──────────────────
+
+test('fanAdversary: providerNames overrides n — fan width equals number of providers', async () => {
+  const calls = [];
+  const completeFn = async (call) => {
+    calls.push(call);
+    return `from-${call.provider}`;
+  };
+
+  const results = await fanAdversary({
+    gates: [gate()],
+    n: 6, // ignored — providerNames wins
+    providerNames: ['anthropic', 'openai', 'gemini'],
+    completeFn,
+  });
+
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls.map((c) => c.provider), ['anthropic', 'openai', 'gemini']);
+  assert.equal(results.length, 3);
+  assert.deepEqual(results.map((r) => r.provider), ['anthropic', 'openai', 'gemini']);
+  assert.deepEqual(results.map((r) => r.value), ['from-anthropic', 'from-openai', 'from-gemini']);
+});
+
+test('fanAdversary: providerNames assigns one DISTINCT gate/seed pairing per provider (not resampling)', async () => {
+  const calls = [];
+  const completeFn = async (call) => {
+    calls.push(call);
+    return 'x';
+  };
+
+  await fanAdversary({
+    gates: [gate('gate-a'), gate('gate-b')],
+    providerNames: ['anthropic', 'openai'],
+    completeFn,
+  });
+
+  // Each call has a distinct system/user prompt (cycles through gates), and
+  // a distinct provider — this is N genuinely different calls, not N
+  // resamples of identical call options.
+  assert.notEqual(calls[0].system, undefined);
+  assert.equal(new Set(calls.map((c) => c.provider)).size, 2);
+});
+
+test('fanAdversary: a named provider that fails (e.g. missing API key) surfaces per-instance, others unaffected', async () => {
+  const completeFn = async (call) => {
+    if (call.provider === 'openai') throw new Error('provider "openai" is not available');
+    return `from-${call.provider}`;
+  };
+
+  const results = await fanAdversary({
+    gates: [gate()],
+    providerNames: ['anthropic', 'openai', 'gemini'],
+    completeFn,
+  });
+
+  assert.equal(results.length, 3);
+  const openaiResult = results.find((r) => r.provider === 'openai');
+  assert.equal(openaiResult.ok, false);
+  assert.match(openaiResult.error, /openai/);
+  assert.ok(results.find((r) => r.provider === 'anthropic').ok);
+  assert.ok(results.find((r) => r.provider === 'gemini').ok);
+});
+
+test('fanAdversary: real (non-injected) path threads providerNames through to core complete() (fails closed, no network — no API keys configured)', async () => {
+  // Force a clean slate regardless of the ambient environment: this test
+  // asserts the fail-closed path, so it must never accidentally have real
+  // credentials available and attempt a live network call.
+  const keys = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'ADLC_AGY', 'ADLC_PROVIDER'];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  for (const k of keys) delete process.env[k];
+  try {
+    const results = await fanAdversary({
+      gates: [gate()],
+      providerNames: ['anthropic', 'openai'],
+      completeFn: null,
+    });
+
+    assert.equal(results.length, 2);
+    // No provider is configured in this test environment — both calls should
+    // fail closed with a provider-specific error, never silently succeed or
+    // hang on a real network call.
+    assert.ok(results.every((r) => r.ok === false));
+    assert.ok(results.some((r) => /anthropic/.test(r.error)));
+    assert.ok(results.some((r) => /openai/.test(r.error)));
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+});
+
+// ─── buildPromptOnlyOutput ────────────────────────────────────────────────────
+
+test('buildPromptOnlyOutput: produces one prompt block per fan instance, labeled by gate/strategy', () => {
+  const out = buildPromptOnlyOutput([gate('g1')], 2);
+  assert.equal(out.length, 2);
+  assert.match(out[0], /Fan instance 1\/2/);
+  assert.match(out[0], /Gate: g1/);
+});


### PR DESCRIPTION
## Summary

- Adds per-invocation provider selection to `packages/core/lib/llm.mjs`: `detectProvider(env, forceProvider)` now accepts an optional override (takes precedence over `ADLC_PROVIDER`, additive only, fails closed on unknown/unavailable names), `complete(opts, env)` accepts `opts.provider`, and a new `fanProviders(opts, providerNames, env)` issues one `complete()` call per named provider instead of resampling one auto-detected provider N times. New `PROVIDER_NAMES` export for CLI validation.
- Wires `--provider <name>` / `--providers <a,b,c>` (mutually exclusive) into the two highest-value model-calling packages named in the issue:
  - `consensus-fix`: `runConsensusFix` draws one candidate per named provider (fan width = `providerNames.length`, overriding `--n`) instead of N samples of one provider; each survivor records which provider produced it.
  - `gate-fuzzing`: `fanAdversary` fans mutation-strategy instances across distinct providers (or forces a single provider for all resamples).
- Both packages validate provider names and fail closed with a clear operational error (exit 1, no network attempt) before any LLM call if a requested provider is missing its API key.
- Single-provider auto-detect remains the default everywhere — this is purely additive, not a default-behavior change (ADR-0007's cost/latency default is untouched).

Fixes #63

## Test plan

- [x] `node --test packages/core/test/core.test.mjs`
- [x] `node --test packages/consensus-fix/test/runner.test.mjs packages/consensus-fix/test/bin.test.mjs`
- [x] `node --test packages/gate-fuzzing/test/fan.test.mjs packages/gate-fuzzing/test/bin.test.mjs`
- [x] Full sweep for all three touched packages: `node --test packages/core/test/*.test.mjs packages/consensus-fix/test/*.test.mjs packages/gate-fuzzing/test/*.test.mjs` — 215 passed, 0 failed, 1 skipped
- [x] Verified all tests pass with zero real API keys configured (mocked `completeFn`/`fetch`); fail-closed paths exercised by deliberately clearing provider API keys
- [x] 2 consecutive clean adversarial-review rounds (rounds 3 and 4 of 4; round 2 findings addressed in `b61807d`)