### PR TITLE
feat(ci): ship risk-gated adversarial-review CI template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,10 @@ package READMEs.
   for folding this check into an already-required job instead.
 - [`ci/adlc-maintenance.yml`](./ci/adlc-maintenance.yml) — weekly advisory cron for
   skill-rot, model-ratchet, and gate-fuzzing checks.
+- [`ci/adversarial-review.yml`](./ci/adversarial-review.yml) — risk-gated PR check that
+  runs the `adversarial-review` multi-provider quorum on ADR-0007 high-blast-radius paths
+  (auth/trust boundary, deny paths, secrets, data-loss ops, schema/migration, CI/CD) and a
+  cheap single-model pass otherwise; records the verdict via `gate-manifest`.
 
 ## Repository shape
 

--- a/docs/ci/adversarial-review.yml
+++ b/docs/ci/adversarial-review.yml
@@ -21,14 +21,32 @@
 #      else defaults to single cross-model review"). Advisory only: it never
 #      blocks the PR and does not record gate-manifest evidence.
 #
-# --loop vs plain mode (IMPORTANT): per voodootikigod/adversarial-review#9,
-# `--loop` (the local fix-and-reconverge mode) currently silently drops
-# `--providers` — a multi-provider request would quietly degrade to a single
-# provider under `--loop`, defeating the whole point of the ADR-0007 risk gate
-# without any visible error. This template therefore uses the PLAIN
-# (non-loop, one-shot) review mode everywhere, which does respect
-# `--providers`. Do not add `--loop` to either job below without first
-# re-checking that upstream issue is closed.
+# --loop vs plain mode (IMPORTANT): historically (voodootikigod/adversarial-
+# review#9, filed against v2.5.1), `--loop` silently dropped `--providers` —
+# a multi-provider request would quietly degrade to a single provider under
+# `--loop`, defeating the whole point of the ADR-0007 risk gate without any
+# visible error. That bug is FIXED as of adversarial-review 2.6.0 (the exact
+# version this template pins) — confirmed directly against the published
+# 2.6.0 package: its own `--help` states `--loop` "Composes with --providers:
+# each round is reviewed by every requested provider and gated by the quorum
+# verdict", and `src/loop.js`'s `runProviderRound` is reached whenever
+# `args.providers` is set. Issue #9 itself was closed upstream. Do NOT use
+# that closed issue as license to add `--loop` here, though — see the next
+# paragraph for the real, independent, still-true blocker.
+#
+# This template uses PLAIN (non-loop, one-shot) review mode for a *different*
+# and durable reason, unrelated to #9: `--loop` only supports reviewing the
+# working tree. Per 2.6.0's own `src/loop.js` (`runLoop`), it hard-exits
+# (exit 1) if invoked with `--base <ref>` or `--scope branch` — exactly the
+# branch-diff invocation (`--base "origin/$BASE_REF"`) this CI gate needs to
+# review a PR's committed changes against its base branch without checking
+# the PR out and mutating the working tree. Swapping to `--loop` here isn't
+# a flag change; it would mean re-architecting this gate around checking out
+# the PR branch and running the loop's local fix-and-reconverge flow instead
+# of a read-only diff review — a materially different design. Do not add
+# `--loop` to either job below without doing that redesign deliberately (and
+# re-confirming this scope/base restriction still holds in whatever version
+# you pin at the time).
 #
 # ACTION REQUIRED before enabling this workflow:
 #   1. `adversarial-review` lives in a separate repo
@@ -155,12 +173,17 @@ jobs:
           ADVERSARIAL_REVIEW_VERSION: 2.6.0
         run: |
           set +e
-          # Plain (non-loop) review mode -- NOT --loop. Per
-          # voodootikigod/adversarial-review#9, --loop currently silently
-          # drops --providers, so a multi-provider request would silently
-          # degrade to a single provider under --loop. This plain one-shot
-          # invocation is the only mode that actually delivers the >=2
-          # distinct-provider quorum ADR-0007 requires for this risk tier.
+          # Plain (non-loop) review mode -- NOT --loop. Historically
+          # (voodootikigod/adversarial-review#9, now fixed as of the 2.6.0
+          # pin above) --loop silently dropped --providers; that is no
+          # longer why plain mode is used here. The real, still-true reason:
+          # --loop refuses to run against --base/branch-scope (2.6.0's
+          # src/loop.js exits 1 on --base or --scope branch -- it only
+          # supports --scope working-tree), and this job needs a read-only
+          # diff of origin/$BASE_REF against the PR head, not a working-tree
+          # fix-and-reconverge. This plain one-shot invocation is the mode
+          # that delivers the >=2 distinct-provider quorum ADR-0007 requires
+          # for this risk tier without mutating the checkout.
           #
           # --fail-on-empty is required here (not optional). Per the pinned
           # v2.6.0 source (bin/cli.js / src/git-context.js): when the
@@ -301,7 +324,8 @@ jobs:
           set +e
           # No --providers here on purpose: today's default single
           # cross-model behavior, not the multi-provider quorum. Still plain
-          # (non-loop) mode for the same --loop/#9 reason noted above.
+          # (non-loop) mode for the same --loop/--base incompatibility
+          # reason noted above (not the now-fixed #9 provider-drop bug).
           npx --yes "adversarial-review@${ADVERSARIAL_REVIEW_VERSION}" \
             --base "origin/$BASE_REF" \
             --fail-on high \

--- a/docs/ci/adversarial-review.yml
+++ b/docs/ci/adversarial-review.yml
@@ -88,7 +88,16 @@ jobs:
           #   data-loss / destructive / irreversible ops
           #   schema / migration changes
           #   CI/CD / supply-chain config
-          PATTERN='(^|/|-|_)auth[a-z]*(/|-|_|\.|$)'
+          # No before/after separator boundary here (unlike the `guard`
+          # alternative below) -- a boundary requirement misses extremely
+          # common real-world auth filenames that don't have a separator
+          # directly adjacent to the literal "auth": an `oauth/` directory,
+          # a `reauth.ts` file, or CamelCase composites like
+          # `OAuthCallback.ts`, `GoogleAuth.java`, `isAuthenticated.ts`. A
+          # bare substring match is deliberately over-inclusive (see the
+          # ACTION REQUIRED note above) -- there is no common non-auth
+          # English word that contains "auth" as a substring.
+          PATTERN='auth'
           PATTERN="$PATTERN|trust-boundary"
           PATTERN="$PATTERN|(^|/|-|_)(rails?-)?guard"
           PATTERN="$PATTERN|validat(e|or|ion)"

--- a/docs/ci/adversarial-review.yml
+++ b/docs/ci/adversarial-review.yml
@@ -1,0 +1,278 @@
+# ADLC adversarial-review CI gate — copy into your repo as
+# .github/workflows/adversarial-review.yml
+#
+# Risk-gated per ADR-0007/ADR-0008: `adversarial-review` with a multi-provider
+# quorum is a real LLM cost, so it must not run unconditionally on every PR.
+# This template mirrors the docs/ci/adlc-maintenance.yml pattern — a
+# DOCUMENTED TEMPLATE, not force-installed into .github/workflows/ by this
+# repo. Copy it in deliberately and configure the ACTION REQUIRED items below.
+#
+# What it does:
+#   1. `changes` — diffs the PR against its base and classifies it into the
+#      ADR-0007 risk tiers (auth/trust boundary, security controls/deny paths,
+#      secrets, data-loss/destructive/irreversible ops, schema/migration,
+#      CI/CD/supply-chain config).
+#   2. `adversarial-review` (risk=high) — runs the full `--providers auto`
+#      quorum, fails on a `high`-or-above finding, posts the report as a PR
+#      comment, and records the verdict via `gate-manifest record
+#      adversarial-review` (P6 evidence — see docs/toolkit.md).
+#   3. `adversarial-review-cheap` (risk=low) — a single-model informational
+#      pass instead of the full quorum (cost control per ADR-0007's "everything
+#      else defaults to single cross-model review"). Advisory only: it never
+#      blocks the PR and does not record gate-manifest evidence.
+#
+# --loop vs plain mode (IMPORTANT): per voodootikigod/adversarial-review#9,
+# `--loop` (the local fix-and-reconverge mode) currently silently drops
+# `--providers` — a multi-provider request would quietly degrade to a single
+# provider under `--loop`, defeating the whole point of the ADR-0007 risk gate
+# without any visible error. This template therefore uses the PLAIN
+# (non-loop, one-shot) review mode everywhere, which does respect
+# `--providers`. Do not add `--loop` to either job below without first
+# re-checking that upstream issue is closed.
+#
+# ACTION REQUIRED before enabling this workflow:
+#   1. `adversarial-review` lives in a separate repo
+#      (voodootikigod/adversarial-review) and is not vendored or
+#      version-pinned anywhere in *this* repo, so this template cannot ship a
+#      pre-audited version pin the way docs/ci/adlc-maintenance.yml pins
+#      `@adlc/cli`. Replace `ADVERSARIAL_REVIEW_VERSION: latest` below with an
+#      exact version you have audited before relying on this as a required
+#      check — do not leave a mutable `latest` resolving on every PR from a
+#      runner with repo/comment-posting access.
+#   2. Provider credentials: `--providers auto` needs whichever provider
+#      API keys / local CLIs your `adversarial-review` install expects
+#      (e.g. Anthropic/OpenAI/Gemini API keys as repo secrets). Wire those
+#      into `env:` on the `adversarial-review` job before enabling it.
+#   3. The risk-tier PATTERN below is deliberately conservative/over-inclusive
+#      (a false positive just costs one extra full review; a false negative
+#      skips the gate entirely) — tune it to your own directory layout.
+
+name: Adversarial Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      risk: ${{ steps.classify.outputs.risk }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # full history so the base-ref diff is meaningful
+
+      - name: Classify PR against the ADR-0007 risk tiers
+        id: classify
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          set -e
+          git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+          CHANGED="$(git diff --name-only "origin/$BASE_REF...HEAD")"
+          echo "changed files:"
+          echo "$CHANGED"
+
+          # ADR-0007 risk tiers, one alternative per category. Path/name based
+          # (not content-based) — deliberately over-inclusive; see ACTION
+          # REQUIRED item 3 above.
+          #   auth / authn / authz / trust boundary
+          #   security controls / deny paths: rail guards, validators, sandboxes
+          #   secrets handling
+          #   data-loss / destructive / irreversible ops
+          #   schema / migration changes
+          #   CI/CD / supply-chain config
+          PATTERN='(^|/|-|_)(auth|authn|authz)(/|-|_|\.|$)'
+          PATTERN="$PATTERN|trust-boundary"
+          PATTERN="$PATTERN|(^|/|-|_)(rails?-)?guard"
+          PATTERN="$PATTERN|validat(e|or)"
+          PATTERN="$PATTERN|sandbox"
+          PATTERN="$PATTERN|secret"
+          PATTERN="$PATTERN|destructive|irreversible|data-loss"
+          PATTERN="$PATTERN|migrat(e|ion)"
+          PATTERN="$PATTERN|schema"
+          PATTERN="$PATTERN|(^|/)\.github/workflows/"
+          PATTERN="$PATTERN|(^|/)package(-lock)?\.json$"
+          PATTERN="$PATTERN|(^|/)(Dockerfile|\.dockerignore)$"
+
+          if printf '%s\n' "$CHANGED" | grep -qiE "$PATTERN"; then
+            echo "risk=high" >> "$GITHUB_OUTPUT"
+            echo "Matched an ADR-0007 risk-tier path -- full multi-provider quorum required."
+          else
+            echo "risk=low" >> "$GITHUB_OUTPUT"
+            echo "No ADR-0007 risk-tier path matched -- cheap single-model pass only."
+          fi
+
+  adversarial-review:
+    needs: changes
+    if: needs.changes.outputs.risk == 'high'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # to post the report as a PR comment via `gh`
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+
+      - name: Install the ADLC toolkit (for gate-manifest recording)
+        # Pinned to an exact, audited version for the same supply-chain reason
+        # as docs/ci/adlc-maintenance.yml. Bump deliberately after review.
+        run: npm install -g --ignore-scripts @adlc/cli@1.1.0
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      - name: Run multi-provider adversarial review (plain, non-loop mode)
+        id: review
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          # See ACTION REQUIRED item 1 above -- pin before relying on this.
+          ADVERSARIAL_REVIEW_VERSION: latest
+        run: |
+          set +e
+          # Plain (non-loop) review mode -- NOT --loop. Per
+          # voodootikigod/adversarial-review#9, --loop currently silently
+          # drops --providers, so a multi-provider request would silently
+          # degrade to a single provider under --loop. This plain one-shot
+          # invocation is the only mode that actually delivers the >=2
+          # distinct-provider quorum ADR-0007 requires for this risk tier.
+          npx --yes "adversarial-review@${ADVERSARIAL_REVIEW_VERSION}" \
+            --base "origin/$BASE_REF" \
+            --providers auto \
+            --fail-on high \
+            > review-report.txt 2>&1
+          rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          cat review-report.txt
+          exit 0 # never fail this step -- the dedicated gate step decides pass/fail
+
+      - name: Post review report as a PR comment
+        if: always() && github.event.pull_request.number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "### Adversarial review (risk-tier: high, providers: auto)"
+            echo
+            echo '```'
+            head -c 60000 review-report.txt
+            echo
+            echo '```'
+          } > pr-comment-body.md
+          gh pr comment "$PR_NUMBER" --body-file pr-comment-body.md
+
+      - name: Record adversarial-review verdict (P6 gate evidence)
+        if: always()
+        run: |
+          rc="${{ steps.review.outputs.rc }}"
+          case "$rc" in
+            0) verdict=approve ;;
+            2) verdict=needs-attention ;;
+            *) verdict=error ;;
+          esac
+
+          # Best-effort provider extraction from the report text -- "auto" is
+          # what was requested, but adversarial-review resolves it internally
+          # to specific distinct-family providers. Fall back to "auto" if none
+          # of the known provider identifiers appear in the report text.
+          providers="$(grep -oiE '\b(claude|gpt|codex|gemini)\b' review-report.txt | sort -u | tr '\n' ',' | sed 's/,$//')"
+          [ -n "$providers" ] || providers=auto
+
+          if [ "$rc" = "2" ]; then surviving=unknown-see-report; else surviving=0; fi
+
+          # NOTE: this is the plain (non-loop) mode, so there is no
+          # loop_start/review/fix/loop_end NDJSON stream -- iterations is
+          # always 1 and there is no loop exitReason to report (see
+          # docs/toolkit.md's "Recording an adversarial-review verdict" note).
+          #
+          # gate-manifest record only supports --data '{json}' (not the
+          # --evidence 'k=v; k=v' string previously documented in
+          # docs/toolkit.md, which node's strict-mode parseArgs rejects with
+          # ERR_PARSE_ARGS_UNKNOWN_OPTION) -- see docs/toolkit.md for the
+          # corrected convention.
+          adlc gate-manifest record adversarial-review \
+            --data "{\"providers\":\"$providers\",\"iterations\":1,\"verdict\":\"$verdict\",\"exitReason\":\"n/a-non-loop-single-pass\",\"surviving\":\"$surviving\",\"accepted\":0}"
+
+      - name: Gate on adversarial-review verdict
+        run: |
+          rc="${{ steps.review.outputs.rc }}"
+          if [ "$rc" = "1" ]; then
+            echo "::error::adversarial-review could not complete (exit 1) -- provider/config error, see the report above."
+            exit 1
+          elif [ "$rc" = "2" ]; then
+            echo "::error::adversarial-review found a material finding at/above --fail-on high."
+            exit 1
+          elif [ "$rc" != "0" ]; then
+            echo "::error::adversarial-review exited $rc (unexpected)."
+            exit 1
+          fi
+          echo "adversarial-review: clean approve."
+
+  adversarial-review-cheap:
+    # Cost control per ADR-0007: "everything else defaults to single
+    # cross-model review (today's behavior)". Advisory only -- posts an
+    # informational comment, never blocks the PR, and does not record
+    # gate-manifest evidence (that ledger is reserved for the risk-gated
+    # quorum verdict above).
+    needs: changes
+    if: needs.changes.outputs.risk == 'low'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      - name: Run single-model adversarial review (plain, non-loop mode)
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          ADVERSARIAL_REVIEW_VERSION: latest
+        run: |
+          set +e
+          # No --providers here on purpose: today's default single
+          # cross-model behavior, not the multi-provider quorum. Still plain
+          # (non-loop) mode for the same --loop/#9 reason noted above.
+          npx --yes "adversarial-review@${ADVERSARIAL_REVIEW_VERSION}" \
+            --base "origin/$BASE_REF" \
+            --fail-on high \
+            > review-report.txt 2>&1
+          echo "(informational only -- this job's exit code is not the gate)"
+
+      - name: Post informational review as a PR comment
+        if: always() && github.event.pull_request.number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "### Adversarial review (risk-tier: low, single-model, informational only)"
+            echo
+            echo '```'
+            head -c 60000 review-report.txt
+            echo
+            echo '```'
+          } > pr-comment-body.md
+          gh pr comment "$PR_NUMBER" --body-file pr-comment-body.md

--- a/docs/ci/adversarial-review.yml
+++ b/docs/ci/adversarial-review.yml
@@ -173,11 +173,26 @@ jobs:
             echo
             echo '```'
           } > pr-comment-body.md
-          gh pr comment "$PR_NUMBER" --body-file pr-comment-body.md
+          # Never let a comment-posting failure fail the job: PRs from forks
+          # get a read-only GITHUB_TOKEN regardless of the `pull-requests:
+          # write` permission declared above, so `gh pr comment` predictably
+          # fails there. That must not mask/override the actual review
+          # verdict (the dedicated gate step below decides pass/fail).
+          gh pr comment "$PR_NUMBER" --body-file pr-comment-body.md \
+            || echo "::warning::could not post PR comment (forked PR? read-only GITHUB_TOKEN?)"
 
       - name: Record adversarial-review verdict (P6 gate evidence)
         if: always()
         run: |
+          set +e
+          # GitHub Actions runs `run:` blocks with `bash -eo pipefail` by
+          # default. Without `set +e` here, a review-report.txt that happens
+          # not to contain a literal claude/gpt/codex/gemini token makes the
+          # `grep` below exit 1, which -- under errexit+pipefail -- would abort
+          # this whole step *before* `gate-manifest record` runs, silently
+          # dropping the P6 evidence and skipping the actual gate decision in
+          # the next step. See the sibling review-invocation steps, which
+          # already `set +e` for the same reason.
           rc="${{ steps.review.outputs.rc }}"
           case "$rc" in
             0) verdict=approve ;;
@@ -278,4 +293,11 @@ jobs:
             echo
             echo '```'
           } > pr-comment-body.md
-          gh pr comment "$PR_NUMBER" --body-file pr-comment-body.md
+          # Never let a comment-posting failure fail the job: PRs from forks
+          # get a read-only GITHUB_TOKEN regardless of the `pull-requests:
+          # write` permission declared above, so `gh pr comment` predictably
+          # fails there. This is the last step in this job, so an unhandled
+          # failure here would fail the whole job -- directly contradicting
+          # this job's "advisory only, never blocks the PR" contract.
+          gh pr comment "$PR_NUMBER" --body-file pr-comment-body.md \
+            || echo "::warning::could not post PR comment (forked PR? read-only GITHUB_TOKEN?)"

--- a/docs/ci/adversarial-review.yml
+++ b/docs/ci/adversarial-review.yml
@@ -95,8 +95,11 @@ jobs:
           # a `reauth.ts` file, or CamelCase composites like
           # `OAuthCallback.ts`, `GoogleAuth.java`, `isAuthenticated.ts`. A
           # bare substring match is deliberately over-inclusive (see the
-          # ACTION REQUIRED note above) -- there is no common non-auth
-          # English word that contains "auth" as a substring.
+          # ACTION REQUIRED note above): yes, this also matches unrelated
+          # "auth" substrings like `author`/`AUTHORS.md`/`src/author.ts` --
+          # that is an accepted false positive under the same "a false
+          # positive just costs one extra full review" tradeoff, not a gap
+          # to close.
           PATTERN='auth'
           PATTERN="$PATTERN|trust-boundary"
           PATTERN="$PATTERN|(^|/|-|_)(rails?-)?guard"
@@ -158,10 +161,27 @@ jobs:
           # degrade to a single provider under --loop. This plain one-shot
           # invocation is the only mode that actually delivers the >=2
           # distinct-provider quorum ADR-0007 requires for this risk tier.
+          #
+          # --fail-on-empty is required here (not optional). Per the pinned
+          # v2.6.0 source (bin/cli.js / src/git-context.js): when the
+          # resolved diff is empty (fileCount==0 && diffBytes==0) the tool
+          # logs a warning and exits 0 -- an unconditional approve -- unless
+          # --fail-on-empty is passed, in which case it exits 1 instead. This
+          # job re-fetches origin/$BASE_REF and re-derives the diff itself
+          # (separately from the `changes` job above), so it can end up with
+          # a zero-diff scope even on a PR the `changes` job classified as
+          # risk=high -- e.g. main advances between the two jobs so the
+          # branch is now fully merged/no-op, or a rebased/duplicate PR
+          # re-triggers `synchronize`. Without this flag, that empty-diff
+          # case would exit 0 with no model ever consulted, and the "Record
+          # adversarial-review verdict" step below would permanently record
+          # a false "approve" P6 gate-manifest entry for a high-risk PR that
+          # was never actually reviewed.
           npx --yes "adversarial-review@${ADVERSARIAL_REVIEW_VERSION}" \
             --base "origin/$BASE_REF" \
             --providers auto \
             --fail-on high \
+            --fail-on-empty \
             > review-report.txt 2>&1
           rc=$?
           echo "rc=$rc" >> "$GITHUB_OUTPUT"

--- a/docs/ci/adversarial-review.yml
+++ b/docs/ci/adversarial-review.yml
@@ -32,13 +32,15 @@
 #
 # ACTION REQUIRED before enabling this workflow:
 #   1. `adversarial-review` lives in a separate repo
-#      (voodootikigod/adversarial-review) and is not vendored or
-#      version-pinned anywhere in *this* repo, so this template cannot ship a
-#      pre-audited version pin the way docs/ci/adlc-maintenance.yml pins
-#      `@adlc/cli`. Replace `ADVERSARIAL_REVIEW_VERSION: latest` below with an
-#      exact version you have audited before relying on this as a required
-#      check — do not leave a mutable `latest` resolving on every PR from a
-#      runner with repo/comment-posting access.
+#      (voodootikigod/adversarial-review) and is not vendored anywhere in
+#      *this* repo, so this template cannot ship a pre-audited version pin the
+#      way docs/ci/adlc-maintenance.yml pins `@adlc/cli` against an in-repo
+#      release process. `ADVERSARIAL_REVIEW_VERSION` below defaults to
+#      `2.6.0` (latest at the time this template was last reviewed) rather
+#      than a mutable `latest` tag, so a copy of this file does not silently
+#      start running a different, unaudited release on every PR. Re-audit and
+#      bump this pin deliberately when you adopt the template and periodically
+#      thereafter -- do not widen it back to `latest`.
 #   2. Provider credentials: `--providers auto` needs whichever provider
 #      API keys / local CLIs your `adversarial-review` install expects
 #      (e.g. Anthropic/OpenAI/Gemini API keys as repo secrets). Wire those
@@ -86,10 +88,10 @@ jobs:
           #   data-loss / destructive / irreversible ops
           #   schema / migration changes
           #   CI/CD / supply-chain config
-          PATTERN='(^|/|-|_)(auth|authn|authz)(/|-|_|\.|$)'
+          PATTERN='(^|/|-|_)auth[a-z]*(/|-|_|\.|$)'
           PATTERN="$PATTERN|trust-boundary"
           PATTERN="$PATTERN|(^|/|-|_)(rails?-)?guard"
-          PATTERN="$PATTERN|validat(e|or)"
+          PATTERN="$PATTERN|validat(e|or|ion)"
           PATTERN="$PATTERN|sandbox"
           PATTERN="$PATTERN|secret"
           PATTERN="$PATTERN|destructive|irreversible|data-loss"
@@ -137,8 +139,8 @@ jobs:
         id: review
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
-          # See ACTION REQUIRED item 1 above -- pin before relying on this.
-          ADVERSARIAL_REVIEW_VERSION: latest
+          # See ACTION REQUIRED item 1 above -- re-audit and bump deliberately.
+          ADVERSARIAL_REVIEW_VERSION: 2.6.0
         run: |
           set +e
           # Plain (non-loop) review mode -- NOT --loop. Per
@@ -249,7 +251,8 @@ jobs:
       - name: Run single-model adversarial review (plain, non-loop mode)
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
-          ADVERSARIAL_REVIEW_VERSION: latest
+          # See ACTION REQUIRED item 1 above -- re-audit and bump deliberately.
+          ADVERSARIAL_REVIEW_VERSION: 2.6.0
         run: |
           set +e
           # No --providers here on purpose: today's default single

--- a/docs/specs/ci-adversarial-review-template.md
+++ b/docs/specs/ci-adversarial-review-template.md
@@ -57,7 +57,7 @@ the shipped template.
 ## Verification
 
 ```sh
-node --test scripts/test/adversarial-review-template.test.mjs   # this feature's tests (14 pass)
+node --test scripts/test/adversarial-review-template.test.mjs   # this feature's tests (17 pass)
 npm test                                                         # full repo suite, no regressions
 python3 -c "import yaml; yaml.safe_load(open('docs/ci/adversarial-review.yml'))"  # YAML sanity
 ```

--- a/docs/specs/ci-adversarial-review-template.md
+++ b/docs/specs/ci-adversarial-review-template.md
@@ -57,7 +57,7 @@ the shipped template.
 ## Verification
 
 ```sh
-node --test scripts/test/adversarial-review-template.test.mjs   # this feature's tests (12 pass)
+node --test scripts/test/adversarial-review-template.test.mjs   # this feature's tests (14 pass)
 npm test                                                         # full repo suite, no regressions
 python3 -c "import yaml; yaml.safe_load(open('docs/ci/adversarial-review.yml'))"  # YAML sanity
 ```

--- a/docs/specs/ci-adversarial-review-template.md
+++ b/docs/specs/ci-adversarial-review-template.md
@@ -1,0 +1,63 @@
+# Spec note — CI adversarial-review template (issue #60)
+
+**Phase:** P1-lite record for a documented CI template deliverable (no ticket rails).
+
+## Issue
+
+[voodootikigod/adlc#60](https://github.com/voodootikigod/adlc/issues/60): `.github/workflows/ci.yml`
+has no `adversarial-review` job, and `docs/ci/adlc-maintenance.yml` deliberately excludes
+LLM-backed gates by design. Adversarial review was reachable only if a human remembered to run
+`npx adversarial-review` before merging — CI, the layer that "can't be forgotten under pressure,"
+didn't know the gate existed.
+
+## Acceptance criteria
+
+1. `docs/ci/adversarial-review.yml` exists as a documented, **not force-installed** template
+   (same pattern as `docs/ci/adlc-maintenance.yml`) — not wired into `.github/workflows/` by
+   this change.
+2. Path-filters PRs to the ADR-0007 risk tiers: auth/trust boundary, security controls/deny
+   paths (rail guards, validators, sandboxes), secrets handling, data-loss/destructive/
+   irreversible ops, schema/migration changes, CI/CD/supply-chain config.
+3. On a matching PR: runs `npx adversarial-review --base origin/$BASE --providers auto
+   --fail-on high`, posts the report as a PR comment, and records the verdict via
+   `adlc gate-manifest record adversarial-review`.
+4. On a non-matching PR: runs a cheap single-model pass (no `--providers`) instead of the full
+   quorum, informational only (never blocks, no gate-manifest record) — cost control per
+   ADR-0007.
+5. Uses **plain (non-loop)** review mode throughout, never `--loop`, with a comment explaining
+   why: per [voodootikigod/adversarial-review#9](https://github.com/voodootikigod/adversarial-review/issues/9),
+   `--loop` currently silently drops `--providers`, which would defeat the multi-provider quorum
+   without any visible error.
+6. `docs/toolkit.md` and `docs/README.md` reference the new template, mirroring how
+   `docs/ci/adlc-maintenance.yml` is referenced elsewhere in the repo.
+
+## A pre-existing bug found and fixed en route
+
+`docs/toolkit.md` documented `gate-manifest record adversarial-review --evidence 'k=v; k=v'` as
+"the exact evidence-string convention" (also quoted verbatim in issue #60's proposed direction).
+The real `gate-manifest` CLI (`packages/gate-manifest/bin/gate-manifest.mjs`) has no `--evidence`
+flag — only `--ticket`, `--data '{json}'`, `--files`, `--dir`, `--json` — and node's strict-mode
+`parseArgs` throws an uncaught `ERR_PARSE_ARGS_UNKNOWN_OPTION` on any unknown flag (confirmed by
+running it directly). Since the CI template's whole job is to actually invoke this command, using
+the documented-but-fictional `--evidence` flag would have crashed every risk-gated PR. Fixed the
+convention in `docs/toolkit.md` to the real `--data '{json}'` form (same semantic fields:
+providers, iterations, verdict, exitReason, surviving, accepted) and used the corrected form in
+the shipped template.
+
+## Files changed
+
+- `docs/ci/adversarial-review.yml` (new) — the template.
+- `docs/toolkit.md` — corrected the `gate-manifest record` evidence convention (`--data`, not
+  `--evidence`) and added a short section referencing the new template.
+- `docs/README.md` — added the template to the "CI templates" list.
+- `scripts/test/adversarial-review-template.test.mjs` (new) — structural assertions on the
+  template plus a functional check that runs the real `gate-manifest` binary against the exact
+  `--data` payload shape the template emits.
+
+## Verification
+
+```sh
+node --test scripts/test/adversarial-review-template.test.mjs   # this feature's tests (12 pass)
+npm test                                                         # full repo suite, no regressions
+python3 -c "import yaml; yaml.safe_load(open('docs/ci/adversarial-review.yml'))"  # YAML sanity
+```

--- a/docs/specs/ci-adversarial-review-template.md
+++ b/docs/specs/ci-adversarial-review-template.md
@@ -25,9 +25,13 @@ didn't know the gate existed.
    quorum, informational only (never blocks, no gate-manifest record) — cost control per
    ADR-0007.
 5. Uses **plain (non-loop)** review mode throughout, never `--loop`, with a comment explaining
-   why: per [voodootikigod/adversarial-review#9](https://github.com/voodootikigod/adversarial-review/issues/9),
-   `--loop` currently silently drops `--providers`, which would defeat the multi-provider quorum
-   without any visible error.
+   why. Historically ([voodootikigod/adversarial-review#9](https://github.com/voodootikigod/adversarial-review/issues/9),
+   filed against v2.5.1) `--loop` silently dropped `--providers`, which would have defeated the
+   multi-provider quorum without any visible error; that bug is fixed as of the 2.6.0 pin this
+   template uses. The durable reason plain mode is required here is unrelated to #9: `--loop`
+   only supports `--scope working-tree` and hard-errors on `--base <ref>`/`--scope branch`
+   (confirmed against 2.6.0's `src/loop.js`), which is incompatible with this gate's read-only
+   `--base origin/$BASE_REF` diff review of a PR.
 6. `docs/toolkit.md` and `docs/README.md` reference the new template, mirroring how
    `docs/ci/adlc-maintenance.yml` is referenced elsewhere in the repo.
 

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -78,16 +78,27 @@ Run the review itself via `adlc review` (dispatcher passthrough to `npx
 adversarial-review`) or invoke `npx adversarial-review` directly. The adversarial-review
 loop emits NDJSON events (`loop_start` / `review` / `fix` /
 `loop_end`); `loop_end.exitReason === "clean"` is the SHIP signal. Record the verdict as
-first-class human-gate evidence:
+first-class human-gate evidence. `gate-manifest record` only accepts a `--data '{json}'`
+payload (there is no `--evidence 'k=v; k=v'` flag — node's strict-mode `parseArgs` throws
+`ERR_PARSE_ARGS_UNKNOWN_OPTION` on it), so shape the same fields as JSON:
 
     adlc gate-manifest record adversarial-review \
-      --evidence 'providers=<a,b>; iterations=<n>; verdict=<approve|needs-attention>; exitReason=<clean|no-progress|ceiling>; surviving=<n>; accepted=<n>'
+      --data '{"providers":"<a,b>","iterations":<n>,"verdict":"<approve|needs-attention>","exitReason":"<clean|no-progress|ceiling>","surviving":<n>,"accepted":<n>}'
 
 Capture: providers used, iterations, final verdict, exit reason, surviving findings, and
 accepted-with-justification findings. See
 [ADR-0008](./adr/0008-adversarial-review-coverage-map.md). (A helper to emit this record
 directly from the loop is a deferred `adversarial-review` follow-on — the loop-convergence
 summary.)
+
+A risk-gated CI wiring of this exact recording step — path-filtered to the ADR-0007 risk
+tiers, running the full `--providers` quorum only on matching PRs and a cheap single-model
+pass otherwise — ships as a documented, not-force-installed template at
+[`ci/adversarial-review.yml`](./ci/adversarial-review.yml) (mirrors the
+[`ci/adlc-maintenance.yml`](./ci/adlc-maintenance.yml) "template, not force-installed"
+pattern). It also uses plain, non-loop review mode throughout — see the template's header
+comment for why `--loop` is deliberately avoided
+([voodootikigod/adversarial-review#9](https://github.com/voodootikigod/adversarial-review/issues/9)).
 
 The package READMEs define each tool's exact schema. Treat these docs as a routing map,
 then follow the linked README for command-specific details.

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -97,8 +97,10 @@ pass otherwise — ships as a documented, not-force-installed template at
 [`ci/adversarial-review.yml`](./ci/adversarial-review.yml) (mirrors the
 [`ci/adlc-maintenance.yml`](./ci/adlc-maintenance.yml) "template, not force-installed"
 pattern). It also uses plain, non-loop review mode throughout — see the template's header
-comment for why `--loop` is deliberately avoided
-([voodootikigod/adversarial-review#9](https://github.com/voodootikigod/adversarial-review/issues/9)).
+comment for why `--loop` is deliberately avoided (not because of
+[voodootikigod/adversarial-review#9](https://github.com/voodootikigod/adversarial-review/issues/9),
+which is fixed as of the pinned version, but because `--loop` is incompatible with the
+`--base <ref>` branch-diff review this gate needs).
 
 The package READMEs define each tool's exact schema. Treat these docs as a routing map,
 then follow the linked README for command-specific details.

--- a/scripts/test/adversarial-review-template.test.mjs
+++ b/scripts/test/adversarial-review-template.test.mjs
@@ -223,11 +223,25 @@ test('AC3c: ADVERSARIAL_REVIEW_VERSION is pinned to an exact version, not the mu
   assert.equal(npxInvocations, 2, 'expected both the high-risk and cheap jobs to invoke the pinned version');
 });
 
-test('AC4: uses plain (non-loop) review mode and documents why, citing adversarial-review#9', () => {
+test('AC4: uses plain (non-loop) review mode and documents the durable reason (--loop is incompatible with --base/branch-scope review, independent of the now-closed adversarial-review#9)', () => {
+  // Round-5 adversarial-review finding: adversarial-review#9 ("--loop
+  // silently drops --providers") was closed upstream and the fix shipped in
+  // the exact 2.6.0 version this template pins -- verified directly against
+  // the published 2.6.0 package (--help text + src/loop.js's
+  // runProviderRound path). So #9 is no longer a valid reason to avoid
+  // --loop, and this test must not encode "cites #9" as the thing that
+  // makes the design correct. The durable, still-true reason plain mode is
+  // required is that 2.6.0's --loop hard-errors on --base <ref> / --scope
+  // branch (it only supports --scope working-tree), which is incompatible
+  // with this gate's read-only branch-diff review -- that's what this test
+  // now asserts is documented, alongside the historical #9 context.
   const text = readTemplate();
   const executable = stripComments(text);
-  assert.ok(!/--loop\b/.test(executable), 'no executable line may pass --loop (silently drops --providers per adversarial-review#9)');
-  assert.match(text, /adversarial-review#9/, 'must document the reason, citing the upstream issue');
+  assert.ok(!/--loop\b/.test(executable), 'no executable line may pass --loop (incompatible with --base/branch-scope review)');
+  assert.match(text, /adversarial-review#9/, 'should still document the historical #9 context');
+  assert.match(text, /2\.6\.0/, 'must note the fix shipped in the pinned 2.6.0 version, not leave #9 looking open');
+  assert.match(text, /--base(?: <ref>| "?origin)?.{0,40}(incompatible|refuses|hard-errors|exits 1)|(incompatible|refuses|hard-errors|exits 1).{0,60}--base/is,
+    'must document the real, durable blocker: --loop is incompatible with --base/branch-scope review');
   assert.match(text, /--providers/);
 });
 

--- a/scripts/test/adversarial-review-template.test.mjs
+++ b/scripts/test/adversarial-review-template.test.mjs
@@ -74,6 +74,44 @@ test('AC3: risk-tier path filter covers every ADR-0007 category', () => {
   assert.match(text, /\.github\/workflows/);
 });
 
+test('AC3b: risk-tier PATTERN actually matches realistic auth/validator file paths (not just substrings in prose)', () => {
+  // Regression for a review finding: the PATTERN string could contain the
+  // words "auth"/"validat" in comments/other alternatives while the *regex*
+  // still failed to match common real-world file names like
+  // `authentication/`, `authorization.ts`, or `validation.ts`. This test
+  // extracts the exact `PATTERN=`/`PATTERN="$PATTERN|...` construction lines
+  // from the classify step and runs the real `grep -qiE` the workflow runs,
+  // against realistic sample paths -- the same verification method used to
+  // find the bug.
+  const text = readTemplate();
+  const patternLines = text
+    .split('\n')
+    .filter((line) => /^\s*PATTERN=/.test(line))
+    .map((line) => line.trim());
+  assert.ok(patternLines.length > 1, 'expected the multi-line PATTERN construction in the classify step');
+
+  const mustMatch = [
+    'src/authentication/handler.js',
+    'lib/authorization.ts',
+    'src/validation.ts',
+    'src/input-validation.ts',
+    'src/auth/handler.js',
+  ];
+  const mustNotNecessarilyBlockUnrelated = ['src/components/Button.tsx', 'README.md'];
+
+  for (const file of mustMatch) {
+    const script = `${patternLines.join('\n')}\nprintf '%s\\n' ${JSON.stringify(file)} | grep -qiE "$PATTERN"`;
+    const rc = execFileSync('bash', ['-c', `${script}; echo $?`], { encoding: 'utf8' }).trim();
+    assert.equal(rc, '0', `expected PATTERN to classify "${file}" as risk=high (a real auth/validator path), but it did not match`);
+  }
+
+  for (const file of mustNotNecessarilyBlockUnrelated) {
+    const script = `${patternLines.join('\n')}\nprintf '%s\\n' ${JSON.stringify(file)} | grep -qiE "$PATTERN"`;
+    const rc = execFileSync('bash', ['-c', `${script}; echo $?`], { encoding: 'utf8' }).trim();
+    assert.equal(rc, '1', `expected PATTERN to NOT classify unrelated file "${file}" as risk=high`);
+  }
+});
+
 test('AC4: uses plain (non-loop) review mode and documents why, citing adversarial-review#9', () => {
   const text = readTemplate();
   const executable = stripComments(text);

--- a/scripts/test/adversarial-review-template.test.mjs
+++ b/scripts/test/adversarial-review-template.test.mjs
@@ -17,7 +17,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+  existsSync, readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -39,6 +41,50 @@ function stripComments(text) {
     .split('\n')
     .filter((line) => !line.trim().startsWith('#'))
     .join('\n');
+}
+
+// Extracts and dedents the `run: |` script body of the step whose `- name:`
+// line contains `stepNameSubstring`, so tests can actually execute a step's
+// script under bash -eo pipefail (GitHub Actions' default shell) rather than
+// only pattern-matching its text. This is what lets AC12/AC13 catch a
+// regression even if a future edit reorders or rewrites the surrounding
+// lines while dropping the behavior under test.
+function extractStepScript(text, stepNameSubstring) {
+  const lines = text.split('\n');
+  const startIdx = lines.findIndex(
+    (l) => l.trim().startsWith('- name:') && l.includes(stepNameSubstring),
+  );
+  assert.ok(startIdx >= 0, `expected to find a step named like "${stepNameSubstring}"`);
+  const stepIndent = lines[startIdx].match(/^(\s*)/)[1].length;
+
+  let runIdx = -1;
+  for (let i = startIdx + 1; i < lines.length; i += 1) {
+    const l = lines[i];
+    const indent = l.match(/^(\s*)/)[1].length;
+    if (l.trim().startsWith('- name:') && indent <= stepIndent) break;
+    if (/^\s*run:\s*\|\s*$/.test(l)) {
+      runIdx = i;
+      break;
+    }
+  }
+  assert.ok(runIdx >= 0, `expected a "run: |" block for step "${stepNameSubstring}"`);
+  const runIndent = lines[runIdx].match(/^(\s*)/)[1].length;
+
+  const scriptLines = [];
+  for (let i = runIdx + 1; i < lines.length; i += 1) {
+    const l = lines[i];
+    if (l.trim() === '') {
+      scriptLines.push('');
+      continue;
+    }
+    const indent = l.match(/^(\s*)/)[1].length;
+    if (indent <= runIndent) break;
+    scriptLines.push(l);
+  }
+
+  const nonEmpty = scriptLines.filter((l) => l.trim() !== '');
+  const minIndent = Math.min(...nonEmpty.map((l) => l.match(/^(\s*)/)[1].length));
+  return scriptLines.map((l) => (l.trim() === '' ? '' : l.slice(minIndent))).join('\n');
 }
 
 test('AC1: docs/ci/adversarial-review.yml exists and is a documented template (not force-installed)', () => {
@@ -96,6 +142,15 @@ test('AC3b: risk-tier PATTERN actually matches realistic auth/validator file pat
     'src/validation.ts',
     'src/input-validation.ts',
     'src/auth/handler.js',
+    // Regression for a round-3 review finding: the previous PATTERN required
+    // a `/`/`-`/`_`/start-of-string boundary immediately before the literal
+    // "auth", which missed these extremely common real-world auth file
+    // names that don't have a separator directly adjacent to "auth".
+    'src/oauth/callback.ts',
+    'src/OAuthCallback.ts',
+    'src/GoogleAuth.java',
+    'src/isAuthenticated.ts',
+    'lib/reauth.ts',
   ];
   const mustNotNecessarilyBlockUnrelated = ['src/components/Button.tsx', 'README.md'];
 
@@ -231,4 +286,103 @@ test('AC10: docs/toolkit.md\'s gate-manifest record example uses the real --data
 test('AC11: docs/README.md CI templates section lists the new template, mirroring adlc-maintenance.yml', () => {
   const readme = readFileSync(join(ROOT, 'docs', 'README.md'), 'utf8');
   assert.match(readme, /ci\/adversarial-review\.yml/);
+});
+
+test('AC12: "Record adversarial-review verdict" step tolerates a review-report.txt with no provider token under bash -eo pipefail (regression for a missing `set +e`)', () => {
+  // Regression for a round-3 review finding: commit 4e347ff added `set +e`
+  // before the provider-extraction grep specifically because GitHub Actions
+  // runs `run:` blocks with `bash -eo pipefail` by default, and a
+  // review-report.txt without a literal claude/gpt/codex/gemini token makes
+  // that grep exit 1 -- which, without `set +e`, aborts the step *before*
+  // `adlc gate-manifest record` runs. This actually executes the extracted
+  // step script (not just a text match) under that same shell mode, so a
+  // future edit that drops or reorders the guard fails this test.
+  const text = readTemplate();
+  let script = extractStepScript(text, 'Record adversarial-review verdict');
+  // Substitute the one GitHub Actions expression the runner would normally
+  // resolve before invoking the shell.
+  script = script.replace('${{ steps.review.outputs.rc }}', '0');
+
+  const dir = mkdtempSync(join(tmpdir(), 'adv-review-record-'));
+  try {
+    // Deliberately no claude/gpt/codex/gemini token -- this is exactly the
+    // input that made the unguarded grep exit 1.
+    writeFileSync(join(dir, 'review-report.txt'), 'no matching provider tokens in this report\n');
+
+    // Stub `adlc` on PATH: touch a marker file so we can prove the script
+    // reached this command instead of aborting earlier under pipefail.
+    const stubDir = join(dir, 'bin');
+    mkdirSync(stubDir);
+    const marker = join(dir, 'adlc-was-called');
+    writeFileSync(join(stubDir, 'adlc'), `#!/bin/sh\ntouch ${JSON.stringify(marker)}\nexit 0\n`);
+    chmodSync(join(stubDir, 'adlc'), 0o755);
+
+    const fullScript = `set -eo pipefail\n${script}`;
+    execFileSync('bash', ['-c', fullScript], {
+      cwd: dir,
+      env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+    });
+
+    assert.ok(
+      existsSync(marker),
+      'expected `adlc gate-manifest record` to run even when review-report.txt has no ' +
+        'provider token -- if this fails, the step is missing (or lost) its `set +e` guard ' +
+        'against bash -eo pipefail aborting the provider-extraction grep',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('AC13: both "Post ... PR comment" steps tolerate a failing `gh pr comment` (forked PR, read-only GITHUB_TOKEN)', () => {
+  // Regression for a round-3 review finding: commit 4e347ff appended
+  // `|| echo "::warning..."` to both `gh pr comment` invocations so a
+  // forked PR's read-only GITHUB_TOKEN can't fail the job. For the "cheap"
+  // job this also protects the documented "advisory only, never blocks the
+  // PR" contract. This both text-checks the fallback and actually executes
+  // each step's script with a `gh` stub that always fails, so a future edit
+  // that drops the `|| echo` (or reintroduces a bare `gh pr comment`) fails
+  // this test instead of shipping unnoticed.
+  const text = readTemplate();
+  const stepNames = [
+    'Post review report as a PR comment',
+    'Post informational review as a PR comment',
+  ];
+
+  for (const stepName of stepNames) {
+    const script = extractStepScript(text, stepName);
+    assert.match(
+      script,
+      /gh pr comment[\s\S]*\|\|\s*echo\s+"::warning/,
+      `expected "${stepName}" to fall back with "|| echo ::warning" instead of letting ` +
+        '`gh pr comment` fail the job',
+    );
+
+    const dir = mkdtempSync(join(tmpdir(), 'adv-review-comment-'));
+    try {
+      writeFileSync(join(dir, 'review-report.txt'), 'some review output\n');
+
+      // Stub `gh` on PATH to always fail, simulating a forked PR's
+      // read-only GITHUB_TOKEN rejecting `gh pr comment`.
+      const stubDir = join(dir, 'bin');
+      mkdirSync(stubDir);
+      writeFileSync(join(stubDir, 'gh'), '#!/bin/sh\nexit 1\n');
+      chmodSync(join(stubDir, 'gh'), 0o755);
+
+      const fullScript = `set -eo pipefail\n${script}`;
+      assert.doesNotThrow(() => {
+        execFileSync('bash', ['-c', fullScript], {
+          cwd: dir,
+          env: {
+            ...process.env,
+            PATH: `${stubDir}:${process.env.PATH}`,
+            GH_TOKEN: 'fake',
+            PR_NUMBER: '123',
+          },
+        });
+      }, `expected "${stepName}" to survive a failing \`gh pr comment\` under bash -eo pipefail`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
 });

--- a/scripts/test/adversarial-review-template.test.mjs
+++ b/scripts/test/adversarial-review-template.test.mjs
@@ -112,6 +112,29 @@ test('AC3b: risk-tier PATTERN actually matches realistic auth/validator file pat
   }
 });
 
+test('AC3c: ADVERSARIAL_REVIEW_VERSION is pinned to an exact version, not the mutable "latest" tag', () => {
+  // Regression for the other half of commit 0790478 ("...and pin
+  // adversarial-review version"): AC3b already regression-tests the regex
+  // fix from that commit, but nothing previously asserted the version pin
+  // itself, so a future edit could silently reintroduce `latest` -- exactly
+  // the supply-chain risk the "ACTION REQUIRED item 1" comment warns
+  // against -- and still pass a fully green test suite.
+  const text = readTemplate();
+  const executable = stripComments(text);
+  const pinLines = executable.match(/ADVERSARIAL_REVIEW_VERSION:\s*\S+/g) || [];
+  assert.ok(pinLines.length > 0, 'expected at least one ADVERSARIAL_REVIEW_VERSION: env assignment');
+  for (const line of pinLines) {
+    assert.ok(!/latest/i.test(line), `ADVERSARIAL_REVIEW_VERSION must not be pinned to the mutable "latest" tag: "${line}"`);
+    assert.match(line, /ADVERSARIAL_REVIEW_VERSION:\s*['"]?\d+\.\d+\.\d+['"]?/,
+      `ADVERSARIAL_REVIEW_VERSION must be an exact semver pin, got: "${line}"`);
+  }
+  // Both jobs (adversarial-review and adversarial-review-cheap) invoke
+  // npx with this version -- both must be pinned identically, not just one.
+  assert.match(executable, /npx --yes ["']?adversarial-review@\$\{ADVERSARIAL_REVIEW_VERSION\}/);
+  const npxInvocations = (executable.match(/npx --yes ["']?adversarial-review@\$\{ADVERSARIAL_REVIEW_VERSION\}/g) || []).length;
+  assert.equal(npxInvocations, 2, 'expected both the high-risk and cheap jobs to invoke the pinned version');
+});
+
 test('AC4: uses plain (non-loop) review mode and documents why, citing adversarial-review#9', () => {
   const text = readTemplate();
   const executable = stripComments(text);

--- a/scripts/test/adversarial-review-template.test.mjs
+++ b/scripts/test/adversarial-review-template.test.mjs
@@ -1,0 +1,173 @@
+// adversarial-review-template.test.mjs — prosecutes issue #60: a documented,
+// not-force-installed CI template that wires `adversarial-review` into a risk
+// gate (ADR-0007), mirroring the docs/ci/adlc-maintenance.yml "template, not
+// force-installed" pattern.
+//
+// This file lives outside any single package (like rails-guard-ci.test.mjs
+// and flag-consistency.test.mjs) because it asserts properties of a template
+// document plus a cross-cutting CLI-usage contract, not the behavior of one
+// package.
+//
+// Structural checks only (no YAML parser is a repo dependency, matching how
+// the sibling docs/ci/*.yml templates are tested elsewhere in this repo —
+// via hashing/shell execution rather than schema parsing). The one dynamic
+// check (T-adlc60/AC6) actually runs the real gate-manifest binary against
+// the exact --data payload shape the template emits, so the recording
+// command is proven to work, not just present as text.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const TEMPLATE = join(ROOT, 'docs', 'ci', 'adversarial-review.yml');
+const GATE_MANIFEST_BIN = join(ROOT, 'packages', 'gate-manifest', 'bin', 'gate-manifest.mjs');
+
+function readTemplate() {
+  assert.ok(existsSync(TEMPLATE), `expected ${TEMPLATE} to exist`);
+  return readFileSync(TEMPLATE, 'utf8');
+}
+
+// Explanatory `#` comments legitimately mention --loop/--evidence (to say why
+// NOT to use them); only the executable (non-comment) lines must avoid them.
+function stripComments(text) {
+  return text
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('#'))
+    .join('\n');
+}
+
+test('AC1: docs/ci/adversarial-review.yml exists and is a documented template (not force-installed)', () => {
+  const text = readTemplate();
+  // Same "copy into your repo" framing as docs/ci/adlc-maintenance.yml — this
+  // template must not be wired into .github/workflows/ directly by this change.
+  assert.match(text, /copy into your repo as/i);
+  assert.ok(!existsSync(join(ROOT, '.github', 'workflows', 'adversarial-review.yml')),
+    'the template must not be force-installed into .github/workflows/');
+});
+
+test('AC2: triggers on pull_request against main', () => {
+  const text = readTemplate();
+  assert.match(text, /on:\s*\n\s*pull_request:/);
+});
+
+test('AC3: risk-tier path filter covers every ADR-0007 category', () => {
+  const text = readTemplate();
+  // auth / trust boundary
+  assert.match(text, /auth/i);
+  // security controls / deny paths: rail guards, validators, sandboxes
+  assert.match(text, /guard/i);
+  assert.match(text, /validat/i);
+  assert.match(text, /sandbox/i);
+  // secrets handling
+  assert.match(text, /secret/i);
+  // data-loss / destructive / irreversible ops
+  assert.match(text, /destructive|irreversible|data-loss/i);
+  // schema / migration changes
+  assert.match(text, /migrat/i);
+  assert.match(text, /schema/i);
+  // CI/CD / supply-chain config
+  assert.match(text, /\.github\/workflows/);
+});
+
+test('AC4: uses plain (non-loop) review mode and documents why, citing adversarial-review#9', () => {
+  const text = readTemplate();
+  const executable = stripComments(text);
+  assert.ok(!/--loop\b/.test(executable), 'no executable line may pass --loop (silently drops --providers per adversarial-review#9)');
+  assert.match(text, /adversarial-review#9/, 'must document the reason, citing the upstream issue');
+  assert.match(text, /--providers/);
+});
+
+test('AC5: high-risk job runs the documented invocation shape and posts a PR comment', () => {
+  const text = readTemplate();
+  assert.match(text, /npx --yes ["']?adversarial-review/);
+  assert.match(text, /--base ["']?"?origin\/\$BASE_REF/);
+  assert.match(text, /--providers auto/);
+  assert.match(text, /--fail-on high/);
+  assert.match(text, /gh pr comment/);
+});
+
+test('AC6: records the verdict via the CLI flag gate-manifest actually supports (--data, not the stale --evidence doc convention)', () => {
+  const text = readTemplate();
+  const executable = stripComments(text);
+  assert.match(executable, /gate-manifest record adversarial-review/);
+  assert.ok(!executable.includes('--evidence'),
+    'gate-manifest record has no --evidence flag (node:util parseArgs strict mode throws ' +
+    'ERR_PARSE_ARGS_UNKNOWN_OPTION) -- must use the real --data JSON flag');
+  assert.match(executable, /--data\s+["']/);
+});
+
+test('AC6b: the --data JSON payload shape the template emits is accepted by the real gate-manifest binary', () => {
+  const text = readTemplate();
+  // Pull the record step's --data template out of the yml and substitute
+  // sample values for the shell variables it interpolates, so we exercise
+  // gate-manifest with the exact JSON *shape* the workflow will send. The
+  // template double-quotes the payload for bash variable interpolation and
+  // backslash-escapes the inner JSON quotes (`\"`) -- undo that escaping here
+  // since we invoke the binary directly (no shell) with execFileSync.
+  const match = text.match(/--data\s+"(\{[^\n]*\})"/);
+  assert.ok(match, 'expected a --data "{...}" JSON payload in the record step');
+  const sample = match[1]
+    .replaceAll('\\"', '"')
+    .replaceAll('$providers', 'claude,gpt')
+    .replaceAll('$verdict', 'needs-attention')
+    .replaceAll('$surviving', '1');
+
+  const dir = mkdtempSync(join(tmpdir(), 'gm-adv-review-'));
+  try {
+    const out = execFileSync(
+      process.execPath,
+      [GATE_MANIFEST_BIN, 'record', 'adversarial-review', '--data', sample, '--dir', dir, '--json'],
+      { encoding: 'utf8' },
+    );
+    const entry = JSON.parse(out);
+    assert.equal(entry.gate, 'adversarial-review');
+    assert.equal(entry.data.verdict, 'needs-attention');
+    assert.equal(entry.data.providers, 'claude,gpt');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('AC7: non-risk-tier paths skip the full quorum (cost control per ADR-0007)', () => {
+  const text = readTemplate();
+  // There must be a second job path gated on the low-risk output that does
+  // NOT request the full multi-provider quorum.
+  assert.match(text, /risk\s*==\s*['"]low['"]/);
+  const lowJobMatch = text.match(/risk[^\n]*low[\s\S]*?(?=\njobs:|$)/);
+  assert.ok(lowJobMatch);
+});
+
+test('AC8: pins actions to full commit SHAs, matching the sibling template convention', () => {
+  const text = readTemplate();
+  assert.match(text, /actions\/checkout@[0-9a-f]{40}/);
+  if (/actions\/setup-node@/.test(text)) {
+    assert.match(text, /actions\/setup-node@[0-9a-f]{40}/);
+  }
+});
+
+test('AC9: docs/toolkit.md references the new CI template', () => {
+  const toolkit = readFileSync(join(ROOT, 'docs', 'toolkit.md'), 'utf8');
+  assert.match(toolkit, /ci\/adversarial-review\.yml/);
+});
+
+test('AC10: docs/toolkit.md\'s gate-manifest record example uses the real --data flag, not --evidence', () => {
+  const toolkit = readFileSync(join(ROOT, 'docs', 'toolkit.md'), 'utf8');
+  // The runnable example is the indented ("    adlc gate-manifest record ...")
+  // code sample -- prose above it is allowed to name the old, incorrect
+  // --evidence flag while explaining the correction.
+  const exampleMatch = toolkit.match(/^ {4}adlc gate-manifest record adversarial-review[\s\S]*?\n\n/m);
+  assert.ok(exampleMatch, 'expected a runnable gate-manifest record example in docs/toolkit.md');
+  assert.match(exampleMatch[0], /--data\s+'/);
+  assert.ok(!exampleMatch[0].includes('--evidence'),
+    'the runnable example must not use the nonexistent --evidence flag');
+});
+
+test('AC11: docs/README.md CI templates section lists the new template, mirroring adlc-maintenance.yml', () => {
+  const readme = readFileSync(join(ROOT, 'docs', 'README.md'), 'utf8');
+  assert.match(readme, /ci\/adversarial-review\.yml/);
+});

--- a/scripts/test/adversarial-review-template.test.mjs
+++ b/scripts/test/adversarial-review-template.test.mjs
@@ -167,6 +167,39 @@ test('AC3b: risk-tier PATTERN actually matches realistic auth/validator file pat
   }
 });
 
+test('AC3d: bare "auth" substring accepted false positive is documented and exercised (e.g. author/AUTHORS.md)', () => {
+  // Regression for a review finding: the classify step's comment used to
+  // assert (incorrectly) that "there is no common non-auth English word
+  // that contains 'auth' as a substring". `author`/`AUTHORS.md` are an
+  // easy, common counterexample -- an `AUTHORS.md` file or an
+  // `src/author.ts` model field has nothing to do with authn/authz but
+  // still matches the bare `auth` alternative. This is an accepted false
+  // positive under the file's own "a false positive just costs one extra
+  // full review" tradeoff (not a bug), but the tradeoff must actually be
+  // exercised here rather than only asserted in prose.
+  const text = readTemplate();
+  const patternLines = text
+    .split('\n')
+    .filter((line) => /^\s*PATTERN=/.test(line))
+    .map((line) => line.trim());
+  assert.ok(patternLines.length > 1, 'expected the multi-line PATTERN construction in the classify step');
+
+  const acceptedFalsePositives = ['AUTHORS.md', 'src/author.ts', 'docs/authors/team.md'];
+  for (const file of acceptedFalsePositives) {
+    const script = `${patternLines.join('\n')}\nprintf '%s\\n' ${JSON.stringify(file)} | grep -qiE "$PATTERN"`;
+    const rc = execFileSync('bash', ['-c', `${script}; echo $?`], { encoding: 'utf8' }).trim();
+    assert.equal(rc, '0',
+      `expected the bare "auth" substring match to (over-inclusively) flag "${file}" as risk=high -- ` +
+      'this is the documented, accepted false-positive tradeoff, not a gap');
+  }
+
+  // The comment must no longer assert the false "no non-auth word contains
+  // auth" claim; it must instead document this as an accepted tradeoff.
+  assert.ok(!/there is no common non-auth/i.test(text),
+    'the classify-step comment must not claim no non-auth English word contains "auth" as a substring -- ' +
+    '"author"/"AUTHORS.md" are a common counterexample');
+});
+
 test('AC3c: ADVERSARIAL_REVIEW_VERSION is pinned to an exact version, not the mutable "latest" tag', () => {
   // Regression for the other half of commit 0790478 ("...and pin
   // adversarial-review version"): AC3b already regression-tests the regex


### PR DESCRIPTION
Fixes #60

## Summary

Ships `docs/ci/adversarial-review.yml`: a documented (not force-installed)
GitHub Actions template that path-filters PRs against the ADR-0007 risk
tiers (auth/trust boundary, deny paths/rail guards/validators/sandboxes,
secrets, data-loss ops, schema/migration, CI/CD). Risk-tier matches run the
full `--providers auto` adversarial-review quorum with `--fail-on high`,
post the report as a PR comment, and record the verdict via
`gate-manifest`. Non-matching PRs get a cheap, non-blocking single-model
informational pass for cost control.

While wiring this up, also corrected `docs/toolkit.md`'s documented
`gate-manifest` evidence convention (`--evidence 'k=v'`, which doesn't
exist and crashes under Node's strict `parseArgs`) to the real `--data
'{json}'` flag, and referenced the new template from `docs/toolkit.md` and
`docs/README.md`.

### Fix history (5 adversarial-review rounds)

- **Round 1** (`0790478`): closed a risk-tier regex gap where
  `src/authentication/handler.js` / `lib/authorization.ts` /
  `src/validation.ts` were misclassified `risk=low`, silently skipping the
  mandated quorum; pinned `ADVERSARIAL_REVIEW_VERSION` to `2.6.0` instead of
  a floating `latest`.
- **Round 2** (`4e347ff`): added `set +e` around the verdict-recording step
  so a report with no literal provider token doesn't abort the step under
  `bash -eo pipefail` before `gate-manifest record` runs (which was
  silently dropping P6 evidence); made `gh pr comment` failures
  non-fatal in both jobs so a fork PR's read-only token can't mask the
  actual review verdict.
- **Round 3** (`b1d50ca`): dropped an over-strict boundary requirement from
  the auth risk-tier pattern that missed real-world names like `oauth/`,
  `reauth.ts`, `OAuthCallback.ts`; added executable-script regression tests
  (AC12/AC13) for the round-2 shell-safety fixes, which previously had zero
  coverage.
- **Round 4** (`4293d1f`): added `--fail-on-empty` so a zero-diff scope
  (base moves between classify/gate, or a rebase/no-op re-triggers
  `synchronize`) can't silently exit 0 and record a false "approve" P6
  entry for a high-risk PR without ever consulting a model; documented the
  accepted `auth`-substring false-positive tradeoff and added a test for
  it.
- **Round 5** (`218945e`): the template originally justified plain
  (non-`--loop`) review mode by citing
  `voodootikigod/adversarial-review#9` ("`--loop` silently drops
  `--providers`"). Verified against the actual published `2.6.0` package
  that issue #9 is closed and `--loop` does compose with `--providers` in
  that version — the cited rationale was stale/false. The *conclusion*
  (use plain mode) is still correct, but for a different, durable reason:
  `2.6.0`'s `--loop` hard-errors on `--base <ref>` / branch-scope review,
  which is incompatible with this gate's read-only PR-diff review. Updated
  the YAML comments, the spec doc, and `docs/toolkit.md` to state the real
  reason, and reworked AC4 so it asserts the durable incompatibility
  instead of freezing the stale "#9" premise.

## CLEAN — round 6 verification pass (no code changes)

A follow-up, skeptical re-review confirmed round 5's fix and closed out the
outstanding concerns from the earlier "NOT CLEAN" note:

1. **Round-5 rationale re-verified, and consistent everywhere.** The YAML
   header/inline comments in `docs/ci/adversarial-review.yml`, the spec doc
   (`docs/specs/ci-adversarial-review-template.md`), and `docs/toolkit.md`
   all now state the same thing and agree with each other: issue #9 is
   closed and fixed as of the pinned `2.6.0`, and the durable, independent
   reason plain mode is required is that `2.6.0`'s `--loop` hard-errors on
   `--base <ref>` / `--scope branch` (it only supports `--scope
   working-tree`), which is incompatible with this gate's read-only
   branch-diff review. No stale or conflicting wording found between the
   three docs.
2. **No phantom automation for the version pin.** Confirmed there is no
   Renovate/Dependabot config or any other doc claiming an automated bump
   process for `ADVERSARIAL_REVIEW_VERSION`. Every reference (YAML header,
   inline env comment, spec doc) consistently describes the pin as a
   deliberate manual re-audit-and-bump action — matching reality.
3. **No GitHub Actions expression-injection vector.** Re-scanned
   `docs/ci/adversarial-review.yml` for the classic
   `${{ github.event.pull_request.title }}` (or `.body`)-in-`run:` pattern.
   The template never references PR title or body at all; the only
   `github.event.*` field used is `github.event.pull_request.number` (a
   numeric field, not attacker-controlled text), and it's passed through an
   `env:` var (`PR_NUMBER`), not interpolated inline into a shell script —
   the safe pattern. The only other inline `${{ }}` uses in `run:` blocks
   are `steps.review.outputs.rc`, a value the job itself sets to `0`/`1`/`2`.
4. Re-ran `node --test scripts/test/adversarial-review-template.test.mjs`
   (17/17 pass) and the full `npm test` (all suites green, 0 failures) after
   this pass — no regressions, no changes needed.

No code or doc changes were made in this pass; the branch was already
correct. Ready to merge from an adversarial-review-process standpoint.

## Test plan

- [x] `node --test scripts/test/adversarial-review-template.test.mjs` — 17/17 pass
- [x] Full repo suite (`npm test`) — all packages green
- [x] Round-6 skeptical re-verification of round 5's fix — consistent across
      YAML/spec/toolkit docs
- [x] Confirmed no automated version-bump process is falsely claimed anywhere
- [x] Re-scanned for GitHub Actions expression injection via PR title/body —
      none present
- [ ] Dry-run the template against a real auth-tagged PR in a scratch repo
      before enabling it here
