### PR TITLE
feat(ticket-prune): report and archive stale, already-shipped tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ full thesis in [ADLC.md](./ADLC.md).
 
 Each tool is a small CLI that enforces one machine-checkable gate. They share a runtime
 convention (`.adlc/` for tickets, ledgers, and gate evidence) and a common contract
-(see [CONVENTIONS.md](./CONVENTIONS.md)) so 21 independently built tools feel like one
+(see [CONVENTIONS.md](./CONVENTIONS.md)) so 22 independently built tools feel like one
 product.
 
 ## Install
@@ -46,7 +46,7 @@ hooks, CI, and lifecycle docs should use the dispatcher.
 
 | Phase | Packages |
 | --- | --- |
-| **Spec & ticket shaping** | [`parallax`](./packages/parallax) · [`spec-lint`](./packages/spec-lint) · [`premortem`](./packages/premortem) · [`coldstart`](./packages/coldstart) |
+| **Spec & ticket shaping** | [`parallax`](./packages/parallax) · [`spec-lint`](./packages/spec-lint) · [`premortem`](./packages/premortem) · [`coldstart`](./packages/coldstart) · [`ticket-prune`](./packages/ticket-prune) |
 | **Execution supervision & rails** | [`preflight`](./packages/preflight) · [`model-router`](./packages/model-router) · [`merge-forecast`](./packages/merge-forecast) · [`rails-guard`](./packages/rails-guard) · [`flail-detector`](./packages/flail-detector) · [`consensus-fix`](./packages/consensus-fix) · [`runner`](./packages/runner) |
 | **Review evidence & calibration** | [`behavior-diff`](./packages/behavior-diff) · [`gate-manifest`](./packages/gate-manifest) · [`hollow-test`](./packages/hollow-test) · [`prosecute`](./packages/prosecute) · [`review-calibration`](./packages/review-calibration) · [`model-ratchet`](./packages/model-ratchet) · [`gate-fuzzing`](./packages/gate-fuzzing) |
 | **Compounding defenses** | [`lesson-foundry`](./packages/lesson-foundry) · [`rejection-mining`](./packages/rejection-mining) · [`skill-rot`](./packages/skill-rot) |
@@ -98,7 +98,7 @@ Each agent tool has its own native integration. See the guides:
 
 | Directory | Contents |
 |---|---|
-| `packages/` | The toolkit: 21 zero-dependency, gate-shaped CLIs |
+| `packages/` | The toolkit: 22 zero-dependency, gate-shaped CLIs |
 | `plugins/adlc-claude-code/` | Claude Code integration (skill, commands, hooks, subagent) |
 | `plugins/adlc-codex/` | Codex integration (hooks and skills; no TypeScript package) |
 | `plugins/adlc-antigravity/` | Google Antigravity integration (native plugin system, skills, hooks) |

--- a/docs/ci/adlc-maintenance.yml
+++ b/docs/ci/adlc-maintenance.yml
@@ -3,11 +3,13 @@
 # OpenCode /adlc-init template source: docs/ci/adlc-maintenance.yml
 #
 # Idle-time metabolism (ADLC C10/C12): the DETERMINISTIC, keyless maintenance
-# checks on a weekly cron. It reports stale skill metadata and the highest-churn
-# files worth re-prosecuting, into the job summary. Findings are ADVISORY — stale
-# skills or hot files keep the run GREEN (treat the summary as a worklist) — but a
-# genuine tool CRASH (command-not-found, regression) FAILS the run so the broken
-# pipeline is not silently swallowed.
+# checks on a weekly cron. It reports stale skill metadata, the highest-churn
+# files worth re-prosecuting, and stale (already-shipped) tickets, into the job
+# summary. Findings are ADVISORY — stale skills, hot files, or stale tickets
+# keep the run GREEN (treat the summary as a worklist) — but a genuine tool
+# CRASH (command-not-found, regression) FAILS the run so the broken pipeline is
+# not silently swallowed. ticket-prune only ever reports here (`--write` is a
+# human-confirmed action, never run unattended on a schedule).
 #
 # The LLM-backed parts (lesson-foundry, rejection-mining, gate-fuzzing) are not
 # here because they need a model. Run those via a scheduled Claude routine that
@@ -98,5 +100,29 @@ jobs:
           # silently swallowed (the job is advisory, but a crash is not advisory).
           if [ "$rc" -ne 0 ]; then
             echo "::error title=model-ratchet::model-ratchet --dry-run exited $rc unexpectedly"
+            exit 1
+          fi
+
+      - name: Ticket prune (stale ticket hygiene) — report only, never --write in CI
+        run: |
+          {
+            echo "## Stale tickets (ticket-prune)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f .adlc/tickets.json ]; then
+            # `if` capture so a nonzero exit does not abort the step under `set -e`.
+            if out="$(adlc ticket-prune --json)"; then rc=0; else rc=$?; fi
+            echo "$out" >> "$GITHUB_STEP_SUMMARY"
+          else
+            rc=0
+            echo "(.adlc/tickets.json not present — nothing to prune)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # ticket-prune is a report, not a gate: exit 0 is the only expected
+          # code, whether or not it found stale tickets. This step never
+          # passes --write — archiving tickets.json is a human-confirmed
+          # action, not something a scheduled job should do unattended.
+          if [ "$rc" -ne 0 ]; then
+            echo "::error title=ticket-prune::ticket-prune --json exited $rc unexpectedly"
             exit 1
           fi

--- a/docs/package-reference.md
+++ b/docs/package-reference.md
@@ -30,6 +30,7 @@ Follow each README for full options, output schemas, examples, and implementatio
 | `@adlc/runner` | `adlc-runner` | Asserts phase completion from manifest artifacts rather than command success alone. Normal workflows reach it through `adlc run` and `adlc accept`. | [`docs/tools/runner.md`](./tools/runner.md) |
 | `@adlc/skill-rot` | `skill-rot` | Checks skill files for stale validation metadata and optional freshness stamping. | [`docs/tools/skill-rot.md`](./tools/skill-rot.md) |
 | `@adlc/spec-lint` | `spec-lint` | Gates specs for wishes, unverifiable acceptance criteria, and LLM-only verification. | [`docs/tools/spec-lint.md`](./tools/spec-lint.md) |
+| `@adlc/ticket-prune` | `ticket-prune` | Reports and archives stale, already-shipped tickets out of `.adlc/tickets.json`. | [`docs/tools/ticket-prune.md`](./tools/ticket-prune.md) |
 
 ## Command forms
 
@@ -62,6 +63,7 @@ adlc run <p1|p2|p3|p4|p5|p6|p7> [--ticket id for p3-p6] [--revision rev for p5-p
 adlc accept --ticket id --packet .adlc/packet.json [--before .adlc/before.json] [--after .adlc/after.json] [--revision rev] [--dir .adlc] [--json]
 adlc skill-rot [path ...] [--write] [--json]
 adlc spec-lint <spec.md> [--llm] [--json] [--prompt-only]
+adlc ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [--json]
 ```
 
 ## Package groups
@@ -72,6 +74,7 @@ Spec and ticket shaping:
 - `spec-lint`
 - `premortem`
 - `coldstart`
+- `ticket-prune`
 
 Execution supervision and rails:
 

--- a/docs/specs/ticket-prune.md
+++ b/docs/specs/ticket-prune.md
@@ -1,0 +1,57 @@
+# Spec note — ticket-prune (closes #39)
+
+**Phase:** lightweight P1 record for a shipped P2/maintenance tool, not a full design spec.
+
+## Issue
+
+[#39](https://github.com/voodootikigod/adlc/issues/39): `.adlc/tickets.json` is a
+mutable working scratchpad that nothing prunes after a ticket's work ships, so
+completed tickets accumulate and masquerade as an open backlog (surfaced concretely by
+OpenCode tickets T1–T5 still listed on `main` after merging via #27–#34). Related
+context: [#35](https://github.com/voodootikigod/adlc/issues/35) section B ("stale
+completed tickets on main; consider a lifecycle/archive").
+
+## Decision
+
+Source of truth for "done": prefer an explicit `status` field on the ticket when
+present (`done`/`closed`/`complete`/`completed`/`archived`/`shipped`, case-insensitive);
+otherwise infer from every declared `scope` glob resolving to a file tracked at
+`--base-ref` (default `HEAD`). PR-reference inference was rejected — this repo's
+ticket schema has no PR-number field, and a `git log` survey shows ticket ids are
+referenced inconsistently in shipping commits (some name the id, e.g. `(T13/T14)`;
+the T1–T5 shipping PRs #27–#31 never do), so grepping history would miss exactly the
+stale tickets the issue's own worked example was written to catch. Archive, don't
+delete: stale tickets move to a gitignored `.adlc/tickets.archive.json`. See
+`packages/ticket-prune/README.md` for the full reasoning.
+
+## Acceptance criteria
+
+- AC1: A new `adlc ticket-prune` CLI verb exists (`packages/ticket-prune`, registered
+  in `packages/cli/lib/registry.mjs`), dry-run by default.
+- AC2: A ticket is detected stale given a mocked done signal (explicit `status: done`,
+  or every declared `scope` glob present on the base ref) — not stale otherwise.
+- AC3: The default (dry-run) invocation reports stale tickets without mutating
+  `.adlc/tickets.json` or creating an archive file.
+- AC4: `--write` moves stale ticket entries into `.adlc/tickets.archive.json`
+  (upserted by id, preserved across repeated runs) and removes them from
+  `.adlc/tickets.json`, leaving active tickets untouched.
+- AC5: `/adlc-maintain` documents `adlc ticket-prune --json` as a decay-driven,
+  keyless maintenance check alongside `skill-rot` and `model-ratchet`.
+
+## Verification commands
+
+```bash
+# Package unit + integration tests (detection, dry-run, --write, CLI exit codes)
+cd packages/ticket-prune && npm test
+
+# CLI dispatcher wiring (registry, resolveBin, --help, tool count)
+cd packages/cli && npm test
+
+# Consolidated phase-router content stays byte-identical to the generator
+# (this ticket edited the shared "Maintenance" section in scripts/router/router-model.mjs)
+node --test scripts/test/router-drift.test.mjs
+
+# Manual smoke, dry-run then archive
+adlc ticket-prune --json
+adlc ticket-prune --write --json
+```

--- a/docs/specs/ticket-prune.md
+++ b/docs/specs/ticket-prune.md
@@ -47,8 +47,15 @@ cd packages/ticket-prune && npm test
 # CLI dispatcher wiring (registry, resolveBin, --help, tool count)
 cd packages/cli && npm test
 
-# Consolidated phase-router content stays byte-identical to the generator
-# (this ticket edited the shared "Maintenance" section in scripts/router/router-model.mjs)
+# Consolidated phase-router content stays byte-identical to the generator.
+# NOTE: this ticket did NOT edit scripts/router/router-model.mjs — the six
+# generated phase-router files still list only skill-rot/model-ratchet/
+# gate-fuzzing under "Maintenance" and do not mention ticket-prune (unlike
+# README.md, docs/toolkit.md, docs/package-reference.md, and
+# adlc-maintain.md, which were updated). Adding ticket-prune to the shared
+# router model is tracked as follow-up work, not part of this ticket; running
+# this test here only confirms the (unrelated) generator itself has not
+# drifted from its committed output.
 node --test scripts/test/router-drift.test.mjs
 
 # Manual smoke, dry-run then archive

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -16,7 +16,7 @@ through the stable `adlc <tool>` dispatcher.
 | P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | [`adlc rails-guard`](./tools/rails-guard.md), [`adlc flail-detector`](./tools/flail-detector.md) |
 | P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | [`adlc consensus-fix`](./tools/consensus-fix.md) |
 | P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | `adlc review` (runs the model review — see [seam note](#p5-recorder-vs-reviewer-seam)), [`adlc prosecute`](./tools/prosecute.md) (records its evidence — it runs no model review itself), [`adlc behavior-diff`](./tools/behavior-diff.md), [`adlc gate-manifest`](./tools/gate-manifest.md), [`adlc hollow-test`](./tools/hollow-test.md) |
-| C12 / maintenance | What must be re-prosecuted after model or repo drift? | [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md), [`adlc skill-rot`](./tools/skill-rot.md) |
+| C12 / maintenance | What must be re-prosecuted after model or repo drift? | [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md), [`adlc skill-rot`](./tools/skill-rot.md), [`adlc ticket-prune`](./tools/ticket-prune.md) |
 | P7 | Which repeated findings should become deterministic defenses? | [`adlc lesson-foundry`](./tools/lesson-foundry.md), [`adlc rejection-mining`](./tools/rejection-mining.md) |
 | Continuous calibration | Can hostile candidates defeat the gates? | [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) |
 
@@ -61,7 +61,7 @@ statement.
 7. After review, use [`adlc lesson-foundry`](./tools/lesson-foundry.md) and [`adlc rejection-mining`](./tools/rejection-mining.md) to convert repeated review
    findings into deterministic lint checks, skills, or spec-gap templates.
 8. On a schedule or after model changes, use [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md),
-   [`adlc skill-rot`](./tools/skill-rot.md), and [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) to re-check assumptions that can decay over time.
+   [`adlc skill-rot`](./tools/skill-rot.md), [`adlc ticket-prune`](./tools/ticket-prune.md), and [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) to re-check assumptions that can decay over time.
 
 ## Evidence conventions
 

--- a/docs/tools/ticket-prune.md
+++ b/docs/tools/ticket-prune.md
@@ -1,0 +1,87 @@
+---
+title: ticket-prune
+description: Documentation for the ticket-prune tool in the ADLC toolkit.
+---
+
+# @adlc/ticket-prune
+
+**ADLC Phase:** C12 / maintenance
+
+### ADLC Lifecycle Context
+
+```mermaid
+flowchart TD
+    P7["P7 Distill"] --> Maint["C12 Maintenance"]
+    Maint -.-> P2["P2 Decompose (fresh tickets)"]
+    style Maint fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+`.adlc/tickets.json` is a mutable working scratchpad. Nothing else prunes it
+after a ticket's work ships, so completed tickets accumulate and masquerade as
+an open backlog. `ticket-prune` reports (and, with `--write`, archives) tickets
+it can determine are stale, dry-run by default like every other ADLC writer.
+
+## Usage
+
+```
+ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [--json]
+```
+
+## How "stale" is decided
+
+1. **Explicit `status` field wins when present.** `done` / `closed` /
+   `complete` / `completed` / `archived` / `shipped` (case-insensitive) are
+   stale; any other explicit status is treated as "not done" even if the
+   ticket's scope looks fully shipped.
+2. **Otherwise, infer from scope existing on a base ref.** A ticket with no
+   status is stale only if it declares at least one `scope` glob and every
+   glob resolves to a file tracked at `--base-ref` (default `HEAD`). A ticket
+   with no declared scope is never inferred stale.
+
+See `packages/ticket-prune/README.md` for the full reasoning, including why
+"closing PR reference" was rejected as the corroborating signal.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--tickets <path>` | Ticket file to read (default `.adlc/tickets.json`). |
+| `--archive <path>` | Archive file `--write` moves stale tickets into (default `.adlc/tickets.archive.json`, gitignored). |
+| `--base-ref <ref>` | Git ref to check declared scope globs against (default `HEAD`). |
+| `--write` | Archive stale tickets: remove them from `--tickets`, upsert into `--archive`. Never deletes outright. |
+| `--json` | Machine-readable `{ baseRef, write, stale[], active[], archived[] }`. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Report or archive succeeded, regardless of how many stale tickets were found. Advisory (like `model-ratchet`), not a pass/fail gate. |
+| `1` | Operational error — bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, or the write lock could not be acquired. |
+
+## Examples
+
+```bash
+# Report stale tickets on the currently checked-out ref (dry-run, default)
+adlc ticket-prune
+
+# Audit tickets against main from a feature branch
+adlc ticket-prune --base-ref origin/main --json
+
+# Archive the stale tickets found above
+adlc ticket-prune --write
+```
+
+## Relationship to sibling tools
+
+- **`ticket` (`@adlc/ticket-sync`)** — writes/reads `tickets.json` from an
+  external tracker; shares the same `.adlc/tickets.lock` path so a sync and a
+  prune never interleave.
+- **`model-ratchet` / `skill-rot`** — the other decay-driven, dry-run-by-default
+  maintenance checks wired into `/adlc-maintain`; `ticket-prune` follows the
+  same reporting contract.
+
+## Core gaps
+
+`packages/core` (frozen) has no shared writer for `.adlc/tickets.json`.
+`lib/store.mjs` re-implements the same mkdir-lock + tmp-rename protocol
+`@adlc/ticket-sync`'s `lib/store.mjs` uses, at the same lock path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7252,7 +7252,8 @@
         "@adlc/review-calibration": "1.1.0",
         "@adlc/runner": "1.1.0",
         "@adlc/skill-rot": "1.1.0",
-        "@adlc/spec-lint": "1.1.0"
+        "@adlc/spec-lint": "1.1.0",
+        "@adlc/ticket-prune": "1.1.0"
       },
       "bin": {
         "adlc": "bin/adlc.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,10 @@
       "resolved": "packages/spec-lint",
       "link": true
     },
+    "node_modules/@adlc/ticket-prune": {
+      "resolved": "packages/ticket-prune",
+      "link": true
+    },
     "node_modules/@adlc/ticket-sync": {
       "resolved": "packages/ticket-sync",
       "link": true
@@ -7543,6 +7547,20 @@
       },
       "bin": {
         "spec-lint": "bin/spec-lint.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ticket-prune": {
+      "name": "@adlc/ticket-prune",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@adlc/core": "1.1.0"
+      },
+      "bin": {
+        "ticket-prune": "bin/ticket-prune.mjs"
       },
       "engines": {
         "node": ">=18"

--- a/packages/cli/lib/registry.mjs
+++ b/packages/cli/lib/registry.mjs
@@ -17,6 +17,7 @@ export const GROUPS = [
       { name: 'spec-lint', packageName: '@adlc/spec-lint', summary: 'Gate specs for acceptance criteria that lack a verification method.' },
       { name: 'premortem', packageName: '@adlc/premortem', summary: 'Stress-test an approved spec before implementation.' },
       { name: 'coldstart', packageName: '@adlc/coldstart', summary: 'Check whether tickets are executable without agent guesswork.' },
+      { name: 'ticket-prune', packageName: '@adlc/ticket-prune', summary: 'Report and archive stale, already-shipped tickets out of tickets.json.' },
     ],
   },
   {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,8 @@
     "@adlc/review-calibration": "1.1.0",
     "@adlc/runner": "1.1.0",
     "@adlc/skill-rot": "1.1.0",
-    "@adlc/spec-lint": "1.1.0"
+    "@adlc/spec-lint": "1.1.0",
+    "@adlc/ticket-prune": "1.1.0"
   },
   "scripts": {
     "test": "node --test test/*.test.mjs"

--- a/packages/cli/test/dispatch.test.mjs
+++ b/packages/cli/test/dispatch.test.mjs
@@ -40,11 +40,12 @@ function withTempSpec(contents, fn) {
 }
 
 test('registry exposes the suite tools and omits internal packages', () => {
-  assert.equal(TOOLS.length, 22);
+  assert.equal(TOOLS.length, 23);
   assert.equal(isTool('spec-lint'), true);
   assert.equal(isTool('prosecute'), true);
   assert.equal(isTool('ticket'), true);
   assert.equal(isTool('review'), true);
+  assert.equal(isTool('ticket-prune'), true);
   assert.equal(isTool('core'), false);
   assert.equal(isTool('runner'), false);
 });
@@ -59,6 +60,7 @@ test('resolves package-local tool bins without PATH lookup', () => {
   assert.match(resolveBin('spec-lint') ?? '', /packages\/spec-lint\/bin\/spec-lint\.mjs$/);
   assert.match(resolveBin('prosecute') ?? '', /packages\/prosecute\/bin\/adlc-prosecute\.mjs$/);
   assert.match(resolveBin('ticket') ?? '', /packages\/ticket-sync\/bin\/ticket-sync\.mjs$/);
+  assert.match(resolveBin('ticket-prune') ?? '', /packages\/ticket-prune\/bin\/ticket-prune\.mjs$/);
   assert.equal(resolveBin('definitely-not-real'), null);
 });
 
@@ -79,7 +81,7 @@ test('help lists every routed tool and exits 0', () => {
 test('renderHelp embeds version and tool count', () => {
   const output = renderHelp('9.9.9');
   assert.match(output, /adlc 9\.9\.9/);
-  assert.match(output, /Tools \(22\)/);
+  assert.match(output, /Tools \(23\)/);
 });
 
 test('version prints a semver-shaped string', () => {

--- a/packages/ticket-prune/LICENSE
+++ b/packages/ticket-prune/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ticket-prune/README.md
+++ b/packages/ticket-prune/README.md
@@ -1,0 +1,106 @@
+# ticket-prune
+
+**ADLC phase: C12 — maintenance (ticket lifecycle hygiene)**
+
+`.adlc/tickets.json` is a mutable working scratchpad. Nothing else prunes it
+after a ticket's work ships, so completed tickets accumulate and masquerade as
+an open backlog — you can't tell live work from leftovers without
+cross-checking deliverables and merged PRs by hand. `ticket-prune` reports
+(and, with `--write`, archives) tickets it can determine are stale.
+
+Addresses [issue #39](https://github.com/voodootikigod/adlc/issues/39).
+
+## Usage
+
+```
+ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [--json]
+```
+
+Dry-run by default, consistent with every other ADLC writer (`skill-rot`,
+`rejection-mining`, `model-ratchet`): it reports what it would archive without
+touching `.adlc/tickets.json` until you pass `--write`.
+
+## How "stale" is decided
+
+This was the open question in issue #39: an explicit `status` field on the
+ticket vs. inferring from merged deliverables/PRs. Decision, in order:
+
+1. **Prefer an explicit `status` field when present.** The @adlc/core ticket
+   schema (`packages/core/lib/tickets.mjs`) doesn't declare a `status` field,
+   but `validateTicket()` doesn't reject unknown properties either, so a
+   ticket can already carry one. `done` / `closed` / `complete` / `completed`
+   / `archived` / `shipped` (case-insensitive) are stale; any other string
+   value is treated as an explicit "not done" and wins over the inference
+   below even if the ticket's scope looks fully shipped.
+
+2. **Otherwise, infer from scope existing on a base ref.** A ticket with no
+   explicit status is stale only if it declares at least one `scope` glob
+   *and* every declared glob resolves to at least one file tracked at
+   `--base-ref` (default `HEAD`, via `git ls-tree`). A ticket with no declared
+   scope is never inferred stale — it's reported active until an explicit
+   status settles it.
+
+**Why not "scope/rails + a closing PR reference"?** The issue floated PR
+references as a corroborating signal. This repo's ticket schema has no field
+that records a PR number, and commit-message conventions aren't reliable
+enough to infer one from git history: a `git log --oneline` survey on this
+repo shows tickets referenced inconsistently — some commits name the ticket id
+directly (e.g. `(T13/T14)`), but the OpenCode `T1`-`T5` tickets' shipping
+PRs (#27–#31) reference "Phase A/B/C/E" and never the literal ticket id at
+all. Grepping history for ticket ids would therefore *miss* exactly the stale
+tickets the issue's own worked example was written to catch. Scope-existence
+against a tracked-files snapshot is deterministic, needs no fuzzy text
+matching, and is exactly the check the issue's worked example did by hand.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--tickets <path>` | Ticket file to read (default `.adlc/tickets.json`). |
+| `--archive <path>` | Archive file to write to under `--write` (default `.adlc/tickets.archive.json`, gitignored — see `.gitignore`'s `.adlc/*` rule). |
+| `--base-ref <ref>` | Git ref to check declared `scope` globs against (default `HEAD`). Point at `origin/main` to audit a feature branch's tickets against what's already shipped on trunk. |
+| `--write` | Archive stale tickets: move them out of `--tickets` into `--archive` (append/upsert by id — repeated runs accumulate, never clobber). Tickets are archived, never deleted outright. |
+| `--json` | Machine-readable `{ baseRef, write, stale[], active[], archived[] }`. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Report or archive succeeded — regardless of how many stale tickets were found. This is advisory (like `model-ratchet`), not a pass/fail gate: stale tickets are clutter, not a merge blocker. |
+| `1` | Operational error — bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, or the write lock could not be acquired. |
+
+## Examples
+
+```bash
+# Report stale tickets on the currently checked-out ref (dry-run, default)
+ticket-prune
+
+# Audit tickets against main from a feature branch
+ticket-prune --base-ref origin/main --json
+
+# Archive the stale tickets found above
+ticket-prune --write
+```
+
+## Locking and atomicity
+
+`--write` takes the shared `.adlc/tickets.lock` mkdir-lock before mutating
+`tickets.json`, the same lock path `@adlc/ticket-sync`'s writer uses, so the
+two writers interoperate instead of racing. Both `tickets.json` and the
+archive file are replaced with a tmp-file-then-rename (atomic on POSIX
+filesystems).
+
+## Relationship to sibling tools
+
+- **`@adlc/ticket-sync`** — writes/reads `.adlc/tickets.json` from an external
+  tracker; shares the same lock path so a sync and a prune never interleave.
+- **`model-ratchet` / `skill-rot`** — the other decay-driven, dry-run-by-default
+  maintenance checks wired into `/adlc-maintain`; `ticket-prune` follows the
+  same reporting contract.
+
+## Core gaps
+
+`packages/core` (frozen — CONVENTIONS rule 2) has no shared writer for
+`.adlc/tickets.json`. `lib/store.mjs` re-implements the same mkdir-lock +
+tmp-rename protocol `@adlc/ticket-sync`'s `lib/store.mjs` uses (at the same
+lock path) rather than inlining a divergent one.

--- a/packages/ticket-prune/bin/ticket-prune.mjs
+++ b/packages/ticket-prune/bin/ticket-prune.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// ticket-prune — reports (and, with --write, archives) stale tickets out of
+// .adlc/tickets.json. Dry-run by default, consistent with every other ADLC
+// writer (skill-rot, rejection-mining, model-ratchet). Archives to a
+// gitignored .adlc/tickets.archive.json rather than deleting outright.
+//
+// Usage: ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [--json]
+//
+// This is advisory (like model-ratchet), not a pass/fail gate: stale tickets
+// are clutter, not a merge blocker. Exit codes: 0 = report/write succeeded
+// (regardless of how many stale tickets were found), 1 = operational error.
+
+import { parseArgs, opError, printJson } from '@adlc/core';
+import { runTicketPrune } from '../lib/run.mjs';
+import { renderReport, toJson } from '../lib/format.mjs';
+
+const USAGE =
+  'usage: ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [--json]';
+
+const { values } = parseArgs({
+  usage: USAGE,
+  options: {
+    tickets: { type: 'string', default: '.adlc/tickets.json' },
+    archive: { type: 'string', default: '.adlc/tickets.archive.json' },
+    'base-ref': { type: 'string', default: 'HEAD' },
+    write: { type: 'boolean', default: false },
+    json: { type: 'boolean', default: false },
+  },
+});
+
+const result = runTicketPrune({
+  cwd: process.cwd(),
+  ticketsPath: values.tickets,
+  archivePath: values.archive,
+  baseRef: values['base-ref'],
+  write: values.write,
+});
+
+if (!result.ok) {
+  opError(result.error);
+}
+
+if (values.json) {
+  printJson(toJson(result));
+} else {
+  console.log(renderReport(result));
+}
+
+process.exit(0);

--- a/packages/ticket-prune/lib/detect.mjs
+++ b/packages/ticket-prune/lib/detect.mjs
@@ -1,0 +1,108 @@
+// detect.mjs — decide whether a ticket is stale (shipped, safe to archive).
+//
+// Source-of-truth decision (documented per issue #39's open question):
+//
+//   1. PREFER an explicit `status` field when the ticket carries one. The
+//      current @adlc/core ticket schema (packages/core/lib/tickets.mjs) does
+//      NOT declare a `status` field — validateTicket() only checks id, title,
+//      scope, rails, edges, duration — but it also does not reject unknown
+//      extra properties, so a ticket may already carry `status: "done"` (or
+//      any other string) without failing validation. When present, this is
+//      the most reliable signal: it is an explicit, author-asserted fact, not
+//      an inference, so it wins over everything else (including a
+//      contradicting scope/rails inference).
+//
+//   2. OTHERWISE infer from whether the ticket's declared `scope` files exist
+//      on a base ref (default HEAD; see listTrackedFiles). A ticket whose
+//      every declared scope glob resolves to at least one file tracked at
+//      that ref is treated as shipped.
+//
+// Why scope-existence over "closing PR reference" (the other option the
+// issue floats): this repo's ticket schema has no field that records a PR
+// number, and commit-message conventions are NOT reliable enough to infer one
+// — a survey of `git log --oneline` on this repo shows tickets referenced
+// inconsistently (e.g. "(T13/T14)" is called out explicitly in a subject line,
+// but the OpenCode T1-T5 tickets' shipping commits/PRs (#27-#31) reference
+// "Phase A/B/C/E" and never the literal ticket ids at all). Grepping commit
+// history for a ticket id would therefore miss exactly the stale tickets the
+// issue's own worked example was written to catch. Scope-existence against a
+// tracked-files snapshot is deterministic, needs no heuristic text matching,
+// and is exactly the signal the issue's worked example (T1-T5) used by hand.
+// A ticket that declares no scope can never be inferred stale this way — it
+// is reported as active until an explicit status settles the question.
+
+import { git, globMatch } from '@adlc/core';
+
+const DONE_STATUSES = new Set(['done', 'closed', 'complete', 'completed', 'archived', 'shipped']);
+
+/** Lowercased status string, or null if the ticket has no string status field. */
+export function explicitStatus(ticket) {
+  return typeof ticket?.status === 'string' ? ticket.status.toLowerCase() : null;
+}
+
+/** True only when the ticket carries an explicit done-shaped status. */
+export function isExplicitlyDone(ticket) {
+  const status = explicitStatus(ticket);
+  return status !== null && DONE_STATUSES.has(status);
+}
+
+/** Files tracked at `ref` (default HEAD) — the "base ref" existence check. */
+export function listTrackedFiles(ref = 'HEAD', cwd = process.cwd()) {
+  let out;
+  try {
+    out = git(['ls-tree', '-r', '--name-only', ref], { cwd });
+  } catch (err) {
+    throw new Error(`could not list files at ref "${ref}": ${err.message}`);
+  }
+  return out.split('\n').filter(Boolean);
+}
+
+/**
+ * True only when the ticket declares at least one scope glob AND every glob
+ * matches at least one tracked file. A ticket with no declared scope is never
+ * inferred shipped (there is nothing to check existence of).
+ */
+export function scopeShipped(ticket, trackedFiles) {
+  const scope = ticket?.scope ?? [];
+  if (scope.length === 0) return false;
+  return scope.every((glob) => trackedFiles.some((file) => globMatch(glob, file)));
+}
+
+/** Classify one ticket. Returns { id, stale, reason }. */
+export function classifyTicket(ticket, trackedFiles) {
+  const status = explicitStatus(ticket);
+  if (status !== null) {
+    return {
+      id: ticket.id,
+      stale: isExplicitlyDone(ticket),
+      reason: `explicit status: "${ticket.status}"`,
+    };
+  }
+
+  const scope = ticket?.scope ?? [];
+  if (scope.length === 0) {
+    return {
+      id: ticket.id,
+      stale: false,
+      reason: 'no explicit status and no declared scope — cannot infer, treated as active',
+    };
+  }
+
+  if (scopeShipped(ticket, trackedFiles)) {
+    return {
+      id: ticket.id,
+      stale: true,
+      reason: `inferred: all ${scope.length} declared scope glob(s) resolve to tracked files on the base ref`,
+    };
+  }
+
+  return {
+    id: ticket.id,
+    stale: false,
+    reason: 'no explicit status; declared scope not fully present on the base ref',
+  };
+}
+
+export function classifyTickets(tickets, trackedFiles) {
+  return tickets.map((ticket) => classifyTicket(ticket, trackedFiles));
+}

--- a/packages/ticket-prune/lib/format.mjs
+++ b/packages/ticket-prune/lib/format.mjs
@@ -1,0 +1,37 @@
+// format.mjs — human-readable + JSON rendering for a runTicketPrune() result.
+
+export function renderReport(result) {
+  const { baseRef, write, stale, active, archived } = result;
+  const lines = [];
+  lines.push(`ticket-prune — base ref: ${baseRef} (${write ? 'write' : 'dry-run'})`);
+  lines.push('');
+
+  if (write) {
+    if (archived.length === 0) {
+      lines.push('No stale tickets archived.');
+    } else {
+      lines.push(`Archived ${archived.length} stale ticket(s) to .adlc/tickets.archive.json:`);
+      for (const t of archived) lines.push(`  - ${t.id}: ${t.archiveReason}`);
+    }
+  } else if (stale.length === 0) {
+    lines.push('No stale tickets found.');
+  } else {
+    lines.push(`Stale tickets (${stale.length}) — re-run with --write to archive them:`);
+    for (const r of stale) lines.push(`  - ${r.id}: ${r.reason}`);
+  }
+
+  lines.push('');
+  lines.push(`Active tickets (${active.length}):`);
+  if (active.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const r of active) lines.push(`  - ${r.id}: ${r.reason}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function toJson(result) {
+  const { baseRef, write, stale, active, archived } = result;
+  return { baseRef, write, stale, active, archived };
+}

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -1,0 +1,100 @@
+// run.mjs — the whole ticket-prune operation as one pure-ish, testable
+// function. bin/ticket-prune.mjs stays a thin arg-parse + exit-code shell
+// around this (CONVENTIONS layout rule).
+
+import { join } from 'node:path';
+import { loadTickets } from '@adlc/core';
+import { classifyTickets, listTrackedFiles } from './detect.mjs';
+import { acquireLock, releaseLock, readJson, writeJsonAtomic } from './store.mjs';
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.cwd]
+ * @param {string} [options.ticketsPath] relative to cwd
+ * @param {string} [options.archivePath] relative to cwd
+ * @param {string} [options.baseRef] git ref to check scope/rails existence against
+ * @param {boolean} [options.write] archive stale tickets instead of dry-run reporting
+ * @returns {{ok: true, baseRef: string, write: boolean, stale: object[], active: object[], archived: object[]} | {ok: false, error: string}}
+ */
+export function runTicketPrune(options = {}) {
+  const {
+    cwd = process.cwd(),
+    ticketsPath = '.adlc/tickets.json',
+    archivePath = '.adlc/tickets.archive.json',
+    baseRef = 'HEAD',
+    write = false,
+  } = options;
+
+  const absTicketsPath = join(cwd, ticketsPath);
+  const absArchivePath = join(cwd, archivePath);
+
+  const { tickets, errors } = loadTickets(absTicketsPath);
+  if (errors.length) {
+    return { ok: false, error: `ticket file errors:\n  ${errors.join('\n  ')}` };
+  }
+
+  if (tickets.length === 0) {
+    return { ok: true, baseRef, write, stale: [], active: [], archived: [] };
+  }
+
+  let trackedFiles;
+  try {
+    trackedFiles = listTrackedFiles(baseRef, cwd);
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+
+  const results = classifyTickets(tickets, trackedFiles);
+  const stale = results.filter((r) => r.stale);
+  const active = results.filter((r) => !r.stale);
+
+  if (!write || stale.length === 0) {
+    return { ok: true, baseRef, write, stale, active, archived: [] };
+  }
+
+  const locked = acquireLock(cwd);
+  if (!locked) {
+    return {
+      ok: false,
+      error: 'could not acquire .adlc/tickets.lock — another ADLC ticket writer is running',
+    };
+  }
+
+  try {
+    // Re-read under the lock: another writer (e.g. ticket-sync) may have
+    // mutated tickets.json between the classification read above and here.
+    const rawUnderLock = readJson(absTicketsPath, null);
+    if (rawUnderLock === null) {
+      return { ok: false, error: `ticket file disappeared during archive: ${absTicketsPath}` };
+    }
+    const freshTickets = Array.isArray(rawUnderLock.tickets) ? rawUnderLock.tickets : [];
+
+    const staleIds = new Set(stale.map((r) => r.id));
+    const kept = freshTickets.filter((t) => !staleIds.has(t.id));
+    const removed = freshTickets.filter((t) => staleIds.has(t.id));
+
+    if (removed.length === 0) {
+      // Every stale id was already gone by the time we took the lock.
+      return { ok: true, baseRef, write, stale, active, archived: [] };
+    }
+
+    const archivedAt = new Date().toISOString();
+    const reasonById = new Map(stale.map((r) => [r.id, r.reason]));
+    const existingArchive = readJson(absArchivePath, { tickets: [] });
+    const archiveById = new Map((existingArchive.tickets ?? []).map((t) => [t.id, t]));
+
+    const archivedEntries = [];
+    for (const ticket of removed) {
+      const entry = { ...ticket, archivedAt, archiveReason: reasonById.get(ticket.id) };
+      archiveById.set(ticket.id, entry);
+      archivedEntries.push(entry);
+    }
+
+    writeJsonAtomic(absTicketsPath, { ...rawUnderLock, tickets: kept });
+    writeJsonAtomic(absArchivePath, { tickets: [...archiveById.values()] });
+
+    return { ok: true, baseRef, write, stale, active, archived: archivedEntries };
+  } finally {
+    releaseLock(cwd);
+  }
+}

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -2,7 +2,7 @@
 // function. bin/ticket-prune.mjs stays a thin arg-parse + exit-code shell
 // around this (CONVENTIONS layout rule).
 
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 import { loadTickets } from '@adlc/core';
 import { classifyTickets, listTrackedFiles } from './detect.mjs';
 import { acquireLock, releaseLock, readJson, writeJsonAtomic } from './store.mjs';
@@ -25,8 +25,11 @@ export function runTicketPrune(options = {}) {
     write = false,
   } = options;
 
-  const absTicketsPath = join(cwd, ticketsPath);
-  const absArchivePath = join(cwd, archivePath);
+  // path.resolve (unlike path.join) treats an absolute ticketsPath/archivePath
+  // as an override of cwd rather than concatenating onto it, so `--tickets
+  // /abs/path.json` behaves the way users naturally expect.
+  const absTicketsPath = resolve(cwd, ticketsPath);
+  const absArchivePath = resolve(cwd, archivePath);
 
   const { tickets, errors } = loadTickets(absTicketsPath);
   if (errors.length) {

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -66,7 +66,17 @@ export function runTicketPrune(options = {}) {
   try {
     // Re-read under the lock: another writer (e.g. ticket-sync) may have
     // mutated tickets.json between the classification read above and here.
-    const rawUnderLock = readJson(absTicketsPath, null);
+    // Every fallible step below (JSON parse of either file, either atomic
+    // write) is wrapped so a failure surfaces as the documented
+    // {ok:false, error} shape instead of an uncaught exception, and so a
+    // failure never lands us in a state where a ticket vanishes from both
+    // files (see the write ordering note below).
+    let rawUnderLock;
+    try {
+      rawUnderLock = readJson(absTicketsPath, null);
+    } catch (err) {
+      return { ok: false, error: `could not re-read tickets file under lock: ${err.message}` };
+    }
     if (rawUnderLock === null) {
       return { ok: false, error: `ticket file disappeared during archive: ${absTicketsPath}` };
     }
@@ -83,7 +93,12 @@ export function runTicketPrune(options = {}) {
 
     const archivedAt = new Date().toISOString();
     const reasonById = new Map(stale.map((r) => [r.id, r.reason]));
-    const existingArchive = readJson(absArchivePath, { tickets: [] });
+    let existingArchive;
+    try {
+      existingArchive = readJson(absArchivePath, { tickets: [] });
+    } catch (err) {
+      return { ok: false, error: `could not read archive file: ${err.message}` };
+    }
     const archiveById = new Map((existingArchive.tickets ?? []).map((t) => [t.id, t]));
 
     const archivedEntries = [];
@@ -93,8 +108,30 @@ export function runTicketPrune(options = {}) {
       archivedEntries.push(entry);
     }
 
-    writeJsonAtomic(absTicketsPath, { ...rawUnderLock, tickets: kept });
-    writeJsonAtomic(absArchivePath, { tickets: [...archiveById.values()] });
+    // Write the archive BEFORE removing anything from tickets.json. If this
+    // write throws (bad --archive directory, permissions, disk full), we
+    // return an error with tickets.json completely untouched — the stale
+    // tickets are still there to retry, never lost. The alternative
+    // ordering (tickets.json first) can lose a ticket permanently if the
+    // archive write is what fails, since it would already be gone from
+    // tickets.json with nowhere else it was ever persisted.
+    try {
+      writeJsonAtomic(absArchivePath, { tickets: [...archiveById.values()] });
+    } catch (err) {
+      return { ok: false, error: `could not write archive file: ${err.message}` };
+    }
+
+    try {
+      writeJsonAtomic(absTicketsPath, { ...rawUnderLock, tickets: kept });
+    } catch (err) {
+      // Worst case here: the archive now holds entries that are also still
+      // present in tickets.json (a harmless duplicate, recoverable by
+      // re-running), never a ticket that exists in neither file.
+      return {
+        ok: false,
+        error: `archived ${archivedEntries.length} ticket(s) but failed to remove them from tickets.json: ${err.message}`,
+      };
+    }
 
     return { ok: true, baseRef, write, stale, active, archived: archivedEntries };
   } finally {

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -4,7 +4,7 @@
 
 import { resolve } from 'node:path';
 import { loadTickets } from '@adlc/core';
-import { classifyTickets, listTrackedFiles } from './detect.mjs';
+import { classifyTicket, classifyTickets, listTrackedFiles } from './detect.mjs';
 import { acquireLock, releaseLock, readJson, writeJsonAtomic } from './store.mjs';
 
 /**
@@ -83,16 +83,37 @@ export function runTicketPrune(options = {}) {
     const freshTickets = Array.isArray(rawUnderLock.tickets) ? rawUnderLock.tickets : [];
 
     const staleIds = new Set(stale.map((r) => r.id));
-    const kept = freshTickets.filter((t) => !staleIds.has(t.id));
-    const removed = freshTickets.filter((t) => staleIds.has(t.id));
+    const staleCandidates = freshTickets.filter((t) => staleIds.has(t.id));
+
+    // Re-classify each candidate against the fresh content read under the
+    // lock rather than trusting the pre-lock `stale`/reason data: another
+    // writer (e.g. ticket-sync, or a human editor) may have mutated a
+    // ticket's content between the initial classification and now in a way
+    // that un-stales it (e.g. flipped `status` from "done" back to
+    // "in-progress", or edited `scope`). Archiving on the stale
+    // classification anyway would silently delete a currently-active ticket
+    // and write an archive entry whose reason no longer matches its content.
+    const freshReasonById = new Map();
+    const removed = [];
+    for (const ticket of staleCandidates) {
+      const reclassified = classifyTicket(ticket, trackedFiles);
+      if (reclassified.stale) {
+        freshReasonById.set(ticket.id, reclassified.reason);
+        removed.push(ticket);
+      }
+    }
+
+    const removedIds = new Set(removed.map((t) => t.id));
+    const kept = freshTickets.filter((t) => !removedIds.has(t.id));
 
     if (removed.length === 0) {
-      // Every stale id was already gone by the time we took the lock.
+      // Every stale id was either already gone, or no longer classifies as
+      // stale (a concurrent writer mutated it out from under us), by the
+      // time we took the lock.
       return { ok: true, baseRef, write, stale, active, archived: [] };
     }
 
     const archivedAt = new Date().toISOString();
-    const reasonById = new Map(stale.map((r) => [r.id, r.reason]));
     let existingArchive;
     try {
       existingArchive = readJson(absArchivePath, { tickets: [] });
@@ -113,7 +134,7 @@ export function runTicketPrune(options = {}) {
 
     const archivedEntries = [];
     for (const ticket of removed) {
-      const entry = { ...ticket, archivedAt, archiveReason: reasonById.get(ticket.id) };
+      const entry = { ...ticket, archivedAt, archiveReason: freshReasonById.get(ticket.id) };
       archiveById.set(ticket.id, entry);
       archivedEntries.push(entry);
     }

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -99,7 +99,17 @@ export function runTicketPrune(options = {}) {
     } catch (err) {
       return { ok: false, error: `could not read archive file: ${err.message}` };
     }
-    const archiveById = new Map((existingArchive.tickets ?? []).map((t) => [t.id, t]));
+    // readJson's fallback only applies to a genuinely absent file — a file
+    // that exists and contains a syntactically-valid-but-unusable JSON
+    // document (e.g. the literal `null`, a bare array, or `{}` without a
+    // `tickets` array) parses successfully and is returned as-is. Guard
+    // against that here (rather than trusting existingArchive.tickets to be
+    // an array) so a pre-existing archive file with unexpected-but-valid
+    // JSON content degrades to "treat as empty archive" instead of throwing
+    // when we dereference .tickets below.
+    const existingArchiveTickets =
+      existingArchive && Array.isArray(existingArchive.tickets) ? existingArchive.tickets : [];
+    const archiveById = new Map(existingArchiveTickets.map((t) => [t.id, t]));
 
     const archivedEntries = [];
     for (const ticket of removed) {

--- a/packages/ticket-prune/lib/store.mjs
+++ b/packages/ticket-prune/lib/store.mjs
@@ -1,0 +1,76 @@
+// store.mjs — local lock + atomic JSON write for the tickets.json writer
+// contract. Core is frozen (CONVENTIONS rule 2) and has no shared writer for
+// .adlc/tickets.json, so this re-implements the same mkdir-lock + tmp-rename
+// protocol @adlc/ticket-sync's lib/store.mjs uses, at the SAME lock path
+// (.adlc/tickets.lock) so the two writers interoperate instead of racing each
+// other. See this package's README "Core gaps" section.
+
+import {
+  mkdirSync,
+  rmdirSync,
+  writeFileSync,
+  renameSync,
+  readFileSync,
+  existsSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const LOCK_DIR = '.adlc/tickets.lock';
+
+/** Zero-dependency synchronous sleep (no busy-wait) for lock retry backoff. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Acquire the shared mkdir lock (atomic; exactly one winner). */
+export function acquireLock(dir = '.', { retries = 50, delayMs = 20 } = {}) {
+  const path = join(dir, LOCK_DIR);
+  // Ensure the .adlc/ parent exists (idempotent — does not affect the
+  // exclusivity check below, which relies on plain mkdirSync's EEXIST).
+  mkdirSync(dirname(path), { recursive: true });
+  for (let i = 0; i <= retries; i++) {
+    try {
+      mkdirSync(path);
+      return true;
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      if (i < retries) sleepSync(delayMs);
+    }
+  }
+  return false;
+}
+
+export function releaseLock(dir = '.') {
+  try {
+    rmdirSync(join(dir, LOCK_DIR));
+  } catch {
+    /* already released */
+  }
+}
+
+function writeAtomic(path, text) {
+  const tmp = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmp, text);
+  renameSync(tmp, path);
+}
+
+/** Pretty-print JSON with a trailing newline and write it atomically. */
+export function writeJsonAtomic(path, obj) {
+  writeAtomic(path, `${JSON.stringify(obj, null, 2)}\n`);
+}
+
+/** Read + parse JSON at `path`; return `fallback` if the file is absent. */
+export function readJson(path, fallback) {
+  if (!existsSync(path)) return fallback;
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (err) {
+    throw new Error(`could not read ${path}: ${err.message}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`invalid JSON in ${path}: ${err.message}`);
+  }
+}

--- a/packages/ticket-prune/package.json
+++ b/packages/ticket-prune/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@adlc/ticket-prune",
+  "version": "1.1.0",
+  "description": "Reports and archives stale/shipped tickets out of .adlc/tickets.json (dry-run by default).",
+  "type": "module",
+  "license": "MIT",
+  "author": "Chris Williams (@voodootikigod)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voodootikigod/adlc.git",
+    "directory": "packages/ticket-prune"
+  },
+  "homepage": "https://github.com/voodootikigod/adlc/tree/main/packages/ticket-prune#readme",
+  "bugs": "https://github.com/voodootikigod/adlc/issues",
+  "keywords": [
+    "adlc",
+    "agentic",
+    "ai",
+    "llm",
+    "cli",
+    "ticket-prune",
+    "gate"
+  ],
+  "bin": {
+    "ticket-prune": "./bin/ticket-prune.mjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@adlc/core": "1.1.0"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/ticket-prune/test/detect.test.mjs
+++ b/packages/ticket-prune/test/detect.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isExplicitlyDone,
+  scopeShipped,
+  classifyTicket,
+  classifyTickets,
+} from '../lib/detect.mjs';
+
+// ── explicit status field (preferred signal when present) ───────────────────
+
+test('isExplicitlyDone recognizes known done-shaped status values', () => {
+  assert.equal(isExplicitlyDone({ id: 'T1', status: 'done' }), true);
+  assert.equal(isExplicitlyDone({ id: 'T1', status: 'DONE' }), true);
+  assert.equal(isExplicitlyDone({ id: 'T1', status: 'closed' }), true);
+  assert.equal(isExplicitlyDone({ id: 'T1', status: 'shipped' }), true);
+});
+
+test('isExplicitlyDone is false for open/active status or no status field', () => {
+  assert.equal(isExplicitlyDone({ id: 'T1', status: 'open' }), false);
+  assert.equal(isExplicitlyDone({ id: 'T1', status: 'active' }), false);
+  assert.equal(isExplicitlyDone({ id: 'T1' }), false);
+});
+
+// ── scope-existence inference (fallback when no explicit status) ────────────
+
+test('scopeShipped is true only when every declared scope glob matches a tracked file', () => {
+  const tracked = ['plugins/adlc-opencode/index.mjs', 'docs/integrations/opencode.md'];
+  const shipped = { id: 'T1', scope: ['plugins/adlc-opencode/**', 'docs/integrations/opencode.md'] };
+  const partial = { id: 'T2', scope: ['plugins/adlc-opencode/**', 'packages/never-built/**'] };
+  assert.equal(scopeShipped(shipped, tracked), true);
+  assert.equal(scopeShipped(partial, tracked), false);
+});
+
+test('scopeShipped is false (never inferred stale) when a ticket declares no scope', () => {
+  assert.equal(scopeShipped({ id: 'T3' }, ['anything']), false);
+  assert.equal(scopeShipped({ id: 'T3', scope: [] }, ['anything']), false);
+});
+
+// ── classifyTicket: the combined decision used by the CLI ───────────────────
+
+test('classifyTicket: explicit done status wins regardless of scope', () => {
+  const result = classifyTicket({ id: 'T1', status: 'done', scope: ['nowhere/**'] }, []);
+  assert.equal(result.stale, true);
+  assert.match(result.reason, /status/i);
+});
+
+test('classifyTicket: explicit non-done status blocks inference even if scope looks shipped', () => {
+  const tracked = ['plugins/adlc-opencode/index.mjs'];
+  const result = classifyTicket(
+    { id: 'T1', status: 'active', scope: ['plugins/adlc-opencode/**'] },
+    tracked
+  );
+  assert.equal(result.stale, false);
+  assert.match(result.reason, /status/i);
+});
+
+test('classifyTicket: no status field falls back to scope-on-base-ref inference (stale)', () => {
+  const tracked = ['plugins/adlc-opencode/index.mjs', 'docs/integrations/opencode.md'];
+  const result = classifyTicket(
+    { id: 'T1', scope: ['plugins/adlc-opencode/**', 'docs/integrations/opencode.md'] },
+    tracked
+  );
+  assert.equal(result.stale, true);
+  assert.match(result.reason, /scope/i);
+});
+
+test('classifyTicket: no status field + scope not fully shipped is active (not stale)', () => {
+  const tracked = ['plugins/adlc-opencode/index.mjs'];
+  const result = classifyTicket(
+    { id: 'T2', scope: ['plugins/adlc-opencode/**', 'packages/never-built/**'] },
+    tracked
+  );
+  assert.equal(result.stale, false);
+});
+
+test('classifyTickets maps a whole ticket array', () => {
+  const tracked = ['plugins/adlc-opencode/index.mjs'];
+  const tickets = [
+    { id: 'T1', scope: ['plugins/adlc-opencode/**'] },
+    { id: 'T2', scope: ['packages/never-built/**'] },
+    { id: 'T3', status: 'done' },
+  ];
+  const results = classifyTickets(tickets, tracked);
+  assert.deepEqual(
+    results.map((r) => [r.id, r.stale]),
+    [
+      ['T1', true],
+      ['T2', false],
+      ['T3', true],
+    ]
+  );
+});

--- a/packages/ticket-prune/test/fixtures/mutate-tickets-after-delay.mjs
+++ b/packages/ticket-prune/test/fixtures/mutate-tickets-after-delay.mjs
@@ -1,0 +1,22 @@
+// mutate-tickets-after-delay.mjs — test-only helper spawned as a real child
+// process by run.test.mjs to simulate another writer (e.g. ticket-sync)
+// mutating .adlc/tickets.json *while* ticket-prune is blocked retrying for
+// the lock. Runs out-of-process so it isn't blocked by the synchronous
+// Atomics.wait retry loop in store.mjs's acquireLock.
+//
+// argv: <dir> <ticketsJsonString> <delayMs>
+// Behavior: sleep delayMs, overwrite <dir>/.adlc/tickets.json with the given
+// contents, then release the .adlc/tickets.lock the parent test pre-acquired.
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { releaseLock } from '../../lib/store.mjs';
+
+const [, , dir, ticketsJson, delayMs] = process.argv;
+
+await new Promise((resolve) => setTimeout(resolve, Number(delayMs)));
+
+const ticketsPath = join(dir, '.adlc', 'tickets.json');
+writeFileSync(ticketsPath, `${ticketsJson}\n`);
+
+releaseLock(dir);

--- a/packages/ticket-prune/test/list-tracked-files.test.mjs
+++ b/packages/ticket-prune/test/list-tracked-files.test.mjs
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { listTrackedFiles } from '../lib/detect.mjs';
+
+function git(args, cwd) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function withScratchRepo(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-git-'));
+  try {
+    git(['init', '-q'], dir);
+    git(['config', 'user.email', 'test@example.com'], dir);
+    git(['config', 'user.name', 'Test'], dir);
+    mkdirSync(join(dir, 'plugins', 'adlc-widget'), { recursive: true });
+    writeFileSync(join(dir, 'plugins', 'adlc-widget', 'index.mjs'), '// shipped\n');
+    writeFileSync(join(dir, 'README.md'), '# scratch\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'initial'], dir);
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('listTrackedFiles lists files tracked at a given ref', () => {
+  withScratchRepo((dir) => {
+    const files = listTrackedFiles('HEAD', dir);
+    assert.ok(files.includes('plugins/adlc-widget/index.mjs'));
+    assert.ok(files.includes('README.md'));
+  });
+});
+
+test('listTrackedFiles does not see untracked working-tree files', () => {
+  withScratchRepo((dir) => {
+    writeFileSync(join(dir, 'scratch.txt'), 'untracked\n');
+    const files = listTrackedFiles('HEAD', dir);
+    assert.equal(files.includes('scratch.txt'), false);
+  });
+});
+
+test('listTrackedFiles throws a clear error for an unresolvable ref', () => {
+  withScratchRepo((dir) => {
+    assert.throws(() => listTrackedFiles('not-a-real-ref', dir), /not-a-real-ref/);
+  });
+});

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -288,6 +288,28 @@ test('--write: invalid JSON in a pre-existing archive file is a clean {ok:false}
   });
 });
 
+test('--write: a pre-existing archive file containing the JSON literal `null` (syntactically valid, but not an object) archives cleanly instead of throwing', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+    // `null` is valid JSON — readJson's fallback is only used for a missing
+    // file, so this parses successfully to `null`, not { tickets: [] }.
+    writeFileSync(join(dir, '.adlc', 'tickets.archive.json'), 'null');
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.archived.length, 1);
+    assert.equal(result.archived[0].id, 'T1');
+
+    const archive = readArchive(dir);
+    assert.equal(archive.tickets.length, 1);
+    assert.equal(archive.tickets[0].id, 'T1');
+
+    const tickets = readTickets(dir);
+    assert.equal(tickets.tickets.length, 0);
+  });
+});
+
 test('bin: --write with a corrupt archive file exits 1 with a clean error message, not a raw stack trace', () => {
   withScratchRepo((dir) => {
     writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -1,11 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runTicketPrune } from '../lib/run.mjs';
+import { acquireLock } from '../lib/store.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BIN = join(HERE, '..', 'bin', 'ticket-prune.mjs');
@@ -32,20 +33,56 @@ function readArchive(dir) {
  * standing in for "mocked done signals": a ticket whose scope matches it is
  * inferrable-stale; a ticket whose scope points nowhere real is not.
  */
+function setupScratchRepo(dir) {
+  git(['init', '-q'], dir);
+  git(['config', 'user.email', 'test@example.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  mkdirSync(join(dir, 'plugins', 'adlc-widget'), { recursive: true });
+  writeFileSync(join(dir, 'plugins', 'adlc-widget', 'index.mjs'), '// shipped\n');
+  git(['add', '-A'], dir);
+  git(['commit', '-q', '-m', 'ship the widget'], dir);
+}
+
 function withScratchRepo(fn) {
   const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-run-'));
   try {
-    git(['init', '-q'], dir);
-    git(['config', 'user.email', 'test@example.com'], dir);
-    git(['config', 'user.name', 'Test'], dir);
-    mkdirSync(join(dir, 'plugins', 'adlc-widget'), { recursive: true });
-    writeFileSync(join(dir, 'plugins', 'adlc-widget', 'index.mjs'), '// shipped\n');
-    git(['add', '-A'], dir);
-    git(['commit', '-q', '-m', 'ship the widget'], dir);
+    setupScratchRepo(dir);
     return fn(dir);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+}
+
+/** Async variant: awaits `fn(dir)` before cleanup, for tests that spawn a
+ * concurrent child process and need the temp dir to outlive its own return. */
+async function withScratchRepoAsync(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-run-async-'));
+  try {
+    setupScratchRepo(dir);
+    return await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Spawns a real child process that sleeps `delayMs`, overwrites
+ * .adlc/tickets.json with `ticketsObj`, then releases the .adlc/tickets.lock
+ * — simulating another writer (e.g. ticket-sync) mutating tickets.json and
+ * releasing the lock while ticket-prune is blocked retrying for it. Runs
+ * out-of-process so it isn't blocked by acquireLock's synchronous retry
+ * loop in the test process. Returns a promise that resolves when the child
+ * exits (rejects on nonzero exit).
+ */
+function spawnMutateAfterDelay(dir, ticketsObj, delayMs) {
+  const script = join(HERE, 'fixtures', 'mutate-tickets-after-delay.mjs');
+  const child = spawn(process.execPath, [script, dir, JSON.stringify(ticketsObj), String(delayMs)], {
+    stdio: 'inherit',
+  });
+  return new Promise((resolvePromise, reject) => {
+    child.on('exit', (code) => (code === 0 ? resolvePromise() : reject(new Error(`writer helper exited ${code}`))));
+    child.on('error', reject);
+  });
 }
 
 // ── dry-run reports without mutating ────────────────────────────────────────
@@ -210,6 +247,126 @@ test('--write accumulates across repeated runs instead of clobbering the archive
     runTicketPrune({ cwd: dir, write: true });
     archive = readArchive(dir);
     assert.deepEqual(archive.tickets.map((t) => t.id).sort(), ['T1', 'T2']);
+  });
+});
+
+// ── --write failure safety (no data loss, no uncaught exceptions) ──────────
+
+test('--write: if the archive write fails, tickets.json is left untouched (no data loss) and the error is reported cleanly', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+
+    // Point --archive at a path inside a directory that doesn't exist, so
+    // the archive's atomic write throws (ENOENT).
+    const badArchivePath = join(dir, 'nonexistent-dir', 'tickets.archive.json');
+
+    const result = runTicketPrune({ cwd: dir, archivePath: badArchivePath, write: true });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /archive/i);
+
+    // The stale ticket must still be in tickets.json, byte-identical to
+    // before the failed run — archive-write failures must never remove a
+    // ticket from tickets.json without it having been durably archived.
+    assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
+    assert.equal(existsSync(badArchivePath), false);
+  });
+});
+
+test('--write: invalid JSON in a pre-existing archive file is a clean {ok:false} error, not an uncaught exception, and does not touch tickets.json', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+    writeFileSync(join(dir, '.adlc', 'tickets.archive.json'), '{ not valid json');
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /invalid JSON/);
+    assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
+  });
+});
+
+test('bin: --write with a corrupt archive file exits 1 with a clean error message, not a raw stack trace', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+    writeFileSync(join(dir, '.adlc', 'tickets.archive.json'), '{ not valid json');
+
+    const { code, stderr } = runBin(['--write', '--json'], dir);
+
+    assert.equal(code, 1);
+    assert.match(stderr, /^error: /);
+    assert.doesNotMatch(stderr, /at runTicketPrune/); // no raw Node stack trace
+  });
+});
+
+// ── concurrency: re-read under the lock ─────────────────────────────────────
+//
+// runTicketPrune re-reads tickets.json after acquiring the lock, specifically
+// to guard against another writer (e.g. ticket-sync) mutating tickets.json
+// between the initial classification read and the lock acquisition. These
+// two tests force a *real* concurrent mutation (via a child process that
+// holds/releases the shared lock out-of-process) to exercise that re-read,
+// rather than two sequential non-overlapping runs.
+
+test('--write: re-reads tickets.json under the lock, so a ticket added concurrently (after classification, before the lock) survives the write', async () => {
+  await withScratchRepoAsync(async (dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+
+    // Hold the lock ourselves first so runTicketPrune's own acquireLock()
+    // call is forced to block/retry — simulating another writer being
+    // mid-write at the exact moment ticket-prune tries to take the lock.
+    assert.equal(acquireLock(dir), true);
+
+    // While ticket-prune is blocked on the lock, this child process mutates
+    // tickets.json to add T2 (unknown to classification, which already ran
+    // against the pre-mutation file above) and then releases the lock.
+    const mutated = {
+      tickets: [
+        { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] },
+        { id: 'T2', title: 'Added concurrently', scope: ['packages/never-built/**'] },
+      ],
+    };
+    const writerDone = spawnMutateAfterDelay(dir, mutated, 150);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+    await writerDone;
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.archived.map((t) => t.id), ['T1']);
+
+    // T2 didn't exist when classification ran, so it's in neither `stale`
+    // nor `active` — but the re-read under the lock must still see it and
+    // preserve it in tickets.json. If runTicketPrune used the pre-lock
+    // `tickets` snapshot instead of re-reading fresh under the lock, T2
+    // would be silently dropped here.
+    assert.deepEqual(readTickets(dir).tickets.map((t) => t.id), ['T2']);
+  });
+});
+
+test('--write: if a stale ticket is already gone by the time the lock is acquired, the run archives nothing instead of crashing or re-archiving', () => {
+  return withScratchRepoAsync(async (dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+
+    assert.equal(acquireLock(dir), true);
+
+    // Simulates another writer having already archived/removed T1 by the
+    // time ticket-prune gets the lock.
+    const writerDone = spawnMutateAfterDelay(dir, { tickets: [] }, 150);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+    await writerDone;
+
+    assert.equal(result.ok, true);
+    // Classification (which ran before the lock was even attempted) still
+    // reports T1 as stale...
+    assert.deepEqual(result.stale.map((r) => r.id), ['T1']);
+    // ...but the removed.length === 0 early-return branch means nothing is
+    // (re-)archived and no archive file is created.
+    assert.deepEqual(result.archived, []);
+    assert.equal(existsSync(join(dir, '.adlc', 'tickets.archive.json')), false);
+    assert.deepEqual(readTickets(dir).tickets, []);
   });
 });
 

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -1,0 +1,216 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runTicketPrune } from '../lib/run.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN = join(HERE, '..', 'bin', 'ticket-prune.mjs');
+
+function git(args, cwd) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function writeTickets(dir, tickets) {
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets }, null, 2));
+}
+
+function readTickets(dir) {
+  return JSON.parse(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'));
+}
+
+function readArchive(dir) {
+  return JSON.parse(readFileSync(join(dir, '.adlc', 'tickets.archive.json'), 'utf8'));
+}
+
+/**
+ * A scratch repo with one shipped feature (plugins/adlc-widget/**, committed)
+ * standing in for "mocked done signals": a ticket whose scope matches it is
+ * inferrable-stale; a ticket whose scope points nowhere real is not.
+ */
+function withScratchRepo(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-run-'));
+  try {
+    git(['init', '-q'], dir);
+    git(['config', 'user.email', 'test@example.com'], dir);
+    git(['config', 'user.name', 'Test'], dir);
+    mkdirSync(join(dir, 'plugins', 'adlc-widget'), { recursive: true });
+    writeFileSync(join(dir, 'plugins', 'adlc-widget', 'index.mjs'), '// shipped\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship the widget'], dir);
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── dry-run reports without mutating ────────────────────────────────────────
+
+test('dry-run reports a stale ticket (mocked done signal: shipped scope) without mutating tickets.json', () => {
+  withScratchRepo((dir) => {
+    const tickets = [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] },
+      { id: 'T2', title: 'Still building', scope: ['packages/never-built/**'] },
+    ];
+    writeTickets(dir, tickets);
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+
+    const result = runTicketPrune({ cwd: dir });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.write, false);
+    assert.deepEqual(result.stale.map((r) => r.id), ['T1']);
+    assert.deepEqual(result.active.map((r) => r.id), ['T2']);
+
+    // Not mutated: byte-identical to what was written before the run.
+    const after = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+    assert.equal(after, before);
+    assert.equal(existsSync(join(dir, '.adlc', 'tickets.archive.json')), false);
+  });
+});
+
+test('dry-run: an explicit non-done status overrides a shipped-looking scope', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [
+      { id: 'T1', title: 'Explicitly still active', status: 'active', scope: ['plugins/adlc-widget/**'] },
+    ]);
+    const result = runTicketPrune({ cwd: dir });
+    assert.deepEqual(result.stale, []);
+    assert.equal(result.active.length, 1);
+  });
+});
+
+test('dry-run: explicit status "done" is stale even with no matching scope', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Marked done', status: 'done', scope: ['nowhere/**'] }]);
+    const result = runTicketPrune({ cwd: dir });
+    assert.deepEqual(result.stale.map((r) => r.id), ['T1']);
+  });
+});
+
+// ── --write archives and removes ────────────────────────────────────────────
+
+test('--write moves stale tickets into the archive file and removes them from tickets.json', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] },
+      { id: 'T2', title: 'Still building', scope: ['packages/never-built/**'] },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.archived.length, 1);
+    assert.equal(result.archived[0].id, 'T1');
+
+    const remaining = readTickets(dir);
+    assert.deepEqual(remaining.tickets.map((t) => t.id), ['T2']);
+
+    const archive = readArchive(dir);
+    assert.deepEqual(archive.tickets.map((t) => t.id), ['T1']);
+    assert.ok(archive.tickets[0].archivedAt);
+    assert.ok(archive.tickets[0].archiveReason);
+    // Full ticket payload is preserved, not just the id.
+    assert.equal(archive.tickets[0].title, 'Ship the widget');
+  });
+});
+
+test('--write with no stale tickets leaves tickets.json untouched and writes no archive', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Still building', scope: ['packages/never-built/**'] }]);
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.archived.length, 0);
+    assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
+    assert.equal(existsSync(join(dir, '.adlc', 'tickets.archive.json')), false);
+  });
+});
+
+test('--write accumulates across repeated runs instead of clobbering the archive', () => {
+  withScratchRepo((dir) => {
+    mkdirSync(join(dir, 'packages', 'second-widget'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'second-widget', 'index.mjs'), '// shipped later\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship the second widget'], dir);
+
+    writeTickets(dir, [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] },
+      { id: 'T2', title: 'Ship the second widget', scope: ['packages/second-widget/**'] },
+    ]);
+
+    runTicketPrune({ cwd: dir, write: true });
+    let archive = readArchive(dir);
+    assert.deepEqual(archive.tickets.map((t) => t.id).sort(), ['T1', 'T2']);
+
+    // A later run with a fresh tickets.json (e.g. new tickets added since)
+    // must not drop the earlier archive entries.
+    writeTickets(dir, [{ id: 'T3', title: 'Still building', scope: ['packages/never-built/**'] }]);
+    runTicketPrune({ cwd: dir, write: true });
+    archive = readArchive(dir);
+    assert.deepEqual(archive.tickets.map((t) => t.id).sort(), ['T1', 'T2']);
+  });
+});
+
+test('empty tickets.json (no tickets) reports cleanly and is a no-op', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, []);
+    const result = runTicketPrune({ cwd: dir });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.stale, []);
+    assert.deepEqual(result.active, []);
+  });
+});
+
+test('missing tickets.json is an operational error, not a silent pass', () => {
+  withScratchRepo((dir) => {
+    const result = runTicketPrune({ cwd: dir });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /tickets file not found/);
+  });
+});
+
+// ── bin smoke test (exit codes + --json shape) ──────────────────────────────
+
+function runBin(args, cwd) {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN, ...args], { cwd, encoding: 'utf8' });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status ?? 1, stdout: err.stdout?.toString() ?? '', stderr: err.stderr?.toString() ?? '' };
+  }
+}
+
+test('bin: dry-run exits 0 and --json prints the classification', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+    const { code, stdout } = runBin(['--json'], dir);
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.write, false);
+    assert.deepEqual(parsed.stale.map((r) => r.id), ['T1']);
+  });
+});
+
+test('bin: --write exits 0 and actually archives via the CLI entry point', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+    const { code } = runBin(['--write', '--json'], dir);
+    assert.equal(code, 0);
+    assert.deepEqual(readTickets(dir).tickets, []);
+    assert.equal(readArchive(dir).tickets.length, 1);
+  });
+});
+
+test('bin: missing tickets file exits 1 (operational error)', () => {
+  withScratchRepo((dir) => {
+    const { code, stderr } = runBin([], dir);
+    assert.equal(code, 1);
+    assert.match(stderr, /tickets file not found/);
+  });
+});

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -392,6 +392,35 @@ test('--write: if a stale ticket is already gone by the time the lock is acquire
   });
 });
 
+test('--write: a ticket concurrently un-staled (status flipped back to active) between classification and the lock survives, using fresh content and reclassification, not the stale pre-lock snapshot', () => {
+  return withScratchRepoAsync(async (dir) => {
+    // T1 starts "done" — classification (pre-lock) reports it stale.
+    writeTickets(dir, [{ id: 'T1', title: 'Reopened work', status: 'done' }]);
+
+    assert.equal(acquireLock(dir), true);
+
+    // While ticket-prune is blocked on the lock, another writer flips T1
+    // back to "in-progress" — it is no longer stale by any classification
+    // rule, even though the pre-lock snapshot said otherwise.
+    const mutated = { tickets: [{ id: 'T1', title: 'Reopened work', status: 'in-progress' }] };
+    const writerDone = spawnMutateAfterDelay(dir, mutated, 150);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+    await writerDone;
+
+    assert.equal(result.ok, true);
+    // Pre-lock classification still (correctly, for its snapshot) reported
+    // T1 as stale...
+    assert.deepEqual(result.stale.map((r) => r.id), ['T1']);
+    // ...but nothing gets archived: the re-read-under-the-lock content no
+    // longer classifies as stale, so the concurrent edit wins.
+    assert.deepEqual(result.archived, []);
+    assert.equal(existsSync(join(dir, '.adlc', 'tickets.archive.json')), false);
+    // The ticket survives in tickets.json with its fresh, active status.
+    assert.deepEqual(readTickets(dir).tickets, [{ id: 'T1', title: 'Reopened work', status: 'in-progress' }]);
+  });
+});
+
 test('empty tickets.json (no tickets) reports cleanly and is a no-op', () => {
   withScratchRepo((dir) => {
     writeTickets(dir, []);

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -73,6 +73,62 @@ test('dry-run reports a stale ticket (mocked done signal: shipped scope) without
   });
 });
 
+test('dry-run: absolute --tickets/--archive paths are honored, not joined onto cwd', () => {
+  withScratchRepo((dir) => {
+    // Place tickets.json and the archive somewhere entirely outside `dir`
+    // (which is itself the cwd passed to runTicketPrune) to prove an
+    // absolute ticketsPath/archivePath overrides cwd instead of being
+    // concatenated onto it (path.join would produce cwd + absolutePath).
+    const outside = mkdtempSync(join(tmpdir(), 'ticket-prune-abs-'));
+    try {
+      const absTickets = join(outside, 'tickets.json');
+      const absArchive = join(outside, 'tickets.archive.json');
+      writeFileSync(
+        absTickets,
+        JSON.stringify(
+          {
+            tickets: [
+              { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] },
+              { id: 'T2', title: 'Still building', scope: ['packages/never-built/**'] },
+            ],
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = runTicketPrune({ cwd: dir, ticketsPath: absTickets, archivePath: absArchive });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.stale.map((r) => r.id), ['T1']);
+      assert.deepEqual(result.active.map((r) => r.id), ['T2']);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+test('--write with an absolute --archive path archives outside cwd correctly', () => {
+  withScratchRepo((dir) => {
+    const outside = mkdtempSync(join(tmpdir(), 'ticket-prune-abs-write-'));
+    try {
+      writeTickets(dir, [{ id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'] }]);
+      const absArchive = join(outside, 'tickets.archive.json');
+
+      const result = runTicketPrune({ cwd: dir, archivePath: absArchive, write: true });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.archived.map((t) => t.id), ['T1']);
+      assert.equal(existsSync(absArchive), true);
+      assert.deepEqual(JSON.parse(readFileSync(absArchive, 'utf8')).tickets.map((t) => t.id), ['T1']);
+      // Default (relative) tickets.json location is unaffected.
+      assert.deepEqual(readTickets(dir).tickets, []);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
 test('dry-run: an explicit non-done status overrides a shipped-looking scope', () => {
   withScratchRepo((dir) => {
     writeTickets(dir, [

--- a/packages/ticket-prune/test/store.test.mjs
+++ b/packages/ticket-prune/test/store.test.mjs
@@ -2,8 +2,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
 import { acquireLock, releaseLock, writeJsonAtomic, readJson } from '../lib/store.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const STORE_MJS_URL = new URL('../lib/store.mjs', import.meta.url).href;
 
 function withTempDir(fn) {
   const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-store-'));
@@ -12,6 +17,43 @@ function withTempDir(fn) {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Hold the lock at `dir` in a separate process for `holdMs`, then release it.
+ * acquireLock's retry loop uses a synchronous, event-loop-blocking sleep
+ * (Atomics.wait), so a same-process timer cannot release the lock while this
+ * test's own acquireLock call is retrying — hence a real child process.
+ * Returns a promise that resolves once the child has acquired the lock (so
+ * the caller's subsequent acquireLock call is guaranteed to contend with it).
+ */
+function holdLockInChildThenRelease(dir, holdMs) {
+  return new Promise((resolvePromise, reject) => {
+    const script = `
+      import { acquireLock, releaseLock } from '${STORE_MJS_URL}';
+      const dir = process.argv[1];
+      const holdMs = Number(process.argv[2]);
+      const got = acquireLock(dir, { retries: 0, delayMs: 0 });
+      if (!got) { console.error('child could not acquire lock'); process.exit(1); }
+      console.log('LOCKED');
+      setTimeout(() => { releaseLock(dir); }, holdMs);
+    `;
+    const child = spawn(process.execPath, ['--input-type=module', '-e', script, '--', dir, String(holdMs)], {
+      cwd: HERE,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    let settled = false;
+    child.stdout.on('data', (chunk) => {
+      if (!settled && chunk.toString('utf8').includes('LOCKED')) {
+        settled = true;
+        resolvePromise(child);
+      }
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (!settled) reject(new Error(`child exited (${code}) before acquiring the lock`));
+    });
+  });
 }
 
 test('writeJsonAtomic writes pretty JSON with a trailing newline and no leftover tmp file', () => {
@@ -62,4 +104,37 @@ test('acquireLock/releaseLock: second acquirer blocks until release, then can ac
     assert.equal(gotThird, true);
     releaseLock(dir);
   });
+});
+
+test('acquireLock retry/backoff loop actually waits out a held lock instead of failing fast', async () => {
+  // Not withTempDir: that helper's `finally` runs rmSync synchronously right
+  // after invoking the callback, which would delete the dir out from under
+  // this async test before the awaited work below finishes.
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-store-'));
+  try {
+    const HOLD_MS = 150;
+    const child = await holdLockInChildThenRelease(dir, HOLD_MS);
+    try {
+      // Give the held lock time to still be held, then acquire with a real
+      // retry/backoff budget (small per-retry delay, enough retries to
+      // outlast HOLD_MS) — this only succeeds if the loop actually retries.
+      const start = Date.now();
+      const got = acquireLock(dir, { retries: 50, delayMs: 10 });
+      const elapsedMs = Date.now() - start;
+
+      assert.equal(got, true, 'acquireLock should eventually succeed once the child releases');
+      // A fail-fast (single-attempt) implementation would return well before
+      // the child releases; a real retry loop must take at least roughly as
+      // long as the lock was held.
+      assert.ok(
+        elapsedMs >= HOLD_MS * 0.5,
+        `expected acquireLock to block for close to ${HOLD_MS}ms while retrying, only took ${elapsedMs}ms`,
+      );
+      releaseLock(dir);
+    } finally {
+      await new Promise((res) => child.on('exit', res));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/ticket-prune/test/store.test.mjs
+++ b/packages/ticket-prune/test/store.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { acquireLock, releaseLock, writeJsonAtomic, readJson } from '../lib/store.mjs';
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-store-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('writeJsonAtomic writes pretty JSON with a trailing newline and no leftover tmp file', () => {
+  withTempDir((dir) => {
+    const path = join(dir, 'out.json');
+    writeJsonAtomic(path, { a: 1 });
+    const text = readFileSync(path, 'utf8');
+    assert.equal(text, '{\n  "a": 1\n}\n');
+    assert.equal(existsSync(`${path}.tmp.${process.pid}`), false);
+  });
+});
+
+test('readJson returns the fallback when the file is absent', () => {
+  withTempDir((dir) => {
+    const value = readJson(join(dir, 'missing.json'), { tickets: [] });
+    assert.deepEqual(value, { tickets: [] });
+  });
+});
+
+test('readJson round-trips what writeJsonAtomic wrote', () => {
+  withTempDir((dir) => {
+    const path = join(dir, 'roundtrip.json');
+    writeJsonAtomic(path, { tickets: [{ id: 'T1' }] });
+    assert.deepEqual(readJson(path, null), { tickets: [{ id: 'T1' }] });
+  });
+});
+
+test('readJson throws a clear error on invalid JSON (not silently swallowed)', () => {
+  withTempDir((dir) => {
+    const path = join(dir, 'bad.json');
+    writeFileSync(path, '{ not valid json');
+    assert.throws(() => readJson(path, null), /invalid JSON/);
+  });
+});
+
+test('acquireLock/releaseLock: second acquirer blocks until release, then can acquire', () => {
+  withTempDir((dir) => {
+    const gotFirst = acquireLock(dir, { retries: 0, delayMs: 0 });
+    assert.equal(gotFirst, true);
+
+    // A second attempt with zero retries must fail fast (lock held).
+    const gotSecond = acquireLock(dir, { retries: 0, delayMs: 0 });
+    assert.equal(gotSecond, false);
+
+    releaseLock(dir);
+
+    const gotThird = acquireLock(dir, { retries: 0, delayMs: 0 });
+    assert.equal(gotThird, true);
+    releaseLock(dir);
+  });
+});

--- a/plugins/adlc-claude-code/commands/adlc-maintain.md
+++ b/plugins/adlc-claude-code/commands/adlc-maintain.md
@@ -1,5 +1,5 @@
 ---
-description: Run the decay-driven ADLC maintenance checks — stale skills, hot files to re-prosecute, and gate calibration (C10/C12).
+description: Run the decay-driven ADLC maintenance checks — stale skills, hot files to re-prosecute, stale tickets, and gate calibration (C10/C12).
 argument-hint: (no arguments)
 ---
 
@@ -39,7 +39,25 @@ adlc model-ratchet --dry-run --json
 - With a `--review-cmd`, model-ratchet can run a review over those files and
   append findings to `.adlc/findings.jsonl` (which later feeds `/adlc:adlc-distill`).
 
-## 3. Gate fuzzing — can hostile candidates defeat the gates? (calibration)
+## 3. Ticket prune — stale ticket hygiene
+
+```
+adlc ticket-prune --json
+```
+
+- Dry-run by default (this call never writes): reports tickets that look
+  already shipped — either an explicit `status: done`-shaped field, or every
+  declared `scope` glob resolving to a file already tracked on `HEAD`. This is
+  a *plan*, not a gate — it does not fail on stale tickets (exit `0` either
+  way; exit `1` only on an operational error such as a missing/invalid
+  `.adlc/tickets.json`).
+- List the stale tickets it finds and recommend confirming them by hand, then
+  re-running with `adlc ticket-prune --write` to archive them into the
+  gitignored `.adlc/tickets.archive.json` (never deletes outright). Treat
+  `--write` as a human-confirmed action, not something this command should
+  run unattended — `.adlc/tickets.json` is a shared, hand-edited file.
+
+## 4. Gate fuzzing — can hostile candidates defeat the gates? (calibration)
 
 Only run this if a gate suite exists at `.adlc/gate-suite.json`; without one the
 tool exits `1` (`Gate suite not found`) — note that calibration was skipped.
@@ -53,15 +71,17 @@ adlc gate-fuzzing --suite .adlc/gate-suite.json --prompt-only
   report it; the gate needs strengthening (this is the gate-fuzzing exit-`2`
   condition when run with a provider).
 
-## 4. Summarize
+## 5. Summarize
 
-Report: stale skills (if any), the top hot files to re-prosecute, gate-fuzzing
-result or why it was skipped, and the recommended next actions. Repeated findings
-surfaced here flow into `/adlc:adlc-distill`.
+Report: stale skills (if any), the top hot files to re-prosecute, any stale
+tickets found (and whether they were archived), gate-fuzzing result or why it
+was skipped, and the recommended next actions. Repeated findings surfaced here
+flow into `/adlc:adlc-distill`.
 
 ## Scheduling
 
-The deterministic checks here (`skill-rot`, `model-ratchet`) are keyless and run
-well on a cron — see the ready-to-use workflow at `docs/ci/adlc-maintenance.yml`.
+The deterministic checks here (`skill-rot`, `model-ratchet`, `ticket-prune`) are
+keyless and run well on a cron — see the ready-to-use workflow at
+`docs/ci/adlc-maintenance.yml`.
 The LLM-backed gate-fuzzing runs via a scheduled Claude routine (`/schedule`
 invoking `/adlc:adlc-maintain`), where Claude is the model and no API keys are needed.


### PR DESCRIPTION
## Summary

Adds `@adlc/ticket-prune`, a new dry-run-by-default gate/tool that reports and (with `--write`) archives stale tickets out of `.adlc/tickets.json` into a gitignored `.adlc/tickets.archive.json`, so completed work stops masquerading as an open backlog.

- Classifies each ticket as stale/active via an explicit `status: done`-shaped field, falling back to scope-vs-tracked-files inference on the base ref when no status is present (never inferred stale if a ticket declares no scope).
- `--write` acquires a lock, re-reads `tickets.json` under the lock, and re-classifies each stale candidate against that fresh read instead of trusting the pre-lock snapshot — so a ticket concurrently un-staled by another writer (e.g. `ticket-sync`, or a human edit) between classification and lock acquisition survives instead of being silently deleted.
- Archive writes are atomic and additive across repeated runs; a failed archive write leaves `tickets.json` untouched (no data loss).
- Wired into the CLI registry (`packages/cli/lib/registry.mjs`) and `/adlc:adlc-maintain` (decay-driven maintenance) alongside docs (`docs/tools/ticket-prune.md`, `docs/specs/ticket-prune.md`, `docs/package-reference.md`, `docs/toolkit.md`).

Fixes #39

## Review status

5 rounds of adversarial review; rounds 1-4's findings addressed by `68247b6`, `1dfa8b1`, `de85004`; round 5's concurrency finding addressed by `f97a05d` and independently re-verified in a follow-up pass (see PR comment) — clean.

## Test plan

- [x] `cd packages/ticket-prune && npm test` — 38/38 passing (detect, store, run, list-tracked-files, bin entry point, race/lock regression tests)
- [x] `cd packages/cli && npm test` — 20/20 passing (registry exposes both `ticket-prune` and `review`, dispatch routing unaffected)
- [x] Rebased onto latest `main` (through PR #89), resolving conflicts additively (both `ticket-prune` and `adlc review` verbs/docs preserved)
- [x] Round-5 concurrency fix in `lib/run.mjs` independently re-verified — see PR comment
