### PR TITLE
fix(adlc-init): track .adlc/specs/, exclude .adlc/ from formatters, warn on ticket-write quality checks

### DIFF
--- a/docs/specs/adlc-init-hygiene.md
+++ b/docs/specs/adlc-init-hygiene.md
@@ -1,0 +1,81 @@
+# Spec — adlc-init hygiene sweep (#46, #42, #43)
+
+**Phase:** P1 record for the `adlc-init-hygiene` cluster. Three related hygiene fixes to
+the per-harness `/adlc-init` bootstrap and the `/adlc-ticket` authoring flow, surfaced by
+running a full P0→P6 ADLC cycle on an external repo.
+
+## Issue #46 — track `.adlc/specs/` by default
+
+**Problem:** every `/adlc-init`'s documented `.gitignore` stanza was `.adlc/*` +
+`!.adlc/tickets.json` only, so the P1 spec at `.adlc/specs/T<n>.md` — arguably the most
+important contract in the lifecycle — was left untracked by default.
+
+**Acceptance criteria:**
+- Every harness's `/adlc-init` (`adlc-claude-code`, `adlc-opencode`, `adlc-antigravity`,
+  `adlc-cursor`) documents a three-line stanza: `.adlc/*`, `!.adlc/tickets.json`,
+  `!.adlc/specs/`.
+- Where a deterministic scaffolder exists (`adlc-opencode`, `adlc-cursor`), `ensureGitignore()`
+  in `lib/scaffold.mjs` writes/repairs this stanza: creates it fresh if `.gitignore` is
+  absent, and adds only the missing `!.adlc/specs/` line if the older two-line form is
+  already present, leaving every other line untouched.
+
+**Verify:**
+```sh
+node --test plugins/adlc-opencode/test/scaffold.test.mjs
+node --test plugins/adlc-cursor/test/scaffold.test.mjs
+```
+
+## Issue #42 — exclude `.adlc/` from repo formatters/linters
+
+**Problem:** `.adlc/tickets.json` is machine-written (`JSON.stringify(…, null, 2)`). Once a
+ticket declares `rails`, the file becomes a frozen trust root that cannot be reformatted on
+a ticket branch without tripping `rails-guard` — so a repo formatter reformatting it turns
+CI red on the very next PR.
+
+**Acceptance criteria:**
+- Every harness's `/adlc-init` documents detecting and updating, only for configs already
+  present in the target repo: Biome (`biome.json` → merged `overrides` entry disabling
+  formatter/linter for `.adlc/**`), Prettier (`.prettierignore` → appended `.adlc/` line),
+  ESLint (`ignorePatterns` in a JSON `.eslintrc*`, or `.eslintignore`; flat
+  `eslint.config.js`/`.mjs`/`.cjs` is detected but not auto-edited).
+- The manual fallback is documented for tools not auto-detected (flat ESLint config, or any
+  other formatter/linter).
+- `lib/scaffold.mjs`'s `ensureFormatterIgnores()` (opencode, cursor) implements this
+  deterministically and is wired into `scaffold()`.
+
+**Verify:**
+```sh
+node --test plugins/adlc-opencode/test/scaffold.test.mjs
+node --test plugins/adlc-cursor/test/scaffold.test.mjs
+```
+
+## Issue #43 — warn if the quality check flags `tickets.json` after a write
+
+**Problem:** nothing in the `/adlc-ticket` authoring flow caught the formatter conflict
+above; it was discovered only on the next PR, after `.adlc/tickets.json` had already been
+committed.
+
+**Acceptance criteria:**
+- Both harnesses that ship `/adlc-ticket` (`adlc-claude-code`, `adlc-opencode`) document a
+  step, run immediately after the atomic write and lock release, that: looks for
+  `scripts.check` then `scripts.lint` in `package.json`; detects the package manager from
+  the lockfile; runs that check scoped to `.adlc/tickets.json` where the underlying tool
+  supports a path argument, else the full script; and on failure **warns** (never fails or
+  reverts the write) with a pointer back to `/adlc-init`'s formatter-ignore step.
+- No script found → skip silently; check passes → continue silently.
+
+**Verify:** manual read-through of `plugins/adlc-claude-code/commands/adlc-ticket.md` §3 and
+`plugins/adlc-opencode/command/adlc-ticket.md` §4 (this is an agentic instruction, not a
+deterministic script — there is no unit test to run).
+
+## Full regression check
+
+```sh
+node --test plugins/adlc-opencode/test/*.test.mjs
+node --test plugins/adlc-cursor/test/*.test.mjs
+node --test plugins/adlc-antigravity/test/*.test.mjs
+node --test plugins/adlc-claude-code/hooks/test/*.test.mjs
+node scripts/cursor-install-smoke.mjs .
+node scripts/opencode-install-smoke.mjs .
+node scripts/antigravity-install-smoke.mjs .
+```

--- a/plugins/adlc-antigravity/commands/adlc-init.md
+++ b/plugins/adlc-antigravity/commands/adlc-init.md
@@ -16,15 +16,36 @@ Bootstrap the ADLC runtime for use with `agy`.
    ```sh
    adlc init || npx @adlc/cli init
    ```
-3. **Add the .gitignore stanza** so only the ticket file is tracked:
+3. **Add the .gitignore stanza** so the ticket file and P1 specs are tracked,
+   everything else under `.adlc/` is not:
    ```
    .adlc/*
    !.adlc/tickets.json
+   !.adlc/specs/
    ```
-4. **Wire the CI gate** (the real guarantee): copy `docs/ci/rails-guard.yml` into your
+   If `.gitignore` already has the older two-line form (no `!.adlc/specs/`),
+   add just the missing `!.adlc/specs/` line — don't touch anything else. The
+   `specs/` directory holds the P1 spec for every ticket, arguably the most
+   important contract in the lifecycle, so it must be tracked by default.
+4. **Exclude `.adlc/` from this repo's formatters/linters.** `.adlc/tickets.json`
+   is machine-written and, once a ticket declares `rails`, becomes a frozen
+   trust root — reformatting it on a ticket branch trips `rails-guard`. Check
+   for these configs and, only for the ones already present, add a `.adlc/`
+   exclusion:
+   - **Biome** (`biome.json`): merge an override —
+     `{ "overrides": [{ "include": [".adlc/**"], "formatter": { "enabled": false }, "linter": { "enabled": false } }] }`.
+   - **Prettier** (`.prettierignore`): append a `.adlc/` line.
+   - **ESLint**: add `.adlc/**` to `ignorePatterns` in a JSON `.eslintrc*`, or
+     append `.adlc/` to `.eslintignore`. For a flat `eslint.config.js`/`.mjs`/`.cjs`,
+     don't auto-edit — tell the user to add `{ ignores: ['.adlc/**'] }` themselves.
+
+   Never create a new formatter/linter config just to add this exclusion. If
+   none of these are present, or the repo uses a different tool, document the
+   manual fallback and move on.
+5. **Wire the CI gate** (the real guarantee): copy `docs/ci/rails-guard.yml` into your
    pipeline and make it a required check. The in-session hook is advisory — `agy`
    fails **open** on a non-zero hook exit, so it cannot substitute for CI. The
    workflow template runs `scripts/rails-guard-ci.mjs` directly; treat that script
    as a required check in branch protection, not just an informational job.
-5. **Activate enforcement** for a build: `export ADLC_P4_ENFORCEMENT=1` with an active
+6. **Activate enforcement** for a build: `export ADLC_P4_ENFORCEMENT=1` with an active
    ticket whose `rails[]` are frozen.

--- a/plugins/adlc-claude-code/commands/adlc-init.md
+++ b/plugins/adlc-claude-code/commands/adlc-init.md
@@ -38,34 +38,74 @@ Run `adlc --version`.
 
 ## 3. Separate the contract from the runtime evidence in git
 
-The ticket file is the **source-of-truth contract** between tools and is worth
-committing. Everything else under `.adlc/` — append-only ledgers, gate evidence,
-the ticket lock, and hook runtime state — is a **runtime artifact** and should
-not be. If a `.gitignore` exists (create one if it does not), ensure it ignores
-all of `.adlc/` *except* the ticket file — add these two lines if absent:
+The ticket file and the P1 specs are the **source-of-truth contracts** between
+tools and are worth committing. Everything else under `.adlc/` — append-only
+ledgers, gate evidence, the ticket lock, and hook runtime state — is a
+**runtime artifact** and should not be. If a `.gitignore` exists (create one if
+it does not), ensure it ignores all of `.adlc/` *except* the ticket file and the
+specs directory — add these three lines if absent:
 
 ```
 .adlc/*
 !.adlc/tickets.json
+!.adlc/specs/
 ```
 
-This negation keeps `tickets.json` tracked while ignoring all current and future
-runtime files (ledgers, `lessons/`, `tickets.lock/`, …) without you having to
-enumerate them. If the repo already has a blanket `.adlc/`
-ignore (which would also hide `tickets.json`), point that out and ask the user
-whether they want to track `tickets.json` (recommended) before changing it.
+These negations keep `tickets.json` and `.adlc/specs/` (the P1 spec for every
+ticket — arguably the most important contract in the lifecycle) tracked while
+ignoring all current and future runtime files (ledgers, `lessons/`,
+`tickets.lock/`, …) without you having to enumerate them. If the repo already
+has a blanket `.adlc/` ignore (which would also hide `tickets.json` and
+`specs/`), point that out and ask the user whether they want to track them
+(recommended) before changing it. If `.gitignore` already has the older
+two-line form (`.adlc/*` + `!.adlc/tickets.json` but no `!.adlc/specs/`), add
+just the missing `!.adlc/specs/` line — don't touch anything else.
 
-## 4. Run a preflight check
+## 4. Exclude `.adlc/` from the repo's formatters and linters
+
+`.adlc/tickets.json` is machine-written (`JSON.stringify(…, null, 2)`,
+multi-line arrays). Once any ticket declares `rails`, this file becomes a
+**frozen trust root** — it cannot be reformatted on a ticket branch without
+tripping `rails-guard`. A repo formatter/linter that reformats it will silently
+break the next PR. Check for the following configs and, only for the ones that
+already exist in this repo, add an `.adlc/` exclusion:
+
+- **Biome** (`biome.json`): add an override that disables the formatter and
+  linter for the directory:
+  ```json
+  {
+    "overrides": [
+      { "include": [".adlc/**"], "formatter": { "enabled": false }, "linter": { "enabled": false } }
+    ]
+  }
+  ```
+  Merge this into any existing `overrides` array — do not replace it.
+- **Prettier** (`.prettierignore`): append a `.adlc/` line.
+- **ESLint**: for a JSON `.eslintrc`/`.eslintrc.json`, add `.adlc/**` to
+  `ignorePatterns`. For an `.eslintignore` file, append a `.adlc/` line. For a
+  flat `eslint.config.js`/`.mjs`/`.cjs`, do not attempt an automated text edit —
+  report it and tell the user to add `{ ignores: ['.adlc/**'] }` to the
+  exported config array themselves.
+
+Only touch a config file that is already present — never create a new
+formatter/linter config just to add this exclusion. If none of these configs
+exist, or the repo uses a formatter/linter not listed here (e.g. StandardJS,
+Ruff, golangci-lint), say so explicitly and document the manual fallback: add
+a `.adlc/` (or `.adlc/**`) ignore/exclude entry to that tool's config yourself
+before the first ticket with `rails` is committed.
+
+## 5. Run a preflight check
 
 Run `adlc preflight --json` and summarize the verdict. This surfaces missing
 tools, a dirty tree, or provider problems before any work fans out. A non-zero
 exit here is informational for setup — report it, do not treat it as a failure of
 this command.
 
-## 5. Summarize
+## 6. Summarize
 
 Report: toolkit version, whether `.adlc/tickets.json` was created or already
-present, what (if anything) was added to `.gitignore`, and the preflight verdict.
-Then point the user at `/adlc:adlc-ticket` to author their first ticket (P0), and note
-that the `adlc` discovery skill will route them through the rest of the
-lifecycle.
+present, what (if anything) was added to `.gitignore`, which formatter/linter
+configs (if any) were updated to exclude `.adlc/` and which need a manual entry,
+and the preflight verdict. Then point the user at `/adlc:adlc-ticket` to author
+their first ticket (P0), and note that the `adlc` discovery skill will route
+them through the rest of the lifecycle.

--- a/plugins/adlc-claude-code/commands/adlc-ticket.md
+++ b/plugins/adlc-claude-code/commands/adlc-ticket.md
@@ -103,7 +103,35 @@ ticket set while rails are frozen is a deliberate, audited action.
 
 Add `.adlc/tickets.lock` to the evidence-ignore set if it is not already covered.
 
-## 3. Check executability (coldstart gate)
+## 3. Warn (don't fail) if the repo's formatter/linter would reformat the write
+
+The atomic write in step 2 just changed `.adlc/tickets.json` on disk. If the
+repo's formatter or linter is not excluding `.adlc/` (see `/adlc:adlc-init` step 4),
+this file can go on to silently red the next PR — nothing in the authoring flow
+would otherwise have caught it before that point. Check now, non-blocking:
+
+1. Read `package.json` at the repo root. Look for a `scripts.check` entry, else
+   a `scripts.lint` entry (in that order). If neither exists, skip this step
+   silently — there is no quality script to run.
+2. Detect the package manager from the lockfile present: `pnpm-lock.yaml` →
+   `pnpm`, `yarn.lock` → `yarn`, `bun.lockb` → `bun`, else `npm`.
+3. Run that check **scoped to the ticket file** if the underlying tool supports
+   a path argument (e.g. the script wraps `biome check` → run
+   `<pm> exec biome check .adlc/tickets.json`; `eslint` → `<pm> exec eslint
+   .adlc/tickets.json`; `prettier --check` → `<pm> exec prettier --check
+   .adlc/tickets.json`). If you can't confidently scope it to one file, run the
+   full `<pm> run check` (or `lint`) script instead.
+4. If the check **fails**, do NOT undo the write or treat this as a command
+   failure. Warn the user plainly: the ticket was written successfully, but the
+   repo's formatter/linter flagged `.adlc/tickets.json` — once this ticket
+   declares `rails`, the file becomes a frozen trust root that can't be
+   reformatted on a branch without tripping `rails-guard`. Point them at
+   `/adlc:adlc-init` step 4 (or the manual fallback) to add a permanent `.adlc/`
+   exclusion so this doesn't recur on every future ticket write.
+5. If the check passes (or no script was found), continue silently — no need
+   to call this out in the summary beyond a one-line confirmation.
+
+## 4. Check executability (coldstart gate)
 
 `coldstart` is LLM-backed, and inside Claude Code **you are the model** — there
 are no API keys. Do NOT run the bare `adlc coldstart <id>` form; with no provider
@@ -123,8 +151,10 @@ configured it exits `1`. Use the prompt-only flow instead:
 call, `adlc coldstart <id> --json` returns the same verdict as exit `0`/`2`; but
 prompt-only is the default in-Claude path.)
 
-## 4. Summarize
+## 5. Summarize
 
-Report the new ticket id and title, what scope/rails it declared, and the
-coldstart verdict. If the ticket passed, point the user at the `adlc` discovery
-skill (or `/adlc-spec`-style spec gates) for the P1 interrogation phase next.
+Report the new ticket id and title, what scope/rails it declared, the
+formatter/linter check result from step 3 (pass, warned, or skipped/no script),
+and the coldstart verdict. If the ticket passed, point the user at the `adlc`
+discovery skill (or `/adlc-spec`-style spec gates) for the P1 interrogation
+phase next.

--- a/plugins/adlc-cursor/command/adlc-init.md
+++ b/plugins/adlc-cursor/command/adlc-init.md
@@ -21,8 +21,10 @@ npm install -g @adlc/cli
 
 - Create `.adlc/` if missing.
 - If `.adlc/tickets.json` is absent, create it as `{ "tickets": [] }`. If present, leave it.
-- Run the deterministic scaffolder to create `.adlc/config.json` (no clobber) and
-  wire `.cursor/hooks.json` + `.cursor/rules/adlc.mdc`:
+- Run the deterministic scaffolder to create `.adlc/config.json` (no clobber),
+  wire `.cursor/hooks.json` + `.cursor/rules/adlc.mdc`, ensure `.gitignore`
+  tracks the ticket + specs contracts, and exclude `.adlc/` from any detected
+  repo formatter/linter:
 
   ```sh
   node "$(dirname "$(node -e "process.stdout.write(require.resolve('@adlc/cursor-package/package.json'))" 2>/dev/null || echo .)")/lib/scaffold-cli.mjs" .
@@ -34,21 +36,47 @@ npm install -g @adlc/cli
 
 ## 3. Separate the contract from runtime evidence in git
 
-Ensure `.gitignore` ignores all of `.adlc/` except the ticket contract:
+Ensure `.gitignore` ignores all of `.adlc/` except the ticket contract and the
+P1 specs contract:
 
 ```
 .adlc/*
 !.adlc/tickets.json
+!.adlc/specs/
 ```
 
-## 4. Preflight
+If an older two-line stanza exists (no `!.adlc/specs/`), add just that missing
+line — the scaffolder above does this automatically (`ensureGitignore` in
+`lib/scaffold.mjs`).
+
+## 4. Exclude `.adlc/` from the repo's formatters and linters
+
+`.adlc/tickets.json` is machine-written and, once a ticket declares `rails`,
+becomes a frozen trust root that a reformat would trip `rails-guard` on. The
+scaffolder's `ensureFormatterIgnores` detects and updates, only if already
+present in the repo:
+
+- **Biome** (`biome.json`) — merges an `overrides` entry disabling the
+  formatter/linter for `.adlc/**`.
+- **Prettier** (`.prettierignore`) — appends a `.adlc/` line.
+- **ESLint** — adds `.adlc/**` to `ignorePatterns` in a JSON `.eslintrc*`, or
+  appends `.adlc/` to `.eslintignore`. Flat `eslint.config.js`/`.mjs`/`.cjs` is
+  only *detected*, not auto-edited; add `{ ignores: ['.adlc/**'] }` to the
+  exported array manually.
+
+If a repo uses a formatter/linter not covered here, document the manual
+fallback: add a `.adlc/` (or `.adlc/**`) ignore/exclude entry to that tool's
+config yourself before the first rails-bearing ticket is committed.
+
+## 5. Preflight
 
 Run `adlc preflight --json` and summarize the verdict (informational for setup).
 
-## 5. Summarize
+## 6. Summarize
 
 Report: toolkit version, whether `.adlc/tickets.json`/`config.json` were created or
-already present, what was wired into `.cursor/`, gitignore changes, and the
+already present, what was wired into `.cursor/`, gitignore changes, which
+formatter/linter configs were updated (or need a manual entry), and the
 preflight verdict. Remind the user that the in-session hook is **advisory** —
 Cursor's `permission: "deny"` is best-effort — and that the unbypassable control
 is the CI rail-freeze gate (`docs/ci/rails-guard.yml`).

--- a/plugins/adlc-cursor/lib/scaffold-cli.mjs
+++ b/plugins/adlc-cursor/lib/scaffold-cli.mjs
@@ -23,10 +23,22 @@ console.log(`  .cursor/rules/adlc.mdc — ${tag(rule)}`);
 console.log(
   `  .gitignore             — ${gitignore.changed ? `updated (added ${gitignore.added.join(', ')})` : 'already tracks tickets.json + specs/'}`
 );
+const logToolLine = (name, r) => {
+  if (r.changed) console.log(`  ${name} — excluded .adlc/ (${r.path})`);
+  else if (r.skipped) console.log(`  ${name} — detected but needs a manual .adlc/ ignore entry: ${r.skipped} (${r.path})`);
+  else console.log(`  ${name} — already excludes .adlc/`);
+};
 for (const [tool, r] of Object.entries(formatterIgnores)) {
   if (!r.detected) continue;
-  if (r.changed) console.log(`  ${tool} — excluded .adlc/ (${r.path})`);
-  else if (r.skipped) console.log(`  ${tool} — detected but needs a manual .adlc/ ignore entry: ${r.skipped} (${r.path})`);
-  else console.log(`  ${tool} — already excludes .adlc/`);
+  // `eslint` may cover both `.eslintrc*` and `.eslintignore` at once when a
+  // repo has both — report each source file individually so neither
+  // mutation is dropped from the summary.
+  if (r.sources) {
+    for (const sr of Object.values(r.sources)) {
+      if (sr.detected) logToolLine(tool, sr);
+    }
+    continue;
+  }
+  logToolLine(tool, r);
 }
 console.log('Next: author a ticket in .adlc/tickets.json, then `adlc rails-guard` to freeze rails.');

--- a/plugins/adlc-cursor/lib/scaffold-cli.mjs
+++ b/plugins/adlc-cursor/lib/scaffold-cli.mjs
@@ -20,9 +20,12 @@ if (hooks.backedUp) {
   console.log(`  ⚠ existing .cursor/hooks.json was unparseable — preserved verbatim at ${hooks.backedUp} before writing a fresh file`);
 }
 console.log(`  .cursor/rules/adlc.mdc — ${tag(rule)}`);
-console.log(
-  `  .gitignore             — ${gitignore.changed ? `updated (added ${gitignore.added.join(', ')})` : 'already tracks tickets.json + specs/'}`
-);
+const gitignoreStatus = gitignore.changed
+  ? gitignore.added.length > 0
+    ? `updated (added ${gitignore.added.join(', ')})`
+    : 'updated (repaired duplicate/misplaced entries)'
+  : 'already tracks tickets.json + specs/';
+console.log(`  .gitignore             — ${gitignoreStatus}`);
 const logToolLine = (name, r) => {
   if (r.changed) console.log(`  ${name} — excluded .adlc/ (${r.path})`);
   else if (r.skipped) console.log(`  ${name} — detected but needs a manual .adlc/ ignore entry: ${r.skipped} (${r.path})`);

--- a/plugins/adlc-cursor/lib/scaffold-cli.mjs
+++ b/plugins/adlc-cursor/lib/scaffold-cli.mjs
@@ -10,7 +10,7 @@ import { resolve } from 'node:path';
 import { scaffold } from './scaffold.mjs';
 
 const projectRoot = resolve(process.argv[2] ?? '.');
-const { config, hooks, rule } = scaffold(projectRoot);
+const { config, hooks, rule, gitignore, formatterIgnores } = scaffold(projectRoot);
 
 const tag = (r) => (r.created ? 'created' : 'present');
 console.log(`adlc-cursor scaffold (${projectRoot}):`);
@@ -20,4 +20,13 @@ if (hooks.backedUp) {
   console.log(`  ⚠ existing .cursor/hooks.json was unparseable — preserved verbatim at ${hooks.backedUp} before writing a fresh file`);
 }
 console.log(`  .cursor/rules/adlc.mdc — ${tag(rule)}`);
+console.log(
+  `  .gitignore             — ${gitignore.changed ? `updated (added ${gitignore.added.join(', ')})` : 'already tracks tickets.json + specs/'}`
+);
+for (const [tool, r] of Object.entries(formatterIgnores)) {
+  if (!r.detected) continue;
+  if (r.changed) console.log(`  ${tool} — excluded .adlc/ (${r.path})`);
+  else if (r.skipped) console.log(`  ${tool} — detected but needs a manual .adlc/ ignore entry: ${r.skipped} (${r.path})`);
+  else console.log(`  ${tool} — already excludes .adlc/`);
+}
 console.log('Next: author a ticket in .adlc/tickets.json, then `adlc rails-guard` to freeze rails.');

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -135,6 +135,15 @@ const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
  * differently-ordered legacy stanza — is therefore relocated to after the
  * anchor rather than left in place (checked unconditionally, even when
  * every stanza line is nominally "present somewhere" in the file).
+ *
+ * A file can also end up with MORE THAN ONE `.adlc/*` line (e.g. a merge of
+ * two branches that each independently appended the stanza, or a second
+ * tool emitting its own copy). Because last-match-wins applies across the
+ * WHOLE file, a later `.adlc/*` anchor re-ignores any negation that
+ * precedes it — including one that was already correctly placed right
+ * after an earlier anchor. Every anchor beyond the first is therefore
+ * collapsed away (not just misplaced negations) before this function
+ * reasons about ordering, so only one anchor ever needs to be considered.
  */
 export function ensureGitignore(projectRoot) {
   const path = join(projectRoot, '.gitignore');
@@ -143,9 +152,9 @@ export function ensureGitignore(projectRoot) {
   let lines = existing.length ? existing.split('\n') : [];
   if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
 
-  const anchorIdx = lines.indexOf('.adlc/*');
+  const anchorCount = lines.filter((line) => line === '.adlc/*').length;
 
-  if (anchorIdx === -1) {
+  if (anchorCount === 0) {
     const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
     // The `.adlc/*` anchor is absent. A pre-existing negation line (e.g. a
     // lone `!.adlc/tickets.json` left over from a partial/legacy edit) may
@@ -164,6 +173,24 @@ export function ensureGitignore(projectRoot) {
     return { path, added: missing, changed: true };
   }
 
+  // One or more anchors are present. Collapse every `.adlc/*` line beyond
+  // the first — keeping the earliest occurrence — so the rest of this
+  // function only ever has to reason about a single anchor position. This
+  // is itself a repair (dropping a duplicate anchor changes the file), even
+  // when no negation line is missing or relocated below.
+  let dedupedAnchor = false;
+  if (anchorCount > 1) {
+    let seenAnchors = 0;
+    lines = lines.filter((line) => {
+      if (line !== '.adlc/*') return true;
+      seenAnchors += 1;
+      return seenAnchors === 1;
+    });
+    dedupedAnchor = true;
+  }
+
+  const anchorIdx = lines.indexOf('.adlc/*');
+
   // The anchor IS present. Relocate any stanza negation line that sits
   // BEFORE it — leaving it there would be silently overridden by the
   // anchor (last-match-wins), re-ignoring the file it was meant to protect.
@@ -175,7 +202,7 @@ export function ensureGitignore(projectRoot) {
 
   const newAnchorIdx = lines.indexOf('.adlc/*');
   const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
-  if (missing.length === 0 && !relocated) return { path, added: [], changed: false };
+  if (missing.length === 0 && !relocated && !dedupedAnchor) return { path, added: [], changed: false };
 
   let insertAt = newAnchorIdx + 1;
   while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
@@ -264,19 +291,44 @@ function ensureEslintRcIgnore(projectRoot) {
 }
 
 /**
+ * Combine the independent `.eslintrc*` and `.eslintignore` outcomes into one
+ * report. Both are always checked/mutated unconditionally by
+ * `ensureFormatterIgnores` — a pre-flat-config repo commonly has BOTH files
+ * at once — so picking only one would silently under-report a real mutation
+ * made to the other. When only one is detected, that single result is
+ * returned unchanged (keeping the common single-file case simple); when
+ * both are detected, `sources` exposes each outcome individually so nothing
+ * is dropped.
+ */
+function mergeEslintReports(eslintrc, eslintignore) {
+  if (!eslintrc.detected) return eslintignore;
+  if (!eslintignore.detected) return eslintrc;
+  const skipped = [eslintrc.skipped, eslintignore.skipped].filter(Boolean).join('; ');
+  return {
+    detected: true,
+    changed: eslintrc.changed || eslintignore.changed,
+    path: [eslintrc.path, eslintignore.path],
+    ...(skipped ? { skipped } : {}),
+    sources: { eslintrc, eslintignore },
+  };
+}
+
+/**
  * Detect and update whichever formatter/linter configs already exist in the
  * repo so none of them touch `.adlc/`: Biome (`biome.json` overrides),
  * Prettier (`.prettierignore`), ESLint (`ignorePatterns` in a JSON
  * `.eslintrc*`, `.eslintignore`, or detection-only for flat config). Never
  * creates a config for a tool that isn't already in use. Returns a summary
- * keyed by tool.
+ * keyed by tool. `eslint` reflects BOTH `.eslintrc*` and `.eslintignore`
+ * when a repo has both (see `mergeEslintReports`) — `eslint.sources` carries
+ * the per-file detail in that case.
  */
 export function ensureFormatterIgnores(projectRoot) {
   const biome = ensureBiomeIgnore(projectRoot);
   const prettier = ensureTextIgnoreFile(projectRoot, '.prettierignore', '.adlc/');
   const eslintrc = ensureEslintRcIgnore(projectRoot);
   const eslintignore = ensureTextIgnoreFile(projectRoot, '.eslintignore', '.adlc/');
-  return { biome, prettier, eslint: eslintrc.detected ? eslintrc : eslintignore };
+  return { biome, prettier, eslint: mergeEslintReports(eslintrc, eslintignore) };
 }
 
 /** Full bootstrap: config + hooks + rule + .gitignore contract + formatter ignores. */

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -111,9 +111,145 @@ export function ensureConfig(projectRoot) {
   return { path: cfgPath, created: true };
 }
 
-/** Full bootstrap: config + hooks + rule. */
+// ---------------------------------------------------------------------------
+// .gitignore: track the ticket contract AND the P1 spec contract, ignore the
+// rest of the runtime (T-issue #46). Never clobbers unrelated gitignore
+// content — only appends the stanza, or the specific negation lines missing
+// from an existing stanza.
+// ---------------------------------------------------------------------------
+
+const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
+
+/**
+ * Ensure `.gitignore` ignores all of `.adlc/` except the tracked contracts
+ * (`tickets.json` and the `specs/` directory). Idempotent: if the stanza is
+ * fully present, nothing is written. If `.adlc/*` is present but a negation
+ * line (e.g. `!.adlc/specs/`) is missing, only the missing line(s) are
+ * inserted right after the existing block — the rest of the file is
+ * untouched. Returns { path, added: string[], changed: boolean }.
+ */
+export function ensureGitignore(projectRoot) {
+  const path = join(projectRoot, '.gitignore');
+  const existing = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const hadTrailingNewline = existing.endsWith('\n');
+  const lines = existing.length ? existing.split('\n') : [];
+  if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
+
+  const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
+  if (missing.length === 0) return { path, added: [], changed: false };
+
+  const anchorIdx = lines.indexOf('.adlc/*');
+  if (anchorIdx === -1) {
+    if (lines.length > 0) lines.push('');
+    lines.push(...GITIGNORE_STANZA);
+  } else {
+    let insertAt = anchorIdx + 1;
+    while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
+    lines.splice(insertAt, 0, ...missing);
+  }
+  writeFileSync(path, lines.join('\n') + '\n');
+  return { path, added: missing, changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Formatter/linter ignores: `.adlc/tickets.json` is a machine-written,
+// frozen trust root once rails exist — a repo formatter reformatting it on a
+// ticket branch trips rails-guard. Add `.adlc/` to whichever formatter/linter
+// configs are ALREADY present in the repo (never invent a new tool). (#42)
+// ---------------------------------------------------------------------------
+
+/** Add a line to a plain-text ignore file (gitignore-style) if not already present. */
+function ensureTextIgnoreFile(projectRoot, filename, entry) {
+  const path = join(projectRoot, filename);
+  if (!existsSync(path)) return { path, detected: false, changed: false };
+  const existing = readFileSync(path, 'utf8');
+  const lines = existing.split('\n');
+  if (lines.includes(entry)) return { path, detected: true, changed: false };
+  const needsNewline = existing.length > 0 && !existing.endsWith('\n');
+  writeFileSync(path, existing + (needsNewline ? '\n' : '') + entry + '\n');
+  return { path, detected: true, changed: true };
+}
+
+/** Add a `.adlc/**` override entry to `biome.json` (Biome 1.x `overrides` shape) if present. */
+function ensureBiomeIgnore(projectRoot) {
+  const path = join(projectRoot, 'biome.json');
+  if (!existsSync(path)) return { path, detected: false, changed: false };
+  let config;
+  try {
+    config = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return { path, detected: true, changed: false, skipped: 'unparseable JSON — add manually' };
+  }
+  const overrides = Array.isArray(config.overrides) ? config.overrides : [];
+  const already = overrides.some(
+    (o) => Array.isArray(o?.include) && o.include.includes('.adlc/**')
+  );
+  if (already) return { path, detected: true, changed: false };
+  const next = {
+    ...config,
+    overrides: [
+      ...overrides,
+      { include: ['.adlc/**'], formatter: { enabled: false }, linter: { enabled: false } },
+    ],
+  };
+  writeFileSync(path, JSON.stringify(next, null, 2) + '\n');
+  return { path, detected: true, changed: true };
+}
+
+/** Add an `ignorePatterns` entry to a legacy JSON `.eslintrc*` config if present. */
+function ensureEslintRcIgnore(projectRoot) {
+  for (const filename of ['.eslintrc.json', '.eslintrc']) {
+    const path = join(projectRoot, filename);
+    if (!existsSync(path)) continue;
+    let config;
+    try {
+      config = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      return { path, detected: true, changed: false, skipped: 'unparseable JSON — add manually' };
+    }
+    const ignorePatterns = Array.isArray(config.ignorePatterns) ? config.ignorePatterns : [];
+    if (ignorePatterns.includes('.adlc/**')) return { path, detected: true, changed: false };
+    const next = { ...config, ignorePatterns: [...ignorePatterns, '.adlc/**'] };
+    writeFileSync(path, JSON.stringify(next, null, 2) + '\n');
+    return { path, detected: true, changed: true };
+  }
+  // Flat config (eslint.config.js/.mjs/.cjs) is executable JS — safe text
+  // mutation isn't reliable, so only report detection; document the manual
+  // fallback (an `{ ignores: ['.adlc/**'] }` object in the exported array).
+  for (const filename of ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs']) {
+    if (existsSync(join(projectRoot, filename))) {
+      return {
+        path: join(projectRoot, filename),
+        detected: true,
+        changed: false,
+        skipped: 'flat config — add { ignores: [".adlc/**"] } manually',
+      };
+    }
+  }
+  return { path: null, detected: false, changed: false };
+}
+
+/**
+ * Detect and update whichever formatter/linter configs already exist in the
+ * repo so none of them touch `.adlc/`: Biome (`biome.json` overrides),
+ * Prettier (`.prettierignore`), ESLint (`ignorePatterns` in a JSON
+ * `.eslintrc*`, `.eslintignore`, or detection-only for flat config). Never
+ * creates a config for a tool that isn't already in use. Returns a summary
+ * keyed by tool.
+ */
+export function ensureFormatterIgnores(projectRoot) {
+  const biome = ensureBiomeIgnore(projectRoot);
+  const prettier = ensureTextIgnoreFile(projectRoot, '.prettierignore', '.adlc/');
+  const eslintrc = ensureEslintRcIgnore(projectRoot);
+  const eslintignore = ensureTextIgnoreFile(projectRoot, '.eslintignore', '.adlc/');
+  return { biome, prettier, eslint: eslintrc.detected ? eslintrc : eslintignore };
+}
+
+/** Full bootstrap: config + hooks + rule + .gitignore contract + formatter ignores. */
 export function scaffold(projectRoot, opts = {}) {
   const config = ensureConfig(projectRoot);
   const { hooks, rule } = ensurePluginRegistered(projectRoot, opts);
-  return { config, hooks, rule };
+  const gitignore = ensureGitignore(projectRoot);
+  const formatterIgnores = ensureFormatterIgnores(projectRoot);
+  return { config, hooks, rule, gitignore, formatterIgnores };
 }

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -140,8 +140,11 @@ export function ensureGitignore(projectRoot) {
 
   const anchorIdx = lines.indexOf('.adlc/*');
   if (anchorIdx === -1) {
+    // Push only the entries actually missing — some negation lines may
+    // already exist standalone in the file (without the anchor immediately
+    // preceding them); re-pushing the full stanza would duplicate those.
     if (lines.length > 0) lines.push('');
-    lines.push(...GITIGNORE_STANZA);
+    lines.push(...missing);
   } else {
     let insertAt = anchorIdx + 1;
     while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -123,10 +123,18 @@ const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
 /**
  * Ensure `.gitignore` ignores all of `.adlc/` except the tracked contracts
  * (`tickets.json` and the `specs/` directory). Idempotent: if the stanza is
- * fully present, nothing is written. If `.adlc/*` is present but a negation
- * line (e.g. `!.adlc/specs/`) is missing, only the missing line(s) are
- * inserted right after the existing block — the rest of the file is
- * untouched. Returns { path, added: string[], changed: boolean }.
+ * fully present AND correctly ordered, nothing is written. If `.adlc/*` is
+ * present but a negation line (e.g. `!.adlc/specs/`) is missing, only the
+ * missing line(s) are inserted right after the existing block — the rest of
+ * the file is untouched. Returns { path, added: string[], changed: boolean }.
+ *
+ * Git applies `.gitignore` patterns with last-match-wins semantics: a
+ * negation line (e.g. `!.adlc/tickets.json`) only has effect if it comes
+ * AFTER the `.adlc/*` anchor that would otherwise re-ignore it. A stanza
+ * negation line found BEFORE the anchor — from a hand edit, a merge, or a
+ * differently-ordered legacy stanza — is therefore relocated to after the
+ * anchor rather than left in place (checked unconditionally, even when
+ * every stanza line is nominally "present somewhere" in the file).
  */
 export function ensureGitignore(projectRoot) {
   const path = join(projectRoot, '.gitignore');
@@ -135,11 +143,10 @@ export function ensureGitignore(projectRoot) {
   let lines = existing.length ? existing.split('\n') : [];
   if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
 
-  const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
-  if (missing.length === 0) return { path, added: [], changed: false };
-
   const anchorIdx = lines.indexOf('.adlc/*');
+
   if (anchorIdx === -1) {
+    const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
     // The `.adlc/*` anchor is absent. A pre-existing negation line (e.g. a
     // lone `!.adlc/tickets.json` left over from a partial/legacy edit) may
     // already be present standalone, earlier in the file. Simply pushing
@@ -153,11 +160,27 @@ export function ensureGitignore(projectRoot) {
     lines = lines.filter((line) => !GITIGNORE_STANZA.includes(line));
     if (lines.length > 0) lines.push('');
     lines.push(...GITIGNORE_STANZA);
-  } else {
-    let insertAt = anchorIdx + 1;
-    while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
-    lines.splice(insertAt, 0, ...missing);
+    writeFileSync(path, lines.join('\n') + '\n');
+    return { path, added: missing, changed: true };
   }
+
+  // The anchor IS present. Relocate any stanza negation line that sits
+  // BEFORE it — leaving it there would be silently overridden by the
+  // anchor (last-match-wins), re-ignoring the file it was meant to protect.
+  const beforeCount = lines.length;
+  lines = lines.filter(
+    (line, idx) => !(idx < anchorIdx && line !== '.adlc/*' && GITIGNORE_STANZA.includes(line))
+  );
+  const relocated = lines.length !== beforeCount;
+
+  const newAnchorIdx = lines.indexOf('.adlc/*');
+  const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
+  if (missing.length === 0 && !relocated) return { path, added: [], changed: false };
+
+  let insertAt = newAnchorIdx + 1;
+  while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
+  lines.splice(insertAt, 0, ...missing);
+
   writeFileSync(path, lines.join('\n') + '\n');
   return { path, added: missing, changed: true };
 }

--- a/plugins/adlc-cursor/lib/scaffold.mjs
+++ b/plugins/adlc-cursor/lib/scaffold.mjs
@@ -132,7 +132,7 @@ export function ensureGitignore(projectRoot) {
   const path = join(projectRoot, '.gitignore');
   const existing = existsSync(path) ? readFileSync(path, 'utf8') : '';
   const hadTrailingNewline = existing.endsWith('\n');
-  const lines = existing.length ? existing.split('\n') : [];
+  let lines = existing.length ? existing.split('\n') : [];
   if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
 
   const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
@@ -140,11 +140,19 @@ export function ensureGitignore(projectRoot) {
 
   const anchorIdx = lines.indexOf('.adlc/*');
   if (anchorIdx === -1) {
-    // Push only the entries actually missing — some negation lines may
-    // already exist standalone in the file (without the anchor immediately
-    // preceding them); re-pushing the full stanza would duplicate those.
+    // The `.adlc/*` anchor is absent. A pre-existing negation line (e.g. a
+    // lone `!.adlc/tickets.json` left over from a partial/legacy edit) may
+    // already be present standalone, earlier in the file. Simply pushing
+    // the missing entries (which always includes `.adlc/*` itself here) to
+    // the END of the file would place the broad ignore AFTER that earlier
+    // negation — git applies patterns with last-match-wins semantics, so
+    // the later `.adlc/*` would re-ignore the file the negation was meant
+    // to keep tracked. To guarantee correct order, strip out any
+    // pre-existing standalone stanza lines and re-append the complete
+    // stanza together, in its canonical anchor-first order.
+    lines = lines.filter((line) => !GITIGNORE_STANZA.includes(line));
     if (lines.length > 0) lines.push('');
-    lines.push(...missing);
+    lines.push(...GITIGNORE_STANZA);
   } else {
     let insertAt = anchorIdx + 1;
     while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -107,6 +107,14 @@ test('ensureGitignore does not duplicate a standalone negation line when the .ad
   assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
   assert.match(body, /^\.adlc\/\*$/m);
   assert.match(body, /^!\.adlc\/specs\/$/m);
+  // Order matters for git's last-match-wins semantics: `.adlc/*` MUST
+  // come before the negation lines, otherwise it re-ignores them.
+  const resultLines = body.split('\n').filter((l) => l.length > 0);
+  const anchorPos = resultLines.indexOf('.adlc/*');
+  const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+  const specsPos = resultLines.indexOf('!.adlc/specs/');
+  assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json');
+  assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/');
 });
 
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -96,6 +96,19 @@ test('ensureGitignore is a no-op when the full stanza is already present (idempo
   assert.deepEqual(r.added, []);
 });
 
+test('ensureGitignore does not duplicate a standalone negation line when the .adlc/* anchor is absent', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.gitignore'), '!.adlc/tickets.json\n');
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.added, ['.adlc/*', '!.adlc/specs/']);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  const occurrences = body.split('\n').filter((l) => l === '!.adlc/tickets.json').length;
+  assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
+  assert.match(body, /^\.adlc\/\*$/m);
+  assert.match(body, /^!\.adlc\/specs\/$/m);
+});
+
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
   const root = mkRepo();
   const out = scaffold(root);
@@ -145,6 +158,28 @@ test('ensureFormatterIgnores adds ignorePatterns to an existing .eslintrc.json',
   const cfg = readJson(join(root, '.eslintrc.json'));
   assert.ok(cfg.ignorePatterns.includes('.adlc/**'));
   assert.deepEqual(cfg.extends, ['eslint:recommended']);
+});
+
+test('ensureFormatterIgnores appends .adlc/ to an existing .eslintignore', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.eslintignore'), 'dist/\n');
+  const { eslint } = ensureFormatterIgnores(root);
+  assert.equal(eslint.detected, true);
+  assert.equal(eslint.changed, true);
+  const body = readFileSync(join(root, '.eslintignore'), 'utf8');
+  assert.match(body, /^dist\/$/m);
+  assert.match(body, /^\.adlc\/$/m);
+});
+
+test('ensureFormatterIgnores detects but does not silently mutate a flat eslint.config.js', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, 'eslint.config.js'), 'export default [];\n');
+  const { eslint } = ensureFormatterIgnores(root);
+  assert.equal(eslint.detected, true);
+  assert.equal(eslint.changed, false);
+  assert.ok(eslint.skipped, 'must document the manual fallback');
+  const body = readFileSync(join(root, 'eslint.config.js'), 'utf8');
+  assert.equal(body, 'export default [];\n'); // untouched
 });
 
 test('ensureFormatterIgnores reports nothing detected when no formatter/linter configs exist', () => {

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -170,6 +170,46 @@ test('ensureGitignore does not duplicate a negation line that already correctly 
   assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json');
 });
 
+test('ensureGitignore repairs a duplicate .adlc/* anchor that re-ignores a negation placed after the first anchor', () => {
+  const root = mkRepo();
+  // Two `.adlc/*` anchors (e.g. from a merge of two branches that each
+  // appended the stanza). Git's last-match-wins semantics mean the SECOND
+  // anchor re-ignores `!.adlc/tickets.json`, which sits between the two
+  // anchors — even though every stanza line is nominally "present" and
+  // negations look correctly placed relative to the FIRST anchor alone.
+  writeFileSync(
+    join(root, '.gitignore'),
+    '.adlc/*\n!.adlc/tickets.json\nfoo\n.adlc/*\n!.adlc/specs/\n'
+  );
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true, 'a duplicate anchor must be treated as a repair, not a no-op');
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  const resultLines = body.split('\n').filter((l) => l.length > 0);
+  const anchorOccurrences = resultLines.filter((l) => l === '.adlc/*').length;
+  assert.equal(anchorOccurrences, 1, 'duplicate .adlc/* anchor must be collapsed to one');
+  assert.match(body, /foo/); // unrelated line untouched
+  const anchorPos = resultLines.indexOf('.adlc/*');
+  const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+  const specsPos = resultLines.indexOf('!.adlc/specs/');
+  assert.ok(anchorPos < ticketsPos && anchorPos < specsPos, 'sole anchor must precede both negations');
+  assert.ok(
+    resultLines.lastIndexOf('.adlc/*') < ticketsPos && resultLines.lastIndexOf('.adlc/*') < specsPos,
+    'no anchor may follow either negation (last-match-wins hazard)'
+  );
+});
+
+test('ensureGitignore is idempotent after repairing a duplicate anchor (second call reports no-op)', () => {
+  const root = mkRepo();
+  writeFileSync(
+    join(root, '.gitignore'),
+    '.adlc/*\n!.adlc/tickets.json\nfoo\n.adlc/*\n!.adlc/specs/\n'
+  );
+  ensureGitignore(root);
+  const r2 = ensureGitignore(root);
+  assert.equal(r2.changed, false);
+  assert.deepEqual(r2.added, []);
+});
+
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
   const root = mkRepo();
   const out = scaffold(root);
@@ -241,6 +281,24 @@ test('ensureFormatterIgnores detects but does not silently mutate a flat eslint.
   assert.ok(eslint.skipped, 'must document the manual fallback');
   const body = readFileSync(join(root, 'eslint.config.js'), 'utf8');
   assert.equal(body, 'export default [];\n'); // untouched
+});
+
+test('ensureFormatterIgnores reports BOTH .eslintrc.json and .eslintignore outcomes when a repo has both', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.eslintrc.json'), JSON.stringify({ extends: ['eslint:recommended'] }));
+  writeFileSync(join(root, '.eslintignore'), 'dist/\n');
+  const { eslint } = ensureFormatterIgnores(root);
+  assert.equal(eslint.detected, true);
+  assert.equal(eslint.changed, true);
+  // Both files must actually be mutated on disk...
+  const rc = readJson(join(root, '.eslintrc.json'));
+  assert.ok(rc.ignorePatterns.includes('.adlc/**'));
+  const ignoreBody = readFileSync(join(root, '.eslintignore'), 'utf8');
+  assert.match(ignoreBody, /^\.adlc\/$/m);
+  // ...and the returned report must not silently drop either mutation.
+  assert.ok(eslint.sources, 'must expose per-file detail when both are present');
+  assert.equal(eslint.sources.eslintrc.changed, true);
+  assert.equal(eslint.sources.eslintignore.changed, true);
 });
 
 test('ensureFormatterIgnores reports nothing detected when no formatter/linter configs exist', () => {

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -117,6 +117,59 @@ test('ensureGitignore does not duplicate a standalone negation line when the .ad
   assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/');
 });
 
+test('ensureGitignore relocates a negation line that precedes the .adlc/* anchor (last-match-wins hazard)', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.gitignore'), '!.adlc/tickets.json\n.adlc/*\n');
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  const resultLines = body.split('\n').filter((l) => l.length > 0);
+  const occurrences = resultLines.filter((l) => l === '!.adlc/tickets.json').length;
+  assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
+  const anchorPos = resultLines.indexOf('.adlc/*');
+  const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+  const specsPos = resultLines.indexOf('!.adlc/specs/');
+  assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json after relocation');
+  assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/');
+});
+
+test('ensureGitignore relocates a misordered stanza even when every line is nominally present (no "missing" entries)', () => {
+  const root = mkRepo();
+  // All three stanza lines exist somewhere in the file, but in the wrong
+  // order relative to the anchor — a naive "is everything present" check
+  // would wrongly treat this as already-correct and skip fixing it.
+  writeFileSync(join(root, '.gitignore'), '!.adlc/tickets.json\n!.adlc/specs/\n.adlc/*\n');
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  const resultLines = body.split('\n').filter((l) => l.length > 0);
+  const anchorPos = resultLines.indexOf('.adlc/*');
+  const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+  const specsPos = resultLines.indexOf('!.adlc/specs/');
+  assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json after relocation');
+  assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/ after relocation');
+});
+
+test('ensureGitignore does not duplicate a negation line that already correctly follows the anchor elsewhere', () => {
+  const root = mkRepo();
+  // `!.adlc/tickets.json` appears twice: once misplaced before the anchor
+  // (stale) and once correctly after it. Only the stale copy should be
+  // removed; the correct copy must not be duplicated.
+  writeFileSync(
+    join(root, '.gitignore'),
+    '!.adlc/tickets.json\n.adlc/*\n!.adlc/tickets.json\n'
+  );
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  const resultLines = body.split('\n').filter((l) => l.length > 0);
+  const occurrences = resultLines.filter((l) => l === '!.adlc/tickets.json').length;
+  assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
+  const anchorPos = resultLines.indexOf('.adlc/*');
+  const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+  assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json');
+});
+
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
   const root = mkRepo();
   const out = scaffold(root);

--- a/plugins/adlc-cursor/test/scaffold.test.mjs
+++ b/plugins/adlc-cursor/test/scaffold.test.mjs
@@ -7,7 +7,13 @@ import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { scaffold, mergeHooks, ensureCursorHooks } from '../lib/scaffold.mjs';
+import {
+  scaffold,
+  mergeHooks,
+  ensureCursorHooks,
+  ensureGitignore,
+  ensureFormatterIgnores,
+} from '../lib/scaffold.mjs';
 
 const mkRepo = () => mkdtempSync(join(tmpdir(), 'adlc-cursor-scaffold-'));
 const readJson = (p) => JSON.parse(readFileSync(p, 'utf8'));
@@ -58,4 +64,93 @@ test('ensureCursorHooks BACKS UP an unparseable existing hooks.json instead of d
   // ...but the original content is preserved verbatim in a backup, not lost.
   assert.ok(res.backedUp, 'a backup path must be reported');
   assert.equal(readFileSync(res.backedUp, 'utf8'), original, 'backup must hold the original bytes');
+});
+
+// ---- ensureGitignore (#46: track .adlc/specs/) ----
+test('ensureGitignore creates the full stanza (including !.adlc/specs/) when no .gitignore exists', () => {
+  const root = mkRepo();
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.added, ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/']);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  assert.match(body, /^!\.adlc\/specs\/$/m);
+});
+
+test('ensureGitignore adds the missing !.adlc/specs/ negation to a pre-existing stanza without touching other content', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.gitignore'), 'node_modules/\n.adlc/*\n!.adlc/tickets.json\ndist/\n');
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, true);
+  assert.deepEqual(r.added, ['!.adlc/specs/']);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  assert.match(body, /^!\.adlc\/specs\/$/m);
+  assert.match(body, /node_modules\//);
+  assert.match(body, /dist\//);
+});
+
+test('ensureGitignore is a no-op when the full stanza is already present (idempotent)', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.gitignore'), '.adlc/*\n!.adlc/tickets.json\n!.adlc/specs/\n');
+  const r = ensureGitignore(root);
+  assert.equal(r.changed, false);
+  assert.deepEqual(r.added, []);
+});
+
+test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
+  const root = mkRepo();
+  const out = scaffold(root);
+  const body = readFileSync(join(root, '.gitignore'), 'utf8');
+  assert.match(body, /^!\.adlc\/specs\/$/m);
+  assert.equal(out.gitignore.changed, true);
+});
+
+// ---- ensureFormatterIgnores (#42: keep formatters/linters off .adlc/) ----
+test('ensureFormatterIgnores adds a .adlc/** override to an existing biome.json', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, 'biome.json'), JSON.stringify({ formatter: { enabled: true } }));
+  const { biome } = ensureFormatterIgnores(root);
+  assert.equal(biome.detected, true);
+  assert.equal(biome.changed, true);
+  const cfg = readJson(join(root, 'biome.json'));
+  assert.ok(cfg.overrides.some((o) => o.include.includes('.adlc/**')));
+  assert.equal(cfg.formatter.enabled, true);
+});
+
+test('ensureFormatterIgnores is idempotent on biome.json (no duplicate override)', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, 'biome.json'), JSON.stringify({}));
+  ensureFormatterIgnores(root);
+  const { biome } = ensureFormatterIgnores(root);
+  assert.equal(biome.changed, false);
+  const cfg = readJson(join(root, 'biome.json'));
+  assert.equal(cfg.overrides.length, 1);
+});
+
+test('ensureFormatterIgnores appends .adlc/ to an existing .prettierignore', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.prettierignore'), 'dist/\n');
+  const { prettier } = ensureFormatterIgnores(root);
+  assert.equal(prettier.changed, true);
+  const body = readFileSync(join(root, '.prettierignore'), 'utf8');
+  assert.match(body, /^dist\/$/m);
+  assert.match(body, /^\.adlc\/$/m);
+});
+
+test('ensureFormatterIgnores adds ignorePatterns to an existing .eslintrc.json', () => {
+  const root = mkRepo();
+  writeFileSync(join(root, '.eslintrc.json'), JSON.stringify({ extends: ['eslint:recommended'] }));
+  const { eslint } = ensureFormatterIgnores(root);
+  assert.equal(eslint.detected, true);
+  assert.equal(eslint.changed, true);
+  const cfg = readJson(join(root, '.eslintrc.json'));
+  assert.ok(cfg.ignorePatterns.includes('.adlc/**'));
+  assert.deepEqual(cfg.extends, ['eslint:recommended']);
+});
+
+test('ensureFormatterIgnores reports nothing detected when no formatter/linter configs exist', () => {
+  const root = mkRepo();
+  const { biome, prettier, eslint } = ensureFormatterIgnores(root);
+  assert.equal(biome.detected, false);
+  assert.equal(prettier.detected, false);
+  assert.equal(eslint.detected, false);
 });

--- a/plugins/adlc-opencode/command/adlc-init.md
+++ b/plugins/adlc-opencode/command/adlc-init.md
@@ -21,29 +21,59 @@ npm install -g @adlc/cli
 - Create `.adlc/` if missing.
 - If `.adlc/tickets.json` is absent, create it as `{ "tickets": [] }`. If present, leave it.
 - Run the deterministic scaffolder to create `.adlc/config.json` (defaults, no
-  clobber) and deploy this plugin's `command/` and `skill/` into `.opencode/`:
+  clobber), deploy this plugin's `command/` and `skill/` into `.opencode/`, ensure
+  `.gitignore` tracks the ticket + specs contracts, and exclude `.adlc/` from any
+  detected repo formatter/linter:
 
   !`node "$(dirname "$(node -e "process.stdout.write(require.resolve('@adlc/opencode-package/package.json'))" 2>/dev/null || echo .)")/lib/scaffold-cli.mjs" .`
 
   (If the helper is unavailable, scaffold manually: create `.adlc/config.json`
-  with `{"securityMode":"unsigned-fallback"}` and copy the plugin's `command/*.md`
-  into `.opencode/commands/` and `skill/*.md` into `.opencode/skill/`.)
+  with `{"securityMode":"unsigned-fallback"}`, copy the plugin's `command/*.md`
+  into `.opencode/commands/` and `skill/*.md` into `.opencode/skill/`, then do
+  steps 3 and 4 below by hand.)
 
 ## 3. Separate the contract from runtime evidence in git
 
-Ensure `.gitignore` ignores all of `.adlc/` except the ticket contract:
+Ensure `.gitignore` ignores all of `.adlc/` except the ticket contract and the
+P1 specs contract:
 
 ```
 .adlc/*
 !.adlc/tickets.json
+!.adlc/specs/
 ```
 
-## 4. Preflight
+If an older two-line stanza exists (no `!.adlc/specs/`), add just that missing
+line — the scaffolder above does this automatically (`ensureGitignore` in
+`lib/scaffold.mjs`).
+
+## 4. Exclude `.adlc/` from the repo's formatters and linters
+
+`.adlc/tickets.json` is machine-written and, once a ticket declares `rails`,
+becomes a frozen trust root that a reformat would trip `rails-guard` on. The
+scaffolder's `ensureFormatterIgnores` detects and updates, only if already
+present in the repo:
+
+- **Biome** (`biome.json`) — merges an `overrides` entry disabling the
+  formatter/linter for `.adlc/**`.
+- **Prettier** (`.prettierignore`) — appends a `.adlc/` line.
+- **ESLint** — adds `.adlc/**` to `ignorePatterns` in a JSON `.eslintrc*`, or
+  appends `.adlc/` to `.eslintignore`. Flat `eslint.config.js`/`.mjs`/`.cjs` is
+  only *detected*, not auto-edited (it's executable JS); add
+  `{ ignores: ['.adlc/**'] }` to the exported array manually.
+
+If a repo uses a formatter/linter not covered here, or the scaffolder is
+unavailable, document the manual fallback: add a `.adlc/` (or `.adlc/**`)
+ignore/exclude entry to that tool's config yourself before the first
+rails-bearing ticket is committed.
+
+## 5. Preflight
 
 Run `adlc preflight --json` and summarize the verdict (informational for setup).
 
-## 5. Summarize
+## 6. Summarize
 
 Report: toolkit version, whether `.adlc/tickets.json`/`config.json` were created or
-already present, what was deployed into `.opencode/`, gitignore changes, and the
+already present, what was deployed into `.opencode/`, gitignore changes, which
+formatter/linter configs were updated (or need a manual entry), and the
 preflight verdict. Point the user at `/adlc-ticket` to author their first ticket.

--- a/plugins/adlc-opencode/command/adlc-ticket.md
+++ b/plugins/adlc-opencode/command/adlc-ticket.md
@@ -34,10 +34,26 @@ optional `budget`. Ask the user rather than guess if anything required is ambigu
    restore the snapshot and report; else continue.
 7. Release the lock.
 
-## 4. Check executability (coldstart, keyless)
+## 4. Warn (don't fail) if the repo's formatter/linter would reformat the write
+The write in step 3 just changed `.adlc/tickets.json` on disk. If the repo's
+formatter/linter isn't excluding `.adlc/` (see `/adlc-init` step 4), this file
+can silently red the next PR. Check now, non-blocking:
+1. Read `package.json`'s `scripts.check`, else `scripts.lint`. Neither present →
+   skip silently.
+2. Detect the package manager from the lockfile (`pnpm-lock.yaml` → pnpm,
+   `yarn.lock` → yarn, `bun.lockb` → bun, else npm).
+3. Run the check scoped to `.adlc/tickets.json` if the underlying tool supports
+   a path arg (biome/eslint/prettier); otherwise run the full script.
+4. On failure: do not undo the write or fail the command — warn that the
+   formatter/linter flagged `.adlc/tickets.json`, which becomes a frozen trust
+   root once a ticket declares `rails`, and point the user at `/adlc-init`
+   step 4 (or the manual fallback) to add a permanent exclusion.
+5. On pass (or no script found): continue silently.
+
+## 5. Check executability (coldstart, keyless)
 Run `adlc coldstart <id> --prompt-only`, answer the printed audit yourself, and
 report gaps (none → executable; gaps → offer to revise and re-check).
 
-## 5. Summarize
-Report the new id, title, scope/rails, and the coldstart verdict. Point the user
-at `/adlc-spec` for P1 interrogation next.
+## 6. Summarize
+Report the new id, title, scope/rails, the formatter/linter check result, and
+the coldstart verdict. Point the user at `/adlc-spec` for P1 interrogation next.

--- a/plugins/adlc-opencode/lib/scaffold-cli.mjs
+++ b/plugins/adlc-opencode/lib/scaffold-cli.mjs
@@ -14,11 +14,12 @@ console.log(`adlc-init: plugin ${plugin.alreadyPresent ? 'already registered' : 
 console.log(`adlc-init: deployed ${commands.length} command(s) → .opencode/commands/`);
 console.log(`adlc-init: deployed ${agents.length} agent(s) → .opencode/agents/`);
 console.log(`adlc-init: deployed ${skills.length} skill(s) → .opencode/skill/`);
-console.log(
-  gitignore.changed
+const gitignoreStatus = gitignore.changed
+  ? gitignore.added.length > 0
     ? `adlc-init: .gitignore updated (added ${gitignore.added.join(', ')})`
-    : 'adlc-init: .gitignore already tracks tickets.json + specs/'
-);
+    : 'adlc-init: .gitignore updated (repaired duplicate/misplaced entries)'
+  : 'adlc-init: .gitignore already tracks tickets.json + specs/';
+console.log(gitignoreStatus);
 const logToolLine = (name, r) => {
   if (r.changed) console.log(`adlc-init: excluded .adlc/ from ${name} (${r.path})`);
   else if (r.skipped) console.log(`adlc-init: ${name} detected but needs a manual .adlc/ ignore entry — ${r.skipped} (${r.path})`);

--- a/plugins/adlc-opencode/lib/scaffold-cli.mjs
+++ b/plugins/adlc-opencode/lib/scaffold-cli.mjs
@@ -19,9 +19,21 @@ console.log(
     ? `adlc-init: .gitignore updated (added ${gitignore.added.join(', ')})`
     : 'adlc-init: .gitignore already tracks tickets.json + specs/'
 );
+const logToolLine = (name, r) => {
+  if (r.changed) console.log(`adlc-init: excluded .adlc/ from ${name} (${r.path})`);
+  else if (r.skipped) console.log(`adlc-init: ${name} detected but needs a manual .adlc/ ignore entry — ${r.skipped} (${r.path})`);
+  else console.log(`adlc-init: ${name} already excludes .adlc/`);
+};
 for (const [tool, r] of Object.entries(formatterIgnores)) {
   if (!r.detected) continue;
-  if (r.changed) console.log(`adlc-init: excluded .adlc/ from ${tool} (${r.path})`);
-  else if (r.skipped) console.log(`adlc-init: ${tool} detected but needs a manual .adlc/ ignore entry — ${r.skipped} (${r.path})`);
-  else console.log(`adlc-init: ${tool} already excludes .adlc/`);
+  // `eslint` may cover both `.eslintrc*` and `.eslintignore` at once when a
+  // repo has both — report each source file individually so neither
+  // mutation is dropped from the summary.
+  if (r.sources) {
+    for (const sr of Object.values(r.sources)) {
+      if (sr.detected) logToolLine(tool, sr);
+    }
+    continue;
+  }
+  logToolLine(tool, r);
 }

--- a/plugins/adlc-opencode/lib/scaffold-cli.mjs
+++ b/plugins/adlc-opencode/lib/scaffold-cli.mjs
@@ -8,9 +8,20 @@ import { scaffold } from './scaffold.mjs';
 const projectRoot = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
 const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url))); // plugins/adlc-opencode
 
-const { config, plugin, commands, agents, skills } = scaffold(projectRoot, pkgRoot);
+const { config, plugin, commands, agents, skills, gitignore, formatterIgnores } = scaffold(projectRoot, pkgRoot);
 console.log(`adlc-init: config.json ${config.created ? 'created' : 'present'}`);
 console.log(`adlc-init: plugin ${plugin.alreadyPresent ? 'already registered' : 'registered'} in .opencode/opencode.json (rails-guard hook will load)`);
 console.log(`adlc-init: deployed ${commands.length} command(s) → .opencode/commands/`);
 console.log(`adlc-init: deployed ${agents.length} agent(s) → .opencode/agents/`);
 console.log(`adlc-init: deployed ${skills.length} skill(s) → .opencode/skill/`);
+console.log(
+  gitignore.changed
+    ? `adlc-init: .gitignore updated (added ${gitignore.added.join(', ')})`
+    : 'adlc-init: .gitignore already tracks tickets.json + specs/'
+);
+for (const [tool, r] of Object.entries(formatterIgnores)) {
+  if (!r.detected) continue;
+  if (r.changed) console.log(`adlc-init: excluded .adlc/ from ${tool} (${r.path})`);
+  else if (r.skipped) console.log(`adlc-init: ${tool} detected but needs a manual .adlc/ ignore entry — ${r.skipped} (${r.path})`);
+  else console.log(`adlc-init: ${tool} already excludes .adlc/`);
+}

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -86,10 +86,18 @@ const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
 /**
  * Ensure `.gitignore` ignores all of `.adlc/` except the tracked contracts
  * (`tickets.json` and the `specs/` directory). Idempotent: if the stanza is
- * fully present, nothing is written. If `.adlc/*` is present but a negation
- * line (e.g. `!.adlc/specs/`) is missing, only the missing line(s) are
- * inserted right after the existing block — the rest of the file is
- * untouched. Returns { path, added: string[], changed: boolean }.
+ * fully present AND correctly ordered, nothing is written. If `.adlc/*` is
+ * present but a negation line (e.g. `!.adlc/specs/`) is missing, only the
+ * missing line(s) are inserted right after the existing block — the rest of
+ * the file is untouched. Returns { path, added: string[], changed: boolean }.
+ *
+ * Git applies `.gitignore` patterns with last-match-wins semantics: a
+ * negation line (e.g. `!.adlc/tickets.json`) only has effect if it comes
+ * AFTER the `.adlc/*` anchor that would otherwise re-ignore it. A stanza
+ * negation line found BEFORE the anchor — from a hand edit, a merge, or a
+ * differently-ordered legacy stanza — is therefore relocated to after the
+ * anchor rather than left in place (checked unconditionally, even when
+ * every stanza line is nominally "present somewhere" in the file).
  */
 export function ensureGitignore(root) {
   const path = join(root, '.gitignore');
@@ -98,11 +106,10 @@ export function ensureGitignore(root) {
   let lines = existing.length ? existing.split('\n') : [];
   if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
 
-  const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
-  if (missing.length === 0) return { path, added: [], changed: false };
-
   const anchorIdx = lines.indexOf('.adlc/*');
+
   if (anchorIdx === -1) {
+    const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
     // The `.adlc/*` anchor is absent. A pre-existing negation line (e.g. a
     // lone `!.adlc/tickets.json` left over from a partial/legacy edit) may
     // already be present standalone, earlier in the file. Simply pushing
@@ -116,11 +123,27 @@ export function ensureGitignore(root) {
     lines = lines.filter((line) => !GITIGNORE_STANZA.includes(line));
     if (lines.length > 0) lines.push('');
     lines.push(...GITIGNORE_STANZA);
-  } else {
-    let insertAt = anchorIdx + 1;
-    while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
-    lines.splice(insertAt, 0, ...missing);
+    writeFileSync(path, lines.join('\n') + '\n');
+    return { path, added: missing, changed: true };
   }
+
+  // The anchor IS present. Relocate any stanza negation line that sits
+  // BEFORE it — leaving it there would be silently overridden by the
+  // anchor (last-match-wins), re-ignoring the file it was meant to protect.
+  const beforeCount = lines.length;
+  lines = lines.filter(
+    (line, idx) => !(idx < anchorIdx && line !== '.adlc/*' && GITIGNORE_STANZA.includes(line))
+  );
+  const relocated = lines.length !== beforeCount;
+
+  const newAnchorIdx = lines.indexOf('.adlc/*');
+  const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
+  if (missing.length === 0 && !relocated) return { path, added: [], changed: false };
+
+  let insertAt = newAnchorIdx + 1;
+  while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
+  lines.splice(insertAt, 0, ...missing);
+
   writeFileSync(path, lines.join('\n') + '\n');
   return { path, added: missing, changed: true };
 }

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -103,8 +103,11 @@ export function ensureGitignore(root) {
 
   const anchorIdx = lines.indexOf('.adlc/*');
   if (anchorIdx === -1) {
+    // Push only the entries actually missing — some negation lines may
+    // already exist standalone in the file (without the anchor immediately
+    // preceding them); re-pushing the full stanza would duplicate those.
     if (lines.length > 0) lines.push('');
-    lines.push(...GITIGNORE_STANZA);
+    lines.push(...missing);
   } else {
     let insertAt = anchorIdx + 1;
     while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -74,12 +74,148 @@ export function ensurePluginRegistered(root, pkgName = '@adlc/opencode-package')
   return { registered: true, alreadyPresent: false, path };
 }
 
+// ---------------------------------------------------------------------------
+// .gitignore: track the ticket contract AND the P1 spec contract, ignore the
+// rest of the runtime (T-issue #46). Never clobbers unrelated gitignore
+// content — only appends the stanza, or the specific negation lines missing
+// from an existing stanza.
+// ---------------------------------------------------------------------------
+
+const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
+
+/**
+ * Ensure `.gitignore` ignores all of `.adlc/` except the tracked contracts
+ * (`tickets.json` and the `specs/` directory). Idempotent: if the stanza is
+ * fully present, nothing is written. If `.adlc/*` is present but a negation
+ * line (e.g. `!.adlc/specs/`) is missing, only the missing line(s) are
+ * inserted right after the existing block — the rest of the file is
+ * untouched. Returns { path, added: string[], changed: boolean }.
+ */
+export function ensureGitignore(root) {
+  const path = join(root, '.gitignore');
+  const existing = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const hadTrailingNewline = existing.endsWith('\n');
+  const lines = existing.length ? existing.split('\n') : [];
+  if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
+
+  const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
+  if (missing.length === 0) return { path, added: [], changed: false };
+
+  const anchorIdx = lines.indexOf('.adlc/*');
+  if (anchorIdx === -1) {
+    if (lines.length > 0) lines.push('');
+    lines.push(...GITIGNORE_STANZA);
+  } else {
+    let insertAt = anchorIdx + 1;
+    while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
+    lines.splice(insertAt, 0, ...missing);
+  }
+  writeFileSync(path, lines.join('\n') + '\n');
+  return { path, added: missing, changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Formatter/linter ignores: `.adlc/tickets.json` is a machine-written,
+// frozen trust root once rails exist — a repo formatter reformatting it on a
+// ticket branch trips rails-guard. Add `.adlc/` to whichever formatter/linter
+// configs are ALREADY present in the repo (never invent a new tool). (#42)
+// ---------------------------------------------------------------------------
+
+/** Add a line to a plain-text ignore file (gitignore-style) if not already present. */
+function ensureTextIgnoreFile(root, filename, entry) {
+  const path = join(root, filename);
+  if (!existsSync(path)) return { path, detected: false, changed: false };
+  const existing = readFileSync(path, 'utf8');
+  const lines = existing.split('\n');
+  if (lines.includes(entry)) return { path, detected: true, changed: false };
+  const needsNewline = existing.length > 0 && !existing.endsWith('\n');
+  writeFileSync(path, existing + (needsNewline ? '\n' : '') + entry + '\n');
+  return { path, detected: true, changed: true };
+}
+
+/** Add a `.adlc/**` override entry to `biome.json` (Biome 1.x `overrides` shape) if present. */
+function ensureBiomeIgnore(root) {
+  const path = join(root, 'biome.json');
+  if (!existsSync(path)) return { path, detected: false, changed: false };
+  let config;
+  try {
+    config = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return { path, detected: true, changed: false, skipped: 'unparseable JSON — add manually' };
+  }
+  const overrides = Array.isArray(config.overrides) ? config.overrides : [];
+  const already = overrides.some(
+    (o) => Array.isArray(o?.include) && o.include.includes('.adlc/**')
+  );
+  if (already) return { path, detected: true, changed: false };
+  const next = {
+    ...config,
+    overrides: [
+      ...overrides,
+      { include: ['.adlc/**'], formatter: { enabled: false }, linter: { enabled: false } },
+    ],
+  };
+  writeFileSync(path, JSON.stringify(next, null, 2) + '\n');
+  return { path, detected: true, changed: true };
+}
+
+/** Add an `ignorePatterns` entry to a legacy JSON `.eslintrc*` config if present. */
+function ensureEslintRcIgnore(root) {
+  for (const filename of ['.eslintrc.json', '.eslintrc']) {
+    const path = join(root, filename);
+    if (!existsSync(path)) continue;
+    let config;
+    try {
+      config = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      return { path, detected: true, changed: false, skipped: 'unparseable JSON — add manually' };
+    }
+    const ignorePatterns = Array.isArray(config.ignorePatterns) ? config.ignorePatterns : [];
+    if (ignorePatterns.includes('.adlc/**')) return { path, detected: true, changed: false };
+    const next = { ...config, ignorePatterns: [...ignorePatterns, '.adlc/**'] };
+    writeFileSync(path, JSON.stringify(next, null, 2) + '\n');
+    return { path, detected: true, changed: true };
+  }
+  // Flat config (eslint.config.js/.mjs/.cjs) is executable JS — safe text
+  // mutation isn't reliable, so only report detection; document the manual
+  // fallback (an `{ ignores: ['.adlc/**'] }` object in the exported array).
+  for (const filename of ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs']) {
+    if (existsSync(join(root, filename))) {
+      return {
+        path: join(root, filename),
+        detected: true,
+        changed: false,
+        skipped: 'flat config — add { ignores: [".adlc/**"] } manually',
+      };
+    }
+  }
+  return { path: null, detected: false, changed: false };
+}
+
+/**
+ * Detect and update whichever formatter/linter configs already exist in the
+ * repo so none of them touch `.adlc/`: Biome (`biome.json` overrides),
+ * Prettier (`.prettierignore`), ESLint (`ignorePatterns` in a JSON
+ * `.eslintrc*`, `.eslintignore`, or detection-only for flat config). Never
+ * creates a config for a tool that isn't already in use. Returns a summary
+ * keyed by tool.
+ */
+export function ensureFormatterIgnores(root) {
+  const biome = ensureBiomeIgnore(root);
+  const prettier = ensureTextIgnoreFile(root, '.prettierignore', '.adlc/');
+  const eslintrc = ensureEslintRcIgnore(root);
+  const eslintignore = ensureTextIgnoreFile(root, '.eslintignore', '.adlc/');
+  return { biome, prettier, eslint: eslintrc.detected ? eslintrc : eslintignore };
+}
+
 /**
  * Full scaffold: ensure config, REGISTER the plugin (so the rails-guard hook
- * loads), and deploy command/, agent/, and skill/ into .opencode/. OpenCode
- * discovers project commands under .opencode/commands/, subagents under
- * .opencode/agents/, and skills under .opencode/skill/; the plugin ships them
- * under command/, agent/, and skill/ respectively. Returns a summary.
+ * loads), deploy command/, agent/, and skill/ into .opencode/, ensure the
+ * .gitignore contract stanza, and exclude .adlc/ from any detected repo
+ * formatter/linter. OpenCode discovers project commands under
+ * .opencode/commands/, subagents under .opencode/agents/, and skills under
+ * .opencode/skill/; the plugin ships them under command/, agent/, and skill/
+ * respectively. Returns a summary.
  */
 export function scaffold(root, pkgRoot) {
   const config = ensureConfig(root);
@@ -87,5 +223,7 @@ export function scaffold(root, pkgRoot) {
   const commands = deployDir(pkgRoot, root, 'command', 'commands');
   const agents = deployDir(pkgRoot, root, 'agent', 'agents');
   const skills = deployDir(pkgRoot, root, 'skill', 'skill');
-  return { config, plugin, commands, agents, skills };
+  const gitignore = ensureGitignore(root);
+  const formatterIgnores = ensureFormatterIgnores(root);
+  return { config, plugin, commands, agents, skills, gitignore, formatterIgnores };
 }

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -98,6 +98,15 @@ const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
  * differently-ordered legacy stanza — is therefore relocated to after the
  * anchor rather than left in place (checked unconditionally, even when
  * every stanza line is nominally "present somewhere" in the file).
+ *
+ * A file can also end up with MORE THAN ONE `.adlc/*` line (e.g. a merge of
+ * two branches that each independently appended the stanza, or a second
+ * tool emitting its own copy). Because last-match-wins applies across the
+ * WHOLE file, a later `.adlc/*` anchor re-ignores any negation that
+ * precedes it — including one that was already correctly placed right
+ * after an earlier anchor. Every anchor beyond the first is therefore
+ * collapsed away (not just misplaced negations) before this function
+ * reasons about ordering, so only one anchor ever needs to be considered.
  */
 export function ensureGitignore(root) {
   const path = join(root, '.gitignore');
@@ -106,9 +115,9 @@ export function ensureGitignore(root) {
   let lines = existing.length ? existing.split('\n') : [];
   if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
 
-  const anchorIdx = lines.indexOf('.adlc/*');
+  const anchorCount = lines.filter((line) => line === '.adlc/*').length;
 
-  if (anchorIdx === -1) {
+  if (anchorCount === 0) {
     const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
     // The `.adlc/*` anchor is absent. A pre-existing negation line (e.g. a
     // lone `!.adlc/tickets.json` left over from a partial/legacy edit) may
@@ -127,6 +136,24 @@ export function ensureGitignore(root) {
     return { path, added: missing, changed: true };
   }
 
+  // One or more anchors are present. Collapse every `.adlc/*` line beyond
+  // the first — keeping the earliest occurrence — so the rest of this
+  // function only ever has to reason about a single anchor position. This
+  // is itself a repair (dropping a duplicate anchor changes the file), even
+  // when no negation line is missing or relocated below.
+  let dedupedAnchor = false;
+  if (anchorCount > 1) {
+    let seenAnchors = 0;
+    lines = lines.filter((line) => {
+      if (line !== '.adlc/*') return true;
+      seenAnchors += 1;
+      return seenAnchors === 1;
+    });
+    dedupedAnchor = true;
+  }
+
+  const anchorIdx = lines.indexOf('.adlc/*');
+
   // The anchor IS present. Relocate any stanza negation line that sits
   // BEFORE it — leaving it there would be silently overridden by the
   // anchor (last-match-wins), re-ignoring the file it was meant to protect.
@@ -138,7 +165,7 @@ export function ensureGitignore(root) {
 
   const newAnchorIdx = lines.indexOf('.adlc/*');
   const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
-  if (missing.length === 0 && !relocated) return { path, added: [], changed: false };
+  if (missing.length === 0 && !relocated && !dedupedAnchor) return { path, added: [], changed: false };
 
   let insertAt = newAnchorIdx + 1;
   while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;
@@ -227,19 +254,44 @@ function ensureEslintRcIgnore(root) {
 }
 
 /**
+ * Combine the independent `.eslintrc*` and `.eslintignore` outcomes into one
+ * report. Both are always checked/mutated unconditionally by
+ * `ensureFormatterIgnores` — a pre-flat-config repo commonly has BOTH files
+ * at once — so picking only one would silently under-report a real mutation
+ * made to the other. When only one is detected, that single result is
+ * returned unchanged (keeping the common single-file case simple); when
+ * both are detected, `sources` exposes each outcome individually so nothing
+ * is dropped.
+ */
+function mergeEslintReports(eslintrc, eslintignore) {
+  if (!eslintrc.detected) return eslintignore;
+  if (!eslintignore.detected) return eslintrc;
+  const skipped = [eslintrc.skipped, eslintignore.skipped].filter(Boolean).join('; ');
+  return {
+    detected: true,
+    changed: eslintrc.changed || eslintignore.changed,
+    path: [eslintrc.path, eslintignore.path],
+    ...(skipped ? { skipped } : {}),
+    sources: { eslintrc, eslintignore },
+  };
+}
+
+/**
  * Detect and update whichever formatter/linter configs already exist in the
  * repo so none of them touch `.adlc/`: Biome (`biome.json` overrides),
  * Prettier (`.prettierignore`), ESLint (`ignorePatterns` in a JSON
  * `.eslintrc*`, `.eslintignore`, or detection-only for flat config). Never
  * creates a config for a tool that isn't already in use. Returns a summary
- * keyed by tool.
+ * keyed by tool. `eslint` reflects BOTH `.eslintrc*` and `.eslintignore`
+ * when a repo has both (see `mergeEslintReports`) — `eslint.sources` carries
+ * the per-file detail in that case.
  */
 export function ensureFormatterIgnores(root) {
   const biome = ensureBiomeIgnore(root);
   const prettier = ensureTextIgnoreFile(root, '.prettierignore', '.adlc/');
   const eslintrc = ensureEslintRcIgnore(root);
   const eslintignore = ensureTextIgnoreFile(root, '.eslintignore', '.adlc/');
-  return { biome, prettier, eslint: eslintrc.detected ? eslintrc : eslintignore };
+  return { biome, prettier, eslint: mergeEslintReports(eslintrc, eslintignore) };
 }
 
 /**

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -95,7 +95,7 @@ export function ensureGitignore(root) {
   const path = join(root, '.gitignore');
   const existing = existsSync(path) ? readFileSync(path, 'utf8') : '';
   const hadTrailingNewline = existing.endsWith('\n');
-  const lines = existing.length ? existing.split('\n') : [];
+  let lines = existing.length ? existing.split('\n') : [];
   if (hadTrailingNewline && lines[lines.length - 1] === '') lines.pop();
 
   const missing = GITIGNORE_STANZA.filter((entry) => !lines.includes(entry));
@@ -103,11 +103,19 @@ export function ensureGitignore(root) {
 
   const anchorIdx = lines.indexOf('.adlc/*');
   if (anchorIdx === -1) {
-    // Push only the entries actually missing — some negation lines may
-    // already exist standalone in the file (without the anchor immediately
-    // preceding them); re-pushing the full stanza would duplicate those.
+    // The `.adlc/*` anchor is absent. A pre-existing negation line (e.g. a
+    // lone `!.adlc/tickets.json` left over from a partial/legacy edit) may
+    // already be present standalone, earlier in the file. Simply pushing
+    // the missing entries (which always includes `.adlc/*` itself here) to
+    // the END of the file would place the broad ignore AFTER that earlier
+    // negation — git applies patterns with last-match-wins semantics, so
+    // the later `.adlc/*` would re-ignore the file the negation was meant
+    // to keep tracked. To guarantee correct order, strip out any
+    // pre-existing standalone stanza lines and re-append the complete
+    // stanza together, in its canonical anchor-first order.
+    lines = lines.filter((line) => !GITIGNORE_STANZA.includes(line));
     if (lines.length > 0) lines.push('');
-    lines.push(...missing);
+    lines.push(...GITIGNORE_STANZA);
   } else {
     let insertAt = anchorIdx + 1;
     while (insertAt < lines.length && lines[insertAt].startsWith('!')) insertAt++;

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -171,6 +171,65 @@ test('ensureGitignore does not duplicate a standalone negation line when the .ad
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('ensureGitignore relocates a negation line that precedes the .adlc/* anchor (last-match-wins hazard)', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.gitignore'), '!.adlc/tickets.json\n.adlc/*\n');
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    const resultLines = body.split('\n').filter((l) => l.length > 0);
+    const occurrences = resultLines.filter((l) => l === '!.adlc/tickets.json').length;
+    assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
+    const anchorPos = resultLines.indexOf('.adlc/*');
+    const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+    const specsPos = resultLines.indexOf('!.adlc/specs/');
+    assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json after relocation');
+    assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureGitignore relocates a misordered stanza even when every line is nominally present (no "missing" entries)', () => {
+  const root = mkroot();
+  try {
+    // All three stanza lines exist somewhere in the file, but in the wrong
+    // order relative to the anchor — a naive "is everything present" check
+    // would wrongly treat this as already-correct and skip fixing it.
+    writeFileSync(join(root, '.gitignore'), '!.adlc/tickets.json\n!.adlc/specs/\n.adlc/*\n');
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    const resultLines = body.split('\n').filter((l) => l.length > 0);
+    const anchorPos = resultLines.indexOf('.adlc/*');
+    const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+    const specsPos = resultLines.indexOf('!.adlc/specs/');
+    assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json after relocation');
+    assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/ after relocation');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureGitignore does not duplicate a negation line that already correctly follows the anchor elsewhere', () => {
+  const root = mkroot();
+  try {
+    // `!.adlc/tickets.json` appears twice: once misplaced before the anchor
+    // (stale) and once correctly after it. Only the stale copy should be
+    // removed; the correct copy must not be duplicated.
+    writeFileSync(
+      join(root, '.gitignore'),
+      '!.adlc/tickets.json\n.adlc/*\n!.adlc/tickets.json\n'
+    );
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    const resultLines = body.split('\n').filter((l) => l.length > 0);
+    const occurrences = resultLines.filter((l) => l === '!.adlc/tickets.json').length;
+    assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
+    const anchorPos = resultLines.indexOf('.adlc/*');
+    const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+    assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
   const root = mkroot();
   try {

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -7,7 +7,14 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { ensureConfig, deployDir, scaffold, ensurePluginRegistered } from '../lib/scaffold.mjs';
+import {
+  ensureConfig,
+  deployDir,
+  scaffold,
+  ensurePluginRegistered,
+  ensureGitignore,
+  ensureFormatterIgnores,
+} from '../lib/scaffold.mjs';
 import { ALL_BINS, GATE_BINS, DISPATCHERS } from '../gate-bins.mjs';
 
 const PKG = dirname(dirname(fileURLToPath(import.meta.url))); // plugins/adlc-opencode
@@ -100,6 +107,128 @@ test('deployDir on a missing source dir returns [] (no throw)', () => {
   const root = mkroot();
   try {
     assert.deepEqual(deployDir(PKG, root, 'does-not-exist'), []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- ensureGitignore (#46: track .adlc/specs/) ----
+test('ensureGitignore creates the full stanza (including !.adlc/specs/) when no .gitignore exists', () => {
+  const root = mkroot();
+  try {
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true);
+    assert.deepEqual(r.added, ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/']);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    assert.match(body, /^\.adlc\/\*$/m);
+    assert.match(body, /^!\.adlc\/tickets\.json$/m);
+    assert.match(body, /^!\.adlc\/specs\/$/m);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureGitignore adds the missing !.adlc/specs/ negation to a pre-existing stanza without touching other content', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.gitignore'), 'node_modules/\n.adlc/*\n!.adlc/tickets.json\ndist/\n');
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true);
+    assert.deepEqual(r.added, ['!.adlc/specs/']);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    assert.match(body, /^!\.adlc\/specs\/$/m);
+    assert.match(body, /node_modules\//); // untouched
+    assert.match(body, /dist\//); // untouched
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureGitignore is a no-op when the full stanza is already present (idempotent)', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.gitignore'), '.adlc/*\n!.adlc/tickets.json\n!.adlc/specs/\n');
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, false);
+    assert.deepEqual(r.added, []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
+  const root = mkroot();
+  try {
+    const out = scaffold(root, PKG);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    assert.match(body, /^!\.adlc\/specs\/$/m);
+    assert.equal(out.gitignore.changed, true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ---- ensureFormatterIgnores (#42: keep formatters/linters off .adlc/) ----
+test('ensureFormatterIgnores adds a .adlc/** override to an existing biome.json', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, 'biome.json'), JSON.stringify({ formatter: { enabled: true } }));
+    const { biome } = ensureFormatterIgnores(root);
+    assert.equal(biome.detected, true);
+    assert.equal(biome.changed, true);
+    const cfg = JSON.parse(readFileSync(join(root, 'biome.json'), 'utf8'));
+    assert.ok(cfg.overrides.some((o) => o.include.includes('.adlc/**')));
+    assert.equal(cfg.formatter.enabled, true); // untouched
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores is idempotent on biome.json (no duplicate override)', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, 'biome.json'), JSON.stringify({}));
+    ensureFormatterIgnores(root);
+    const { biome } = ensureFormatterIgnores(root);
+    assert.equal(biome.changed, false);
+    const cfg = JSON.parse(readFileSync(join(root, 'biome.json'), 'utf8'));
+    assert.equal(cfg.overrides.length, 1);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores appends .adlc/ to an existing .prettierignore', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.prettierignore'), 'dist/\n');
+    const { prettier } = ensureFormatterIgnores(root);
+    assert.equal(prettier.changed, true);
+    const body = readFileSync(join(root, '.prettierignore'), 'utf8');
+    assert.match(body, /^dist\/$/m);
+    assert.match(body, /^\.adlc\/$/m);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores adds ignorePatterns to an existing .eslintrc.json', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.eslintrc.json'), JSON.stringify({ extends: ['eslint:recommended'] }));
+    const { eslint } = ensureFormatterIgnores(root);
+    assert.equal(eslint.detected, true);
+    assert.equal(eslint.changed, true);
+    const cfg = JSON.parse(readFileSync(join(root, '.eslintrc.json'), 'utf8'));
+    assert.ok(cfg.ignorePatterns.includes('.adlc/**'));
+    assert.deepEqual(cfg.extends, ['eslint:recommended']); // untouched
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores detects but does not silently mutate a flat eslint.config.js', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, 'eslint.config.js'), 'export default [];\n');
+    const { eslint } = ensureFormatterIgnores(root);
+    assert.equal(eslint.detected, true);
+    assert.equal(eslint.changed, false);
+    assert.ok(eslint.skipped, 'must document the manual fallback');
+    const body = readFileSync(join(root, 'eslint.config.js'), 'utf8');
+    assert.equal(body, 'export default [];\n'); // untouched
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores reports nothing detected when no formatter/linter configs exist', () => {
+  const root = mkroot();
+  try {
+    const { biome, prettier, eslint } = ensureFormatterIgnores(root);
+    assert.equal(biome.detected, false);
+    assert.equal(prettier.detected, false);
+    assert.equal(eslint.detected, false);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -148,6 +148,21 @@ test('ensureGitignore is a no-op when the full stanza is already present (idempo
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('ensureGitignore does not duplicate a standalone negation line when the .adlc/* anchor is absent', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.gitignore'), '!.adlc/tickets.json\n');
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true);
+    assert.deepEqual(r.added, ['.adlc/*', '!.adlc/specs/']);
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    const occurrences = body.split('\n').filter((l) => l === '!.adlc/tickets.json').length;
+    assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
+    assert.match(body, /^\.adlc\/\*$/m);
+    assert.match(body, /^!\.adlc\/specs\/$/m);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
   const root = mkroot();
   try {
@@ -206,6 +221,19 @@ test('ensureFormatterIgnores adds ignorePatterns to an existing .eslintrc.json',
     const cfg = JSON.parse(readFileSync(join(root, '.eslintrc.json'), 'utf8'));
     assert.ok(cfg.ignorePatterns.includes('.adlc/**'));
     assert.deepEqual(cfg.extends, ['eslint:recommended']); // untouched
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores appends .adlc/ to an existing .eslintignore', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.eslintignore'), 'dist/\n');
+    const { eslint } = ensureFormatterIgnores(root);
+    assert.equal(eslint.detected, true);
+    assert.equal(eslint.changed, true);
+    const body = readFileSync(join(root, '.eslintignore'), 'utf8');
+    assert.match(body, /^dist\/$/m);
+    assert.match(body, /^\.adlc\/$/m);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -230,6 +230,50 @@ test('ensureGitignore does not duplicate a negation line that already correctly 
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('ensureGitignore repairs a duplicate .adlc/* anchor that re-ignores a negation placed after the first anchor', () => {
+  const root = mkroot();
+  try {
+    // Two `.adlc/*` anchors (e.g. from a merge of two branches that each
+    // appended the stanza). Git's last-match-wins semantics mean the SECOND
+    // anchor re-ignores `!.adlc/tickets.json`, which sits between the two
+    // anchors — even though every stanza line is nominally "present" and
+    // negations look correctly placed relative to the FIRST anchor alone.
+    writeFileSync(
+      join(root, '.gitignore'),
+      '.adlc/*\n!.adlc/tickets.json\nfoo\n.adlc/*\n!.adlc/specs/\n'
+    );
+    const r = ensureGitignore(root);
+    assert.equal(r.changed, true, 'a duplicate anchor must be treated as a repair, not a no-op');
+    const body = readFileSync(join(root, '.gitignore'), 'utf8');
+    const resultLines = body.split('\n').filter((l) => l.length > 0);
+    const anchorOccurrences = resultLines.filter((l) => l === '.adlc/*').length;
+    assert.equal(anchorOccurrences, 1, 'duplicate .adlc/* anchor must be collapsed to one');
+    assert.match(body, /foo/); // unrelated line untouched
+    const anchorPos = resultLines.indexOf('.adlc/*');
+    const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+    const specsPos = resultLines.indexOf('!.adlc/specs/');
+    assert.ok(anchorPos < ticketsPos && anchorPos < specsPos, 'sole anchor must precede both negations');
+    assert.ok(
+      resultLines.lastIndexOf('.adlc/*') < ticketsPos && resultLines.lastIndexOf('.adlc/*') < specsPos,
+      'no anchor may follow either negation (last-match-wins hazard)'
+    );
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureGitignore is idempotent after repairing a duplicate anchor (second call reports no-op)', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(
+      join(root, '.gitignore'),
+      '.adlc/*\n!.adlc/tickets.json\nfoo\n.adlc/*\n!.adlc/specs/\n'
+    );
+    ensureGitignore(root);
+    const r2 = ensureGitignore(root);
+    assert.equal(r2.changed, false);
+    assert.deepEqual(r2.added, []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('scaffold() wires ensureGitignore in so /adlc-init tracks specs/ by default', () => {
   const root = mkroot();
   try {
@@ -314,6 +358,26 @@ test('ensureFormatterIgnores detects but does not silently mutate a flat eslint.
     assert.ok(eslint.skipped, 'must document the manual fallback');
     const body = readFileSync(join(root, 'eslint.config.js'), 'utf8');
     assert.equal(body, 'export default [];\n'); // untouched
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('ensureFormatterIgnores reports BOTH .eslintrc.json and .eslintignore outcomes when a repo has both', () => {
+  const root = mkroot();
+  try {
+    writeFileSync(join(root, '.eslintrc.json'), JSON.stringify({ extends: ['eslint:recommended'] }));
+    writeFileSync(join(root, '.eslintignore'), 'dist/\n');
+    const { eslint } = ensureFormatterIgnores(root);
+    assert.equal(eslint.detected, true);
+    assert.equal(eslint.changed, true);
+    // Both files must actually be mutated on disk...
+    const rc = JSON.parse(readFileSync(join(root, '.eslintrc.json'), 'utf8'));
+    assert.ok(rc.ignorePatterns.includes('.adlc/**'));
+    const ignoreBody = readFileSync(join(root, '.eslintignore'), 'utf8');
+    assert.match(ignoreBody, /^\.adlc\/$/m);
+    // ...and the returned report must not silently drop either mutation.
+    assert.ok(eslint.sources, 'must expose per-file detail when both are present');
+    assert.equal(eslint.sources.eslintrc.changed, true);
+    assert.equal(eslint.sources.eslintignore.changed, true);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -160,6 +160,14 @@ test('ensureGitignore does not duplicate a standalone negation line when the .ad
     assert.equal(occurrences, 1, '!.adlc/tickets.json must not be duplicated');
     assert.match(body, /^\.adlc\/\*$/m);
     assert.match(body, /^!\.adlc\/specs\/$/m);
+    // Order matters for git's last-match-wins semantics: `.adlc/*` MUST
+    // come before the negation lines, otherwise it re-ignores them.
+    const resultLines = body.split('\n').filter((l) => l.length > 0);
+    const anchorPos = resultLines.indexOf('.adlc/*');
+    const ticketsPos = resultLines.indexOf('!.adlc/tickets.json');
+    const specsPos = resultLines.indexOf('!.adlc/specs/');
+    assert.ok(anchorPos < ticketsPos, '.adlc/* must precede !.adlc/tickets.json');
+    assert.ok(anchorPos < specsPos, '.adlc/* must precede !.adlc/specs/');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
Fixes #46
Fixes #42
Fixes #43

## Summary

`adlc-init` (cursor + opencode plugins) had three related hygiene gaps surfaced by running a full P0→P6 cycle on an external repo:

- **#46** — `.adlc/specs/` (the P1 spec, arguably the most important contract in the lifecycle) was left git-ignored because the scaffolded `.gitignore` stanza only negated `.adlc/tickets.json`. `ensureGitignore()` now also negates `!.adlc/specs/`.
- **#42** — a machine-written `.adlc/tickets.json` (multi-line `JSON.stringify`) conflicts with repo formatters/linters (Biome, Prettier, ESLint) — and once a ticket declares `rails`, `tickets.json` becomes a frozen trust root that can't be reformatted on a ticket branch without tripping rails-guard. Added `ensureFormatterIgnores()`, which detects and patches `biome.json`, `.prettierignore`, `.eslintrc.json`/`ignorePatterns`, `.eslintignore`, and reports (but does not silently mutate) flat `eslint.config.js`.
- **#43** — `/adlc-ticket` now runs the repo's detected quality/check script against `.adlc/tickets.json` after the atomic write and warns (non-blocking) on failure, instead of silently letting a bad write turn CI red on the next PR.

Both `adlc-cursor` and `adlc-opencode` carry byte-for-byte duplicated `ensureGitignore`/`ensureFormatterIgnores` implementations (matching the existing duplication pattern in these packages), so every fix below was applied and tested identically in both.

### Review history (5 rounds, iterative hardening of `ensureGitignore`)

Adversarial review surfaced a sequence of git `.gitignore` last-match-wins edge cases in `ensureGitignore`, each fixed in its own commit:

1. Duplicating a standalone negation line when the `.adlc/*` anchor was absent.
2. Negation line ending up *before* a newly-appended anchor when the anchor was absent (silently re-ignoring the negated file despite reporting `changed: true`).
3. A negation line sitting before an *existing* anchor (hand-edit/merge) was never relocated — an early-return masked this because "all lines present, just misordered" looked like "already correct."
4. A duplicate `.adlc/*` anchor (second occurrence from a merge/second tool run) silently re-ignored the negation while reporting `changed: false`. Also: `ensureFormatterIgnores` only reported one of `.eslintrc.json` / `.eslintignore` when both existed, dropping the other mutation from the CLI summary.
5. The CLI printed a misleading "updated (added )" summary when a repair changed nothing in `added` (pure anchor/order repair, no new stanza lines).

## NEEDS ATTENTION — review did not reach a clean verdict

This branch went through **5 rounds of adversarial review and did not reach a clean (0-finding) verdict**:

| Round | Findings |
|-------|----------|
| 1 | 2 |
| 2 | 1 |
| 3 | 2 |
| 4 | 4 |
| 5 | 1 |

Every reported finding through round 5 has a corresponding fix commit (see history above and `git log` on this branch), and the round-5 fix is included in the tip commit (`cb0e72a`). **However, the round-5 fix itself was not re-run through a subsequent clean review round** (the process stopped at the round cap), so it has not been adversarially re-verified.

Please have a human reviewer specifically check before merging:

1. **No further `.gitignore` last-match-wins edge cases remain.** Five rounds in a row found new variants of the same class of bug (anchor absent / misordered / duplicated, negation before/after, partial vs. full stanza). Consider whether the fix is now exhaustive or whether a property-style/fuzz test over anchor+negation permutations would be more convincing than the current example-based regression tests.
2. **The duplicated `ensureGitignore`/`ensureFormatterIgnores` logic across `adlc-cursor` and `adlc-opencode`.** Every fix in this PR had to be applied twice (once per package) to keep them in sync. This PR intentionally did not extract a shared module (per the round-4 commit message, treating that as a separately-scoped consolidation), so a future change to one copy without the other will silently reintroduce drift. Worth a follow-up ticket.
3. **`ensureFormatterIgnores` flat `eslint.config.js` handling** — it only *detects and reports*, it does not mutate. Confirm that's the intended scope for this PR (vs. actually patching flat config).
4. **#43's quality-check-after-write is advisory/warn-only**, not blocking — confirm that matches the issue's intent (issue proposes "warning if it fails," which this implements, but flag for reviewer sign-off given the CI-red history that motivated the issue).

## Test plan

- [x] `node --test plugins/adlc-cursor/test/*.test.mjs` — 54/54 pass
- [x] `node --test plugins/adlc-opencode/test/*.test.mjs` — 71/71 pass
- [x] Full repo suite (`npm test`, covers all packages/plugins/apps) — green, exit 0
- [x] Regression tests added for every round-1–5 finding (duplicate negation, misordered negation, duplicate anchor, dual eslint source reporting, CLI "added" summary wording)
- [ ] Human re-review of the round-5 fix and the open concerns above before merge
