### PR TITLE
feat(build-gate): machine-checkable fitness-to-build gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ hooks, CI, and lifecycle docs should use the dispatcher.
 | Phase | Packages |
 | --- | --- |
 | **Spec & ticket shaping** | [`parallax`](./packages/parallax) · [`spec-lint`](./packages/spec-lint) · [`premortem`](./packages/premortem) · [`coldstart`](./packages/coldstart) · [`ticket-prune`](./packages/ticket-prune) |
-| **Execution supervision & rails** | [`preflight`](./packages/preflight) · [`model-router`](./packages/model-router) · [`merge-forecast`](./packages/merge-forecast) · [`rails-guard`](./packages/rails-guard) · [`flail-detector`](./packages/flail-detector) · [`consensus-fix`](./packages/consensus-fix) · [`runner`](./packages/runner) |
+| **Execution supervision & rails** | [`preflight`](./packages/preflight) · [`model-router`](./packages/model-router) · [`merge-forecast`](./packages/merge-forecast) · [`rails-guard`](./packages/rails-guard) · [`build-gate`](./packages/build-gate) · [`flail-detector`](./packages/flail-detector) · [`consensus-fix`](./packages/consensus-fix) · [`runner`](./packages/runner) |
 | **Review evidence & calibration** | [`behavior-diff`](./packages/behavior-diff) · [`gate-manifest`](./packages/gate-manifest) · [`hollow-test`](./packages/hollow-test) · [`prosecute`](./packages/prosecute) · [`review-calibration`](./packages/review-calibration) · [`model-ratchet`](./packages/model-ratchet) · [`gate-fuzzing`](./packages/gate-fuzzing) |
 | **Compounding defenses** | [`lesson-foundry`](./packages/lesson-foundry) · [`rejection-mining`](./packages/rejection-mining) · [`skill-rot`](./packages/skill-rot) |
 | **Shared foundation** | [`@adlc/cli`](./packages/cli) · [`@adlc/core`](./packages/core) |

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -99,7 +99,7 @@ supplies independent model judgment with cross-lens verification.
 | flail-detection | PostToolUse | Advisory: flags repeated-error / churn loops over a bounded recent window of the transcript. |
 | gate-manifest audit | Stop | Advisory: warns only if the gate-evidence chain is broken. |
 | **rails-guard** | PreToolUse | **Enforcing**: denies structured edits (Edit/Write/MultiEdit) to frozen rail paths declared in tickets. Bash is not gated in-session (a shell can't be reliably parsed); Bash rail mutations are caught by the CI diff gate at commit time. |
-| **build-gate** | PreToolUse | **Enforcing** (issue #48): for the *active* ticket (`ADLC_TICKET` env var or `.adlc/current-ticket.json`), denies a structured edit when the ticket is high-risk (declared `risk: 'high'`, or derived from category/external-effect/identity-mutation/trust-root-touch signals) AND this session's context-fitness signal (transcript tool-call depth or byte size) is past threshold — i.e. a context-rot backstop on the riskiest builds. |
+| **build-gate** | PreToolUse | **Enforcing** (issue #48): for the *active* ticket (`ADLC_TICKET` env var or `.adlc/current-ticket.json`), denies a structured edit when the ticket is high-risk (declared `risk: 'high'`, or derived from category/external-effect/identity-mutation/trust-root-touch signals) AND this session's context-fitness signal (transcript tool-call depth or byte size) is past threshold — i.e. a context-rot backstop on the riskiest builds. Bash is not gated in-session (same reason as rails-guard) and, unlike rails, there is no CI backstop for it — see Gaps below. |
 
 All hooks no-op unless the repo is ADLC-initialized. Rail enforcement
 additionally no-ops until a ticket declares `rails`, so installing the plugin
@@ -291,6 +291,29 @@ Current gaps relative to the formal ADLC doctrine:
 3. **Skill discovery depends on description matching.** The `adlc` phase router
    is one skill with a broad trigger set, but a poorly-phrased request may not
    match the description and will not route through the lifecycle.
+4. **The build-gate active-ticket pointer has no Bash or CI backstop
+   (intentional design, partially mitigated).** `.adlc/current-ticket.json`
+   is frozen as a rails trust root (same as `.adlc/tickets.json`) whenever
+   the ticket set declares ANY rails, so a structured edit that overwrites
+   the pointer is denied. But like rails-guard, build-gate's PreToolUse hook
+   only matches `Edit|Write|MultiEdit|NotebookEdit` — a Bash command can
+   still delete or overwrite `.adlc/current-ticket.json` mid-session (this is
+   never gated, trust-root or not), after which `resolveActiveTicketIdForBuildGate`
+   sees "no active ticket" and every subsequent structured edit is allowed
+   with **zero** risk evaluation and **zero** manifest entry (a strictly
+   weaker outcome than even `ADLC_BUILD_GATE_BYPASS=1`, which at least
+   requires a durably-recorded gate-manifest entry). A ticket that is
+   high-risk without declaring any `rails` (e.g. purely via `category:
+   'contract'`) gets no trust-root protection at all. Unlike the rails Bash
+   gap (#2 above), this one has **no CI diff backstop**:
+   `.adlc/current-ticket.json` is gitignored local session state (see
+   `.gitignore`), not a tracked file, so there is no diff for a commit-time
+   gate to inspect — and build-gate's degradation signal (transcript
+   tool-call depth) can't be reconstructed after the fact anyway. Mitigate by
+   treating `.adlc/current-ticket.json` deletion/edits as a reviewable signal
+   in your own audit tooling (e.g. session logging), and by not relying on
+   build-gate as the sole safeguard for a high-risk ticket — pair it with
+   human review at P5/P6.
 
 ## Boundary
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -99,10 +99,21 @@ supplies independent model judgment with cross-lens verification.
 | flail-detection | PostToolUse | Advisory: flags repeated-error / churn loops over a bounded recent window of the transcript. |
 | gate-manifest audit | Stop | Advisory: warns only if the gate-evidence chain is broken. |
 | **rails-guard** | PreToolUse | **Enforcing**: denies structured edits (Edit/Write/MultiEdit) to frozen rail paths declared in tickets. Bash is not gated in-session (a shell can't be reliably parsed); Bash rail mutations are caught by the CI diff gate at commit time. |
+| **build-gate** | PreToolUse | **Enforcing** (issue #48): for the *active* ticket (`ADLC_TICKET` env var or `.adlc/current-ticket.json`), denies a structured edit when the ticket is high-risk (declared `risk: 'high'`, or derived from category/external-effect/identity-mutation/trust-root-touch signals) AND this session's context-fitness signal (transcript tool-call depth or byte size) is past threshold — i.e. a context-rot backstop on the riskiest builds. |
 
 All hooks no-op unless the repo is ADLC-initialized. Rail enforcement
 additionally no-ops until a ticket declares `rails`, so installing the plugin
-into a repo with no rails can never block editing.
+into a repo with no rails can never block editing. The build-gate similarly
+no-ops until an active ticket is resolved via `ADLC_TICKET`/
+`.adlc/current-ticket.json` — see [`docs/specs/build-gate-fitness.md`](../specs/build-gate-fitness.md)
+and [`@adlc/build-gate`](../../packages/build-gate/README.md).
+
+**Build-gate bypass.** `ADLC_BUILD_GATE_BYPASS=1` overrides a build-gate deny
+only if the override is durably recorded to the gate-manifest (an un-auditable
+bypass is refused) — the same posture as `ADLC_RAILS_BYPASS` above. The
+recommended response to a deny is to resume the ticket in a fresh session (or
+an isolated subagent) rather than overriding — the ticket is coldstart-certified
+to be safely resumable with no conversation context.
 
 **Rails must be tracked files.** The commit-time CI gate inspects the git diff,
 so it only protects files under version control. A gitignored/untracked rail

--- a/docs/package-reference.md
+++ b/docs/package-reference.md
@@ -8,6 +8,7 @@ Follow each README for full options, output schemas, examples, and implementatio
 | Package | Binary | Role | Source |
 | --- | --- | --- | --- |
 | `@adlc/behavior-diff` | `behavior-diff` | Captures and compares HTTP/API behavior snapshots for the P6 human gate. | [`docs/tools/behavior-diff.md`](./tools/behavior-diff.md) |
+| `@adlc/build-gate` | `build-gate` | Denies starting a high-risk ticket's build in a degraded (context-rot) session unless an audited override is recorded. | [`packages/build-gate/README.md`](../packages/build-gate/README.md) |
 | `@adlc/cli` | `adlc` | Provides the stable dispatcher surface for all public ADLC tool execution. | [`docs/tools/cli.md`](./tools/cli.md) |
 | `@adlc/coldstart` | `coldstart` | Checks whether tickets are executable without agent guesswork. | [`docs/tools/coldstart.md`](./tools/coldstart.md) |
 | `@adlc/consensus-fix` | `consensus-fix` | Fans out candidate fixes and recommends, or optionally applies, the consensus winner that passes gates. | [`docs/tools/consensus-fix.md`](./tools/consensus-fix.md) |
@@ -57,6 +58,7 @@ adlc preflight [--test-cmd "..."] [--gh] [--llm] [--worktrees] [--json]
 adlc premortem <spec.md> [--tier cheap|mid|frontier] [--out report.md] [--json] [--prompt-only]
 adlc prosecute --input p5-passes.json --ticket id [--target label] [--revision rev] [--dir .adlc] [--json]
 adlc rails-guard [--base <ref>] [--ticket <id>] [--tickets <path>] [--rails <glob>...] [--record] [--json]
+adlc build-gate <ticket-id> [--depth <n>] [--session-bytes <n>] [--transcript <path>] [--depth-threshold <n>] [--bytes-threshold <n>] [--tickets <path>] [--reason <text>] [--json]
 adlc rejection-mining [--limit N] [--min N] [--out-dir PATH] [--write] [--llm] [--prompt-only] [--json]
 adlc review-calibration --review-cmd "cmd with {base} placeholder" [options]
 adlc run <p1|p2|p3|p4|p5|p6|p7> [--ticket id for p3-p6] [--revision rev for p5-p6] [--dir .adlc] [--json]
@@ -82,6 +84,7 @@ Execution supervision and rails:
 - `model-router`
 - `merge-forecast`
 - `rails-guard`
+- `build-gate`
 - `flail-detector`
 - `consensus-fix`
 - `runner`

--- a/docs/specs/build-gate-fitness.md
+++ b/docs/specs/build-gate-fitness.md
@@ -74,3 +74,34 @@ node --test plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
 node --test packages/cli/test/*.test.mjs
 npm test   # full suite, from the repo root
 ```
+
+## Known limitations
+
+- **Unreadable transcript_path fails closed.** If a high-risk ticket's
+  `transcript_path` exists at hook time (passes `existsSync`) but a subsequent
+  `fileSize`/`readFileSync` fails — permission error, or a TOCTOU race where
+  the file is deleted/replaced between the two checks — the hook denies
+  rather than treating the unreadable file as "zero bytes, not degraded". The
+  context-fitness signal cannot be computed for a ticket already known to be
+  high-risk, so an unverifiable session must not be allowed through.
+- **The active-ticket pointer is a Bash-reachable escape hatch (partially
+  mitigated).** Build-gate is an opt-in gate: "no active ticket declared →
+  allow" is by design (it mirrors rails' "no rails declared → allow").
+  `.adlc/current-ticket.json` is now frozen as a rails trust root (same
+  treatment as `.adlc/tickets.json`) whenever the ticket set declares ANY
+  rails, so a structured edit (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`)
+  that overwrites the pointer is denied. Two gaps remain: (1) the PreToolUse
+  hook only matches those structured-edit tools — never Bash (same reason as
+  rails-guard — see `docs/integrations/claude-code.md`'s Gaps section) — so
+  `rm .adlc/current-ticket.json` or an out-of-band overwrite via Bash still
+  clears the pointer with zero risk evaluation and zero manifest entry,
+  weaker than even `ADLC_BUILD_GATE_BYPASS=1` (which is at least audited);
+  and (2) a ticket that is high-risk *without* declaring any `rails` (e.g.
+  purely via `category: 'contract'`) gets no trust-root protection at all,
+  since rails() no-ops when the ticket set declares zero rails. Unlike
+  rails' equivalent Bash gap, there is **no CI diff backstop** possible here:
+  `.adlc/current-ticket.json` is gitignored local session state (not
+  tracked), so there is no commit-time diff for a CI gate to inspect, and
+  the degradation signal (transcript depth) can't be reconstructed after
+  the fact regardless. Treat build-gate as a strong in-session backstop, not
+  a substitute for human review at P5/P6 on high-risk tickets.

--- a/docs/specs/build-gate-fitness.md
+++ b/docs/specs/build-gate-fitness.md
@@ -1,0 +1,76 @@
+# Spec — Machine-checkable fitness-to-build gate (issue #48)
+
+## Problem
+
+ADLC gates the *quality* of a change (coldstart, prosecute/P5) but nothing
+deterministically prevented **starting** a high-blast-radius ticket's build
+(P4) when the executing session's context was degraded ("context rot"). The
+motivating incident (T9 of `@adlc/ticket-sync`, PR #33: idempotent `gh issue
+create` + id-reassignment with store-wide edge rewrite) was paused correctly
+only because the operator happened to ask "should we pause?" — human judgment,
+not a machine-checkable gate.
+
+## What was built
+
+Per the issue's recommended composition ("ship Path B first, with the
+risk-tier/gate logic factored into a reusable toolkit"):
+
+1. **`@adlc/build-gate`** (`packages/build-gate/`) — the reusable toolkit
+   (Path A):
+   - `lib/risk.mjs` — risk-tier derivation: declared `risk: 'high'`, OR any of
+     `external`, `mutatesIdentity`, scope/rails touching
+     `.adlc/manifest.jsonl` or the trust root (`.adlc/tickets.json`,
+     `.adlc/current-ticket.json`), OR `category` in `{contract, architecture}`.
+     A declared `risk: 'normal'` can never downgrade a derived-high signal.
+   - `lib/depth-signal.mjs` — the context-fitness proxy: tool-call-count
+     (`--depth`) and transcript bytes (`--session-bytes`), mirroring
+     `@adlc/flail-detector`'s existing transcript-size/tool-call-count
+     scanning approach.
+   - `lib/decide.mjs` — the pure allow/deny decision.
+   - `lib/override.mjs` — durable override recording to
+     `.adlc/manifest.jsonl` (`build-gate-bypass` entries).
+   - `lib/active-ticket.mjs` — the shared `ADLC_TICKET` env var /
+     `.adlc/current-ticket.json` active-ticket convention, matching every
+     other ADLC harness integration (codex, opencode, cursor, antigravity).
+   - `bin/build-gate.mjs` — the CLI: `adlc build-gate <ticket-id> [--depth
+     <n>] [--session-bytes <n>] [--transcript <path>] [...]`. Registered in
+     `packages/cli/lib/registry.mjs`.
+2. **Claude Code hook** (`plugins/adlc-claude-code/hooks/adlc-hook.mjs`,
+   `buildgate` mode) — Path B, self-enforcing: a new PreToolUse hook (same
+   `Edit|Write|MultiEdit|NotebookEdit` matcher as `rails`) that resolves the
+   active ticket, computes its risk tier and this session's context-fitness
+   signal **entirely locally** (verbatim-ported copies of the toolkit logic,
+   marked "KEEP IN SYNC", the same convention already used for `globMatch`),
+   and denies the edit when the ticket is high-risk and the session is
+   degraded — unless `ADLC_BUILD_GATE_BYPASS=1` is set AND the override is
+   durably recorded via `adlc gate-manifest record build-gate-bypass`
+   (mirrors the `ADLC_RAILS_BYPASS` pattern exactly: an override that cannot
+   be audited is refused, never silently allowed).
+
+The core enforcement decision does not depend on the `adlc` CLI being on
+`PATH` (mirroring `rails`'s own design) — only the audited-override recording
+does. This means installing the plugin cannot brick a session that hasn't
+opted into the `ADLC_TICKET`/`.adlc/current-ticket.json` convention, and the
+gate keeps working even if `@adlc/cli` isn't globally installed.
+
+## Acceptance criteria
+
+- [x] Risk tier is derivable from ticket fields and overridable via a
+      declared `risk: 'high'` field, without a silent downgrade path.
+- [x] A context-fitness signal (transcript depth/bytes) is exposed to the
+      gate: `--depth`/`--session-bytes`/`--transcript` on the CLI; computed
+      in-session by the CC hook from `transcript_path`.
+- [x] `build-gate` denies a high-risk build past threshold; an audited
+      override is recorded via the gate-manifest; exit code `2` on deny.
+- [x] The CC PreToolUse hook enforces this in-session for declared/derived
+      high-risk tickets.
+- [x] Docs + tests (offline; injected signal) — see below.
+
+## Verification
+
+```
+node --test packages/build-gate/test/*.test.mjs
+node --test plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
+node --test packages/cli/test/*.test.mjs
+npm test   # full suite, from the repo root
+```

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -14,6 +14,7 @@ through the stable `adlc <tool>` dispatcher.
 | P1 / C1-C2 | Is the spec testable and stress-tested? | [`adlc spec-lint`](./tools/spec-lint.md), [`adlc premortem`](./tools/premortem.md), [`adlc parallax`](./tools/parallax.md) |
 | P2 / C3 | Can an agent execute this ticket without guessing? | [`adlc coldstart`](./tools/coldstart.md), [`adlc merge-forecast`](./tools/merge-forecast.md), [`adlc model-router`](./tools/model-router.md) |
 | P3-P4 / C5-C6 | Are frozen rails protected, and is an agent flailing? | [`adlc rails-guard`](./tools/rails-guard.md), [`adlc flail-detector`](./tools/flail-detector.md) |
+| P3→P4 / C13 | Is it safe to START a high-risk ticket's build in THIS session? | [`adlc build-gate`](../packages/build-gate/README.md) |
 | P4 / C7 | Can diverse candidates resolve a hard failing test without breaking rails? | [`adlc consensus-fix`](./tools/consensus-fix.md) |
 | P5-P6 / C14 | Did prosecution dry out, did behavior change, and can a human review the evidence? | `adlc review` (runs the model review — see [seam note](#p5-recorder-vs-reviewer-seam)), [`adlc prosecute`](./tools/prosecute.md) (records its evidence — it runs no model review itself), [`adlc behavior-diff`](./tools/behavior-diff.md), [`adlc gate-manifest`](./tools/gate-manifest.md), [`adlc hollow-test`](./tools/hollow-test.md) |
 | C12 / maintenance | What must be re-prosecuted after model or repo drift? | [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md), [`adlc skill-rot`](./tools/skill-rot.md), [`adlc ticket-prune`](./tools/ticket-prune.md) |
@@ -43,8 +44,10 @@ statement.
    accepted spec has verifiable criteria and known divergences.
 3. Use [`adlc coldstart`](./tools/coldstart.md) to check ticket executability, then [`adlc merge-forecast`](./tools/merge-forecast.md) and [`adlc model-router`](./tools/model-router.md)
    to manage fan-out width and model assignment.
-4. During implementation, use [`adlc rails-guard`](./tools/rails-guard.md) for frozen-test and suppression controls and
-   [`adlc flail-detector`](./tools/flail-detector.md) to catch repeated error loops, scope drift, churn, or oversized logs.
+4. During implementation, use [`adlc rails-guard`](./tools/rails-guard.md) for frozen-test and suppression controls,
+   [`adlc build-gate`](../packages/build-gate/README.md) to deny starting a high-risk ticket's build in a degraded
+   session, and [`adlc flail-detector`](./tools/flail-detector.md) to catch repeated error loops, scope drift, churn,
+   or oversized logs.
 5. For hard failing tests, use [`adlc consensus-fix`](./tools/consensus-fix.md) to fan out independent candidate repairs
    and select a gated consensus winner.
 6. Before review, use [`adlc hollow-test`](./tools/hollow-test.md) to prove tests are load-bearing. Run the actual

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,10 @@
       "resolved": "packages/behavior-diff",
       "link": true
     },
+    "node_modules/@adlc/build-gate": {
+      "resolved": "packages/build-gate",
+      "link": true
+    },
     "node_modules/@adlc/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -7227,12 +7231,27 @@
         "node": ">=18"
       }
     },
+    "packages/build-gate": {
+      "name": "@adlc/build-gate",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@adlc/core": "1.1.0"
+      },
+      "bin": {
+        "build-gate": "bin/build-gate.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "packages/cli": {
       "name": "@adlc/cli",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@adlc/behavior-diff": "1.1.0",
+        "@adlc/build-gate": "1.1.0",
         "@adlc/coldstart": "1.1.0",
         "@adlc/consensus-fix": "1.1.0",
         "@adlc/flail-detector": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7236,7 +7236,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.1.0"
+        "@adlc/core": "1.1.0",
+        "@adlc/gate-manifest": "1.1.0"
       },
       "bin": {
         "build-gate": "bin/build-gate.mjs"

--- a/packages/build-gate/LICENSE
+++ b/packages/build-gate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/build-gate/README.md
+++ b/packages/build-gate/README.md
@@ -97,4 +97,7 @@ cannot be recorded is refused, never silently allowed.
 supplies the in-session context signal (the same transcript-window staging
 the `flail` mode already does) and shells to
 `adlc build-gate <id> --depth <n> --session-bytes <n>` for the active
-high-risk ticket. See `docs/specs/build-gate-fitness.md`.
+high-risk ticket. See `docs/specs/build-gate-fitness.md`, including its
+**Known limitations** section (unreadable-transcript fail-closed behavior,
+and the unprotected `.adlc/current-ticket.json` pointer as a Bash-reachable,
+CI-unbackstopped escape hatch).

--- a/packages/build-gate/README.md
+++ b/packages/build-gate/README.md
@@ -1,0 +1,100 @@
+# build-gate
+
+Machine-checkable fitness-to-build gate (ADLC C13 — [issue #48](https://github.com/voodootikigod/adlc/issues/48)).
+
+Nothing else in ADLC deterministically prevents **starting** a high-blast-radius
+ticket's build (P4) when the executing session's context is degraded ("context
+rot"). `build-gate` closes that gap: it derives a ticket's risk tier, checks a
+machine-checkable context-fitness signal, and denies the build unless an
+audited override is recorded.
+
+## ADLC Phase
+
+**P3 → P4 entry gate.** Sits between rail-freeze (P3) and supervised build
+execution (P4). Guards one invariant: a **high-risk** ticket must not begin
+its build in a **degraded** session.
+
+## Usage
+
+```
+build-gate <ticket-id> [--depth <n>] [--session-bytes <n>] [--transcript <path>]
+           [--depth-threshold <n>] [--bytes-threshold <n>] [--tickets <path>]
+           [--reason <text>] [--json]
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<ticket-id>` | — | Ticket to gate (required) |
+| `--depth <n>` | — | Precomputed tool-call-count depth signal |
+| `--session-bytes <n>` | — | Precomputed transcript byte-size signal |
+| `--transcript <path>` | — | Derive depth/session-bytes from this transcript file |
+| `--depth-threshold <n>` | 40 | Tool-call count past which a session is "degraded" |
+| `--bytes-threshold <n>` | 262144 (256 KiB) | Transcript bytes past which a session is "degraded" |
+| `--tickets <path>` | `.adlc/tickets.json` | Path to tickets file |
+| `--reason <text>` | — | Free-text reason recorded with an override |
+| `--json` | off | Emit machine-readable JSON result |
+| `--help` | — | Print this help and exit 0 |
+
+A CLI process can't observe its own caller's context state — the caller (a
+hook, CI wrapper, or any harness) must supply the signal via `--depth`/
+`--session-bytes`, or point `--transcript` at a transcript file to derive it
+from. Supplying **neither** defaults the signal to "not degraded" — a gate
+given no signal cannot deny.
+
+### Exit codes
+
+```
+0  allow (gate passes)
+1  operational error (bad ticket id, missing tickets file, bad thresholds)
+2  deny (gate fails)
+```
+
+## Risk tier
+
+A ticket is **high risk** if it declares `"risk": "high"`, OR any of these
+derived signals fire from fields already on the ticket:
+
+- `external: true` — writes back to / creates / deletes in an external system
+- `mutatesIdentity: true` — mutates identity
+- `scope`/`rails` glob-matches `.adlc/manifest.jsonl` — mutates the gate-evidence ledger
+- `scope`/`rails` glob-matches `.adlc/tickets.json` or `.adlc/current-ticket.json` — touches the trust root
+- `category` is `contract` or `architecture`
+
+A declared `"risk": "normal"` can **never** downgrade a derived-high signal —
+that would be a silent, undetectable way to defeat the gate.
+
+## Context-fitness signal
+
+A proxy for "this session is deep," mirroring
+[`@adlc/flail-detector`](../flail-detector)'s existing transcript-size /
+tool-call-count scanning approach: a tool-call-count (`--depth`) and a
+transcript byte count (`--session-bytes`), each compared to a threshold.
+Either signal past its threshold means the session is **degraded**.
+
+## Audited override
+
+Set `ADLC_BUILD_GATE_BYPASS=1` to deliberately override a deny (mirrors the
+`ADLC_RAILS_BYPASS` pattern used by [`rails-guard`](../rails-guard)). The
+override is **only** honored if it can be durably recorded to
+`.adlc/manifest.jsonl` as a `build-gate-bypass` entry — an override that
+cannot be recorded is refused, never silently allowed.
+
+## Toolkit modules (Path A — reusable by any harness)
+
+- `lib/risk.mjs` — `computeRiskTier(ticket)` / `deriveRiskSignals(ticket)`
+- `lib/depth-signal.mjs` — `computeDepthSignal({ text, bytes })` / `isDegraded({...})`
+- `lib/decide.mjs` — `decideBuildGate({ riskTier, degraded, bypass, recordBypass })`
+- `lib/override.mjs` — `recordOverride({...})`
+- `lib/active-ticket.mjs` — `resolveActiveTicketId({ dir, env })`, the shared
+  `ADLC_TICKET` env var / `.adlc/current-ticket.json` convention already used
+  by every other harness integration (codex, opencode, cursor, antigravity)
+
+## Claude Code integration (Path B — self-enforcing)
+
+`plugins/adlc-claude-code/hooks/adlc-hook.mjs`'s `buildgate` PreToolUse mode
+supplies the in-session context signal (the same transcript-window staging
+the `flail` mode already does) and shells to
+`adlc build-gate <id> --depth <n> --session-bytes <n>` for the active
+high-risk ticket. See `docs/specs/build-gate-fitness.md`.

--- a/packages/build-gate/README.md
+++ b/packages/build-gate/README.md
@@ -95,9 +95,14 @@ cannot be recorded is refused, never silently allowed.
 
 `plugins/adlc-claude-code/hooks/adlc-hook.mjs`'s `buildgate` PreToolUse mode
 supplies the in-session context signal (the same transcript-window staging
-the `flail` mode already does) and shells to
-`adlc build-gate <id> --depth <n> --session-bytes <n>` for the active
-high-risk ticket. See `docs/specs/build-gate-fitness.md`, including its
-**Known limitations** section (unreadable-transcript fail-closed behavior,
-and the unprotected `.adlc/current-ticket.json` pointer as a Bash-reachable,
-CI-unbackstopped escape hatch).
+the `flail` mode already does) and computes the risk tier, context-fitness
+signal, and allow/deny decision **entirely locally** — verbatim ports of
+this package's `lib/risk.mjs` / `lib/depth-signal.mjs` / `lib/decide.mjs`
+logic, marked "KEEP IN SYNC" in the hook source. It does **not** shell out to
+`adlc build-gate` for the decision; `adlc` (via `gate-manifest`) is invoked
+only to durably record an audited override, mirroring how `rails` never
+needs `adlc` for its own core decision either. See
+`docs/specs/build-gate-fitness.md`, including its **Known limitations**
+section (unreadable-transcript fail-closed behavior, and the unprotected
+`.adlc/current-ticket.json` pointer as a Bash-reachable, CI-unbackstopped
+escape hatch).

--- a/packages/build-gate/bin/build-gate.mjs
+++ b/packages/build-gate/bin/build-gate.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// build-gate — ADLC C13 fitness-to-build gate (issue #48). Thin CLI: parse
+// args, call lib, exit with the correct code.
+//
+// Denies STARTING a high-risk ticket's P4 build when the executing session's
+// context-fitness signal is past threshold, unless an audited override is
+// recorded (mirrors the ADLC_RAILS_BYPASS pattern — see rails-guard/
+// adlc-hook.mjs). A CLI process can't observe its own caller's context state;
+// the caller (a hook, CI wrapper, or any Path-A harness) supplies the signal
+// via --depth/--session-bytes, or a --transcript file to derive it from.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { parseArgs, opError, printJson, loadTickets, ADLC_DIR } from '@adlc/core';
+import { computeRiskTier } from '../lib/risk.mjs';
+import { computeDepthSignal, isDegraded, DEFAULT_DEPTH_THRESHOLD, DEFAULT_BYTES_THRESHOLD } from '../lib/depth-signal.mjs';
+import { decideBuildGate } from '../lib/decide.mjs';
+import { recordOverride } from '../lib/override.mjs';
+
+const { values, positionals } = parseArgs({
+  options: {
+    depth: { type: 'string' },
+    'session-bytes': { type: 'string' },
+    transcript: { type: 'string' },
+    'depth-threshold': { type: 'string', default: String(DEFAULT_DEPTH_THRESHOLD) },
+    'bytes-threshold': { type: 'string', default: String(DEFAULT_BYTES_THRESHOLD) },
+    tickets: { type: 'string' },
+    reason: { type: 'string' },
+    json: { type: 'boolean', default: false },
+    help: { type: 'boolean', default: false },
+  },
+});
+
+if (values.help) {
+  console.log(`build-gate <ticket-id> [options]
+
+Machine-checkable fitness-to-build gate (ADLC C13 / P3→P4 entry gate).
+Denies STARTING a high-risk ticket's build when the executing session's
+context-fitness signal (transcript depth/bytes) is past threshold, unless an
+audited override is recorded.
+
+Arguments:
+  <ticket-id>              Ticket to gate (required)
+
+Options:
+  --depth <n>              Precomputed tool-call-count depth signal
+  --session-bytes <n>      Precomputed transcript byte-size signal
+  --transcript <path>      Derive depth/session-bytes from this transcript file
+                           (a --depth/--session-bytes passed alongside it wins)
+  --depth-threshold <n>    default ${DEFAULT_DEPTH_THRESHOLD}
+  --bytes-threshold <n>    default ${DEFAULT_BYTES_THRESHOLD}
+  --tickets <path>         default .adlc/tickets.json
+  --reason <text>          Free-text reason recorded with an override
+  --json                   Machine-readable JSON output
+  --help                   Show this help
+
+Neither --depth/--session-bytes nor --transcript supplied → the signal
+defaults to "not degraded" (a gate that received no signal cannot deny).
+
+Override:
+  Set ADLC_BUILD_GATE_BYPASS=1 to deliberately override a deny. The override
+  is recorded to .adlc/manifest.jsonl as a 'build-gate-bypass' entry — an
+  override that cannot be durably recorded is refused (never a silent bypass).
+
+Exit codes:
+  0  allow (gate passes)
+  1  operational error (bad ticket id, missing tickets file, bad thresholds)
+  2  deny (gate fails)
+
+ADLC phase: P3 → P4 entry gate (C13)
+`);
+  process.exit(0);
+}
+
+const ticketId = positionals[0];
+if (!ticketId) {
+  opError('usage: build-gate <ticket-id> [options] (use --help for details)');
+}
+
+const ticketsPath = values.tickets ?? `${ADLC_DIR}/tickets.json`;
+const { tickets, errors } = loadTickets(ticketsPath);
+if (errors.length > 0 && tickets.length === 0) {
+  opError(`could not load tickets from ${ticketsPath}: ${errors[0]}`);
+}
+const ticket = tickets.find((t) => t.id === ticketId);
+if (!ticket) {
+  opError(`ticket "${ticketId}" not found in ${ticketsPath}`);
+}
+
+const depthThreshold = parseInt(values['depth-threshold'], 10);
+if (!Number.isInteger(depthThreshold) || depthThreshold < 0) {
+  opError('--depth-threshold must be a non-negative integer');
+}
+const bytesThreshold = parseInt(values['bytes-threshold'], 10);
+if (!Number.isInteger(bytesThreshold) || bytesThreshold < 0) {
+  opError('--bytes-threshold must be a non-negative integer');
+}
+if (values.depth !== undefined && !/^\d+$/.test(values.depth)) {
+  opError('--depth must be a non-negative integer');
+}
+if (values['session-bytes'] !== undefined && !/^\d+$/.test(values['session-bytes'])) {
+  opError('--session-bytes must be a non-negative integer');
+}
+
+let depth = 0;
+let sessionBytes = 0;
+if (values.transcript !== undefined) {
+  if (!existsSync(values.transcript)) {
+    opError(`transcript file not found: ${values.transcript}`);
+  }
+  let text;
+  try {
+    text = readFileSync(values.transcript, 'utf8');
+  } catch (err) {
+    opError(`could not read transcript: ${err.message}`);
+  }
+  const sig = computeDepthSignal({ text });
+  depth = sig.depth;
+  sessionBytes = sig.bytes;
+}
+if (values.depth !== undefined) depth = parseInt(values.depth, 10);
+if (values['session-bytes'] !== undefined) sessionBytes = parseInt(values['session-bytes'], 10);
+
+const { tier, signals } = computeRiskTier(ticket);
+const degraded = isDegraded({ depth, sessionBytes, depthThreshold, bytesThreshold });
+const bypass = process.env.ADLC_BUILD_GATE_BYPASS === '1';
+
+const result = decideBuildGate({
+  riskTier: tier,
+  degraded,
+  bypass,
+  recordBypass: () =>
+    recordOverride({
+      ticketId: ticket.id,
+      signals,
+      depth,
+      sessionBytes,
+      reason: values.reason ?? 'ADLC_BUILD_GATE_BYPASS=1',
+    }),
+});
+
+const output = {
+  tool: 'build-gate',
+  ticket: ticket.id,
+  riskTier: tier,
+  signals,
+  depth,
+  sessionBytes,
+  depthThreshold,
+  bytesThreshold,
+  degraded,
+  decision: result.decision,
+  reason: result.reason,
+  overridden: result.overridden === true,
+};
+
+if (values.json) {
+  printJson(output);
+} else if (result.decision === 'deny') {
+  console.error(`build-gate: DENY (${ticket.id}, risk=${tier}) — ${result.reason}`);
+} else {
+  console.log(`build-gate: allow (${ticket.id}, risk=${tier}) — ${result.reason}`);
+}
+
+process.exit(result.decision === 'deny' ? 2 : 0);

--- a/packages/build-gate/lib/active-ticket.mjs
+++ b/packages/build-gate/lib/active-ticket.mjs
@@ -1,0 +1,50 @@
+// active-ticket.mjs — resolve which ticket is "in flight" for the current
+// build (issue #48, tie-in). Reuses the SAME env var / pointer-file
+// convention every other ADLC harness integration already implements:
+//   - plugins/adlc-codex/hooks/adlc-rails-guard.mjs resolveActiveTicketId()
+//   - plugins/adlc-antigravity/rails-checker.mjs resolveActiveTicketId()
+//   - plugins/adlc-opencode/rails-checker.mjs (same contract)
+// The active ticket is process.env.ADLC_TICKET OR .adlc/current-ticket.json.
+// If both are set and disagree, that is a TAMPER SIGNAL, not an ambiguity to
+// silently resolve — callers must fail closed (conflict: true).
+//
+// This module is the reusable Path-A form of that logic (importable by any
+// harness/CI wrapper with normal npm resolution). Claude Code's own
+// PreToolUse hook cannot resolve @adlc/* packages at runtime (it only shells
+// out to the globally-installed `adlc` binary — see adlc-hook.mjs's
+// globMatch comment), so plugins/adlc-claude-code/hooks/adlc-hook.mjs ports
+// an equivalent copy of resolveActiveTicketId() verbatim, marked "KEEP IN
+// SYNC with @adlc/build-gate".
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.dir] - project root to look for .adlc/current-ticket.json in (default '.')
+ * @param {NodeJS.ProcessEnv} [opts.env] - env to read ADLC_TICKET from (default process.env)
+ * @returns {{ id: string|null, conflict: boolean }}
+ */
+export function resolveActiveTicketId({ dir = '.', env = process.env } = {}) {
+  const envTicket = (env.ADLC_TICKET ?? '').trim() || null;
+  let fileTicket = null;
+
+  const currentPath = join(dir, '.adlc', 'current-ticket.json');
+  if (existsSync(currentPath)) {
+    try {
+      const data = JSON.parse(readFileSync(currentPath, 'utf8'));
+      const raw = typeof data === 'string' ? data : (data?.id ?? data?.ticket);
+      fileTicket = (raw ?? '').toString().trim() || null;
+    } catch {
+      // An unparseable pointer file is itself a tamper signal — fail closed
+      // rather than silently treating it as "no active ticket".
+      return { id: null, conflict: true };
+    }
+  }
+
+  if (envTicket && fileTicket && envTicket !== fileTicket) {
+    return { id: null, conflict: true };
+  }
+
+  return { id: envTicket ?? fileTicket, conflict: false };
+}

--- a/packages/build-gate/lib/decide.mjs
+++ b/packages/build-gate/lib/decide.mjs
@@ -1,0 +1,57 @@
+// decide.mjs — the build-gate deny/allow decision (issue #48, item 3).
+//
+// Pure decision function. Deliberately takes already-computed inputs (risk
+// tier, a boolean "degraded" context-fitness verdict, and a bypass flag) so
+// it has zero I/O and is trivially unit-testable; the CLI/hook wire up the
+// real risk derivation, depth signal, and override recording around it.
+//
+// Contract (mirrors the ADLC_RAILS_BYPASS pattern in
+// plugins/adlc-claude-code/hooks/adlc-hook.mjs's rails() / recordBypass()):
+//   - normal risk           → always allow, no matter how deep the session is.
+//   - high risk, NOT deep   → allow (nothing to guard against yet).
+//   - high risk, deep       → deny UNLESS an override is requested AND that
+//                             override can be DURABLY RECORDED. An override
+//                             that cannot be audited is refused, never
+//                             silently honored — a silent bypass here would
+//                             defeat the entire point of the gate.
+
+/**
+ * @param {object} opts
+ * @param {'high'|'normal'} opts.riskTier
+ * @param {boolean} opts.degraded - the context-fitness verdict (depth/bytes past threshold)
+ * @param {boolean} opts.bypass - was an override requested (e.g. ADLC_BUILD_GATE_BYPASS=1)?
+ * @param {() => boolean} [opts.recordBypass] - side effect that durably records the
+ *   override; must return true only on a confirmed successful write. Called ONLY
+ *   when the override is actually needed (high risk AND degraded AND bypass).
+ * @returns {{ decision: 'allow'|'deny', reason: string, overridden?: boolean }}
+ */
+export function decideBuildGate({ riskTier, degraded, bypass, recordBypass } = {}) {
+  if (riskTier !== 'high') {
+    return { decision: 'allow', reason: `ticket risk tier is '${riskTier ?? 'normal'}' — gate only guards high-risk tickets` };
+  }
+
+  if (!degraded) {
+    return { decision: 'allow', reason: 'high-risk ticket, but the context-fitness signal is not degraded (below threshold)' };
+  }
+
+  // High risk AND degraded — the one state the gate exists to catch.
+  if (bypass) {
+    const recorded = typeof recordBypass === 'function' && recordBypass() === true;
+    if (recorded) {
+      return { decision: 'allow', reason: 'high-risk build in a degraded session, but an audited override was recorded', overridden: true };
+    }
+    return {
+      decision: 'deny',
+      reason:
+        'override requested but could not be durably recorded to the gate-manifest — ' +
+        'an unaudited bypass is refused',
+    };
+  }
+
+  return {
+    decision: 'deny',
+    reason:
+      'high-risk ticket build denied: the context-fitness signal is past threshold in this session. ' +
+      'Resume in a fresh session (or an isolated subagent) rather than continuing here.',
+  };
+}

--- a/packages/build-gate/lib/depth-signal.mjs
+++ b/packages/build-gate/lib/depth-signal.mjs
@@ -1,0 +1,86 @@
+// depth-signal.mjs — the context-fitness proxy (issue #48, item 2).
+//
+// A machine-checkable proxy for "this session is deep" (context rot). Mirrors
+// packages/flail-detector's existing scanning approach: a byte-capped window
+// of the transcript, and a simple occurrence count over it (see
+// flail-detector/lib/signals.mjs detectSizeExceeded / detectEditChurn — same
+// shape: count occurrences of a pattern, compare to a threshold). This module
+// is the shared basis for the --depth/--session-bytes CLI inputs described in
+// the issue: a caller (the CC hook, a CI wrapper, any Path-A harness) reads a
+// bounded window of its own transcript and calls computeDepthSignal() on the
+// raw text, then isDegraded() against a threshold.
+//
+// Deliberately NO filesystem I/O here — staging a bounded window (so this
+// stays cheap on an arbitrarily long transcript) is the caller's job, exactly
+// as it already is in plugins/adlc-claude-code/hooks/adlc-hook.mjs's flail()
+// mode (tailBytes/fileSize). Keeping I/O out of this module makes it trivially
+// unit-testable and reusable by any Path-A harness with its own I/O primitives.
+
+/** Tool-call count past which a session is considered context-degraded. */
+export const DEFAULT_DEPTH_THRESHOLD = 40;
+
+/** Transcript byte count past which a session is considered context-degraded
+ * (mirrors the 256 KiB MAX_SCAN_BYTES window flail-detector's CC hook already
+ * scans, per issue #48's "reuse flail-detector's existing ... approach"). */
+export const DEFAULT_BYTES_THRESHOLD = 256 * 1024;
+
+/**
+ * Count tool-invocation occurrences in transcript text. Two shapes are
+ * recognized (same two the flail-detector precedent — parse-log.mjs's
+ * extractFileTargets / signals.mjs's tool-log line patterns — already know
+ * about): a JSONL `"type":"tool_use"` block (the real Claude Code transcript
+ * shape), and legacy prose "Writing <path>" / "Editing <path>" / "Created
+ * <path>" tool-log lines. A plain occurrence count, not deduped — a tool
+ * called 5 times counts 5, which is exactly the "session is deep" signal we
+ * want (mirrors detectEditChurn's un-deduped per-path counting).
+ *
+ * @param {string} text
+ * @returns {number}
+ */
+export function countToolCalls(text) {
+  if (!text) return 0;
+  const toolUseBlocks = text.match(/"type"\s*:\s*"tool_use"/g) ?? [];
+  const proseToolLines = text.match(/^(?:Writing|Editing|Created)\s+\S+/gim) ?? [];
+  return toolUseBlocks.length + proseToolLines.length;
+}
+
+/**
+ * Compute the raw depth signal from a chunk of transcript text.
+ *
+ * @param {object} opts
+ * @param {string} opts.text - raw transcript text (a bounded window; caller's job to cap it)
+ * @param {number} [opts.bytes] - explicit byte count override (e.g. the ORIGINAL
+ *   file's full size, when `text` is only a tail window of it — the byte
+ *   signal should reflect the whole session, not just the scanned window)
+ * @returns {{ bytes: number, toolCallCount: number, depth: number }}
+ *   `depth` is the tool-call-count proxy (the --depth CLI input); `bytes` is
+ *   the --session-bytes CLI input.
+ */
+export function computeDepthSignal({ text, bytes } = {}) {
+  const toolCallCount = countToolCalls(text ?? '');
+  const resolvedBytes = typeof bytes === 'number' ? bytes : Buffer.byteLength(text ?? '', 'utf8');
+  return { bytes: resolvedBytes, toolCallCount, depth: toolCallCount };
+}
+
+/**
+ * Is the session context-degraded? True when EITHER signal is strictly past
+ * its threshold (mirrors flail-detector's detectSizeExceeded: `bytes >
+ * maxBytes`, not `>=` — exactly at the threshold is not yet degraded).
+ *
+ * @param {object} opts
+ * @param {number} opts.depth
+ * @param {number} opts.sessionBytes
+ * @param {number} [opts.depthThreshold]
+ * @param {number} [opts.bytesThreshold]
+ * @returns {boolean}
+ */
+export function isDegraded({
+  depth,
+  sessionBytes,
+  depthThreshold = DEFAULT_DEPTH_THRESHOLD,
+  bytesThreshold = DEFAULT_BYTES_THRESHOLD,
+}) {
+  const depthDegraded = typeof depth === 'number' && depth > depthThreshold;
+  const bytesDegraded = typeof sessionBytes === 'number' && sessionBytes > bytesThreshold;
+  return depthDegraded || bytesDegraded;
+}

--- a/packages/build-gate/lib/override.mjs
+++ b/packages/build-gate/lib/override.mjs
@@ -3,15 +3,28 @@
 // Mirrors the ADLC_RAILS_BYPASS pattern in
 // plugins/adlc-claude-code/hooks/adlc-hook.mjs's recordBypass(): a bypass is
 // only ever honored if it is durably recorded to the gate-manifest ledger
-// FIRST. Uses @adlc/core's appendEntry directly (the same primitive
-// packages/rails-guard/bin/rails-guard.mjs uses for its own --record path) —
-// not the @adlc/gate-manifest package, matching the existing sibling-package
-// convention of depending only on @adlc/core, never on another sibling tool.
+// FIRST.
+//
+// This calls @adlc/gate-manifest's own record() directly (the exact function
+// backing `adlc gate-manifest record build-gate-bypass`, per
+// docs/specs/build-gate-fitness.md) rather than @adlc/core's raw appendEntry.
+// The gate-manifest ledger format is hash-chained: every entry needs a
+// monotonically increasing `seq` and a `prev` = sha256(previous raw JSONL
+// line) (see packages/gate-manifest/lib/record.mjs / verify.mjs). Building a
+// raw entry by hand here — without those fields, and without the `gate` key
+// verify() expects — corrupts that chain for every entry appended
+// afterward, so this package deliberately depends on @adlc/gate-manifest
+// (unlike sibling tools with no ledger-writing responsibilities) instead of
+// re-deriving its chain/signing logic.
 
-import { appendEntry, ADLC_DIR } from '@adlc/core';
+import { record } from '@adlc/gate-manifest/lib/record.mjs';
+import { ADLC_DIR } from '@adlc/core';
 
 /**
- * Durably record a build-gate override to .adlc/manifest.jsonl.
+ * Durably record a build-gate override to .adlc/manifest.jsonl as a
+ * 'build-gate-bypass' gate-manifest entry (chain-linked and, when
+ * ADLC_MANIFEST_KEY is set, HMAC-signed — exactly like every other entry in
+ * the ledger).
  *
  * @param {object} opts
  * @param {string} opts.ticketId
@@ -24,19 +37,17 @@ import { appendEntry, ADLC_DIR } from '@adlc/core';
  */
 export function recordOverride({ ticketId, signals, depth, sessionBytes, reason, dir = ADLC_DIR }) {
   try {
-    appendEntry(
-      'manifest',
-      {
-        ts: new Date().toISOString(),
-        type: 'build-gate-bypass',
-        ticket: ticketId ?? null,
+    record({
+      gate: 'build-gate-bypass',
+      ticket: ticketId ?? undefined,
+      rawData: JSON.stringify({
         signals: signals ?? [],
         depth: depth ?? null,
         sessionBytes: sessionBytes ?? null,
         reason: reason ?? null,
-      },
-      dir
-    );
+      }),
+      dir,
+    });
     return true;
   } catch {
     // An override that cannot be durably recorded is not a valid override —

--- a/packages/build-gate/lib/override.mjs
+++ b/packages/build-gate/lib/override.mjs
@@ -1,0 +1,46 @@
+// override.mjs — audited-override recording (issue #48, item 3).
+//
+// Mirrors the ADLC_RAILS_BYPASS pattern in
+// plugins/adlc-claude-code/hooks/adlc-hook.mjs's recordBypass(): a bypass is
+// only ever honored if it is durably recorded to the gate-manifest ledger
+// FIRST. Uses @adlc/core's appendEntry directly (the same primitive
+// packages/rails-guard/bin/rails-guard.mjs uses for its own --record path) —
+// not the @adlc/gate-manifest package, matching the existing sibling-package
+// convention of depending only on @adlc/core, never on another sibling tool.
+
+import { appendEntry, ADLC_DIR } from '@adlc/core';
+
+/**
+ * Durably record a build-gate override to .adlc/manifest.jsonl.
+ *
+ * @param {object} opts
+ * @param {string} opts.ticketId
+ * @param {string[]} opts.signals - the risk signals that made this ticket high-risk
+ * @param {number} opts.depth - the tool-call-count depth signal at override time
+ * @param {number} opts.sessionBytes - the transcript-byte signal at override time
+ * @param {string} [opts.reason] - free-text reason supplied by the caller
+ * @param {string} [opts.dir] - ledger directory (default ADLC_DIR, '.adlc')
+ * @returns {boolean} true ONLY if the entry was durably appended; never throws.
+ */
+export function recordOverride({ ticketId, signals, depth, sessionBytes, reason, dir = ADLC_DIR }) {
+  try {
+    appendEntry(
+      'manifest',
+      {
+        ts: new Date().toISOString(),
+        type: 'build-gate-bypass',
+        ticket: ticketId ?? null,
+        signals: signals ?? [],
+        depth: depth ?? null,
+        sessionBytes: sessionBytes ?? null,
+        reason: reason ?? null,
+      },
+      dir
+    );
+    return true;
+  } catch {
+    // An override that cannot be durably recorded is not a valid override —
+    // the caller (decide.mjs via the CLI/hook) must treat this as "refused".
+    return false;
+  }
+}

--- a/packages/build-gate/lib/risk.mjs
+++ b/packages/build-gate/lib/risk.mjs
@@ -62,7 +62,18 @@ export function deriveRiskSignals(ticket) {
   // Mutates identity (e.g. reassigning a ticket's own id/edges store-wide).
   if (t.mutatesIdentity === true) signals.push('mutates-identity');
 
-  const combinedGlobs = [...(t.scope ?? []), ...(t.rails ?? [])];
+  // A malformed (present but non-array) scope/rails field is ambiguous ticket
+  // data, not proof of safety — per the fail-closed design at the top of this
+  // file, ambiguity must fire a signal rather than be silently ignored or
+  // allowed to crash the caller. Array.isArray guards the spread below; the
+  // signal push ensures the malformed field still drives the tier to 'high'.
+  if (t.scope !== undefined && !Array.isArray(t.scope)) signals.push('malformed-scope');
+  if (t.rails !== undefined && !Array.isArray(t.rails)) signals.push('malformed-rails');
+
+  const combinedGlobs = [
+    ...(Array.isArray(t.scope) ? t.scope : []),
+    ...(Array.isArray(t.rails) ? t.rails : []),
+  ];
 
   if (touchesAny(combinedGlobs, [MANIFEST_PATH])) signals.push('mutates-manifest');
   if (touchesAny(combinedGlobs, TRUST_ROOT_PATHS)) signals.push('touches-trust-root');

--- a/packages/build-gate/lib/risk.mjs
+++ b/packages/build-gate/lib/risk.mjs
@@ -1,0 +1,84 @@
+// risk.mjs — risk-tier derivation per ticket (issue #48, item 1).
+//
+// A ticket's risk tier is 'high' when EITHER it declares `risk: 'high'` OR any
+// derived signal fires from fields already on the ticket. This is deliberately
+// OR, not a priority override: a declared `risk: 'normal'` can never suppress a
+// derived-high signal. Letting a normal declaration downgrade a real signal
+// would be a silent, undetectable way to defeat the entire gate — exactly the
+// failure mode this ticket exists to close (see build-gate-fitness.md).
+//
+// Pure, dependency-light (only @adlc/core's globMatch), and reusable by any
+// harness (Path A) as well as the Claude Code hook (Path B).
+
+import { globMatch } from '@adlc/core/tickets';
+
+/**
+ * Paths that constitute the ADLC "trust root": the ticket store itself, the
+ * active-ticket pointer used across every harness integration (see
+ * plugins/adlc-codex/hooks/adlc-rails-guard.mjs, plugins/adlc-antigravity/
+ * rails-checker.mjs, et al.), and the gate-evidence ledger. A ticket whose
+ * declared scope/rails touch any of these is high risk by definition — it can
+ * rewrite the record of what gates have verified.
+ */
+export const TRUST_ROOT_PATHS = ['.adlc/tickets.json', '.adlc/current-ticket.json'];
+
+/** The manifest ledger is checked separately so its signal name is specific. */
+export const MANIFEST_PATH = '.adlc/manifest.jsonl';
+
+/**
+ * Ticket categories that model-router already treats as requiring frontier
+ * models (see packages/model-router/lib/assign.mjs FRONTIER_CATEGORIES). Of
+ * those, 'contract' and 'architecture' are inherently high blast-radius —
+ * 'spec' is deliberately excluded here (a spec ticket does not itself mutate
+ * the trust root or an external system).
+ */
+export const HIGH_RISK_CATEGORIES = new Set(['contract', 'architecture']);
+
+/** True if any glob in `globs` matches (or literally equals) any of `paths`. */
+function touchesAny(globs, paths) {
+  return (globs ?? []).some((g) => paths.some((p) => g === p || globMatch(g, p)));
+}
+
+/**
+ * Derive the list of high-risk signal names that fire for a ticket. Returns
+ * [] for a ticket with no risk markers at all (empty ticket, or a plain
+ * feature ticket with no scope overlap).
+ *
+ * @param {object} ticket
+ * @returns {string[]} signal names, e.g. ['declared-risk-high', 'mutates-manifest']
+ */
+export function deriveRiskSignals(ticket) {
+  const t = ticket ?? {};
+  const signals = [];
+
+  if (t.risk === 'high') signals.push('declared-risk-high');
+
+  // Writes back to / creates / deletes in an external system (e.g. an issue
+  // tracker create+id-reassignment, per the T9/ticket-sync motivating example
+  // in issue #48). Declared explicitly — there is no way to derive this from
+  // scope globs alone.
+  if (t.external === true) signals.push('external-system-effect');
+
+  // Mutates identity (e.g. reassigning a ticket's own id/edges store-wide).
+  if (t.mutatesIdentity === true) signals.push('mutates-identity');
+
+  const combinedGlobs = [...(t.scope ?? []), ...(t.rails ?? [])];
+
+  if (touchesAny(combinedGlobs, [MANIFEST_PATH])) signals.push('mutates-manifest');
+  if (touchesAny(combinedGlobs, TRUST_ROOT_PATHS)) signals.push('touches-trust-root');
+
+  if (HIGH_RISK_CATEGORIES.has(t.category)) signals.push(`high-risk-category:${t.category}`);
+
+  return signals;
+}
+
+/**
+ * Compute the risk tier for a ticket.
+ *
+ * @param {object} ticket
+ * @returns {{ tier: 'high'|'normal', signals: string[] }}
+ */
+export function computeRiskTier(ticket) {
+  const signals = deriveRiskSignals(ticket);
+  return { tier: signals.length > 0 ? 'high' : 'normal', signals };
+}

--- a/packages/build-gate/package.json
+++ b/packages/build-gate/package.json
@@ -31,7 +31,8 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@adlc/core": "1.1.0"
+    "@adlc/core": "1.1.0",
+    "@adlc/gate-manifest": "1.1.0"
   },
   "scripts": {
     "test": "node --test test/*.test.mjs"

--- a/packages/build-gate/package.json
+++ b/packages/build-gate/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@adlc/build-gate",
+  "version": "1.1.0",
+  "description": "Machine-checkable fitness-to-build gate — denies starting a high-risk P4 build in a degraded (context-rot) session unless an audited override is recorded (C13).",
+  "type": "module",
+  "license": "MIT",
+  "author": "Chris Williams (@voodootikigod)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voodootikigod/adlc.git",
+    "directory": "packages/build-gate"
+  },
+  "homepage": "https://github.com/voodootikigod/adlc/tree/main/packages/build-gate#readme",
+  "bugs": "https://github.com/voodootikigod/adlc/issues",
+  "keywords": [
+    "adlc",
+    "agentic",
+    "ai",
+    "llm",
+    "cli",
+    "build-gate",
+    "gate"
+  ],
+  "bin": {
+    "build-gate": "./bin/build-gate.mjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md",
+    "LICENSE"
+  ],
+  "dependencies": {
+    "@adlc/core": "1.1.0"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
+}

--- a/packages/build-gate/test/active-ticket.test.mjs
+++ b/packages/build-gate/test/active-ticket.test.mjs
@@ -1,0 +1,89 @@
+// test/active-ticket.test.mjs — resolve which ticket is "in flight" for the
+// current build. Reuses the SAME convention every other ADLC harness
+// integration already implements (plugins/adlc-codex/hooks/
+// adlc-rails-guard.mjs resolveActiveTicketId(), plugins/adlc-antigravity/
+// rails-checker.mjs resolveActiveTicketId()): ADLC_TICKET env var OR
+// .adlc/current-ticket.json; a conflict between the two is a tamper signal.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveActiveTicketId } from '../lib/active-ticket.mjs';
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-active-ticket-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('no env var, no pointer file → id null, no conflict', () => {
+  withTempDir((dir) => {
+    const r = resolveActiveTicketId({ dir, env: {} });
+    assert.deepEqual(r, { id: null, conflict: false });
+  });
+});
+
+test('ADLC_TICKET env var alone resolves the id', () => {
+  withTempDir((dir) => {
+    const r = resolveActiveTicketId({ dir, env: { ADLC_TICKET: 'T9' } });
+    assert.deepEqual(r, { id: 'T9', conflict: false });
+  });
+});
+
+test('.adlc/current-ticket.json alone resolves the id ({ id })', () => {
+  withTempDir((dir) => {
+    mkdirSync(join(dir, '.adlc'));
+    writeFileSync(join(dir, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T3' }));
+    const r = resolveActiveTicketId({ dir, env: {} });
+    assert.deepEqual(r, { id: 'T3', conflict: false });
+  });
+});
+
+test('.adlc/current-ticket.json with { ticket } shape also resolves', () => {
+  withTempDir((dir) => {
+    mkdirSync(join(dir, '.adlc'));
+    writeFileSync(join(dir, '.adlc', 'current-ticket.json'), JSON.stringify({ ticket: 'T4' }));
+    const r = resolveActiveTicketId({ dir, env: {} });
+    assert.deepEqual(r, { id: 'T4', conflict: false });
+  });
+});
+
+test('env var and pointer file AGREE → resolves cleanly', () => {
+  withTempDir((dir) => {
+    mkdirSync(join(dir, '.adlc'));
+    writeFileSync(join(dir, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T9' }));
+    const r = resolveActiveTicketId({ dir, env: { ADLC_TICKET: 'T9' } });
+    assert.deepEqual(r, { id: 'T9', conflict: false });
+  });
+});
+
+test('env var and pointer file DISAGREE → conflict, fail closed (id null)', () => {
+  withTempDir((dir) => {
+    mkdirSync(join(dir, '.adlc'));
+    writeFileSync(join(dir, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T2' }));
+    const r = resolveActiveTicketId({ dir, env: { ADLC_TICKET: 'T9' } });
+    assert.equal(r.conflict, true);
+    assert.equal(r.id, null);
+  });
+});
+
+test('unparseable pointer file → conflict (a tamper signal, not "no ticket")', () => {
+  withTempDir((dir) => {
+    mkdirSync(join(dir, '.adlc'));
+    writeFileSync(join(dir, '.adlc', 'current-ticket.json'), 'not json');
+    const r = resolveActiveTicketId({ dir, env: {} });
+    assert.equal(r.conflict, true);
+  });
+});
+
+test('empty ADLC_TICKET string is treated as unset', () => {
+  withTempDir((dir) => {
+    const r = resolveActiveTicketId({ dir, env: { ADLC_TICKET: '   ' } });
+    assert.deepEqual(r, { id: null, conflict: false });
+  });
+});

--- a/packages/build-gate/test/cli.test.mjs
+++ b/packages/build-gate/test/cli.test.mjs
@@ -66,6 +66,31 @@ test('normal-risk ticket, deep session → allow, exit 0', () => {
   });
 });
 
+// ---- fail closed on a malformed (non-array) scope/rails field, instead of
+// crashing with an uncaught TypeError (issue #48 review round 3 finding) ----
+
+test('non-array scope field → fails closed to high risk (deny once deep), not a crash', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', scope: 42 }], (dir) => {
+    const r = run(['T1', '--depth', '999', '--json'], { cwd: dir });
+    assert.equal(r.code, 2);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'deny');
+    assert.equal(out.riskTier, 'high');
+    assert.ok(out.signals.includes('malformed-scope'));
+  });
+});
+
+test('non-array rails field (object) → fails closed to high risk, not a crash', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', rails: { foo: 'bar' } }], (dir) => {
+    const r = run(['T1', '--depth', '999', '--json'], { cwd: dir });
+    assert.equal(r.code, 2);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'deny');
+    assert.equal(out.riskTier, 'high');
+    assert.ok(out.signals.includes('malformed-rails'));
+  });
+});
+
 test('high-risk ticket (contract), shallow session → allow, exit 0', () => {
   withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
     const r = run(['T1', '--depth', '1', '--json'], { cwd: dir });

--- a/packages/build-gate/test/cli.test.mjs
+++ b/packages/build-gate/test/cli.test.mjs
@@ -129,8 +129,11 @@ test('ADLC_BUILD_GATE_BYPASS=1 with a writable .adlc → allow + audited manifes
     const manifestPath = join(dir, '.adlc', 'manifest.jsonl');
     assert.ok(existsSync(manifestPath));
     const entry = JSON.parse(readFileSync(manifestPath, 'utf8').trim().split('\n').pop());
-    assert.equal(entry.type, 'build-gate-bypass');
+    assert.equal(entry.gate, 'build-gate-bypass');
     assert.equal(entry.ticket, 'T1');
+    // Chain-linkage fields required by gate-manifest's verify() (issue #48 review finding).
+    assert.equal(entry.seq, 1);
+    assert.equal(entry.prev, null);
   });
 });
 

--- a/packages/build-gate/test/cli.test.mjs
+++ b/packages/build-gate/test/cli.test.mjs
@@ -1,0 +1,142 @@
+// test/cli.test.mjs — end-to-end exercise of the build-gate CLI: exit codes,
+// --json output, and the audited-override recording path via the real
+// manifest ledger.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'build-gate.mjs');
+
+function run(args, { cwd, env = {} } = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN, ...args], {
+      cwd,
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    });
+    return { code: 0, stdout };
+  } catch (e) {
+    return { code: e.status, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+function withTicketRepo(tickets, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-build-gate-cli-'));
+  try {
+    mkdirSync(join(dir, '.adlc'));
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets }));
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('--help exits 0 and prints usage', () => {
+  const r = run(['--help']);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /build-gate/);
+});
+
+test('missing ticket id → operational error, exit 1', () => {
+  withTicketRepo([{ id: 'T1', title: 'x' }], (dir) => {
+    const r = run([], { cwd: dir });
+    assert.equal(r.code, 1);
+  });
+});
+
+test('unknown ticket id → operational error, exit 1', () => {
+  withTicketRepo([{ id: 'T1', title: 'x' }], (dir) => {
+    const r = run(['T404'], { cwd: dir });
+    assert.equal(r.code, 1);
+  });
+});
+
+test('normal-risk ticket, deep session → allow, exit 0', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'feature' }], (dir) => {
+    const r = run(['T1', '--depth', '999', '--json'], { cwd: dir });
+    assert.equal(r.code, 0);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'allow');
+    assert.equal(out.riskTier, 'normal');
+  });
+});
+
+test('high-risk ticket (contract), shallow session → allow, exit 0', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const r = run(['T1', '--depth', '1', '--json'], { cwd: dir });
+    assert.equal(r.code, 0);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'allow');
+    assert.equal(out.riskTier, 'high');
+  });
+});
+
+test('high-risk ticket (contract), deep session, no bypass → DENY, exit 2', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const r = run(['T1', '--depth', '999', '--json'], { cwd: dir });
+    assert.equal(r.code, 2);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.decision, 'deny');
+  });
+});
+
+test('--depth past --depth-threshold triggers deny; below a raised threshold allows', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const deny = run(['T1', '--depth', '50', '--json'], { cwd: dir });
+    assert.equal(deny.code, 2);
+    const allow = run(['T1', '--depth', '50', '--depth-threshold', '100', '--json'], { cwd: dir });
+    assert.equal(allow.code, 0);
+  });
+});
+
+test('--session-bytes past --bytes-threshold triggers deny', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const r = run(['T1', '--session-bytes', '500000', '--bytes-threshold', '100', '--json'], { cwd: dir });
+    assert.equal(r.code, 2);
+  });
+});
+
+test('no --depth/--session-bytes supplied at all → defaults to not-degraded (allow)', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const r = run(['T1', '--json'], { cwd: dir });
+    assert.equal(r.code, 0);
+  });
+});
+
+test('--transcript derives depth from tool_use occurrences in the file', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const transcript = join(dir, 'session.jsonl');
+    const line = JSON.stringify({ type: 'tool_use' });
+    writeFileSync(transcript, Array.from({ length: 100 }, () => line).join('\n'));
+    const r = run(['T1', '--transcript', transcript, '--json'], { cwd: dir });
+    assert.equal(r.code, 2);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.depth, 100);
+  });
+});
+
+test('ADLC_BUILD_GATE_BYPASS=1 with a writable .adlc → allow + audited manifest entry', () => {
+  withTicketRepo([{ id: 'T1', title: 'x', category: 'contract' }], (dir) => {
+    const r = run(['T1', '--depth', '999', '--json'], { cwd: dir, env: { ADLC_BUILD_GATE_BYPASS: '1' } });
+    assert.equal(r.code, 0);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.overridden, true);
+    const manifestPath = join(dir, '.adlc', 'manifest.jsonl');
+    assert.ok(existsSync(manifestPath));
+    const entry = JSON.parse(readFileSync(manifestPath, 'utf8').trim().split('\n').pop());
+    assert.equal(entry.type, 'build-gate-bypass');
+    assert.equal(entry.ticket, 'T1');
+  });
+});
+
+test('bad --depth-threshold value → operational error, exit 1', () => {
+  withTicketRepo([{ id: 'T1', title: 'x' }], (dir) => {
+    const r = run(['T1', '--depth-threshold', 'nope'], { cwd: dir });
+    assert.equal(r.code, 1);
+  });
+});

--- a/packages/build-gate/test/decide.test.mjs
+++ b/packages/build-gate/test/decide.test.mjs
@@ -1,0 +1,88 @@
+// test/decide.test.mjs — build-gate deny/allow decision given a mocked depth
+// signal (issue #48, item 3). Pure decision function: no filesystem, no
+// process I/O — the override side effect is injected so both the "recorded"
+// and "recording failed" (unaudited bypass refused) paths are exercised.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { decideBuildGate } from '../lib/decide.mjs';
+
+test('normal-risk ticket → allow, regardless of degraded signal', () => {
+  const r = decideBuildGate({ riskTier: 'normal', degraded: true, bypass: false });
+  assert.equal(r.decision, 'allow');
+  assert.match(r.reason, /normal/);
+});
+
+test('high-risk ticket, NOT degraded → allow', () => {
+  const r = decideBuildGate({ riskTier: 'high', degraded: false, bypass: false });
+  assert.equal(r.decision, 'allow');
+  assert.match(r.reason, /below threshold|not degraded/i);
+});
+
+test('high-risk ticket, degraded, no bypass → DENY (exit 2 territory)', () => {
+  const r = decideBuildGate({ riskTier: 'high', degraded: true, bypass: false });
+  assert.equal(r.decision, 'deny');
+  assert.match(r.reason, /high-risk/i);
+});
+
+test('high-risk ticket, degraded, bypass requested AND recorded → allow, overridden:true', () => {
+  let recordCalled = false;
+  const r = decideBuildGate({
+    riskTier: 'high',
+    degraded: true,
+    bypass: true,
+    recordBypass: () => {
+      recordCalled = true;
+      return true;
+    },
+  });
+  assert.equal(r.decision, 'allow');
+  assert.equal(r.overridden, true);
+  assert.equal(recordCalled, true);
+});
+
+test('high-risk ticket, degraded, bypass requested but recording FAILS → DENY (unaudited override refused)', () => {
+  const r = decideBuildGate({
+    riskTier: 'high',
+    degraded: true,
+    bypass: true,
+    recordBypass: () => false,
+  });
+  assert.equal(r.decision, 'deny');
+  assert.match(r.reason, /unaudited|could not be (recorded|audited)/i);
+});
+
+test('bypass flag is IGNORED when not degraded (no override needed, no record call)', () => {
+  let recordCalled = false;
+  const r = decideBuildGate({
+    riskTier: 'high',
+    degraded: false,
+    bypass: true,
+    recordBypass: () => {
+      recordCalled = true;
+      return true;
+    },
+  });
+  assert.equal(r.decision, 'allow');
+  assert.equal(recordCalled, false);
+});
+
+test('bypass flag is IGNORED for a normal-risk ticket (no record call)', () => {
+  let recordCalled = false;
+  const r = decideBuildGate({
+    riskTier: 'normal',
+    degraded: true,
+    bypass: true,
+    recordBypass: () => {
+      recordCalled = true;
+      return true;
+    },
+  });
+  assert.equal(r.decision, 'allow');
+  assert.equal(recordCalled, false);
+});
+
+test('bypass requested but no recordBypass function supplied at all → DENY (never silently allow)', () => {
+  const r = decideBuildGate({ riskTier: 'high', degraded: true, bypass: true });
+  assert.equal(r.decision, 'deny');
+});

--- a/packages/build-gate/test/depth-signal.test.mjs
+++ b/packages/build-gate/test/depth-signal.test.mjs
@@ -1,0 +1,65 @@
+// test/depth-signal.test.mjs — the context-fitness proxy (issue #48, item 2).
+//
+// Mirrors flail-detector's transcript-size / tool-call-count scanning approach
+// (packages/flail-detector/lib/signals.mjs detectSizeExceeded, and the JSONL
+// tool_use counting done by parse-log.mjs's extractFileTargets) as the basis
+// for a --depth/--session-bytes input. Pure functions — no filesystem I/O here
+// (that lives in the CLI / hook, which stage a bounded window and pass the raw
+// text in).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { countToolCalls, computeDepthSignal, isDegraded, DEFAULT_DEPTH_THRESHOLD, DEFAULT_BYTES_THRESHOLD } from '../lib/depth-signal.mjs';
+
+test('countToolCalls: plain prose has zero tool calls', () => {
+  assert.equal(countToolCalls('just some words\nmore words\n'), 0);
+});
+
+test('countToolCalls: counts JSONL tool_use blocks', () => {
+  const text = [
+    JSON.stringify({ type: 'assistant', content: [{ type: 'tool_use', name: 'Edit', input: { file_path: 'a.mjs' } }] }),
+    JSON.stringify({ type: 'assistant', content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }] }),
+    JSON.stringify({ type: 'user', content: 'hi' }),
+  ].join('\n');
+  assert.equal(countToolCalls(text), 2);
+});
+
+test('countToolCalls: is a plain occurrence count, not deduped', () => {
+  const text = Array.from({ length: 5 }, () => '"type":"tool_use"').join('\n');
+  assert.equal(countToolCalls(text), 5);
+});
+
+test('computeDepthSignal: reports bytes and toolCallCount from raw text', () => {
+  const text = '"type":"tool_use"\n"type":"tool_use"\nhello';
+  const result = computeDepthSignal({ text });
+  assert.equal(result.toolCallCount, 2);
+  assert.equal(result.bytes, Buffer.byteLength(text, 'utf8'));
+});
+
+test('computeDepthSignal: an explicit bytes override wins over text-derived bytes', () => {
+  const result = computeDepthSignal({ text: 'short', bytes: 999999 });
+  assert.equal(result.bytes, 999999);
+});
+
+test('isDegraded: depth under threshold and bytes under threshold → not degraded', () => {
+  assert.equal(isDegraded({ depth: 5, sessionBytes: 100, depthThreshold: 40, bytesThreshold: 1000 }), false);
+});
+
+test('isDegraded: depth exceeding threshold → degraded', () => {
+  assert.equal(isDegraded({ depth: 41, sessionBytes: 0, depthThreshold: 40, bytesThreshold: 1_000_000 }), true);
+});
+
+test('isDegraded: bytes exceeding threshold → degraded (even with low depth)', () => {
+  assert.equal(isDegraded({ depth: 1, sessionBytes: 300_000, depthThreshold: 40, bytesThreshold: 262_144 }), true);
+});
+
+test('isDegraded: exactly AT threshold is not yet degraded (strictly greater-than, mirrors flail-detector detectSizeExceeded)', () => {
+  assert.equal(isDegraded({ depth: 40, sessionBytes: 262_144, depthThreshold: 40, bytesThreshold: 262_144 }), false);
+});
+
+test('isDegraded: defaults are exported and sane', () => {
+  assert.equal(typeof DEFAULT_DEPTH_THRESHOLD, 'number');
+  assert.equal(typeof DEFAULT_BYTES_THRESHOLD, 'number');
+  assert.ok(DEFAULT_DEPTH_THRESHOLD > 0);
+  assert.ok(DEFAULT_BYTES_THRESHOLD > 0);
+});

--- a/packages/build-gate/test/override.test.mjs
+++ b/packages/build-gate/test/override.test.mjs
@@ -1,0 +1,74 @@
+// test/override.test.mjs — the audited-override recording path (issue #48,
+// item 3). Mirrors rails-guard/adlc-hook.mjs's recordBypass(): the override
+// is written to .adlc/manifest.jsonl via @adlc/core's ledger, and recording
+// success/failure is reported truthfully (never assumed).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, chmodSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { recordOverride } from '../lib/override.mjs';
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-build-gate-override-'));
+  try {
+    return fn(dir);
+  } finally {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      /* ignore */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('recordOverride writes a build-gate-bypass entry to .adlc/manifest.jsonl and returns true', () => {
+  withTempDir((dir) => {
+    const ok = recordOverride({
+      ticketId: 'T9',
+      signals: ['declared-risk-high'],
+      depth: 55,
+      sessionBytes: 300000,
+      reason: 'operator-invoked override',
+      dir: join(dir, '.adlc'),
+    });
+    assert.equal(ok, true);
+    const manifestPath = join(dir, '.adlc', 'manifest.jsonl');
+    assert.ok(existsSync(manifestPath));
+    const lines = readFileSync(manifestPath, 'utf8').trim().split('\n');
+    const entry = JSON.parse(lines[lines.length - 1]);
+    assert.equal(entry.type, 'build-gate-bypass');
+    assert.equal(entry.ticket, 'T9');
+    assert.deepEqual(entry.signals, ['declared-risk-high']);
+    assert.equal(entry.depth, 55);
+    assert.equal(entry.sessionBytes, 300000);
+    assert.equal(entry.reason, 'operator-invoked override');
+    assert.ok(entry.ts);
+  });
+});
+
+test('recordOverride appends (does not clobber) a prior manifest entry', () => {
+  withTempDir((dir) => {
+    recordOverride({ ticketId: 'T1', signals: [], depth: 1, sessionBytes: 1, reason: 'first', dir: join(dir, '.adlc') });
+    recordOverride({ ticketId: 'T2', signals: [], depth: 2, sessionBytes: 2, reason: 'second', dir: join(dir, '.adlc') });
+    const lines = readFileSync(join(dir, '.adlc', 'manifest.jsonl'), 'utf8').trim().split('\n');
+    assert.equal(lines.length, 2);
+    assert.equal(JSON.parse(lines[0]).ticket, 'T1');
+    assert.equal(JSON.parse(lines[1]).ticket, 'T2');
+  });
+});
+
+test('recordOverride returns false (never throws) when the ledger directory cannot be written', () => {
+  withTempDir((dir) => {
+    const adlcDir = join(dir, '.adlc');
+    // Make the parent read-only so mkdir/append fails; simulate an unwritable repo.
+    chmodSync(dir, 0o500);
+    let ok;
+    assert.doesNotThrow(() => {
+      ok = recordOverride({ ticketId: 'T1', signals: [], depth: 1, sessionBytes: 1, reason: 'x', dir: adlcDir });
+    });
+    assert.equal(ok, false);
+  });
+});

--- a/packages/build-gate/test/override.test.mjs
+++ b/packages/build-gate/test/override.test.mjs
@@ -1,7 +1,8 @@
 // test/override.test.mjs — the audited-override recording path (issue #48,
 // item 3). Mirrors rails-guard/adlc-hook.mjs's recordBypass(): the override
-// is written to .adlc/manifest.jsonl via @adlc/core's ledger, and recording
-// success/failure is reported truthfully (never assumed).
+// is written to .adlc/manifest.jsonl via @adlc/gate-manifest's own record()
+// (so it is chain-linked exactly like every other manifest entry), and
+// recording success/failure is reported truthfully (never assumed).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -9,6 +10,8 @@ import { mkdtempSync, rmSync, readFileSync, chmodSync, existsSync } from 'node:f
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { recordOverride } from '../lib/override.mjs';
+import { record } from '@adlc/gate-manifest/lib/record.mjs';
+import { verify } from '@adlc/gate-manifest/lib/verify.mjs';
 
 function withTempDir(fn) {
   const dir = mkdtempSync(join(tmpdir(), 'adlc-build-gate-override-'));
@@ -39,13 +42,17 @@ test('recordOverride writes a build-gate-bypass entry to .adlc/manifest.jsonl an
     assert.ok(existsSync(manifestPath));
     const lines = readFileSync(manifestPath, 'utf8').trim().split('\n');
     const entry = JSON.parse(lines[lines.length - 1]);
-    assert.equal(entry.type, 'build-gate-bypass');
+    assert.equal(entry.gate, 'build-gate-bypass');
     assert.equal(entry.ticket, 'T9');
-    assert.deepEqual(entry.signals, ['declared-risk-high']);
-    assert.equal(entry.depth, 55);
-    assert.equal(entry.sessionBytes, 300000);
-    assert.equal(entry.reason, 'operator-invoked override');
+    assert.deepEqual(entry.data.signals, ['declared-risk-high']);
+    assert.equal(entry.data.depth, 55);
+    assert.equal(entry.data.sessionBytes, 300000);
+    assert.equal(entry.data.reason, 'operator-invoked override');
     assert.ok(entry.ts);
+    // Chain-linkage fields required by gate-manifest's verify() — the whole
+    // point of this entry existing at all (issue #48 review finding).
+    assert.equal(entry.seq, 1);
+    assert.equal(entry.prev, null);
   });
 });
 
@@ -57,6 +64,9 @@ test('recordOverride appends (does not clobber) a prior manifest entry', () => {
     assert.equal(lines.length, 2);
     assert.equal(JSON.parse(lines[0]).ticket, 'T1');
     assert.equal(JSON.parse(lines[1]).ticket, 'T2');
+    // seq must keep incrementing and each prev must chain to the line before it.
+    assert.equal(JSON.parse(lines[0]).seq, 1);
+    assert.equal(JSON.parse(lines[1]).seq, 2);
   });
 });
 
@@ -70,5 +80,39 @@ test('recordOverride returns false (never throws) when the ledger directory cann
       ok = recordOverride({ ticketId: 'T1', signals: [], depth: 1, sessionBytes: 1, reason: 'x', dir: adlcDir });
     });
     assert.equal(ok, false);
+  });
+});
+
+test('gate-manifest verify() still passes after recordOverride appends to an existing chain (regression, issue #48 review)', () => {
+  withTempDir((dir) => {
+    const adlcDir = join(dir, '.adlc');
+    // Seed a normal gate-manifest entry first, exactly like a real preflight run would.
+    record({ gate: 'preflight', ticket: 'T1', rawData: undefined, rawFiles: undefined, dir: adlcDir });
+
+    const ok = recordOverride({
+      ticketId: 'T1',
+      signals: ['declared-risk-high'],
+      depth: 50,
+      sessionBytes: 1000,
+      reason: 'ADLC_BUILD_GATE_BYPASS=1',
+      dir: adlcDir,
+    });
+    assert.equal(ok, true);
+
+    const result = verify(adlcDir);
+    assert.equal(result.valid, true, result.message);
+    assert.equal(result.count, 2);
+  });
+});
+
+test('gate-manifest verify() still passes after further entries are appended following recordOverride', () => {
+  withTempDir((dir) => {
+    const adlcDir = join(dir, '.adlc');
+    recordOverride({ ticketId: 'T1', signals: [], depth: 50, sessionBytes: 1000, reason: 'bypass', dir: adlcDir });
+    record({ gate: 'preflight', ticket: 'T2', rawData: undefined, rawFiles: undefined, dir: adlcDir });
+
+    const result = verify(adlcDir);
+    assert.equal(result.valid, true, result.message);
+    assert.equal(result.count, 2);
   });
 });

--- a/packages/build-gate/test/risk.test.mjs
+++ b/packages/build-gate/test/risk.test.mjs
@@ -115,6 +115,40 @@ test('deriveRiskSignals is pure and returns [] for an empty ticket', () => {
   assert.deepEqual(deriveRiskSignals({}), []);
 });
 
+// ---- fail closed on malformed ticket data (not a crash, not a silent allow) ----
+
+test('non-array scope (e.g. a number) does not throw and fails closed to high tier', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: 42 });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('malformed-scope'));
+});
+
+test('non-array rails (e.g. an object) does not throw and fails closed to high tier', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', rails: { foo: 'bar' } });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('malformed-rails'));
+});
+
+test('non-array scope (a single string glob, a plausible authoring mistake) fails closed', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: 'src/**' });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('malformed-scope'));
+});
+
+test('malformed scope alongside a valid rails array still evaluates the valid rails globs', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: 42, rails: ['.adlc/manifest.jsonl'] });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('malformed-scope'));
+  assert.ok(result.signals.includes('mutates-manifest'));
+});
+
+test('undefined scope/rails are not "malformed" — no false-positive signal', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x' });
+  assert.equal(result.tier, 'normal');
+  assert.equal(result.signals.includes('malformed-scope'), false);
+  assert.equal(result.signals.includes('malformed-rails'), false);
+});
+
 test('exported constants document the trust-root paths and high-risk categories', () => {
   assert.ok(TRUST_ROOT_PATHS.includes('.adlc/tickets.json'));
   assert.equal(MANIFEST_PATH, '.adlc/manifest.jsonl');

--- a/packages/build-gate/test/risk.test.mjs
+++ b/packages/build-gate/test/risk.test.mjs
@@ -1,0 +1,123 @@
+// test/risk.test.mjs — risk-tier derivation from ticket fields (issue #48, item 1).
+//
+// Tier is 'high' if EITHER the ticket declares risk:'high' OR any derived signal
+// fires. A declared risk:'normal' can NEVER downgrade a derived-high signal —
+// that would be exactly the silent bypass the gate exists to prevent.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveRiskSignals, computeRiskTier, TRUST_ROOT_PATHS, MANIFEST_PATH, HIGH_RISK_CATEGORIES } from '../lib/risk.mjs';
+
+test('plain ticket with no risk markers → normal, no signals', () => {
+  const t = { id: 'T1', title: 'x', category: 'feature' };
+  const result = computeRiskTier(t);
+  assert.equal(result.tier, 'normal');
+  assert.deepEqual(result.signals, []);
+});
+
+test('declared risk: high → high tier', () => {
+  const t = { id: 'T1', title: 'x', risk: 'high' };
+  const result = computeRiskTier(t);
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('declared-risk-high'));
+});
+
+test('declared risk: normal with no other signal → normal tier', () => {
+  const t = { id: 'T1', title: 'x', risk: 'normal' };
+  const result = computeRiskTier(t);
+  assert.equal(result.tier, 'normal');
+});
+
+test('declared risk: normal CANNOT downgrade a derived-high signal (no silent bypass)', () => {
+  const t = { id: 'T1', title: 'x', risk: 'normal', category: 'contract' };
+  const result = computeRiskTier(t);
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.some((s) => s.startsWith('high-risk-category')));
+});
+
+test('category "contract" → high (derived)', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', category: 'contract' });
+  assert.equal(result.tier, 'high');
+});
+
+test('category "architecture" → high (derived)', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', category: 'architecture' });
+  assert.equal(result.tier, 'high');
+});
+
+test('category "feature" → not high on its own', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', category: 'feature' });
+  assert.equal(result.tier, 'normal');
+});
+
+test('ticket.external === true → high (writes back to/creates/deletes in an external system)', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', external: true });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('external-system-effect'));
+});
+
+test('ticket.mutatesIdentity === true → high', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', mutatesIdentity: true });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('mutates-identity'));
+});
+
+test('scope touching .adlc/manifest.jsonl → high (mutates-manifest)', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: ['.adlc/manifest.jsonl'] });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('mutates-manifest'));
+});
+
+test('rails glob touching .adlc/manifest.jsonl → high (mutates-manifest)', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', rails: ['.adlc/**'] });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('mutates-manifest'));
+});
+
+test('scope touching .adlc/tickets.json (trust root) → high', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: ['.adlc/tickets.json'] });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('touches-trust-root'));
+});
+
+test('scope touching .adlc/current-ticket.json (trust root) → high', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: ['.adlc/current-ticket.json'] });
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('touches-trust-root'));
+});
+
+test('unrelated scope globs do not touch the trust root or manifest → normal', () => {
+  const result = computeRiskTier({ id: 'T1', title: 'x', scope: ['src/**', 'test/**'] });
+  assert.equal(result.tier, 'normal');
+});
+
+test('multiple signals can fire simultaneously and are all reported', () => {
+  const t = {
+    id: 'T1',
+    title: 'x',
+    risk: 'high',
+    category: 'architecture',
+    external: true,
+    mutatesIdentity: true,
+    scope: ['.adlc/manifest.jsonl', '.adlc/tickets.json'],
+  };
+  const result = computeRiskTier(t);
+  assert.equal(result.tier, 'high');
+  assert.ok(result.signals.includes('declared-risk-high'));
+  assert.ok(result.signals.includes('external-system-effect'));
+  assert.ok(result.signals.includes('mutates-identity'));
+  assert.ok(result.signals.includes('mutates-manifest'));
+  assert.ok(result.signals.includes('touches-trust-root'));
+  assert.ok(result.signals.some((s) => s.startsWith('high-risk-category')));
+});
+
+test('deriveRiskSignals is pure and returns [] for an empty ticket', () => {
+  assert.deepEqual(deriveRiskSignals({}), []);
+});
+
+test('exported constants document the trust-root paths and high-risk categories', () => {
+  assert.ok(TRUST_ROOT_PATHS.includes('.adlc/tickets.json'));
+  assert.equal(MANIFEST_PATH, '.adlc/manifest.jsonl');
+  assert.ok(HIGH_RISK_CATEGORIES.has('contract'));
+  assert.ok(HIGH_RISK_CATEGORIES.has('architecture'));
+});

--- a/packages/cli/lib/registry.mjs
+++ b/packages/cli/lib/registry.mjs
@@ -27,6 +27,7 @@ export const GROUPS = [
       { name: 'model-router', packageName: '@adlc/model-router', summary: 'Assign tickets to frontier, direct, or ladder model strategies.' },
       { name: 'merge-forecast', packageName: '@adlc/merge-forecast', summary: 'Estimate fan-out width, dependency pressure, and merge backpressure.' },
       { name: 'rails-guard', packageName: '@adlc/rails-guard', summary: 'Enforce frozen rails, declared suppressions, and manifest recording.' },
+      { name: 'build-gate', packageName: '@adlc/build-gate', summary: 'Deny starting a high-risk ticket build in a degraded (context-rot) session unless audited.' },
       { name: 'flail-detector', packageName: '@adlc/flail-detector', summary: 'Detect repeated errors, scope violations, edit churn, and oversized logs.' },
       { name: 'consensus-fix', packageName: '@adlc/consensus-fix', summary: 'Fan out candidate fixes and select the gated consensus winner.' },
     ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "@adlc/behavior-diff": "1.1.0",
+    "@adlc/build-gate": "1.1.0",
     "@adlc/coldstart": "1.1.0",
     "@adlc/consensus-fix": "1.1.0",
     "@adlc/flail-detector": "1.1.0",

--- a/packages/cli/test/dispatch.test.mjs
+++ b/packages/cli/test/dispatch.test.mjs
@@ -40,12 +40,15 @@ function withTempSpec(contents, fn) {
 }
 
 test('registry exposes the suite tools and omits internal packages', () => {
-  assert.equal(TOOLS.length, 23);
+  // 24 as of build-gate's registration (issue #48) — bump deliberately when a
+  // tool is intentionally added/removed from the registry.
+  assert.equal(TOOLS.length, 24);
   assert.equal(isTool('spec-lint'), true);
   assert.equal(isTool('prosecute'), true);
   assert.equal(isTool('ticket'), true);
   assert.equal(isTool('review'), true);
   assert.equal(isTool('ticket-prune'), true);
+  assert.equal(isTool('build-gate'), true);
   assert.equal(isTool('core'), false);
   assert.equal(isTool('runner'), false);
 });
@@ -81,7 +84,11 @@ test('help lists every routed tool and exits 0', () => {
 test('renderHelp embeds version and tool count', () => {
   const output = renderHelp('9.9.9');
   assert.match(output, /adlc 9\.9\.9/);
-  assert.match(output, /Tools \(23\)/);
+  // Derived from the live registry rather than a hardcoded literal: a
+  // hardcoded count (e.g. `/Tools \(22\)/`) silently goes stale every time a
+  // tool is registered/removed (this exact test was still asserting 22 after
+  // build-gate's registration bumped TOOLS.length to 23 — closes #48 CI red).
+  assert.match(output, new RegExp(`Tools \\(${TOOLS.length}\\)`));
 });
 
 test('version prints a semver-shaped string', () => {

--- a/plugins/adlc-claude-code/hooks/adlc-hook-run.mjs
+++ b/plugins/adlc-claude-code/hooks/adlc-hook-run.mjs
@@ -27,18 +27,23 @@ if (!existsSync(hookScript)) {
 
 // Self-terminate before CC's outer timeout fires to prevent silent session hangs.
 // Timeouts mirror hooks.json values minus a 5 s buffer so the wrapper exits cleanly
-// before CC sends SIGKILL. 'rails' uses 10 s (hooks.json: 15 s) because it is the
-// security-critical enforcing hook — a timeout here must be a hard deny, not silence.
-// If CC reliably sends SIGKILL at its own timeout boundary this is belt-and-suspenders;
-// confirm CC timeout enforcement during the live install test.
+// before CC sends SIGKILL. 'rails'/'buildgate' use 10 s (hooks.json: 15 s) because
+// they are the security-critical enforcing hooks — a timeout here must be a hard
+// deny, not silence. If CC reliably sends SIGKILL at its own timeout boundary this
+// is belt-and-suspenders; confirm CC timeout enforcement during the live install test.
 const mode = process.argv[2] ?? '';
 const TIMEOUTS_MS = {
-  preflight: 55_000, // hooks.json: 60 s
-  flail: 25_000,     // hooks.json: 30 s
-  manifest: 25_000,  // hooks.json: 30 s
-  rails: 10_000,     // hooks.json: 15 s — enforcing hook: deny on timeout
+  preflight: 55_000,  // hooks.json: 60 s
+  flail: 25_000,      // hooks.json: 30 s
+  manifest: 25_000,   // hooks.json: 30 s
+  rails: 10_000,      // hooks.json: 15 s — enforcing hook: deny on timeout
+  buildgate: 10_000,  // hooks.json: 15 s — enforcing hook: deny on timeout
 };
 const timeoutMs = TIMEOUTS_MS[mode] ?? 25_000;
+
+// The enforcing modes (rails, buildgate) must deny — not silently allow — on a
+// timeout or a kill signal. Advisory modes exit 0 so they never block the user.
+const ENFORCING_MODES = new Set(['rails', 'buildgate']);
 
 const result = spawnSync(
   process.execPath,
@@ -56,9 +61,7 @@ if (result.error) {
     process.stderr.write(
       `adlc-hook-run: hook timed out after ${timeoutMs} ms (mode: ${mode || '(none)'})\n`
     );
-    // rails mode is enforcing — deny the structured edit on timeout (fail closed).
-    // Advisory hooks exit 0 on timeout so they never block the user.
-    process.exit(mode === 'rails' ? 1 : 0);
+    process.exit(ENFORCING_MODES.has(mode) ? 1 : 0);
   }
   process.stderr.write(`adlc-hook-run: failed to spawn adlc-hook.mjs: ${result.error.message}\n`);
   process.exit(1);
@@ -69,7 +72,7 @@ if (result.signal) {
   process.stderr.write(
     `adlc-hook-run: hook killed by signal ${result.signal} (mode: ${mode || '(none)'})\n`
   );
-  process.exit(mode === 'rails' ? 1 : 0);
+  process.exit(ENFORCING_MODES.has(mode) ? 1 : 0);
 }
 
 process.exit(result.status ?? 0);

--- a/plugins/adlc-claude-code/hooks/adlc-hook.mjs
+++ b/plugins/adlc-claude-code/hooks/adlc-hook.mjs
@@ -871,6 +871,10 @@ function computeRiskTierForBuildGate(ticket) {
   if (t.risk === 'high') signals.push('declared-risk-high');
   if (t.external === true) signals.push('external-system-effect');
   if (t.mutatesIdentity === true) signals.push('mutates-identity');
+  // A malformed (present but non-array) scope/rails field is ambiguous, not
+  // proof of safety — it must fire a signal, not be silently ignored.
+  if (t.scope !== undefined && !Array.isArray(t.scope)) signals.push('malformed-scope');
+  if (t.rails !== undefined && !Array.isArray(t.rails)) signals.push('malformed-rails');
   const combinedGlobs = [
     ...(Array.isArray(t.scope) ? t.scope : []),
     ...(Array.isArray(t.rails) ? t.rails : []),

--- a/plugins/adlc-claude-code/hooks/adlc-hook.mjs
+++ b/plugins/adlc-claude-code/hooks/adlc-hook.mjs
@@ -1,17 +1,30 @@
 #!/usr/bin/env node
-// ADLC hooks — one helper, four modes:
+// ADLC hooks — one helper, five modes:
 //   preflight  (SessionStart)  → environment readiness before fan-out  [advisory]
 //   flail      (PostToolUse)    → flail-detection over the transcript    [advisory]
 //   manifest   (Stop)           → gate-evidence chain integrity audit    [advisory]
 //   rails      (PreToolUse)     → block edits to frozen rail paths        [ENFORCING]
+//   buildgate  (PreToolUse)     → fitness-to-build gate (issue #48)        [ENFORCING]
 //
 // CONTRACT: the three advisory modes must NEVER block and stay SILENT unless
-// there is something to flag. The `rails` mode is the ONE enforcement hook — it
-// can DENY an Edit/Write (via a permissionDecision in its JSON output, not via
-// exit code). All four modes still ALWAYS exit 0 and never surface their own
-// errors; if the toolkit isn't installed or the repo isn't ADLC-initialized,
-// every mode no-ops. The rails enforcement is itself a no-op until a ticket
-// declares `rails` paths, so installing the plugin can't brick a clean repo.
+// there is something to flag. `rails` and `buildgate` are the two enforcement
+// hooks — either can DENY an Edit/Write (via a permissionDecision in its JSON
+// output, not via exit code, though exit 2 is also set as a fail-closed
+// belt-and-suspenders). All five modes still ALWAYS exit 0 on the allow path
+// and never surface their own errors; if the toolkit isn't installed or the
+// repo isn't ADLC-initialized, every mode no-ops. Both enforcing gates are
+// themselves a no-op until a ticket declares `rails` paths / an active ticket
+// is resolved, so installing the plugin can't brick a clean repo.
+//
+// `buildgate`'s core decision (risk-tier derivation, the depth/session-bytes
+// context-fitness signal, and the allow/deny decision) is computed ENTIRELY
+// LOCALLY in this file — it does not shell out to `adlc` for the decision,
+// mirroring how `rails` never needs `adlc` for its own core decision either.
+// `adlc` (via gate-manifest) is used ONLY to durably record an audited
+// override, exactly like rails' ADLC_RAILS_BYPASS. The toolkit package
+// @adlc/build-gate is the canonical source of this logic (reusable by other
+// harnesses per issue #48's Path A); the copies here are verbatim ports
+// marked "KEEP IN SYNC", the same convention already used for globMatch.
 //
 // Output: when there is something to say, print ONE JSON object using fields
 // Claude Code recognizes (`systemMessage`; `hookSpecificOutput.additionalContext`
@@ -105,12 +118,17 @@ function parseJson(text) {
 
 function main() {
   const parsed = parseJson(readStdin());
-  // The enforcing rails hook must FAIL CLOSED if it cannot even read/parse its own
-  // input (empty stdin, malformed JSON) — it cannot verify rails. Advisory modes
-  // tolerate a missing payload and no-op.
+  // The enforcing rails/buildgate hooks must FAIL CLOSED if they cannot even
+  // read/parse their own input (empty stdin, malformed JSON) — they cannot
+  // verify rails or the fitness-to-build gate. Advisory modes tolerate a
+  // missing payload and no-op.
   if (MODE === 'rails' && parsed === null) {
     denyRail('rails hook received unreadable/malformed input — failing closed');
     return; // unreachable: denyRail exits 2
+  }
+  if (MODE === 'buildgate' && parsed === null) {
+    denyBuildGate('build-gate hook received unreadable/malformed input — failing closed');
+    return; // unreachable: denyBuildGate exits 2
   }
   const input = parsed ?? {};
 
@@ -125,11 +143,20 @@ function main() {
   try {
     process.chdir(dir);
   } catch {
-    // The enforcing rails hook must FAIL CLOSED if it can't even enter the project
-    // dir (it cannot verify rails). Advisory modes just no-op.
+    // The enforcing rails/buildgate hooks must FAIL CLOSED if they can't even
+    // enter the project dir (they cannot verify rails or the build gate).
+    // Advisory modes just no-op.
     if (MODE === 'rails') {
       try {
         denyRail('rails hook could not enter the project directory — failing closed');
+      } catch {
+        /* deny emit failed; the exit 2 below still blocks */
+      }
+      process.exit(2);
+    }
+    if (MODE === 'buildgate') {
+      try {
+        denyBuildGate('build-gate hook could not enter the project directory — failing closed');
       } catch {
         /* deny emit failed; the exit 2 below still blocks */
       }
@@ -159,10 +186,18 @@ function main() {
     try {
       process.chdir(root);
     } catch {
-      // Found the ADLC root but can't enter it → can't verify rails → fail closed.
+      // Found the ADLC root but can't enter it → can't verify rails/build-gate → fail closed.
       if (MODE === 'rails') {
         try {
           denyRail('rails hook found the ADLC root but could not enter it — failing closed');
+        } catch {
+          /* exit 2 below still blocks */
+        }
+        process.exit(2);
+      }
+      if (MODE === 'buildgate') {
+        try {
+          denyBuildGate('build-gate hook found the ADLC root but could not enter it — failing closed');
         } catch {
           /* exit 2 below still blocks */
         }
@@ -176,6 +211,7 @@ function main() {
   if (MODE === 'flail') return flail(input);
   if (MODE === 'manifest') return manifest();
   if (MODE === 'rails') return rails(input);
+  if (MODE === 'buildgate') return buildgate(input);
   // unknown mode → no-op
 }
 
@@ -739,16 +775,253 @@ function rails(input) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// build-gate (issue #48) — machine-checkable fitness-to-build gate.
+//
+// PreToolUse (Edit/Write/MultiEdit/NotebookEdit, same matcher as rails): for
+// the ACTIVE ticket (resolved the same way every other ADLC harness
+// integration resolves it — ADLC_TICKET env var OR .adlc/current-ticket.json,
+// conflict fails closed), deny the build when the ticket is HIGH RISK and
+// this session's context-fitness signal (transcript depth/bytes) is past
+// threshold, unless an audited override is recorded.
+//
+// Fail-safe contract, mirroring rails():
+//   • no .adlc / no tickets.json / no active ticket resolved → ALLOW (no-op);
+//     installing this hook cannot brick a session that hasn't opted into the
+//     active-ticket convention.
+//   • a conflicting active-ticket signal, an unloadable/malformed
+//     tickets.json, or an active ticket id not found → DENY (fail closed —
+//     the ticket's risk cannot be verified).
+//   • active ticket resolved but risk tier is 'normal' → ALLOW (this gate
+//     only guards high-risk tickets).
+//   • high-risk ticket, session not degraded → ALLOW.
+//   • high-risk ticket, session degraded, transcript_path unreadable → DENY
+//     (the context-fitness signal cannot be computed for a ticket we already
+//     know is high-risk).
+//   • high-risk ticket, session degraded → DENY, unless
+//     ADLC_BUILD_GATE_BYPASS=1 AND the override is durably recorded to the
+//     gate-manifest; an unaudited override is refused.
+// ---------------------------------------------------------------------------
+
+/**
+ * Active-ticket resolution — KEEP IN SYNC with
+ * packages/build-gate/lib/active-ticket.mjs's resolveActiveTicketId(). Ported
+ * verbatim (same reason globMatch is ported above: this hook cannot resolve
+ * @adlc/build-gate at runtime, it only shells to the globally-installed
+ * `adlc` binary). Also mirrors plugins/adlc-codex/hooks/adlc-rails-guard.mjs
+ * and plugins/adlc-antigravity/rails-checker.mjs's resolveActiveTicketId().
+ */
+function resolveActiveTicketIdForBuildGate() {
+  const env = process.env;
+  const envTicket = (env.ADLC_TICKET ?? '').trim() || null;
+  let fileTicket = null;
+  const currentPath = join('.adlc', 'current-ticket.json');
+  if (existsSync(currentPath)) {
+    try {
+      const data = JSON.parse(readFileSync(currentPath, 'utf8'));
+      const raw = typeof data === 'string' ? data : (data?.id ?? data?.ticket);
+      fileTicket = (raw ?? '').toString().trim() || null;
+    } catch {
+      return { id: null, conflict: true }; // unparseable pointer is itself a tamper signal
+    }
+  }
+  if (envTicket && fileTicket && envTicket !== fileTicket) {
+    return { id: null, conflict: true };
+  }
+  return { id: envTicket ?? fileTicket, conflict: false };
+}
+
+/** Trust-root paths — KEEP IN SYNC with packages/build-gate/lib/risk.mjs's TRUST_ROOT_PATHS. */
+const BUILD_GATE_TRUST_ROOT_PATHS = ['.adlc/tickets.json', '.adlc/current-ticket.json'];
+/** KEEP IN SYNC with packages/build-gate/lib/risk.mjs's MANIFEST_PATH. */
+const BUILD_GATE_MANIFEST_PATH = '.adlc/manifest.jsonl';
+/** KEEP IN SYNC with packages/build-gate/lib/risk.mjs's HIGH_RISK_CATEGORIES. */
+const BUILD_GATE_HIGH_RISK_CATEGORIES = new Set(['contract', 'architecture']);
+
+function buildGateTouchesAny(globs, paths) {
+  return (globs ?? []).some((g) => paths.some((p) => g === p || globMatch(g, p)));
+}
+
+/**
+ * Risk-tier derivation — KEEP IN SYNC with packages/build-gate/lib/risk.mjs's
+ * deriveRiskSignals()/computeRiskTier(). A declared risk:'normal' can never
+ * downgrade a derived-high signal (see that module's header comment for why).
+ */
+function computeRiskTierForBuildGate(ticket) {
+  const t = ticket ?? {};
+  const signals = [];
+  if (t.risk === 'high') signals.push('declared-risk-high');
+  if (t.external === true) signals.push('external-system-effect');
+  if (t.mutatesIdentity === true) signals.push('mutates-identity');
+  const combinedGlobs = [
+    ...(Array.isArray(t.scope) ? t.scope : []),
+    ...(Array.isArray(t.rails) ? t.rails : []),
+  ];
+  if (buildGateTouchesAny(combinedGlobs, [BUILD_GATE_MANIFEST_PATH])) signals.push('mutates-manifest');
+  if (buildGateTouchesAny(combinedGlobs, BUILD_GATE_TRUST_ROOT_PATHS)) signals.push('touches-trust-root');
+  if (BUILD_GATE_HIGH_RISK_CATEGORIES.has(t.category)) signals.push(`high-risk-category:${t.category}`);
+  return { tier: signals.length > 0 ? 'high' : 'normal', signals };
+}
+
+/** KEEP IN SYNC with packages/build-gate/lib/depth-signal.mjs's DEFAULT_DEPTH_THRESHOLD. */
+const BUILD_GATE_DEPTH_THRESHOLD = 40;
+/** KEEP IN SYNC with packages/build-gate/lib/depth-signal.mjs's DEFAULT_BYTES_THRESHOLD. */
+const BUILD_GATE_BYTES_THRESHOLD = 256 * 1024;
+
+/**
+ * Tool-call-count depth signal — KEEP IN SYNC with
+ * packages/build-gate/lib/depth-signal.mjs's countToolCalls(). A plain
+ * occurrence count over a (possibly windowed) transcript chunk.
+ */
+function countToolCallsForBuildGate(text) {
+  if (!text) return 0;
+  const toolUseBlocks = text.match(/"type"\s*:\s*"tool_use"/g) ?? [];
+  const proseToolLines = text.match(/^(?:Writing|Editing|Created)\s+\S+/gim) ?? [];
+  return toolUseBlocks.length + proseToolLines.length;
+}
+
+/**
+ * Emit a PreToolUse DENY and exit 2 for the build-gate. Fails closed two ways,
+ * exactly like denyRail: the structured `permissionDecision: deny` payload,
+ * AND a non-zero exit.
+ */
+function denyBuildGate(reason) {
+  emit({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+    systemMessage: `ADLC build-gate: ${reason}`,
+  });
+  process.exit(2);
+}
+
+/**
+ * Audit an ADLC_BUILD_GATE_BYPASS override to the gate-manifest via the real
+ * `adlc gate-manifest record` command (chain-linked, optionally HMAC-signed —
+ * the same mechanism rails' recordBypass uses). Returns true ONLY if the
+ * record was durably written.
+ */
+function recordBuildGateBypass(ticketId, signals, depth, sessionBytes) {
+  const r = runAdlc([
+    'gate-manifest',
+    'record',
+    'build-gate-bypass',
+    '--ticket',
+    ticketId,
+    '--data',
+    JSON.stringify({ signals, depth, sessionBytes }),
+  ]);
+  return !!r && r.status === 0;
+}
+
+function buildgate(input) {
+  if (!existsSync('.adlc')) return; // not an ADLC repo → allow
+  const ticketsPath = join('.adlc', 'tickets.json');
+  if (!existsSync(ticketsPath)) return; // no tickets → nothing to gate → allow
+
+  const active = resolveActiveTicketIdForBuildGate();
+  if (active.conflict) {
+    return denyBuildGate(
+      'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json) — failing closed'
+    );
+  }
+  if (!active.id) return; // no active ticket declared → allow (opt-in gate)
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(ticketsPath, 'utf8'));
+  } catch (e) {
+    return denyBuildGate(
+      `cannot read .adlc/tickets.json (${e.message}) — active ticket ${active.id}'s risk cannot be verified, failing closed`
+    );
+  }
+  const isObject = parsed && typeof parsed === 'object' && !Array.isArray(parsed);
+  if (!isObject || !Array.isArray(parsed.tickets)) {
+    return denyBuildGate(
+      '.adlc/tickets.json is not in the expected { "tickets": [...] } shape — failing closed'
+    );
+  }
+  const ticket = parsed.tickets.find((t) => t && typeof t === 'object' && t.id === active.id);
+  if (!ticket) {
+    return denyBuildGate(`active ticket ${active.id} not found in .adlc/tickets.json — failing closed`);
+  }
+
+  const { tier, signals } = computeRiskTierForBuildGate(ticket);
+  if (tier !== 'high') return; // this gate only guards high-risk tickets → allow
+
+  // Context-fitness signal: bounded transcript scan, mirroring flail()'s own
+  // MAX_SCAN_BYTES windowing so this stays O(MAX_SCAN_BYTES) regardless of how
+  // long the session runs. `sessionBytes` reflects the WHOLE transcript file
+  // (fileSize), while the tool-call count is over a bounded recent window —
+  // same split flail() already makes.
+  const tp = input.transcript_path;
+  if (!tp || !existsSync(tp)) {
+    // We already know the ticket is high-risk; without a readable transcript
+    // we cannot compute the context-fitness signal at all — fail closed
+    // rather than assume "shallow".
+    return denyBuildGate(
+      `active ticket ${active.id} is high-risk but no readable transcript_path was supplied — ` +
+        `the context-fitness signal cannot be verified, failing closed`
+    );
+  }
+
+  let sessionBytes = fileSize(tp);
+  if (sessionBytes < 0) sessionBytes = 0;
+
+  let windowText;
+  if (sessionBytes > MAX_SCAN_BYTES) {
+    windowText = tailBytes(tp, MAX_SCAN_BYTES);
+  } else {
+    try {
+      windowText = readFileSync(tp, 'utf8');
+    } catch {
+      windowText = null;
+    }
+  }
+  const depth = windowText ? countToolCallsForBuildGate(windowText) : 0;
+
+  const degraded = depth > BUILD_GATE_DEPTH_THRESHOLD || sessionBytes > BUILD_GATE_BYTES_THRESHOLD;
+  if (!degraded) return; // high-risk, but this session isn't deep yet → allow
+
+  const bypass = process.env.ADLC_BUILD_GATE_BYPASS === '1';
+  if (bypass) {
+    if (recordBuildGateBypass(active.id, signals, depth, sessionBytes)) return; // audited → allow
+    return denyBuildGate(
+      `ADLC_BUILD_GATE_BYPASS is set but the override could not be recorded to the gate-manifest ` +
+        `(is @adlc/cli installed and .adlc writable?). An unaudited bypass is refused — the build is blocked.`
+    );
+  }
+
+  return denyBuildGate(
+    `active ticket ${active.id} is high-risk (${signals.join(', ') || 'declared'}) and this session's ` +
+      `context-fitness signal is past threshold (depth=${depth}, sessionBytes=${sessionBytes}). Continuing a ` +
+      `high-blast-radius build in a degraded/deep session risks context-rot bugs. Resume in a FRESH session ` +
+      `(or an isolated subagent) rather than continuing here. To override deliberately, set ` +
+      `ADLC_BUILD_GATE_BYPASS=1 (the bypass is recorded to the gate-manifest).`
+  );
+}
+
 try {
   main();
 } catch (err) {
-  // The `rails` mode is ENFORCING — a crash must FAIL CLOSED, never fall through
-  // to exit 0 (which the harness reads as "allow"). Emit a deny and exit 2 so the
-  // PreToolUse call is blocked even if the deny payload is missed. The advisory
-  // modes (preflight/flail/manifest) legitimately swallow their own errors.
+  // The `rails`/`buildgate` modes are ENFORCING — a crash must FAIL CLOSED,
+  // never fall through to exit 0 (which the harness reads as "allow"). Emit a
+  // deny and exit 2 so the PreToolUse call is blocked even if the deny
+  // payload is missed. The advisory modes (preflight/flail/manifest)
+  // legitimately swallow their own errors.
   if (MODE === 'rails') {
     try {
       denyRail(`rails hook errored (${err?.message ?? 'unknown'}) — failing closed`);
+    } catch {
+      /* even emit failed — the non-zero exit below still blocks */
+    }
+    process.exit(2);
+  }
+  if (MODE === 'buildgate') {
+    try {
+      denyBuildGate(`build-gate hook errored (${err?.message ?? 'unknown'}) — failing closed`);
     } catch {
       /* even emit failed — the non-zero exit below still blocks */
     }

--- a/plugins/adlc-claude-code/hooks/adlc-hook.mjs
+++ b/plugins/adlc-claude-code/hooks/adlc-hook.mjs
@@ -733,6 +733,24 @@ function rails(input) {
     railDecls.push({ glob: ticketsResolved, ticket: '(rail trust root, resolved)' });
   }
 
+  // .adlc/current-ticket.json is the OTHER half of the shared trust root (see
+  // BUILD_GATE_TRUST_ROOT_PATHS below): build-gate's active-ticket resolution
+  // trusts this pointer file, so once any rails exist, a structured edit
+  // (Edit/Write/MultiEdit/NotebookEdit) that overwrites it to point away from
+  // a high-risk ticket must be frozen exactly like tickets.json itself — an
+  // unprotected pointer would otherwise let a single edit silently disable
+  // build-gate for the rest of the session with no risk evaluation and no
+  // manifest entry. This does not cover Bash (see this hook's matcher and
+  // docs/integrations/claude-code.md's Gaps section for that documented,
+  // unbackstopped limitation — current-ticket.json is gitignored local state,
+  // so there is no commit-time diff for a CI gate to inspect either).
+  const currentTicketPath = join('.adlc', 'current-ticket.json');
+  railDecls.push({ glob: '.adlc/current-ticket.json', ticket: '(rail trust root)' });
+  const currentTicketResolved = toRepoRelative(currentTicketPath);
+  if (currentTicketResolved && currentTicketResolved !== '.adlc/current-ticket.json') {
+    railDecls.push({ glob: currentTicketResolved, ticket: '(rail trust root, resolved)' });
+  }
+
   // A structured edit whose target path we couldn't extract, while rails are
   // declared, can't be verified → fail closed.
   if (fps.length === 0) {
@@ -967,8 +985,20 @@ function buildgate(input) {
     );
   }
 
-  let sessionBytes = fileSize(tp);
-  if (sessionBytes < 0) sessionBytes = 0;
+  const sessionBytes = fileSize(tp);
+  if (sessionBytes < 0) {
+    // existsSync(tp) passed above, but the file could not be stat'd/opened
+    // here — a permissions error, or a TOCTOU race where the file was
+    // deleted/replaced/swapped for a directory between the two checks. Either
+    // way the context-fitness signal cannot be computed for a ticket we
+    // already know is high-risk, so this must fail closed rather than treat
+    // the unreadable file as "zero bytes, not degraded".
+    return denyBuildGate(
+      `active ticket ${active.id} is high-risk but transcript_path could not be read after the ` +
+        `existence check (permission error, or the file changed underneath us) — the context-fitness ` +
+        `signal cannot be verified, failing closed`
+    );
+  }
 
   let windowText;
   if (sessionBytes > MAX_SCAN_BYTES) {
@@ -980,7 +1010,17 @@ function buildgate(input) {
       windowText = null;
     }
   }
-  const depth = windowText ? countToolCallsForBuildGate(windowText) : 0;
+  if (windowText == null) {
+    // Same fail-closed reasoning as above: fileSize succeeded but the actual
+    // read of the (possibly windowed) transcript failed. Silently treating
+    // this as depth=0 would let an unverifiable session through, exactly the
+    // bypass this gate exists to prevent.
+    return denyBuildGate(
+      `active ticket ${active.id} is high-risk but the transcript window could not be read — the ` +
+        `context-fitness signal cannot be verified, failing closed`
+    );
+  }
+  const depth = countToolCallsForBuildGate(windowText);
 
   const degraded = depth > BUILD_GATE_DEPTH_THRESHOLD || sessionBytes > BUILD_GATE_BYTES_THRESHOLD;
   if (!degraded) return; // high-risk, but this session isn't deep yet → allow

--- a/plugins/adlc-claude-code/hooks/hooks.json
+++ b/plugins/adlc-claude-code/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/adlc-hook-run.mjs rails",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/adlc-hook-run.mjs buildgate",
+            "timeout": 15
           }
         ]
       }

--- a/plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
@@ -242,6 +242,26 @@ test('declared risk:"normal" cannot downgrade a derived-high signal → still de
   assert.equal(r.verdict, 'deny');
 });
 
+// ---- fail closed on malformed ticket data (not a silent allow) ----
+
+test('non-array scope field on the active ticket → fails closed to high risk, deny once deep', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', scope: 42 }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('non-array rails field on the active ticket → fails closed to high risk, deny once deep', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', rails: { foo: 'bar' } }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
 test('.adlc/current-ticket.json alone (no env var) resolves the active ticket and gates it', () => {
   const r = runBuildGate({
     tickets: [{ id: 'T9', title: 'x', category: 'contract' }],

--- a/plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
@@ -1,0 +1,266 @@
+// build-gate.test.mjs — the PreToolUse fitness-to-build gate (issue #48) is
+// security-critical, so it gets a committed regression test. Drives the real
+// hook entrypoint as a subprocess (the hook is a script, not an importable
+// module), the same way rails.test.mjs does.
+//
+// Contract: no .adlc / no tickets.json / no active ticket → allow (no-op).
+// A conflicting active-ticket signal, unloadable tickets.json, or unknown
+// active ticket → deny (fail closed). Normal-risk active ticket → allow
+// regardless of session depth. High-risk active ticket → deny once the
+// context-fitness signal (tool-call depth or transcript bytes) is past
+// threshold, unless an audited ADLC_BUILD_GATE_BYPASS override is recorded.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const HOOK = join(dirname(fileURLToPath(import.meta.url)), '..', 'adlc-hook.mjs');
+const NODE_DIR = dirname(process.execPath);
+const REPO_BIN = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', 'node_modules', '.bin');
+const WITH_ADLC = `${REPO_BIN}:${NODE_DIR}:${process.env.PATH ?? ''}`; // recorder reachable
+
+/** Build a transcript file with N tool_use JSONL lines. */
+function makeTranscript(dir, name, toolUseCount, { padBytes = 0 } = {}) {
+  const line = JSON.stringify({ type: 'assistant', content: [{ type: 'tool_use', name: 'Edit' }] });
+  const lines = Array.from({ length: toolUseCount }, () => line);
+  if (padBytes > 0) lines.push('x'.repeat(padBytes));
+  const p = join(dir, name);
+  writeFileSync(p, lines.join('\n'));
+  return p;
+}
+
+/**
+ * Run the buildgate hook in a throwaway repo.
+ * @returns {{ verdict: 'deny'|'allow', out: string, manifest: string, dir: string }}
+ */
+function runBuildGate({ tickets, activeTicketEnv, currentTicketFile, transcriptToolCalls, transcriptPadBytes, env = {} }) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-buildgate-'));
+  try {
+    mkdirSync(join(dir, '.adlc'));
+    if (tickets !== undefined) {
+      writeFileSync(join(dir, '.adlc', 'tickets.json'), typeof tickets === 'string' ? tickets : JSON.stringify({ tickets }));
+    }
+    if (currentTicketFile !== undefined) {
+      writeFileSync(join(dir, '.adlc', 'current-ticket.json'), typeof currentTicketFile === 'string' ? currentTicketFile : JSON.stringify(currentTicketFile));
+    }
+    let transcriptPath;
+    if (transcriptToolCalls !== undefined) {
+      transcriptPath = makeTranscript(dir, 'transcript.jsonl', transcriptToolCalls, { padBytes: transcriptPadBytes ?? 0 });
+    }
+    const input = JSON.stringify({
+      cwd: dir,
+      tool_name: 'Edit',
+      tool_input: { file_path: join(dir, 'src', 'app.mjs') },
+      ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
+    });
+    const hookEnv = { ...process.env, CLAUDE_PROJECT_DIR: '', ...env };
+    if (activeTicketEnv !== undefined) hookEnv.ADLC_TICKET = activeTicketEnv;
+    let out = '';
+    let status = 0;
+    try {
+      out = execFileSync(process.execPath, [HOOK, 'buildgate'], { input, encoding: 'utf8', env: hookEnv });
+    } catch (e) {
+      out = e.stdout ?? '';
+      status = e.status;
+    }
+    const mp = join(dir, '.adlc', 'manifest.jsonl');
+    const manifest = existsSync(mp) ? readFileSync(mp, 'utf8') : '';
+    const verdict = out.includes('"permissionDecision":"deny"') || status === 2 ? 'deny' : 'allow';
+    return { verdict, out, manifest, status };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- no-op: cannot brick a repo that hasn't opted in ----
+
+test('no tickets file → allow', () => {
+  const r = runBuildGate({ tickets: undefined, activeTicketEnv: 'T1' });
+  assert.equal(r.verdict, 'allow');
+});
+
+test('tickets file exists but NO active ticket resolved → allow', () => {
+  const r = runBuildGate({ tickets: [{ id: 'T1', title: 'x', category: 'contract' }] });
+  assert.equal(r.verdict, 'allow');
+});
+
+test('active ticket resolved but risk tier is normal → allow regardless of depth', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'feature' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'allow');
+});
+
+// ---- fail closed: ambiguous/untrustworthy state ----
+
+test('ADLC_TICKET conflicts with .adlc/current-ticket.json → deny', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x' }, { id: 'T2', title: 'y' }],
+    activeTicketEnv: 'T1',
+    currentTicketFile: { id: 'T2' },
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('unparseable .adlc/current-ticket.json → deny (tamper signal)', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x' }],
+    currentTicketFile: 'not json',
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('active ticket id not found in tickets.json → deny', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x' }],
+    activeTicketEnv: 'T404',
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('unparseable tickets.json with an active ticket set → deny', () => {
+  const r = runBuildGate({ tickets: '{ not json', activeTicketEnv: 'T1' });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('tickets.json not in the expected shape (bare array) → deny', () => {
+  const r = runBuildGate({ tickets: '[]', activeTicketEnv: 'T1' });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('high-risk active ticket but no transcript_path supplied → deny (cannot verify signal)', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+    activeTicketEnv: 'T1',
+    // transcriptToolCalls omitted → no transcript_path in the payload
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+// ---- enforcement: high risk + degraded session ----
+
+test('high-risk ticket (category: contract), shallow session → allow', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 2,
+  });
+  assert.equal(r.verdict, 'allow');
+});
+
+test('high-risk ticket (category: architecture), deep session (tool-call depth) → deny', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'architecture' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('high-risk ticket, deep session by BYTES (large transcript, low tool-call count) → deny', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 1,
+    transcriptPadBytes: 300_000, // > 256 KiB threshold
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('high-risk ticket via declared risk:"high" (not category) → deny once deep', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', risk: 'high' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('declared risk:"normal" cannot downgrade a derived-high signal → still deny once deep', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', risk: 'normal', category: 'contract' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+test('.adlc/current-ticket.json alone (no env var) resolves the active ticket and gates it', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T9', title: 'x', category: 'contract' }],
+    currentTicketFile: { id: 'T9' },
+    transcriptToolCalls: 500,
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+// ---- audited override ----
+
+test('bypass on a degraded high-risk build WITH a working recorder → allow + audited manifest entry', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T9', title: 'x', category: 'contract' }],
+    activeTicketEnv: 'T9',
+    transcriptToolCalls: 500,
+    env: { ADLC_BUILD_GATE_BYPASS: '1', PATH: WITH_ADLC },
+  });
+  assert.equal(r.verdict, 'allow');
+  assert.match(r.manifest, /build-gate-bypass/);
+  assert.match(r.manifest, /T9/);
+});
+
+test('bypass with the recorder UNAVAILABLE → deny (an unaudited override is refused)', () => {
+  const noAdlcDir = mkdtempSync(join(tmpdir(), 'adlc-no-recorder-'));
+  try {
+    const r = runBuildGate({
+      tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+      activeTicketEnv: 'T1',
+      transcriptToolCalls: 500,
+      env: { ADLC_BUILD_GATE_BYPASS: '1', PATH: noAdlcDir },
+    });
+    assert.equal(r.verdict, 'deny');
+  } finally {
+    rmSync(noAdlcDir, { recursive: true, force: true });
+  }
+});
+
+test('bypass flag is ignored (no manifest write) when the session is NOT degraded', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+    activeTicketEnv: 'T1',
+    transcriptToolCalls: 1,
+    env: { ADLC_BUILD_GATE_BYPASS: '1', PATH: WITH_ADLC },
+  });
+  assert.equal(r.verdict, 'allow');
+  assert.equal(r.manifest.includes('build-gate-bypass'), false);
+});
+
+// ---- fail closed on unreadable/malformed input ----
+
+test('malformed stdin in buildgate mode → fail closed (deny)', () => {
+  let status = 0;
+  try {
+    execFileSync(process.execPath, [HOOK, 'buildgate'], { input: 'not json at all', encoding: 'utf8' });
+  } catch (e) {
+    status = e.status;
+  }
+  assert.equal(status, 2);
+});
+
+// ---- the buildgate matcher is wired into hooks.json ----
+
+test('the PreToolUse matcher includes a buildgate hook entry (excludes Bash)', () => {
+  const hooksJson = JSON.parse(
+    readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'hooks.json'), 'utf8')
+  );
+  const entry = hooksJson.hooks.PreToolUse.find((e) =>
+    e.hooks.some((h) => h.command.includes('adlc-hook-run.mjs') && h.command.includes('buildgate'))
+  );
+  assert.ok(entry, 'a PreToolUse buildgate hook entry exists');
+  assert.equal(/\bBash\b/.test(entry.matcher), false);
+});

--- a/plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/build-gate.test.mjs
@@ -12,7 +12,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -37,7 +37,15 @@ function makeTranscript(dir, name, toolUseCount, { padBytes = 0 } = {}) {
  * Run the buildgate hook in a throwaway repo.
  * @returns {{ verdict: 'deny'|'allow', out: string, manifest: string, dir: string }}
  */
-function runBuildGate({ tickets, activeTicketEnv, currentTicketFile, transcriptToolCalls, transcriptPadBytes, env = {} }) {
+function runBuildGate({
+  tickets,
+  activeTicketEnv,
+  currentTicketFile,
+  transcriptToolCalls,
+  transcriptPadBytes,
+  transcriptPathOverride,
+  env = {},
+}) {
   const dir = mkdtempSync(join(tmpdir(), 'adlc-buildgate-'));
   try {
     mkdirSync(join(dir, '.adlc'));
@@ -50,6 +58,13 @@ function runBuildGate({ tickets, activeTicketEnv, currentTicketFile, transcriptT
     let transcriptPath;
     if (transcriptToolCalls !== undefined) {
       transcriptPath = makeTranscript(dir, 'transcript.jsonl', transcriptToolCalls, { padBytes: transcriptPadBytes ?? 0 });
+    }
+    // Lets a test point transcript_path at something that EXISTS (so the
+    // hook's existsSync guard passes) but cannot actually be read — a
+    // directory, or a chmod'd-unreadable file — to exercise the post-exists
+    // read-failure path distinctly from "no transcript_path at all".
+    if (transcriptPathOverride !== undefined) {
+      transcriptPath = transcriptPathOverride(dir);
     }
     const input = JSON.stringify({
       cwd: dir,
@@ -139,6 +154,42 @@ test('high-risk active ticket but no transcript_path supplied → deny (cannot v
     tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
     activeTicketEnv: 'T1',
     // transcriptToolCalls omitted → no transcript_path in the payload
+  });
+  assert.equal(r.verdict, 'deny');
+});
+
+// ---- fail closed: transcript_path exists (passes existsSync) but a later
+// read fails — TOCTOU / permissions / wrong file type. Must deny, not
+// silently treat the unreadable file as "zero bytes, not degraded". ----
+
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+test(
+  'high-risk ticket, transcript_path exists but is unreadable (chmod 0) → deny, not silently allow',
+  { skip: isRoot ? 'chmod 0o000 has no effect when running as root' : false },
+  () => {
+    const r = runBuildGate({
+      tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+      activeTicketEnv: 'T1',
+      transcriptPathOverride: (dir) => {
+        const p = makeTranscript(dir, 'unreadable-transcript.jsonl', 500);
+        chmodSync(p, 0o000);
+        return p;
+      },
+    });
+    assert.equal(r.verdict, 'deny');
+  }
+);
+
+test('high-risk ticket, transcript_path exists but is a directory (EISDIR on read) → deny', () => {
+  const r = runBuildGate({
+    tickets: [{ id: 'T1', title: 'x', category: 'contract' }],
+    activeTicketEnv: 'T1',
+    transcriptPathOverride: (dir) => {
+      const p = join(dir, 'transcript-is-a-dir.jsonl');
+      mkdirSync(p);
+      return p;
+    },
   });
   assert.equal(r.verdict, 'deny');
 });

--- a/plugins/adlc-claude-code/hooks/test/rails.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/rails.test.mjs
@@ -100,6 +100,17 @@ test('editing .adlc/tickets.json with NO rails declared → allow (authoring the
   assert.equal(runRails('{"tickets":[]}', '.adlc/tickets.json').verdict, 'allow');
 });
 
+// ---- trust root: .adlc/current-ticket.json is frozen once rails exist too
+// (build-gate's active-ticket pointer — see issue #48 follow-up review) ----
+
+test('editing .adlc/current-ticket.json while rails exist → deny (trust root)', () => {
+  assert.equal(runRails(RAIL_T, '.adlc/current-ticket.json').verdict, 'deny');
+});
+
+test('editing .adlc/current-ticket.json with NO rails declared → allow (build-gate not opted into rails)', () => {
+  assert.equal(runRails('{"tickets":[]}', '.adlc/current-ticket.json').verdict, 'allow');
+});
+
 // ---- multi-file / nested-path edit payloads ----
 
 /** Run the hook with an arbitrary tool_input payload; returns 'deny'|'allow'. */


### PR DESCRIPTION
Fixes #48

## Summary

Adds `@adlc/build-gate`: a machine-checkable P3→P4 fitness-to-build gate that denies **starting** a high-risk ticket's build when the executing session's context is degraded (context rot), unless an audited override is recorded. Previously nothing prevented this deterministically — it relied on an operator noticing and asking to pause.

**Toolkit (Path A, reusable by any harness)** — `packages/build-gate`:
- `lib/risk.mjs` — risk-tier derivation: declared `risk: 'high'`, or derived from category in `{contract, architecture}`, external-system effects, identity mutation, or scope/rails touching the trust root / gate-manifest ledger. A declared `risk: 'normal'` can never downgrade a derived-high signal.
- `lib/depth-signal.mjs` — the context-fitness proxy (tool-call depth + transcript bytes), mirroring `@adlc/flail-detector`'s existing transcript-size/tool-call-count scanning approach.
- `lib/decide.mjs` — the pure allow/deny decision.
- `lib/override.mjs` — durable override recording, routed through `@adlc/gate-manifest`'s real chain builder so bypass entries are hash-chain-linked and signed like every other ledger entry.
- `lib/active-ticket.mjs` — the shared `ADLC_TICKET`/`.adlc/current-ticket.json` active-ticket convention already used by every other harness integration.
- `bin/build-gate.mjs` — `adlc build-gate <ticket-id> [--depth n] [--session-bytes n] [--transcript path] [...]`, registered in `packages/cli/lib/registry.mjs`.

**Claude Code hook (Path B, self-enforcing, the primary deliverable)** — a new `buildgate` PreToolUse mode in `plugins/adlc-claude-code/hooks/adlc-hook.mjs`, wired alongside `rails` in `hooks.json`. It resolves the active ticket and computes risk tier + context-fitness entirely locally (verbatim KEEP-IN-SYNC ports of the toolkit logic), denying the edit when the ticket is high-risk and the session is degraded — unless `ADLC_BUILD_GATE_BYPASS=1` is set **and** the override is durably recorded via `adlc gate-manifest record build-gate-bypass` (mirrors `ADLC_RAILS_BYPASS`: an unauditable override is refused, never silent). The core decision does not depend on the `adlc` CLI being on `PATH`, so installing the plugin cannot brick a session that hasn't opted into the active-ticket convention.

### Review history (5 rounds)

| Round | Findings | Fix |
|-------|----------|-----|
| 1 | 2 | `b5dffda` — fail closed when a high-risk ticket's `transcript_path` exists but reading it fails (permission error / TOCTOU race) instead of silently treating it as zero bytes; freeze `.adlc/current-ticket.json` as a rails trust root (mirroring `.adlc/tickets.json`) so a structured edit can't silently repoint the active-ticket pointer for a ticket that declares rails. |
| 2 | 1 | `a5f0489` — `recordOverride()` was appending a raw manifest entry directly instead of going through `@adlc/gate-manifest`'s real chain builder, which broke the hash chain (no `seq`/`prev`, wrong shape) and made `gate-manifest verify` falsely report tampering after a legitimate bypass. Now routes through `gate-manifest`'s `record()`. |
| 3 | 1 | `0355d75` — `deriveRiskSignals()` spread a ticket's `scope`/`rails` fields with no `Array.isArray` guard; a malformed field (string glob, number, object) threw an uncaught `TypeError` and crashed the CLI. Now fails closed: a malformed field drives the tier to `high` (`malformed-scope`/`malformed-rails`) instead of crashing or being silently dropped. |
| 4 | 0 | — |
| 5 | 1 | `8433d86` — corrected a README claim in `docs/integrations/claude-code.md` stating the buildgate hook "shells to `adlc build-gate <id>`" for its decision; it doesn't — the risk-tier/context-fitness/decide logic is computed entirely locally via the KEEP-IN-SYNC ports. `adlc` is only invoked to record an audited bypass. |

## NEEDS ATTENTION — review did not reach a clean verdict

This branch went through **5 rounds of adversarial review and did not conclude with a clean (0-finding) round** — round 5 found 1 finding, which was fixed in the tip commit (`8433d86`), but that fix was **not re-run through a subsequent clean review round** (the process stopped at the round cap). Please have a human reviewer specifically check before merging:

1. **The round-5 fix itself is unverified by re-review.** `8433d86` is a docs-only correction (no code change), so the blast radius should be small, but confirm no other doc/behavior claims in `docs/integrations/claude-code.md` or `docs/specs/build-gate-fitness.md` still overstate what the hook actually checks.
2. **Bash bypasses the gate entirely (self-documented, not fixed).** The PreToolUse hook only matches structured-edit tools (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) — never `Bash` — same documented limitation as `rails-guard`. `rm .adlc/current-ticket.json` or any out-of-band overwrite via Bash clears the active-ticket pointer with zero risk evaluation and zero manifest entry. See `docs/specs/build-gate-fitness.md`'s "Known limitations" section.
3. **A high-risk ticket with no declared `rails` has no trust-root protection at all.** The `.adlc/current-ticket.json` freeze only activates when the ticket set declares at least one rail; a ticket that's high-risk purely via `category: 'contract'`/`architecture` (no rails) gets no trust-root protection, and — unlike rails' Bash gap — there is **no CI diff backstop** possible here, since `.adlc/current-ticket.json` is gitignored local session state, not tracked. Confirm this residual gap is acceptable for merge, or whether it needs a follow-up ticket.
4. **Unreadable `transcript_path` fails closed by design** — confirm the team is comfortable that a permission error / TOCTOU race on the transcript file denies the edit outright (rather than degrading gracefully), since this is a hard "unverifiable session must not be allowed through" stance with no fallback.

Treat build-gate as a strong in-session backstop, not a substitute for human review at P5/P6 on high-risk tickets — this is called out explicitly in the spec doc.

## Test plan

- [x] `node --test packages/build-gate/test/*.test.mjs` — 67/67 pass
- [x] `node --test packages/cli/test/*.test.mjs` — 14/14 pass
- [x] `node --test plugins/adlc-claude-code/hooks/test/*.test.mjs` — 69/69 pass
- [x] Full repo suite (`npm test`, covers all packages/plugins/apps) — green, exit 0, zero failures across all 32 test files
- [x] Regression tests added for every round 1–5 finding (TOCTOU transcript read failure, current-ticket.json trust-root freeze, gate-manifest chain-linked override recording + `verify()` after append, non-array scope/rails fail-closed)
- [ ] Human re-review of the round-5 fix and the open concerns above before merge
