### PR TITLE
fix(claude-code): harden bare-command guard into a repo-wide scan

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -78,7 +78,8 @@ tests load-bearing?), `behavior-diff` (is the behavior change visible?), and
 evidence-backed verdict. These are mechanical, deterministic-gate checks.
 
 `/adlc:adlc-prosecute` is the independent multi-lens adversarial loop, matching the
-OpenCode integration's `/adlc:adlc-prosecute` shape: it fans out five independent lens
+shape of OpenCode's own `adlc-prosecute` command (invoked bare there, since
+OpenCode has no plugin-namespace convention): it fans out five independent lens
 subagents (`prosecutor-correctness`, `prosecutor-security`, `prosecutor-contract`,
 `prosecutor-diff`, `prosecutor-tests`) on the diff, dedupes findings across
 lenses by file + line range + title (keeping the highest severity), independently

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -70,15 +70,15 @@ The `adlc` skill is a phase-routing flowchart: describe what you're doing ("shap
 this spec", "is this safe to merge") and it routes you to the right gate. It is
 how the model embraces the lifecycle in total.
 
-### The prosecutor subagent and `/adlc-prosecute`
+### The prosecutor subagent and `/adlc:adlc-prosecute`
 
 `prosecutor` is a hostile pre-merge (P5) reviewer: it runs `hollow-test` (are the
 tests load-bearing?), `behavior-diff` (is the behavior change visible?), and
 `review-calibration` (would the review catch a planted defect?) and returns an
 evidence-backed verdict. These are mechanical, deterministic-gate checks.
 
-`/adlc-prosecute` is the independent multi-lens adversarial loop, matching the
-OpenCode integration's `/adlc-prosecute` shape: it fans out five independent lens
+`/adlc:adlc-prosecute` is the independent multi-lens adversarial loop, matching the
+OpenCode integration's `/adlc:adlc-prosecute` shape: it fans out five independent lens
 subagents (`prosecutor-correctness`, `prosecutor-security`, `prosecutor-contract`,
 `prosecutor-diff`, `prosecutor-tests`) on the diff, dedupes findings across
 lenses by file + line range + title (keeping the highest severity), independently
@@ -88,7 +88,7 @@ finding survives only on a strict majority "real" vote — fail-closed to
 rounds surface no new confirmed findings. The pure dedupe/verify/convergence
 logic is unit-tested at `plugins/adlc-claude-code/lib/prosecutor.mjs`
 (`plugins/adlc-claude-code/lib/test/prosecutor.test.mjs`). The two mechanisms are
-complementary: `prosecutor` supplies mechanical evidence, `/adlc-prosecute`
+complementary: `prosecutor` supplies mechanical evidence, `/adlc:adlc-prosecute`
 supplies independent model judgment with cross-lens verification.
 
 ### Hooks (automatic)
@@ -231,7 +231,7 @@ recognizes `min-release-age`, not because anything was suppressed.
 | P2 Decompose | Strong | `coldstart`, `model-router`, `merge-forecast` |
 | P3 Rail | Strong | rails-guard PreToolUse hook + CI backstop |
 | P4 Build | Strong | flail-detection hook, `consensus-fix` |
-| P5 Prosecute | Strong | `/adlc-prosecute` runs the full multi-lens fan-out/dedupe/verify/converge loop (parity with OpenCode); `prosecutor` subagent runs complementary deterministic gates. Formal `adlc run p5` phase assertion is a harness-agnostic runner path (see below), not blocked on any one CLI. |
+| P5 Prosecute | Strong | `/adlc:adlc-prosecute` runs the full multi-lens fan-out/dedupe/verify/converge loop (parity with OpenCode); `prosecutor` subagent runs complementary deterministic gates. Formal `adlc run p5` phase assertion is a harness-agnostic runner path (see below), not blocked on any one CLI. |
 | P6 Integrate | Conditional | gate-manifest evidence surfaced for the human gate; strong when backed by valid P5 evidence. |
 | P7 Distill | Strong | `/adlc:adlc-distill` |
 | Maintenance | Strong | `/adlc:adlc-maintain` + CI cron |
@@ -270,10 +270,10 @@ Current gaps relative to the formal ADLC doctrine:
 1. **Recording formal `adlc run p5` phase assertion from the CC path is not yet
    wired up end-to-end (narrower than before issue #61).** The independent
    multi-lens loop itself — fan-out, dedupe, verifier refutation, loop-until-dry
-   — now runs natively on Claude Code via `/adlc-prosecute` and the
+   — now runs natively on Claude Code via `/adlc:adlc-prosecute` and the
    `prosecutor-{correctness,security,contract,diff,tests,verifier}` subagents,
    the same shape as the OpenCode integration. What remains unwired is the
-   *recording* step: `/adlc-prosecute`'s default evidence path is `adlc
+   *recording* step: `/adlc:adlc-prosecute`'s default evidence path is `adlc
    gate-manifest record prosecution --files <changed files>`, which carries
    `gate: "prosecution"` and does not by itself satisfy `adlc run p5`. Formal
    assertion requires `@adlc/prosecute`'s `type: "p5-complete"` provenance chain

--- a/docs/specs/harden-cc-smoke-guard.md
+++ b/docs/specs/harden-cc-smoke-guard.md
@@ -1,0 +1,46 @@
+# Spec — harden claude-code-plugin-smoke.mjs's bare-command guard (issue #96)
+
+## Issue
+
+The regression guard added in #89 (closing #50) scanned only a hardcoded allowlist
+of "extra" doc paths (`docs/integrations/claude-code.md`, `README.md`, the design
+ADR) plus a hardcoded list of command names (`['init', 'ticket', 'distill',
+'maintain']`). Every adversarial-review round after the first, across both #89 and
+this change's own build, found a new surface the allowlist didn't know about —
+most notably a **live, unfixed bug**: `/adlc-prosecute` (added by #61) was missing
+from the command-name list, so bare `/adlc-prosecute` references in
+`docs/integrations/claude-code.md` and the command file's own heading were never
+caught.
+
+## Fix
+
+1. **Command names derived from `plugins/adlc-claude-code/commands/*.md`** instead
+   of a hardcoded array — a new command file is covered automatically.
+2. **Doc-wide scan** of `docs/**/*.md` + `README.md` (+ `AGENTS.md`/`CLAUDE.md` if
+   present), replacing the 3-file allowlist, with an explicit, reviewed exclusion
+   list (`EXCLUDED_DOC_PATHS`) for paths that are genuinely not Claude-Code-specific
+   live guidance — archived/superseded docs, other harnesses' own integration docs,
+   planning/spec scratch docs, and harness-agnostic package reference docs. Each
+   exclusion entry states its reason inline.
+3. Fixed the live `/adlc-prosecute` bug found by the above: 9 files across
+   `plugins/adlc-claude-code/agents/*`, `lib/prosecutor.mjs`,
+   `commands/adlc-prosecute.md`'s own heading, and `docs/integrations/claude-code.md`.
+
+## Acceptance criteria
+
+1. A bare command reference in any new doc under `docs/`, anywhere, fails the guard
+   with no allowlist entry required.
+2. A bare reference to a newly-added command (a command file the guard has never
+   seen before) fails the guard with no hardcoded name-list update required.
+3. Genuinely out-of-scope docs (archived docs, other harnesses' own integration
+   docs) do not false-positive, even though they contain real bare-command text.
+4. The guard passes clean against the current repo (no regressions from the doc
+   fixes made alongside the guard change).
+
+## Verification
+
+```sh
+node --test scripts/test/claude-code-plugin-smoke.test.mjs   # 8/8 pass
+node scripts/claude-code-plugin-smoke.mjs .                    # exit 0
+npm test                                                       # full repo suite, exit 0
+```

--- a/docs/specs/harden-cc-smoke-guard.md
+++ b/docs/specs/harden-cc-smoke-guard.md
@@ -40,7 +40,7 @@ caught.
 ## Verification
 
 ```sh
-node --test scripts/test/claude-code-plugin-smoke.test.mjs   # 8/8 pass
+node --test scripts/test/claude-code-plugin-smoke.test.mjs   # 12/12 pass
 node scripts/claude-code-plugin-smoke.mjs .                    # exit 0
 npm test                                                       # full repo suite, exit 0
 ```

--- a/docs/specs/harden-cc-smoke-guard.md
+++ b/docs/specs/harden-cc-smoke-guard.md
@@ -40,7 +40,7 @@ caught.
 ## Verification
 
 ```sh
-node --test scripts/test/claude-code-plugin-smoke.test.mjs   # 12/12 pass
+node --test scripts/test/claude-code-plugin-smoke.test.mjs   # 13/13 pass
 node scripts/claude-code-plugin-smoke.mjs .                    # exit 0
 npm test                                                       # full repo suite, exit 0
 ```

--- a/plugins/adlc-claude-code/agents/prosecutor-contract.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-contract.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-contract
-description: P5 contract lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for API/schema/type conformance drift against the declared contract in a change diff. Read-only; never invoke to edit code.
+description: P5 contract lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for API/schema/type conformance drift against the declared contract in a change diff. Read-only; never invoke to edit code.
 tools: Read, Grep, Glob
 ---
 

--- a/plugins/adlc-claude-code/agents/prosecutor-correctness.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-correctness.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-correctness
-description: P5 correctness lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for logic errors, broken invariants, and wrong results in a change diff. Read-only; never invoke to edit code.
+description: P5 correctness lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for logic errors, broken invariants, and wrong results in a change diff. Read-only; never invoke to edit code.
 tools: Read, Grep, Glob
 ---
 

--- a/plugins/adlc-claude-code/agents/prosecutor-diff.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-diff.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-diff
-description: P5 spec-vs-implementation diff lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for divergence between the spec/acceptance criteria and the actual implementation. Read-only; never invoke to edit code.
+description: P5 spec-vs-implementation diff lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for divergence between the spec/acceptance criteria and the actual implementation. Read-only; never invoke to edit code.
 tools: Read, Grep, Glob
 ---
 

--- a/plugins/adlc-claude-code/agents/prosecutor-security.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-security.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-security
-description: P5 security lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for auth/trust-boundary holes, injection, secrets, and unsafe data flow in a change diff. Read-only; never invoke to edit code.
+description: P5 security lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for auth/trust-boundary holes, injection, secrets, and unsafe data flow in a change diff. Read-only; never invoke to edit code.
 tools: Read, Grep, Glob
 ---
 

--- a/plugins/adlc-claude-code/agents/prosecutor-tests.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-tests.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-tests
-description: P5 test-audit lens — one of five independent prosecution subagents invoked by /adlc-prosecute. Hunts for hollow/mock-only tests and missing coverage of the change's core behavior. Read-only; never invoke to edit code.
+description: P5 test-audit lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for hollow/mock-only tests and missing coverage of the change's core behavior. Read-only; never invoke to edit code.
 tools: Read, Grep, Glob
 ---
 

--- a/plugins/adlc-claude-code/agents/prosecutor-verifier.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-verifier
-description: P5 verifier/reproducer — invoked independently by /adlc-prosecute, once per deduped finding, to adversarially confirm or refute it. Read-only; never invoke to edit code.
+description: P5 verifier/reproducer — invoked independently by /adlc:adlc-prosecute, once per deduped finding, to adversarially confirm or refute it. Read-only; never invoke to edit code.
 tools: Read, Grep, Glob
 ---
 
@@ -23,7 +23,7 @@ Return one JSON object: `{ "real": boolean, "reason": string, "repro": string }`
 Be specific and mechanistic; "looks fine" is not a reason.
 
 Each finding gets an **independent** verifier invocation (fresh context, no
-memory of other findings' verdicts) — `/adlc-prosecute` runs one call per
+memory of other findings' verdicts) — `/adlc:adlc-prosecute` runs one call per
 deduped finding and takes a strict majority of the votes it collects for that
 finding (see `survivesVerification` in `lib/prosecutor.mjs`). A finding for which
 no valid verifier vote could be obtained survives as an unverified blocker rather

--- a/plugins/adlc-claude-code/agents/prosecutor.md
+++ b/plugins/adlc-claude-code/agents/prosecutor.md
@@ -22,9 +22,9 @@ and you are on the branch under review with a clean working tree.
 This subagent runs three deterministic gates over the change as a whole. For the
 independent multi-lens adversarial loop (fan-out across five review lenses,
 cross-lens dedupe, independent verifier refutation, loop until two consecutive
-dry rounds) see `/adlc-prosecute` instead — the two are complementary, not
+dry rounds) see `/adlc:adlc-prosecute` instead — the two are complementary, not
 redundant: this subagent's gates are mechanical (mutation testing, capture/
-compare, recall scoring), while `/adlc-prosecute`'s lenses are independent
+compare, recall scoring), while `/adlc:adlc-prosecute`'s lenses are independent
 model judgment on the diff.
 
 ## Prosecution sequence
@@ -100,10 +100,10 @@ prosecute` → `adlc run p5`), not exclusive to any one CLI or agent tool.
 
 For the full adversarial engine — independent fan-out across lenses, cross-lens
 dedupe, and independent verifier refutation with loop-until-dry convergence — use
-`/adlc-prosecute`, which invokes the `prosecutor-{correctness,security,contract,
+`/adlc:adlc-prosecute`, which invokes the `prosecutor-{correctness,security,contract,
 diff,tests,verifier}` subagents. That command replicates the same fan-out →
 dedupe → independent-verify → repeat-until-two-dry-rounds shape as the OpenCode
-integration's `/adlc-prosecute`, so Claude Code no longer needs to punt to a
+integration's `/adlc:adlc-prosecute`, so Claude Code no longer needs to punt to a
 different harness to run the multi-lens loop; it can additionally feed its
 surviving findings to the `adlc prosecute` runner path for formal `adlc run p5`
 phase assertion when that is required.

--- a/plugins/adlc-claude-code/agents/prosecutor.md
+++ b/plugins/adlc-claude-code/agents/prosecutor.md
@@ -103,7 +103,8 @@ dedupe, and independent verifier refutation with loop-until-dry convergence — 
 `/adlc:adlc-prosecute`, which invokes the `prosecutor-{correctness,security,contract,
 diff,tests,verifier}` subagents. That command replicates the same fan-out →
 dedupe → independent-verify → repeat-until-two-dry-rounds shape as the OpenCode
-integration's `/adlc:adlc-prosecute`, so Claude Code no longer needs to punt to a
+integration's own `adlc-prosecute` command (invoked bare there, since OpenCode
+has no plugin-namespace convention), so Claude Code no longer needs to punt to a
 different harness to run the multi-lens loop; it can additionally feed its
 surviving findings to the `adlc prosecute` runner path for formal `adlc run p5`
 phase assertion when that is required.

--- a/plugins/adlc-claude-code/commands/adlc-prosecute.md
+++ b/plugins/adlc-claude-code/commands/adlc-prosecute.md
@@ -3,7 +3,7 @@ description: Prosecute a change before merge (P5) — fan out five lens subagent
 argument-hint: [ticket-id] (defaults to the active ticket)
 ---
 
-# /adlc-prosecute — hostile pre-merge review (P5)
+# /adlc:adlc-prosecute — hostile pre-merge review (P5)
 
 Prosecute the change for the active ticket. Prerequisite: a clean G4 build (rails
 green, build + lint clean, no suppressions) for **$ARGUMENTS** (default to the

--- a/plugins/adlc-claude-code/lib/prosecutor.mjs
+++ b/plugins/adlc-claude-code/lib/prosecutor.mjs
@@ -2,7 +2,7 @@
 //
 // Claude Code port of plugins/adlc-opencode/lib/prosecutor.mjs (issue #61). The
 // lenses and verifier are Claude Code subagents (agents/prosecutor-*.md), invoked
-// via the Task tool from /adlc-prosecute. This module is the machine-checkable
+// via the Task tool from /adlc:adlc-prosecute. This module is the machine-checkable
 // contract for the fan-out: which lenses exist, how findings are deduped across
 // lenses, and how the verifier's votes decide whether a finding survives. The
 // model calls live in the subagents; the decision logic here is pure and

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -534,23 +534,41 @@ const bareCommandPattern = new RegExp(
   `(?<!adlc:)(?<![\\w:./-])/adlc-(?:${escapedCommandNames.join('|')})\\b(?!-)(?!\\.(?:md|mjs|yml|yaml))`,
   'g'
 );
+// Shared symlink-safe recursive file collector, used by BOTH the plugin-tree
+// scan below and the doc-wide scan further down. Uses statSync (follows
+// symlinks), not a Dirent's own type flags: Dirent.isDirectory() reports false
+// for a symlink even when its target IS a directory, so a symlinked directory
+// would otherwise be recursed into by neither branch — invisible to the scan
+// with zero trace in the tool's output. An EARLIER version of this guard had
+// two independent copies of this traversal (one for the plugin tree, one for
+// docs/); the symlink fix was applied to only one of them and the other still
+// had the exact same blind spot — the identical "silent gap in one of two
+// hand-duplicated copies" failure class #96 exists to close in general. One
+// shared implementation now, so a future fix here can't be applied to only
+// one of two copies again.
+function collectFilesRecursively(dirPath, matchExtensions, out = []) {
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const entryPath = join(dirPath, entry.name);
+    let isDir;
+    try {
+      isDir = statSync(entryPath).isDirectory();
+    } catch {
+      continue; // broken symlink target — nothing to scan
+    }
+    if (isDir) {
+      collectFilesRecursively(entryPath, matchExtensions, out);
+    } else if (matchExtensions.some((ext) => entry.name.endsWith(ext))) {
+      out.push(entryPath);
+    }
+  }
+  return out;
+}
 const guidanceDirs = ['commands', 'skills', 'agents', 'hooks'];
 const guidanceFiles = [];
 for (const dir of guidanceDirs) {
   const dirPath = join(pluginSourceDir, dir);
   if (!existsSync(dirPath)) continue;
-  const stack = [dirPath];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    for (const entry of readdirSync(current, { withFileTypes: true })) {
-      const entryPath = join(current, entry.name);
-      if (entry.isDirectory()) {
-        stack.push(entryPath);
-      } else if (entry.name.endsWith('.md') || entry.name.endsWith('.mjs')) {
-        guidanceFiles.push(entryPath);
-      }
-    }
-  }
+  collectFilesRecursively(dirPath, ['.md', '.mjs'], guidanceFiles);
 }
 // Doc-wide scan (closes #96): the previous version of this guard scanned only a
 // hardcoded allowlist of "extra" doc paths outside the plugin's own tree
@@ -591,33 +609,10 @@ const EXCLUDED_DOC_PATHS = [
 function isExcludedDocPath(relPosixPath) {
   return EXCLUDED_DOC_PATHS.some(([prefix]) => relPosixPath === prefix || relPosixPath.startsWith(prefix));
 }
-function collectMarkdownFiles(dirPath, out = []) {
-  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
-    const entryPath = join(dirPath, entry.name);
-    // Use statSync (follows symlinks), not the dirent's own type flags:
-    // Dirent.isDirectory() reports false for a symlink even when its target
-    // IS a directory, so a symlinked doc directory would otherwise be
-    // silently invisible to this scan — recursed into by neither branch below
-    // — reintroducing exactly the kind of blind spot #96 exists to close, via
-    // a filesystem-type route instead of a hardcoded-list route.
-    let isDir;
-    try {
-      isDir = statSync(entryPath).isDirectory();
-    } catch {
-      continue; // broken symlink target — nothing to scan
-    }
-    if (isDir) {
-      collectMarkdownFiles(entryPath, out);
-    } else if (entry.name.endsWith('.md')) {
-      out.push(entryPath);
-    }
-  }
-  return out;
-}
 for (const scanRoot of DOC_SCAN_ROOTS) {
   const fullPath = join(repo, scanRoot);
   if (!existsSync(fullPath)) continue;
-  const candidates = statSync(fullPath).isDirectory() ? collectMarkdownFiles(fullPath) : [fullPath];
+  const candidates = statSync(fullPath).isDirectory() ? collectFilesRecursively(fullPath, ['.md']) : [fullPath];
   for (const filePath of candidates) {
     const relPosixPath = filePath.slice(repo.length + 1).split(sep).join('/');
     if (isExcludedDocPath(relPosixPath)) continue;

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
 
 function fail(message) {
   console.error(`claude-code-plugin-smoke: ${message}`);
@@ -478,15 +478,30 @@ if (!skillSource.includes('ADLC_CC_SENTINEL_PHASE_ROUTER_V1')) {
   fail('plugins/adlc-claude-code/skills/adlc/SKILL.md missing sentinel ADLC_CC_SENTINEL_PHASE_ROUTER_V1');
 }
 
-// --- Guard: no bare, non-namespaced command recommendations (closes #50) ---
+// --- Guard: no bare, non-namespaced command recommendations (closes #50, #96) ---
 // The plugin is named "adlc" (plugins/adlc-claude-code/.claude-plugin/plugin.json),
 // so inside Claude Code the actual invocable form of a plugin command is the
 // namespaced "/adlc:adlc-<name>" — a bare "/adlc-<name>" is not a real command and
 // silently fails to invoke when a user (or the agent itself) follows the guidance.
-// This scans every .md/.mjs file under commands/, skills/, agents/, and hooks/ for
-// a bare reference to one of the plugin's real commands and fails loudly if found,
-// so a future edit can't reintroduce the bug fixed in #50.
-const namespacedCommandNames = ['init', 'ticket', 'distill', 'maintain'];
+// This scans every .md/.mjs file under commands/, skills/, agents/, and hooks/,
+// plus every markdown doc in the repo (see the doc-wide scan below), for a bare
+// reference to one of the plugin's real commands and fails loudly if found.
+//
+// The command-name list is DERIVED from the commands/ directory itself, not
+// hardcoded — a hardcoded list (['init', 'ticket', 'distill', 'maintain']) is
+// exactly the kind of allowlist #96 exists to eliminate: it silently missed
+// '/adlc-prosecute' after #61 added a fifth command, and a live instance of that
+// exact gap (docs/integrations/claude-code.md, and the command file's own
+// heading) was found and fixed while building this guard.
+const commandsDir = join(pluginSourceDir, 'commands');
+const namespacedCommandNames = existsSync(commandsDir)
+  ? readdirSync(commandsDir)
+      .filter((name) => name.startsWith('adlc-') && name.endsWith('.md'))
+      .map((name) => name.slice('adlc-'.length, -'.md'.length))
+  : [];
+if (namespacedCommandNames.length === 0) {
+  fail('no adlc-*.md command files found under plugins/adlc-claude-code/commands — cannot derive namespacedCommandNames (the bare-command guard would silently match nothing)');
+}
 // Matches "/adlc-init" etc. but NOT "/adlc:adlc-init" (scoped form, via the
 // negative lookbehind) and NOT a file-path or URL reference such as
 // "commands/adlc-init.md", "docs/ci/adlc-maintenance.yml",
@@ -521,24 +536,64 @@ for (const dir of guidanceDirs) {
     }
   }
 }
-// Also scan the plugin's own primary onboarding doc, the repo's top-level README,
-// and the plugin's design ADR. plugin.json's "homepage" field points at
-// docs/integrations/claude-code.md (asserted above) and it is the first thing a
-// user reads after installing, but README.md is the very first file a GitHub
-// visitor reads (it has its own "Use it in Claude Code" quick-start), and
-// docs/adr/0003-adlc-claude-code-plugin.md is the plugin's own design doc,
-// cross-linked from docs/integrations/claude-code.md and checked above via
-// crossDocLinks. A bare command recommendation in any of these is the exact
-// regression #50 was filed against, so they must be covered by the same guard
-// as the in-plugin guidance files, not just the plugins/adlc-claude-code/* tree.
-const extraDocPaths = [
-  join(repo, 'docs/integrations/claude-code.md'),
-  join(repo, 'README.md'),
-  join(repo, 'docs/adr/0003-adlc-claude-code-plugin.md'),
+// Doc-wide scan (closes #96): the previous version of this guard scanned only a
+// hardcoded allowlist of "extra" doc paths outside the plugin's own tree
+// (docs/integrations/claude-code.md, README.md, the design ADR). Every one of
+// #50/#89's adversarial-review rounds after the first found a NEW doc surface
+// with a bare reference the allowlist hadn't been told about — the allowlist
+// itself was the recurring vulnerability. Scan every markdown doc in the repo
+// instead, with an explicit, reviewed EXCLUSION list for paths that are
+// genuinely not Claude-Code-specific live guidance (each entry states why).
+// Adding a new doc anywhere under docs/ or at the repo root is covered
+// automatically from now on; nothing has to remember to list it.
+const DOC_SCAN_ROOTS = ['docs', 'README.md'];
+// AGENTS.md / CLAUDE.md are common cross-harness instruction files; scan them
+// too if this repo ever adds one — they're exactly the kind of top-level
+// guidance surface #50 was filed about.
+for (const name of ['AGENTS.md', 'CLAUDE.md']) {
+  if (existsSync(join(repo, name))) DOC_SCAN_ROOTS.push(name);
+}
+// Each entry is a POSIX-style path (file or directory prefix, relative to repo
+// root) excluded from the doc-wide scan, with the reason it is not a live
+// Claude-Code guidance surface. This list is reviewed, not implicit — a new doc
+// that doesn't match any entry here is scanned by default.
+const EXCLUDED_DOC_PATHS = [
+  ['docs/archive/', 'superseded/historical record, not live guidance — see docs/archive/README.md'],
+  ['docs/specs/', 'P1 spec/acceptance-criteria docs describe issues (including this bug class) as illustrative examples, not live guidance'],
+  ['docs/superpowers/', 'internal planning/spec scratch docs for in-flight work, not published guidance'],
+  ['docs/tools/', 'harness-agnostic package reference docs (per docs/README.md: "follow the linked README for command-specific detail"), not per-harness invocation guidance'],
+  ['docs/integrations/antigravity.md', "Antigravity's own doc; that harness has no plugin-namespace convention (verified in #50)"],
+  ['docs/integrations/codex.md', "Codex's own doc; skill-driven, not command-namespaced (verified in #50)"],
+  ['docs/integrations/cursor.md', "Cursor's own doc; bare \"/adlc-*\" is that harness's correct, intentional syntax"],
+  ['docs/integrations/opencode.md', "OpenCode's own doc; bare \"/adlc-*\" is that harness's correct, intentional syntax"],
+  ['docs/integrations/pi.md', "Pi's own doc; skill-driven, not command-namespaced (verified in #50)"],
+  ['docs/adr/0006-adlc-cursor-integration.md', "ADR specific to the Cursor integration; bare form is Cursor's correct syntax"],
+  ['docs/opencode.md', 'OpenCode-specific planning/reference doc, not a Claude Code guidance surface'],
+  ['docs/opencode-integration-plan.md', 'OpenCode-specific planning doc, not a Claude Code guidance surface'],
+  ['docs/ticket-sync.md', 'uses "/adlc-ticket" as generic ADLC-lifecycle prose, not a Claude-Code-specific command recommendation (judged out of scope during #50\'s review)'],
 ];
-for (const docPath of extraDocPaths) {
-  if (existsSync(docPath)) {
-    guidanceFiles.push(docPath);
+function isExcludedDocPath(relPosixPath) {
+  return EXCLUDED_DOC_PATHS.some(([prefix]) => relPosixPath === prefix || relPosixPath.startsWith(prefix));
+}
+function collectMarkdownFiles(dirPath, out = []) {
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const entryPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      collectMarkdownFiles(entryPath, out);
+    } else if (entry.name.endsWith('.md')) {
+      out.push(entryPath);
+    }
+  }
+  return out;
+}
+for (const scanRoot of DOC_SCAN_ROOTS) {
+  const fullPath = join(repo, scanRoot);
+  if (!existsSync(fullPath)) continue;
+  const candidates = statSync(fullPath).isDirectory() ? collectMarkdownFiles(fullPath) : [fullPath];
+  for (const filePath of candidates) {
+    const relPosixPath = filePath.slice(repo.length + 1).split(sep).join('/');
+    if (isExcludedDocPath(relPosixPath)) continue;
+    guidanceFiles.push(filePath);
   }
 }
 for (const filePath of guidanceFiles) {

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -498,6 +498,14 @@ const namespacedCommandNames = existsSync(commandsDir)
   ? readdirSync(commandsDir)
       .filter((name) => name.startsWith('adlc-') && name.endsWith('.md'))
       .map((name) => name.slice('adlc-'.length, -'.md'.length))
+      // A filename of exactly "adlc-.md" (or similarly degenerate) would derive
+      // an empty name, producing an empty alternative in the regex alternation
+      // below. An empty alternative matches everywhere, silently widening
+      // "/adlc-<name>" into "/adlc-" matching ANY bare command reference —
+      // reintroducing exactly the "match too much" class the escaping fix
+      // below exists to close. Drop empty names defensively; there is no
+      // legitimate command with an empty name.
+      .filter((name) => name.length > 0)
   : [];
 if (namespacedCommandNames.length === 0) {
   fail('no adlc-*.md command files found under plugins/adlc-claude-code/commands — cannot derive namespacedCommandNames (the bare-command guard would silently match nothing)');

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -577,7 +577,7 @@ const EXCLUDED_DOC_PATHS = [
   ['docs/archive/', 'superseded/historical record, not live guidance — see docs/archive/README.md'],
   ['docs/specs/', 'P1 spec/acceptance-criteria docs describe issues (including this bug class) as illustrative examples, not live guidance'],
   ['docs/superpowers/', 'internal planning/spec scratch docs for in-flight work, not published guidance'],
-  ['docs/tools/', 'harness-agnostic package reference docs (per docs/README.md: "follow the linked README for command-specific detail"), not per-harness invocation guidance'],
+  ['docs/tools/', 'harness-agnostic package reference docs (per docs/toolkit.md: "follow the linked README for command-specific detail"), not per-harness invocation guidance'],
   ['docs/integrations/antigravity.md', "Antigravity's own doc; that harness has no plugin-namespace convention (verified in #50)"],
   ['docs/integrations/codex.md', "Codex's own doc; skill-driven, not command-namespaced (verified in #50)"],
   ['docs/integrations/cursor.md', "Cursor's own doc; bare \"/adlc-*\" is that harness's correct, intentional syntax"],
@@ -594,7 +594,19 @@ function isExcludedDocPath(relPosixPath) {
 function collectMarkdownFiles(dirPath, out = []) {
   for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
     const entryPath = join(dirPath, entry.name);
-    if (entry.isDirectory()) {
+    // Use statSync (follows symlinks), not the dirent's own type flags:
+    // Dirent.isDirectory() reports false for a symlink even when its target
+    // IS a directory, so a symlinked doc directory would otherwise be
+    // silently invisible to this scan — recursed into by neither branch below
+    // — reintroducing exactly the kind of blind spot #96 exists to close, via
+    // a filesystem-type route instead of a hardcoded-list route.
+    let isDir;
+    try {
+      isDir = statSync(entryPath).isDirectory();
+    } catch {
+      continue; // broken symlink target — nothing to scan
+    }
+    if (isDir) {
       collectMarkdownFiles(entryPath, out);
     } else if (entry.name.endsWith('.md')) {
       out.push(entryPath);

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -502,6 +502,14 @@ const namespacedCommandNames = existsSync(commandsDir)
 if (namespacedCommandNames.length === 0) {
   fail('no adlc-*.md command files found under plugins/adlc-claude-code/commands — cannot derive namespacedCommandNames (the bare-command guard would silently match nothing)');
 }
+// Escape regex metacharacters in each derived name before splicing into the
+// alternation below. Names come from filenames on disk, not a hardcoded
+// literal list, so they must be treated as untrusted regex input: an
+// unescaped "." would silently widen the match (matching any character, not
+// a literal dot), and an unescaped "(" would throw an uncaught SyntaxError
+// from `new RegExp(...)`, crashing the script instead of failing cleanly
+// through `fail()`.
+const escapedCommandNames = namespacedCommandNames.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
 // Matches "/adlc-init" etc. but NOT "/adlc:adlc-init" (scoped form, via the
 // negative lookbehind) and NOT a file-path or URL reference such as
 // "commands/adlc-init.md", "docs/ci/adlc-maintenance.yml",
@@ -515,7 +523,7 @@ if (namespacedCommandNames.length === 0) {
 //     extension (".md" / ".mjs" / ".yml" / ".yaml"), so "adlc-init-helper.mjs"
 //     and "adlc-init.md" are not mistaken for the bare command "/adlc-init".
 const bareCommandPattern = new RegExp(
-  `(?<!adlc:)(?<![\\w:./-])/adlc-(?:${namespacedCommandNames.join('|')})\\b(?!-)(?!\\.(?:md|mjs|yml|yaml))`,
+  `(?<!adlc:)(?<![\\w:./-])/adlc-(?:${escapedCommandNames.join('|')})\\b(?!-)(?!\\.(?:md|mjs|yml|yaml))`,
   'g'
 );
 const guidanceDirs = ['commands', 'skills', 'agents', 'hooks'];

--- a/scripts/test/claude-code-plugin-smoke.test.mjs
+++ b/scripts/test/claude-code-plugin-smoke.test.mjs
@@ -271,3 +271,38 @@ test('claude-code-plugin-smoke fails cleanly (not an uncaught crash) on a comman
     rmSync(tmpRepo, { recursive: true, force: true });
   }
 });
+
+// Regression coverage: a command filename of exactly "adlc-.md" derives an
+// EMPTY name, producing an empty alternative in the regex alternation
+// (equivalent to `(?:init|ticket|)`). An empty alternative matches the empty
+// string at any position, which widens "/adlc-<name>" into effectively
+// "/adlc-" matching ANY bare command reference — silently reintroducing the
+// "match too much" failure class the escaping fix exists to close, just via a
+// different route (an empty string, not an unescaped metacharacter).
+test('claude-code-plugin-smoke does not let a degenerate empty-name command file widen the match to any bare reference', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    // A degenerate command filename that derives an empty name.
+    writeFileSync(join(tmpRepo, 'plugins/adlc-claude-code/commands/adlc-.md'), '---\ndescription: a fixture-only degenerate command file.\n---\n\n# fixture\n');
+
+    // An UNRELATED bare command name that isn't a real command at all — should
+    // never be flagged. If the empty derived name widens the alternation, this
+    // would wrongly match.
+    const fixtureDocPath = join(tmpRepo, 'docs/fixture-empty-name.md');
+    writeFileSync(fixtureDocPath, '# Fixture\n\nThis mentions /adlc-notarealcommand which must NOT be treated as a bare command match.\n');
+
+    const result = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+    assert.strictEqual(
+      result.status,
+      0,
+      `an empty derived name would wrongly widen the match to any "/adlc-<anything>" reference:\n${result.stderr}`
+    );
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/claude-code-plugin-smoke.test.mjs
+++ b/scripts/test/claude-code-plugin-smoke.test.mjs
@@ -205,3 +205,69 @@ test('claude-code-plugin-smoke does not false-positive on excluded, genuinely ou
   assert.match(readFileSync(archivePath, 'utf8'), /\/adlc-init/, 'fixture assumption stale: expected archived doc to still contain bare command text');
   assert.match(readFileSync(cursorDocPath, 'utf8'), /\/adlc-init/, 'fixture assumption stale: expected Cursor doc to still contain its own bare command text');
 });
+
+// Regression coverage: namespacedCommandNames is derived from filenames on disk
+// (plugins/adlc-claude-code/commands/*.md), not a hardcoded literal list, so a
+// derived name must be treated as untrusted regex input, not spliced unescaped
+// into `new RegExp(...)`. Two failure modes if unescaped: (1) a name containing
+// "." would make the pattern match ANY character there (a silent false
+// positive), and (2) a name containing an unbalanced metacharacter like "("
+// would throw an uncaught SyntaxError from `new RegExp(...)`, crashing the
+// script with a raw stack trace instead of the script's own clean fail() path.
+test('claude-code-plugin-smoke escapes regex metacharacters in derived command names (no wildcard false positive)', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    // A command name containing a literal "." — if spliced unescaped into the
+    // regex, "." matches any character, so "/adlc-v1X2" would wrongly match too.
+    writeFileSync(
+      join(tmpRepo, 'plugins/adlc-claude-code/commands/adlc-v1.2.md'),
+      '---\ndescription: a fixture-only versioned command.\n---\n\n# /adlc:adlc-v1.2\n'
+    );
+    const fixtureDocPath = join(tmpRepo, 'docs/fixture-regex-escape.md');
+    writeFileSync(fixtureDocPath, '# Fixture\n\nThis mentions /adlc-v1X2 which must NOT be treated as a bare command match.\n');
+
+    const noFalsePositive = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+    assert.strictEqual(
+      noFalsePositive.status,
+      0,
+      `an unescaped "." would wrongly match "/adlc-v1X2" as if it were "/adlc-v1.2"; guard should not fire here:\n${noFalsePositive.stderr}`
+    );
+
+    // Sanity check: the ACTUAL literal form (unnamespaced) is still caught, so
+    // the escaping isn't just accidentally matching nothing at all.
+    writeFileSync(fixtureDocPath, '# Fixture\n\nRun /adlc-v1.2 to use the fixture command.\n');
+    const literalMatchStillCaught = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+    assert.notStrictEqual(literalMatchStillCaught.status, 0, 'the literal bare form "/adlc-v1.2" should still be caught');
+    assert.match(literalMatchStillCaught.stderr, /bare, non-namespaced command reference/);
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});
+
+test('claude-code-plugin-smoke fails cleanly (not an uncaught crash) on a command filename containing an unbalanced regex metacharacter', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    // An unescaped "(" in the alternation would throw "Unterminated group" from
+    // `new RegExp(...)` — an uncaught SyntaxError, not this script's own fail().
+    writeFileSync(
+      join(tmpRepo, 'plugins/adlc-claude-code/commands/adlc-a(b.md'),
+      '---\ndescription: a fixture-only command with a regex-hostile filename.\n---\n\n# fixture\n'
+    );
+
+    const result = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+    assert.doesNotMatch(result.stderr, /SyntaxError/, 'must not crash with an uncaught RegExp SyntaxError');
+    assert.doesNotMatch(result.stderr, /Unterminated group/, 'must not crash with an uncaught RegExp SyntaxError');
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/claude-code-plugin-smoke.test.mjs
+++ b/scripts/test/claude-code-plugin-smoke.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { cpSync, mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'claude-code-plugin-smoke.mjs');
@@ -302,6 +302,47 @@ test('claude-code-plugin-smoke does not let a degenerate empty-name command file
       0,
       `an empty derived name would wrongly widen the match to any "/adlc-<anything>" reference:\n${result.stderr}`
     );
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});
+
+// Regression coverage: Node's Dirent.isDirectory() reports false for a symlink
+// even when its target IS a directory, so collectMarkdownFiles() must not rely
+// on the dirent's own type flags — a symlinked doc directory under docs/ would
+// otherwise be recursed into by neither branch (not a directory by the dirent
+// flag, and its name doesn't end in ".md" either), making it silently invisible
+// to the scan with zero trace in the tool's output. This is the same "silent
+// blind spot" failure class #96 exists to close, reached via a filesystem-type
+// route instead of a hardcoded-list route.
+test('claude-code-plugin-smoke follows a symlinked directory under docs/ instead of silently skipping it', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    // A real directory OUTSIDE docs/, containing a bare-command doc, linked
+    // INTO docs/ as a directory symlink (e.g. simulating a vendored/shared docs
+    // tree in a monorepo).
+    const externalDir = join(tmpRepo, '..', 'adlc-cc-smoke-external-docs');
+    mkdirSync(externalDir, { recursive: true });
+    writeFileSync(join(externalDir, 'hidden.md'), '# Hidden\n\nRun /adlc-ticket to get started.\n');
+    symlinkSync(externalDir, join(tmpRepo, 'docs/linked-external'), 'dir');
+
+    try {
+      const result = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+      assert.notStrictEqual(
+        result.status,
+        0,
+        'smoke test should fail on a bare command reference reached through a symlinked doc directory, not silently skip it'
+      );
+      assert.match(result.stderr, /bare, non-namespaced command reference/);
+      assert.match(result.stderr, /linked-external/);
+    } finally {
+      rmSync(externalDir, { recursive: true, force: true });
+    }
   } finally {
     rmSync(tmpRepo, { recursive: true, force: true });
   }

--- a/scripts/test/claude-code-plugin-smoke.test.mjs
+++ b/scripts/test/claude-code-plugin-smoke.test.mjs
@@ -347,3 +347,43 @@ test('claude-code-plugin-smoke follows a symlinked directory under docs/ instead
     rmSync(tmpRepo, { recursive: true, force: true });
   }
 });
+
+// Regression coverage: an earlier version of this guard had TWO independent,
+// hand-duplicated recursive file-collection loops — one for the plugin's own
+// guidance tree (commands/skills/agents/hooks), one for the doc-wide scan
+// (docs/). The symlinked-directory fix (see the test above) was applied to
+// only the doc-wide copy, leaving the plugin-tree copy with the IDENTICAL
+// blind spot: a symlinked directory under commands/ (or skills/, agents/,
+// hooks/) was invisible to the scan. Both now share one traversal
+// (collectFilesRecursively) so this can't recur as "fixed in one of two
+// copies but not the other" a third time. Prove the plugin-tree scan follows
+// a symlinked directory too.
+test('claude-code-plugin-smoke follows a symlinked directory under the plugin guidance tree instead of silently skipping it', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    const externalDir = join(tmpRepo, '..', 'adlc-cc-smoke-external-commands');
+    mkdirSync(externalDir, { recursive: true });
+    writeFileSync(join(externalDir, 'hidden.md'), '# Hidden\n\nRun /adlc-ticket to get started.\n');
+    symlinkSync(externalDir, join(tmpRepo, 'plugins/adlc-claude-code/commands/linked-external'), 'dir');
+
+    try {
+      const result = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+      assert.notStrictEqual(
+        result.status,
+        0,
+        'smoke test should fail on a bare command reference reached through a symlinked directory under commands/, not silently skip it'
+      );
+      assert.match(result.stderr, /bare, non-namespaced command reference/);
+      assert.match(result.stderr, /linked-external/);
+    } finally {
+      rmSync(externalDir, { recursive: true, force: true });
+    }
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/claude-code-plugin-smoke.test.mjs
+++ b/scripts/test/claude-code-plugin-smoke.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { cpSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'claude-code-plugin-smoke.mjs');
@@ -127,4 +127,81 @@ test('claude-code-plugin-smoke fails on a bare command recommendation in the des
   } finally {
     rmSync(tmpRepo, { recursive: true, force: true });
   }
+});
+
+// Regression coverage for issue #96: the pre-#96 guard only scanned a hardcoded
+// allowlist of "extra" doc paths (docs/integrations/claude-code.md, README.md,
+// the design ADR). Every round of #50/#89's adversarial review after the first
+// found a NEW doc surface with a bare reference the allowlist didn't know about.
+// Prove the guard now covers an ARBITRARY new doc under docs/ with no allowlist
+// entry required — the whole point of the fix.
+test('claude-code-plugin-smoke fails on a bare command recommendation in an arbitrary new doc under docs/', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    // A brand-new doc, nested two levels deep, never listed in any allowlist.
+    const newDocDir = join(tmpRepo, 'docs/guides/onboarding');
+    mkdirSync(newDocDir, { recursive: true });
+    const newDocPath = join(newDocDir, 'quickstart.md');
+    writeFileSync(newDocPath, '# Quickstart\n\nRun /adlc-ticket to get started.\n');
+
+    const result = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+    assert.notStrictEqual(result.status, 0, 'smoke test should fail on a bare command reference in a brand-new, never-allowlisted doc');
+    assert.match(result.stderr, /bare, non-namespaced command reference/);
+    assert.match(result.stderr, /docs\/guides\/onboarding\/quickstart\.md/);
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});
+
+// Regression coverage for issue #96: the command-name list itself was a second,
+// independent hardcoded allowlist (['init', 'ticket', 'distill', 'maintain']) that
+// silently missed '/adlc-prosecute' after the prosecutor-parity feature (#61) added
+// a fifth command — a live, real instance of exactly this bug class was found on
+// docs/integrations/claude-code.md and plugins/adlc-claude-code/commands/adlc-prosecute.md's
+// own heading while building this fix. Prove the guard derives its command names from
+// the commands/ directory itself, so a newly added command file is covered automatically.
+test('claude-code-plugin-smoke fails on a bare reference to a newly-added command with no hardcoded name update', () => {
+  const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-smoke-'));
+  try {
+    cpSync(REPO, tmpRepo, {
+      recursive: true,
+      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+    });
+
+    // Add a brand-new command file the guard has never been told about by name.
+    const newCommandPath = join(tmpRepo, 'plugins/adlc-claude-code/commands/adlc-brandnew.md');
+    writeFileSync(
+      newCommandPath,
+      '---\ndescription: a fixture-only command.\n---\n\n# /adlc:adlc-brandnew\n\nSee also /adlc-brandnew for the bare (buggy) form.\n'
+    );
+
+    const result = spawnSync(process.execPath, [SCRIPT, tmpRepo], { encoding: 'utf8' });
+    assert.notStrictEqual(result.status, 0, 'smoke test should fail on a bare reference to a command it discovers dynamically, with no code change to a name list');
+    assert.match(result.stderr, /bare, non-namespaced command reference/);
+    assert.match(result.stderr, /adlc-brandnew/);
+  } finally {
+    rmSync(tmpRepo, { recursive: true, force: true });
+  }
+});
+
+// Regression coverage for issue #96: a repo-wide scan must not false-positive on
+// paths that are genuinely not live Claude-Code guidance — archived/superseded
+// docs (which deliberately preserve the historical bare-command text as a record)
+// and other harnesses' own integration docs (where a bare "/adlc-*" is that
+// harness's correct, intentional invocation syntax, verified per-harness in #50).
+test('claude-code-plugin-smoke does not false-positive on excluded, genuinely out-of-scope docs', () => {
+  const result = spawnSync(process.execPath, [SCRIPT, REPO], { encoding: 'utf8' });
+  assert.strictEqual(result.status, 0, `smoke test should pass against the real repo, which has known bare-command text in excluded paths:\n${result.stderr}`);
+
+  // Sanity-check the fixture assumption: these files DO contain bare command
+  // text today (proving the pass above isn't just "nothing to find").
+  const archivePath = join(REPO, 'docs/archive/claude-code-plan.md');
+  const cursorDocPath = join(REPO, 'docs/integrations/cursor.md');
+  assert.match(readFileSync(archivePath, 'utf8'), /\/adlc-init/, 'fixture assumption stale: expected archived doc to still contain bare command text');
+  assert.match(readFileSync(cursorDocPath, 'utf8'), /\/adlc-init/, 'fixture assumption stale: expected Cursor doc to still contain its own bare command text');
 });


### PR DESCRIPTION
## Summary

Fixes #96.

`scripts/claude-code-plugin-smoke.mjs`'s bare-command regression guard (added by #89, closing #50) had two independent hardcoded allowlists that kept getting caught out by new surfaces:

1. A **doc-path allowlist** (`docs/integrations/claude-code.md`, `README.md`, the design ADR) — 3 of #89's 5 review rounds found a new doc surface the allowlist didn't know about.
2. A **command-name allowlist** (`['init', 'ticket', 'distill', 'maintain']`) — silently missing `prosecute` (added by #61), so bare `/adlc-prosecute` references went completely unguarded.

## What changed

- **Command names** are now derived from `plugins/adlc-claude-code/commands/*.md` filenames instead of a hardcoded array.
- **Doc scan** covers every markdown file under `docs/` + `README.md` (+ `AGENTS.md`/`CLAUDE.md` if present), replacing the 3-file allowlist, with an explicit `EXCLUDED_DOC_PATHS` list — each entry states why it's genuinely not live Claude-Code guidance (archived docs, other harnesses' own docs, planning/spec scratch docs, harness-agnostic package reference docs).
- Fixed the **live, previously-unguarded `/adlc-prosecute` bug** this surfaced: 9 files corrected to the namespaced `/adlc:adlc-prosecute` form.

## Review history (6 rounds, 18 lens-passes total)

This went through repeated 3-lens adversarial review (correctness / security-and-scope / test-quality), each round targeting the previous round's fix:

| Round | Findings | Fix |
|---|---|---|
| 1 | 2 | A blanket find/replace had also rewritten two sentences describing **OpenCode's own** (correctly bare) command syntax into the CC-namespaced form — factually wrong. Also: derived command names were spliced unescaped into `new RegExp(...)` — a `.` in a name would wildcard-match, and an unbalanced `(` would throw an uncaught crash. |
| 2 | 1 | A degenerate `adlc-.md` filename derives an empty name, which as a regex alternative matches *any* bare command reference (including real command files' own filenames). |
| 3 | 0 | — |
| 4 | 1 | `Dirent.isDirectory()` returns `false` for a symlink even when its target is a directory — a symlinked doc directory was silently invisible to the scan. |
| 5 | 1 | The guard had **two independently hand-duplicated traversal loops** (plugin tree vs. doc-wide scan); round 4's symlink fix was applied to only one. Unified both into one shared `collectFilesRecursively()` helper. |
| 6 | 0 | — |

Every fix has a dedicated regression test, each confirmed RED against the pre-fix code (via `git stash`/temporary revert) before the fix and GREEN after.

**Known, accepted residual limitation** (flagged in round 6, not introduced by this PR, doesn't affect current behavior): reaching an excluded doc via a symlinked path could bypass `EXCLUDED_DOC_PATHS`'s prefix match, since the exclusion list matches literal paths, not resolved ones. No real symlinks exist in the doc tree today, so this doesn't currently misfire; noting it here rather than expanding scope further.

## Test plan

- [x] `node --test scripts/test/claude-code-plugin-smoke.test.mjs` — 13/13 pass
- [x] `node scripts/claude-code-plugin-smoke.mjs .` — exit 0
- [x] `npm test` (full repo suite) — exit 0