### PR TITLE
docs(site): complete the fumadocs fan-out — all 44 pages real, zero stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ prosecutor subagent, and hooks that fire the gates automatically), with no API
 keys (Claude is the model via `--prompt-only`).
 
 **Recommended:** install with [`plugins`](https://www.npmjs.com/package/plugins), the
-vendor-neutral installer that auto-detects your agent tools (Claude Code, Cursor) and
-installs the plugin into each:
+vendor-neutral installer that auto-detects your agent tools and installs the plugin
+into each (Claude Code today; other harnesses as their plugin packages publish — each
+has a native install path below; see [ADR-0009](./docs/adr/0009-universal-install-via-plugins.md)
+for why this is the preferred path):
 
 ```sh
 npx plugins add voodootikigod/adlc   # install the plugin into your agent tool(s)

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -1,8 +1,77 @@
 ---
 title: Getting started
-description: Getting started documentation (coming soon).
+description: Install the ADLC toolkit, bootstrap a repo, and run your first gate in under five minutes.
 ---
 
 # Getting started
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+The toolkit is a set of gate-shaped CLIs published under the `@adlc` npm scope.
+One install gives you every gate behind the stable `adlc <tool>` dispatcher.
+
+## 1. Install the CLI
+
+```sh
+npm install -g @adlc/cli
+adlc --help          # lists every tool, grouped by lifecycle phase
+
+# or run without installing
+npx @adlc/cli spec-lint <spec.md>
+```
+
+## 2. Run your first gate
+
+`spec-lint` is the P1 gate: every acceptance criterion in a spec must name how
+it will be verified.
+
+```sh
+adlc spec-lint spec.md
+```
+
+Exit code `0` means the gate passes, `2` means it fails (wishes found — line
+numbers printed), `1` means an operational error. Every gate in the toolkit
+follows this [exit-code convention](/docs/reference/exit-codes), so they compose
+in scripts and CI without special-casing.
+
+No API keys are required for the core checks. Gates with an LLM-assisted pass
+accept `--prompt-only`, which prints the exact prompt and exits `0` — paste it
+into whatever harness you already have.
+
+## 3. Bootstrap a repo
+
+Check the workspace is ready before any fan-out — the P0 gate:
+
+```sh
+adlc preflight        # environment & permissions table, pass/fail verdict
+```
+
+Gates that need shared state (tickets, frozen rails, evidence) read it from a
+committable `.adlc/` directory. Bootstrap it from inside your agent harness with
+`/adlc-init` (see [integrations](/docs/integrations)). The
+[.adlc runtime reference](/docs/reference/adlc-runtime) documents every file the
+gates read and write.
+
+## 4. Wire it into your harness
+
+The lifecycle is meant to run where your agent runs. Native integrations ship
+for six harnesses — skills, hooks, and commands that fire the gates
+automatically:
+
+```sh
+npx plugins add voodootikigod/adlc   # vendor-neutral installer — Claude Code today
+npm install -g @adlc/cli             # the toolkit the plugin shells out to
+```
+
+The [`plugins` installer](https://www.npmjs.com/package/plugins) covers harnesses whose
+plugin packages are published (Claude Code today); every integration page below also
+documents its native install path.
+
+Then `/adlc-init` once per repo. See the per-harness guides:
+[Claude Code](/docs/integrations/claude-code), [Codex](/docs/integrations/codex),
+[Cursor](/docs/integrations/cursor), [opencode](/docs/integrations/opencode),
+[pi](/docs/integrations/pi), and [Antigravity](/docs/integrations/antigravity).
+
+## Where to go next
+
+- [The Lifecycle](/docs/lifecycle) — which gate guards each phase, end to end.
+- [Toolkit](/docs/toolkit) — every tool's flags, exit codes, and examples.
+- [Theory](/docs/theory) — the eight failure modes the gates defend against.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -14,7 +14,7 @@ This site documents the toolkit, the theory behind it, and its integrations with
   <Card title="The Lifecycle" href="/docs/lifecycle" description="Eight phases, eight gates — end-to-end." />
   <Card title="Getting Started" href="/docs/getting-started" description="Install the CLI and run your first gate." />
   <Card title="Toolkit" href="/docs/toolkit" description="Every gate command, flags, exit codes, and examples." />
-  <Card title="Integrations" href="/docs/integrations" description="Claude Code, Cursor, and CI/CD wiring." />
+  <Card title="Integrations" href="/docs/integrations" description="Claude Code, Codex, Cursor, opencode, pi, Antigravity, and CI/CD wiring." />
 </Cards>
 
 Read the full theory series at [voodootikigod.com/series/adlc](https://voodootikigod.com/series/adlc).

--- a/apps/docs/content/docs/integrations/claude-code.mdx
+++ b/apps/docs/content/docs/integrations/claude-code.mdx
@@ -43,14 +43,15 @@ npm install -g @adlc/cli
 | **P1 Interrogate** | `adlc spec-lint`, `parallax` | Phase-routing skill runs the spec gates. |
 | **P2 Decompose** | `adlc coldstart`, `model-router` | Skill resolves ticket scope and routes work by tier. |
 | **P3–P4 Rail & Build** | `adlc rails-guard` | Hook blocks edits to frozen rails on every structured edit. |
-| **P5 Prosecute** | `prosecutor` subagent | Fresh-context, refute-chartered review before merge. |
+| **P5 Prosecute** | `/adlc-prosecute` → `prosecutor` subagent | Fresh-context, refute-chartered review before merge. |
 | **P7 Distill** | `/adlc-distill` | Turns repeated findings into deterministic defenses. |
 
 ## What gets installed
 
 - **Skill:** the `adlc` phase-routing skill that picks the right gate.
-- **Commands:** `/adlc-init`, `/adlc-ticket`, `/adlc-distill`, `/adlc-maintain`.
-- **Subagent:** `adlc:prosecutor` — the P5 pre-merge gate.
+- **Commands:** `/adlc-init`, `/adlc-ticket`, `/adlc-prosecute`, `/adlc-distill`, `/adlc-maintain`.
+- **Subagents:** `adlc:prosecutor` — the P5 pre-merge gate — backed by a specialist
+  panel (contract, correctness, diff, security, tests, verifier).
 - **Hooks:** structured-edit rails-guard + CI backstop.
 
 Source: [`plugins/adlc-claude-code/`](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-claude-code).

--- a/apps/docs/content/docs/integrations/codex.mdx
+++ b/apps/docs/content/docs/integrations/codex.mdx
@@ -1,8 +1,93 @@
 ---
-title: codex
-description: codex documentation (coming soon).
+title: Codex
+description: Native ADLC integration for the OpenAI Codex CLI — five phase skills plus a PreToolUse rail hook that gates structured edits and shell writes.
 ---
 
-# codex
+# ADLC in Codex
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+Native Codex plugin using exactly two Codex surfaces: **progressive-disclosure
+skills** (five, one per lifecycle segment) and one **`PreToolUse` lifecycle
+hook** that protects frozen rails during the build phase. No custom prompts, no
+custom subagents — routing lives in skills, and truth lives in `.adlc/`
+evidence, never in narration.
+
+## Install
+
+The plugin ships in this repo at `plugins/adlc-codex/`, registered in the
+`.agents/plugins/marketplace.json` marketplace manifest. **There is no published
+package or out-of-repo install path yet** — install and verify from a checkout:
+
+```sh
+node scripts/codex-install-smoke.mjs .
+```
+
+That smoke test validates the marketplace entry, plugin manifest, bundled hook,
+and all five skill sentinels — fully offline; it does not run `codex` or mutate
+`~/.codex`.
+
+Maintainers can exercise the real install end-to-end in a **disposable
+environment** (throwaway `CODEX_HOME`, `HOME`, and XDG roots under `/tmp`):
+
+```sh
+ADLC_CODEX_LIVE_INSTALL=1 node scripts/codex-install-smoke.mjs .
+```
+
+## How each phase maps into Codex
+
+| ADLC phase | Skill | Gates it routes to |
+| --- | --- | --- |
+| **P0 Triage** | `adlc` (phase router) | `adlc preflight --json`, work classification |
+| **P1–P2 Interrogate & Decompose** | `adlc-spec` | `adlc spec-lint`, `premortem`, `parallax`, `coldstart`, `merge-forecast`, `model-router`; stops for human spec approval |
+| **P3–P4 Rail & Build** | `adlc-rail-build` + the rail hook | `adlc rails-guard`, `hollow-test`, `flail-detector`, `adlc run p4` |
+| **P5–P6 Prosecute & Integrate** | `adlc-prosecute` | `adlc prosecute` (records reviewer evidence — it does not run the reviewer), `behavior-diff`, `adlc accept`, `adlc run p5/p6` |
+| **P7 Distill** | `adlc-distill` | `lesson-foundry`, `rejection-mining`, `skill-rot`, `model-ratchet` |
+
+Skills route work but can never declare a phase complete from narration — the
+truth is `.adlc/manifest.jsonl` evidence and `adlc run <phase> --json` passing.
+
+## Rail enforcement — two layers
+
+1. **In-session `PreToolUse` hook.** Denies by exiting `2`; inactive
+   (fail-open) unless `ADLC_P4_ENFORCEMENT=1`, and **fail-closed once active**:
+   a missing or conflicting active ticket, a zero-rail ticket, an opaque
+   mutating command, or a shell expansion it can't parse all block. Unlike the
+   sibling integrations, this hook **does gate shell writes**: a read-only
+   allowlist passes, recognized mutations (`> redirects`, `tee`, `rm`, in-place
+   `sed`/`perl`, mutating `git`, interpreter `writeFile` calls, …) are
+   rail-checked, and anything unrecognized fails closed.
+2. **Commit-time CI gate (the guarantee).** `scripts/rails-guard-ci.mjs` reads
+   the frozen rail set **from the trusted base ref** and rejects any PR that
+   edits a rail, however the edit was made. **Make it a required check.** The
+   in-session hook assists it; it never replaces it.
+
+## Rail contract
+
+Identical engine semantics to the sibling integrations:
+
+- Active ticket via `ADLC_TICKET` **or** `.adlc/current-ticket.json`; a conflict
+  between the two fails closed. `ADLC_TICKETS` overrides the tickets-file path.
+- Enforcement is phase-scoped to `ADLC_P4_ENFORCEMENT=1`; otherwise the hook is
+  an explicit no-op.
+- Rails in force = the single active ticket's `rails` plus the trust-root rails
+  `.adlc/tickets.json` and `.adlc/current-ticket.json`.
+- Symlinks are resolved before matching; `apply_patch` bodies and
+  `multi_tool_use.parallel` wrappers are unwrapped and every path checked.
+
+## Gaps
+
+1. **P5 is partial.** Review evidence is machine-checkable, but there is no
+   first-party deterministic orchestrator that fans out lenses and loops until
+   dry — `adlc prosecute` records evidence produced elsewhere.
+2. **No user-facing install path outside a checkout.** Published-package and
+   git-backed marketplace installs are not yet supported.
+
+## Using with Claude Code
+
+The Codex and [Claude Code](/docs/integrations/claude-code) plugins are designed
+to coexist: both read the same `.adlc/` workspace and ticket schema. A common
+split uses Codex for CI workers and Claude Code for interactive sessions.
+
+## Go deeper
+
+Source: [`plugins/adlc-codex/`](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-codex)
+· design rationale: [ADR 0001](https://github.com/voodootikigod/adlc/blob/main/docs/adr/0001-codex-native-adlc-integration.md).

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -11,16 +11,16 @@ harness below.
 
 - **[Claude Code](/docs/integrations/claude-code)** — phase-routing skill, gate
   commands, a `prosecutor` subagent, and hooks that fire the gates automatically.
-- **[Codex](/docs/integrations/codex)** — the OpenAI Codex CLI integration for the
-  ADLC toolkit; full walkthrough still being written.
+- **[Codex](/docs/integrations/codex)** — five phase skills plus a `PreToolUse`
+  rail hook that gates structured edits *and* shell writes.
 - **[Cursor](/docs/integrations/cursor)** — a `preToolUse` rails dispatcher, hook
   parity (audit + flail, advisory shell notice, opt-in build-gate), the full
   `/adlc-*` command suite, and the sequential five-lens `/adlc-prosecute` loop,
   backed by the CI rail-freeze gate.
-- **[opencode](/docs/integrations/opencode)** — the opencode CLI integration for the
-  ADLC toolkit; full walkthrough still being written.
-- **[pi](/docs/integrations/pi)** — the pi CLI integration for the ADLC toolkit;
-  full walkthrough still being written.
+- **[opencode](/docs/integrations/opencode)** — rails-guard plugin hook, eight
+  lifecycle commands, a five-lens prosecutor panel, and a keyless gate bridge.
+- **[pi](/docs/integrations/pi)** — native extension with proactive rail blocking,
+  git-diff revert, and a suppression gate; five phase skills wrap the CLIs.
 - **[Antigravity](/docs/integrations/antigravity)** — native `agy` plugin with an
   in-session rails-guard hook, backed by the unbypassable CI rail-freeze gate.
 

--- a/apps/docs/content/docs/integrations/opencode.mdx
+++ b/apps/docs/content/docs/integrations/opencode.mdx
@@ -1,8 +1,112 @@
 ---
 title: opencode
-description: opencode documentation (coming soon).
+description: Native ADLC integration for the opencode terminal agent — rails-guard plugin hook, eight lifecycle commands, a five-lens prosecutor panel, and a keyless gate bridge.
 ---
 
-# opencode
+# ADLC in opencode
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+Brings the lifecycle into the [opencode](https://opencode.ai) terminal agent as
+a native plugin: an in-session rails-guard hook (`tool.execute.before`),
+advisory session hooks, eight lifecycle commands, the `adlc` phase-routing
+skill, and a six-agent P5 prosecution panel. All six integration phases (A–F of
+the design plan) ship.
+
+## What you get
+
+- **Rails-guard hook** on `tool.execute.before` — denies structured
+  `edit`/`write` to a frozen rail declared by the active ticket.
+- **Advisory session hooks** — `session.created` preflight and a `session.idle`
+  gate-manifest audit; they warn, never throw.
+- **Commands:** `/adlc-init`, `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`,
+  `/adlc-decompose`, `/adlc-verify-build`, `/adlc-prosecute`, `/adlc-distill`.
+- **Subagents:** the five P5 prosecution lenses
+  (`@prosecutor-correctness|security|contract|diff|tests`) plus
+  `@prosecutor-verifier` — all edit- and bash-denied.
+- **Keyless gate bridge** — every LLM-backed gate runs in `--prompt-only` mode
+  with the prompts routed to the host model; no API keys.
+
+## Install
+
+`@adlc/opencode-package` is **not yet published to npm**, so install from
+source (peer dependency: `@opencode-ai/plugin` ≥ 1.17.11):
+
+```sh
+npm install -g @adlc/cli                 # the gate toolkit the plugin shells out to
+
+# make the plugin available to opencode
+ln -s /path/to/adlc/plugins/adlc-opencode .opencode/plugin/adlc-opencode
+# …or add its path to the "plugin" array in .opencode/opencode.json
+```
+
+Then, inside the opencode TUI, run `/adlc-init` — it bootstraps `.adlc/`,
+deploys the command/agent/skill surface into `.opencode/`, and **registers the
+plugin in `opencode.json` so the rails-guard hook actually loads** (the markdown
+surfaces are inert without it). First-time, before the command exists:
+
+```sh
+node /path/to/adlc/plugins/adlc-opencode/lib/scaffold-cli.mjs .
+```
+
+Restart opencode so the hooks load. Verify locally without an `opencode` binary:
+
+```sh
+node scripts/opencode-install-smoke.mjs .
+```
+
+## Rail enforcement — two layers
+
+1. **In-session (capability-gated).** The hook only *actually blocks* when the
+   host SDK honors a thrown denial — a runtime capability probe decides
+   (`ADLC_OPENCODE_ENFORCES=1/0` forces it). When the capability is unproven,
+   the hook **fails closed** unless `ADLC_ALLOW_ADVISORY_HOOKS=1` explicitly
+   permits advisory mode (surface the violation loudly, don't block). Bash
+   writes are **not** gated in-session; unrecognized structured tools carrying a
+   path fail closed.
+2. **Commit-time (unbypassable).** The real control is
+   `scripts/rails-guard-ci.mjs` (via `docs/ci/rails-guard.yml`): it reads the
+   frozen rail set **from the trusted base ref** and rejects any PR that edits a
+   rail — including the shell-driven writes the in-session hook cannot see.
+   **Make it a required check.**
+
+## Rail contract
+
+Mirrors the sibling integrations; all glob/ticket logic delegates to `@adlc/core`:
+
+- Active ticket via `ADLC_TICKET` **or** `.adlc/current-ticket.json`; a conflict
+  fails closed.
+- Enforcement is phase-scoped to `ADLC_P4_ENFORCEMENT=1`; otherwise no-op.
+- Rails in force = the **single** active ticket's `rails` plus the trust-root
+  rails `.adlc/tickets.json` and `.adlc/current-ticket.json`.
+- Symlink-aware: both the lexical path and the resolved real path are matched.
+
+## Formal ADLC coverage
+
+| Phase | Status | Wired via |
+| --- | --- | --- |
+| P0 Triage | **Yes** | `/adlc-ticket` |
+| P1 Interrogate | **Yes** | `/adlc-spec` + `/adlc-approve-spec` (G1) + the `adlc` skill |
+| P2 Decompose | **Yes** | `/adlc-decompose` |
+| P3 Rail | **MVP** | in-session rails-guard hook + CI gate |
+| P4 Build | Partial | rails-guard hook + `session.created` preflight |
+| P5 Prosecute | **Yes** | `/adlc-verify-build` (G4) + five lenses + verifier + `/adlc-prosecute` |
+| P6 Integrate | Partial | `session.idle` gate-manifest audit; the human gate is by design |
+| P7 Distill | **Yes** | `/adlc-distill` |
+
+## Gaps
+
+1. In-session enforcement depends on the host SDK honoring a thrown denial —
+   until proven, the CI gate is the real control.
+2. The keyless bridge's isolated sub-context call depends on a proposed opencode
+   SDK extension; it degrades or fails closed, never silently skips a gate.
+3. `/adlc-prosecute`'s fan-out → verify → loop-until-dry protocol is executed by
+   the model, not a deterministic first-party runner (the decision helpers are
+   unit-tested).
+4. A live deny-proof against a real opencode binary is the remaining GA gate.
+
+## Go deeper
+
+Source: [`plugins/adlc-opencode/`](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-opencode)
+· design rationale: [ADR 0004](https://github.com/voodootikigod/adlc/blob/main/docs/adr/0004-adlc-opencode-integration.md).
+
+The prosecution panel this integration ships:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/integrations/pi.mdx
+++ b/apps/docs/content/docs/integrations/pi.mdx
@@ -1,8 +1,87 @@
 ---
 title: pi
-description: pi documentation (coming soon).
+description: Native ADLC extension for the pi coding agent — in-session rail, scope, and suppression enforcement with git-diff revert, plus five phase skills.
 ---
 
-# pi
+# ADLC in pi
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+A native [pi](https://pi.dev) TypeScript extension plus five skills. pi
+intentionally skips built-in orchestrators, so ADLC slots in through pi's
+Extension API: the extension enforces rails in-session while the skills route
+each phase to the deterministic `adlc` gates.
+
+## What you get
+
+- **Proactive rail gate** (`tool_call`) — blocks `write`/`edit`/`bash` before it
+  touches disk when the target is a frozen rail, out of the ticket's scope, or
+  the ADLC trust roots. **Bash writes are gated here** — redirects, `tee`,
+  `rm`/`mv`/`cp`, in-place `sed`/`perl`, mutating `git` subcommands, and
+  interpreter file-write APIs are recognized and rail-checked.
+- **Reactive revert gate** (`tool_result`) — after any write/edit/bash, reads
+  the actual `git diff`; a rail violation is reverted via
+  `git checkout HEAD -- <file>` and the tool result is replaced with a
+  `GATE FAILED` error. Added lines are scanned for undeclared suppression
+  markers (`@ts-ignore`, `eslint-disable`, `.skip(`, `# noqa`, …) and reverted
+  unless the ticket allows them.
+- **Ticket doctrine injection** (`before_agent_start`) — the active ticket's
+  scope, rails, and spec are appended to the system prompt every turn
+  (sanitized; the ticket body is fenced as untrusted), defending premature
+  satisfaction and context rot.
+- **`/ticket` command + footer status pill** — constant visibility into the
+  active enforcement context.
+- **Skills:** `adlc` (phase router), `adlc-spec` (P0–P2), `adlc-rail-build`
+  (P3–P4), `adlc-prosecute` (P5–P6), `adlc-distill` (P7) — each wraps the
+  deterministic `adlc` CLIs; hooks are assistive, `adlc rails-guard` is the
+  proof.
+
+## Install
+
+`@adlc/pi-package` is **not yet published to npm**; load it from a checkout:
+
+```sh
+npm install -g @adlc/cli                       # the gate toolkit the skills wrap
+pi --extension /path/to/adlc/plugins/adlc-pi/index.ts
+```
+
+Peer dependency: `@earendil-works/pi-coding-agent` ≥ 0.79.0.
+
+## Enforcement model
+
+Enforcement is **opt-in by activating a ticket** — set `ADLC_TICKET` or write
+`.adlc/current-ticket.json` (tickets file overridable via `ADLC_TICKETS`). With
+no active ticket the extension is inert. Once a ticket id resolves, the
+extension **fails closed**: an unreadable or unparseable tickets file, or an
+unknown ticket id, blocks *all* tool calls until fixed (with a red status pill
+telling you why). Unlike the sibling integrations, this plugin does not use
+`ADLC_P4_ENFORCEMENT` — the active ticket is the switch.
+
+`.adlc/tickets.json` and `.adlc/current-ticket.json` are unconditionally
+blocked from edits regardless of rails — the agent can't rewrite its own
+constraints. An empty ticket `scope` means unrestricted; `.adlc/` and `.omo/`
+stay writable for evidence.
+
+The commit-time backstop is the same harness-agnostic CI gate as every other
+integration: `scripts/rails-guard-ci.mjs` reads the frozen rail set **from the
+trusted base ref** and rejects any PR that edits a rail, however the edit was
+made. **Make it a required check.**
+
+## Formal ADLC coverage
+
+| Phase | pi surface |
+| --- | --- |
+| P0–P2 Triage → Decompose | `adlc-spec` skill (`parallax`, `spec-lint`, `premortem`, `coldstart`, `merge-forecast`, `model-router`); ticket resolution on `session_start` |
+| **P3–P4 Rail & Build** | **the extension** — proactive `tool_call` block + reactive `tool_result` revert + suppression gate |
+| P5–P6 Prosecute & Integrate | `adlc-prosecute` skill (`prosecute`, `behavior-diff`, `accept`, `adlc run p5/p6`) |
+| P7 Distill | `adlc-distill` skill (`lesson-foundry`, `rejection-mining`, `skill-rot`, `model-ratchet`) |
+
+Automated P5 subagent prosecution, a `session_shutdown` P6 capture, and
+scheduled P7 runs are design intent (see the integration plan), not shipped
+features — P5–P7 run through the skills and the `adlc` CLIs today.
+
+## Go deeper
+
+Source: [`plugins/adlc-pi/`](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-pi)
+· design plan: [docs/integrations/pi.md](https://github.com/voodootikigod/adlc/blob/main/docs/integrations/pi.md).
+
+The rail-freeze gate this extension enforces in-session:
+[Tests Are the Spec](https://voodootikigod.com/adlc-3-tests-are-the-spec).

--- a/apps/docs/content/docs/lifecycle.mdx
+++ b/apps/docs/content/docs/lifecycle.mdx
@@ -16,8 +16,9 @@ Each phase has a machine-checkable gate. The toolkit makes those gates concrete.
 | **P2 Decompose** | Can an agent execute this ticket without guessing? | [coldstart](/docs/toolkit/coldstart), [model-router](/docs/toolkit/model-router), [merge-forecast](/docs/toolkit/merge-forecast) |
 | **P3–P4 Rail & Build** | Are frozen rails protected; is an agent flailing? | [rails-guard](/docs/toolkit/rails-guard), [flail-detector](/docs/toolkit/flail-detector), [consensus-fix](/docs/toolkit/consensus-fix) |
 | **P5 Prosecute** | Did prosecution dry out; did behavior change? | [prosecute](/docs/toolkit/prosecute), [behavior-diff](/docs/toolkit/behavior-diff), [hollow-test](/docs/toolkit/hollow-test), [gate-manifest](/docs/toolkit/gate-manifest) |
-| **Calibration** | What must be re-prosecuted after drift? | [model-ratchet](/docs/toolkit/model-ratchet), [review-calibration](/docs/toolkit/review-calibration), [skill-rot](/docs/toolkit/skill-rot), [gate-fuzzing](/docs/toolkit/gate-fuzzing) |
+| **P6 Integrate** | Is this what I meant, running? (human behavioral acceptance) | [behavior-diff](/docs/toolkit/behavior-diff), [gate-manifest](/docs/toolkit/gate-manifest) |
 | **P7 Distill** | Which findings become permanent defenses? | [lesson-foundry](/docs/toolkit/lesson-foundry), [rejection-mining](/docs/toolkit/rejection-mining) |
+| **Calibration** (maintenance, cross-phase) | What must be re-prosecuted after drift? | [model-ratchet](/docs/toolkit/model-ratchet), [review-calibration](/docs/toolkit/review-calibration), [skill-rot](/docs/toolkit/skill-rot), [gate-fuzzing](/docs/toolkit/gate-fuzzing) |
 
 The two human gates sit at **P1** (spec approval) and **P6** (review). Everything
 between is deterministic — read

--- a/apps/docs/content/docs/reference/adlc-runtime.mdx
+++ b/apps/docs/content/docs/reference/adlc-runtime.mdx
@@ -1,8 +1,104 @@
 ---
-title: .adlc/ runtime
-description: .adlc/ runtime documentation (coming soon).
+title: The .adlc/ Runtime
+description: The on-disk state ADLC gates read and write — tickets, the active-ticket pointer, config, ledgers, evidence — and the environment variables that steer them.
 ---
 
-# .adlc/ runtime
+# The `.adlc/` Runtime
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+`.adlc/` is the project-local directory where ADLC keeps its runtime state. Tools read and
+write it through [`@adlc/core`](/docs/toolkit/core) — none of them re-parse it by hand. The
+directory is created by `/adlc-init` (or the per-editor scaffolders) and grows as gates run.
+
+## Directory layout
+
+```
+.adlc/
+├── tickets.json            # the ticket store (authored) — see Ticket authoring
+├── current-ticket.json     # pointer to the in-flight ticket (rails/prosecution use it)
+├── config.json             # runtime config (ticket-sync, security posture)
+├── manifest.jsonl          # hash-chained gate provenance ledger
+├── manifest.lock           # lock guarding manifest appends
+├── findings.jsonl          # prosecution findings ledger
+└── ticket-sync.state.json  # gitignored sync sidecar (rebuildable cache)
+```
+
+### `tickets.json` — the ticket store
+
+The executable contract between P2 decomposition, P3 rails, P4 build, and P5/P6 evidence.
+Each ticket carries `{ id, title, body, scope[], rails[], edges[], duration, category, budget }`.
+Tools load it with `loadTickets()`, which validates ids, catches duplicates, and
+rejects edges to unknown tickets. `TICKETS_PATH` defaults to `.adlc/tickets.json`. The full
+schema and rules live in
+[`docs/ticket-authoring.md`](https://github.com/voodootikigod/adlc/blob/main/docs/ticket-authoring.md),
+and `.adlc/tickets.example.json` is a complete fixture.
+
+### `current-ticket.json` — the active-ticket pointer
+
+Names which ticket is "in flight" so rails-guard and prosecution know what to enforce. It
+holds either a bare id string or `{ "id": "T7" }`. The active ticket is resolved from
+`ADLC_TICKET` **or** this file. If both are set and **disagree**, that is treated as a
+tamper signal, not an ambiguity — resolution fails closed (`conflict: true`) rather than
+guessing. An unparseable pointer file is likewise a tamper signal and fails closed. This
+resolution is shared verbatim across every harness integration (Codex, Cursor, Antigravity,
+OpenCode) and `@adlc/build-gate`.
+
+### `config.json` — runtime config
+
+Created with safe defaults by the scaffolders and never clobbered on re-init. It carries the
+[`ticket-sync`](/docs/toolkit/ticket-sync) provider configuration and the security posture
+for signed bundles (`securityMode`, `signers`, `revokedKeys`, `securitySensitivePatterns`,
+`maxBundleAgeDays`).
+
+### Ledgers — `manifest.jsonl` and `findings.jsonl`
+
+Append-only JSON-lines ledgers, one object per line, written with `appendEntry` and read
+with `readEntries` (which reports malformed lines rather than swallowing them).
+
+- **`manifest`** — the hash-chained provenance ledger written by
+  [`gate-manifest`](/docs/toolkit/gate-manifest) when a gate is recorded. `manifest.lock`
+  guards concurrent appends, and `verify` walks the chain to detect a break. Entries can be
+  HMAC-signed when `ADLC_MANIFEST_KEY` is set.
+- **`findings`** — prosecution findings, each `{ ts, tool, file, line, category, severity, desc, verdict }`,
+  written by tools like [`lesson-foundry`](/docs/toolkit/lesson-foundry),
+  [`model-ratchet`](/docs/toolkit/model-ratchet), and
+  [`gate-fuzzing`](/docs/toolkit/gate-fuzzing).
+
+### Evidence snapshots
+
+Behavior evidence is captured as JSON snapshots — [`behavior-diff`](/docs/toolkit/behavior-diff)
+writes a before/after route snapshot with `writeSnapshot()` and compares the two to prove a
+change is visible. Snapshots are plain files you point the tool at, not a fixed filename in
+`.adlc/`.
+
+### `ticket-sync.state.json` — the sync sidecar
+
+Sync bookkeeping (tracker node ids, the 3-way base hash, create keys). It is a **gitignored,
+rebuildable cache** — never authored by hand and read by no gate. It is deliberately outside
+the rails trust root, so a routine sync leaves `tickets.json` byte-identical and never trips
+rails-guard. A missing or tampered sidecar fails safe (at worst it forces a conflict prompt
+on the next pull) and can be deleted and rebuilt at any time.
+
+## Rails trust root
+
+A small set of runtime paths is the **trust root** the build gate treats specially. When
+computing whether a builder edited frozen rails, `.adlc/tickets.json` and
+`.adlc/current-ticket.json` are the trust-root inputs, and the mutable ledgers
+(`manifest.jsonl`, `manifest.lock`) are ignored so ordinary gate activity does not read as a
+rail edit.
+
+## Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `ADLC_TICKET` | Sets the active ticket id, overriding / cross-checked against `current-ticket.json`. A disagreement fails closed. |
+| `ADLC_P4_ENFORCEMENT` | In-session rail enforcement is active only when set to `1`. Otherwise the harness hooks are advisory and the CI gate remains authoritative. |
+| `ADLC_PROVIDER` | Forces the LLM provider (`anthropic`, `openai`, `gemini`, `agy`) for LLM-backed tools. |
+| `ADLC_MODEL_CHEAP` / `ADLC_MODEL_MID` / `ADLC_MODEL_FRONTIER` | Override the model id resolved for each tier. |
+| `ADLC_MANIFEST_KEY` | Enables HMAC signing and verification of manifest ledger entries. |
+| `ADLC_RAILS_BYPASS` / `ADLC_BUILD_GATE_BYPASS` | Explicit, recorded bypasses of the rail / build gate (durably logged to the manifest). |
+
+## Related
+
+- [Ticket authoring](https://github.com/voodootikigod/adlc/blob/main/docs/ticket-authoring.md) — the ticket schema and rules in full.
+- [The Lifecycle](/docs/lifecycle) — which gate reads which state, phase by phase.
+- [Tool Conventions](/docs/reference/conventions) and [Exit Codes](/docs/reference/exit-codes) — the contracts tools honor while reading this runtime.

--- a/apps/docs/content/docs/reference/adrs.mdx
+++ b/apps/docs/content/docs/reference/adrs.mdx
@@ -1,8 +1,25 @@
 ---
-title: ADRs
-description: ADRs documentation (coming soon).
+title: Architecture Decision Records
+description: The accepted ADRs behind ADLC's editor integrations and adversarial-review gates.
 ---
 
-# ADRs
+# Architecture Decision Records
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+ADRs capture the decisions that shaped ADLC — chiefly how it integrates with each agentic
+editor and where adversarial review sits in the lifecycle. Each links to the full record in
+the repo. All nine are **Accepted**.
+
+| # | Title | Summary |
+| --- | --- | --- |
+| [0001](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0001-codex-native-adlc-integration.md) | Codex-Native ADLC Integration | How the deterministic `@adlc/*` gates and doctrine are brought natively into Codex, following the Claude Code integration. |
+| [0002](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0002-adlc-command-reconciliation.md) | Reconciling the `adlc` command | Two parallel efforts each shipped an `adlc` bin; resolved with **Option D** — separate concern-focused binaries rather than one conflicting package. |
+| [0003](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0003-adlc-claude-code-plugin.md) | ADLC as a Claude Code plugin | Packages the ~20 gate CLIs as a Claude Code plugin. Shipped GA (phases A–F merged). |
+| [0004](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0004-adlc-opencode-integration.md) | OpenCode integration — rails-guard MVP | The in-session P3 rails-guard hook for OpenCode as an MVP, with the remaining phases as follow-on. |
+| [0005](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0005-adversarial-design-review-gate.md) | Risk-gated adversarial design review | Adds a risk-gated adversarial design-review gate at the P1→P2 boundary, where clarity gates alone are insufficient. Recommended practice; deterministic tooling deferred. |
+| [0006](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0006-adlc-cursor-integration.md) | Cursor native integration — rails-guard MVP | Brings rails-guard to Cursor, the remaining major editor, which has no plugin API. MVP shipped; command suite and prosecutor follow-on. |
+| [0007](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0007-multimodel-adversarial-review.md) | Risk-tiered multi-model adversarial review | Prefers a reviewer model from a different provider than the builder, tiered by risk. Recommended practice; mechanical enforcement deferred. |
+| [0008](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0008-adversarial-review-coverage-map.md) | Adversarial-review coverage map | Maps the mature adversarial-review engine across the whole ADLC, closing the gap where it was wired into only P1→P2 and P5. |
+| [0009](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0009-universal-install-via-plugins.md) | Universal install via the `plugins` installer | `npx plugins add` stays the recommended install path; the third-party-installer supply-chain exposure is an explicitly accepted residual risk, and docs may only claim harness coverage the installer actually has. |
+
+Browse the source directory:
+[`docs/adr/`](https://github.com/voodootikigod/adlc/tree/main/docs/adr).

--- a/apps/docs/content/docs/reference/conventions.mdx
+++ b/apps/docs/content/docs/reference/conventions.mdx
@@ -1,8 +1,77 @@
 ---
-title: Conventions
-description: Conventions documentation (coming soon).
+title: Tool Conventions
+description: The contract every packages/ tool follows so ~20 independently built CLIs feel like one product.
 ---
 
-# Conventions
+# Tool Conventions
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+Every tool under `packages/` follows the same rules. They are the contract that makes a
+suite of independently built CLIs feel like one product. The canonical source is
+[`CONVENTIONS.md`](https://github.com/voodootikigod/adlc/blob/main/CONVENTIONS.md) at the
+repo root; this page summarizes it.
+
+## Layout
+
+Each tool is a self-contained package:
+
+```
+packages/<name>/
+├── package.json        # standard template
+├── bin/<name>.mjs      # CLI entry — thin: parse args, call lib, exit
+├── lib/*.mjs           # logic — pure functions wherever possible
+├── test/*.test.mjs     # node:test — MUST pass offline (no network, no API keys)
+└── README.md           # what it does, usage, exit codes, ADLC phase it serves
+```
+
+The `package.json` is uniform: `@adlc/<name>`, `"type": "module"`, a single `bin` entry,
+`"test": "node --test test/*.test.mjs"`, `"engines": { "node": ">=18" }`, MIT license.
+
+## Hard rules
+
+1. **Zero runtime dependencies.** Node 18+ built-ins and `@adlc/core` only. Core is
+   imported by relative path (`../../core/index.mjs`).
+2. **Core is frozen.** Never edit anything under `packages/core/`. If core lacks
+   something, implement it locally in your `lib/` and note the gap in your README under
+   "Core gaps."
+3. **Scope discipline.** Write ONLY inside your own `packages/<name>/`. Never touch other
+   packages, `ADLC.md`, root files, or `.adlc/`.
+4. **Exit codes are the contract.** `0` = gate passes, `1` = operational error, `2` = gate
+   fails — using `pass` / `opError` / `gateFail` from core. CI gating depends on this. See
+   [Exit Codes](/docs/reference/exit-codes).
+5. **`--prompt-only` on every LLM-backed tool.** Print the exact prompt(s) and exit `0`, so
+   the tool is usable with zero API keys — paste the prompt into any harness. Uses
+   `promptOnly()` from core.
+6. **`--json` on every tool.** Machine-readable output for orchestrators, alongside the
+   default human-readable output.
+7. **Tests run offline and leave no trace.** Test pure logic with fixtures; use
+   `mkdtempSync` temp dirs (with scratch git repos inside them when git behavior is under
+   test) and always clean up. Never call LLM providers in tests.
+8. **Never mutate the working tree without a flag.** Writing tools (e.g. `--write`,
+   `--append`) default to dry-run reporting. Mutation-testing tools restore files in a
+   `finally` block and refuse to run on a dirty tree.
+9. **No silent error swallowing.** Operational failures become `opError` with a clear
+   message; partial data (e.g. skipped ledger lines) is surfaced in the output.
+10. **File size.** Keep files under 400 lines; split `lib/` by concern.
+11. **The README is part of the tool.** It documents usage examples, every flag, exit-code
+    semantics, which ADLC phase (P0–P7 / D1–D3) the tool serves, and its relationship to
+    sibling tools.
+
+## Shared data — read via core, never reinvent
+
+Tools never re-parse shared state; they go through `@adlc/core`:
+
+| Data | Location | Access |
+| --- | --- | --- |
+| Tickets | `.adlc/tickets.json` | `loadTickets()` — schema in `packages/core/lib/tickets.mjs` |
+| Ledgers | `.adlc/<name>.jsonl` | `appendEntry` / `readEntries` |
+| Foundation rails | `rails` paths on a ticket | read-only to builders; enforced by tools that read them |
+
+Well-known ledgers are `manifest` (gate-manifest entries) and `findings` (prosecution
+findings). See [The `.adlc/` Runtime](/docs/reference/adlc-runtime) for the full layout.
+
+## CLI shape
+
+Tools share a verb-and-flags shape (`<name> [verb] [--flags]`) and a common flag
+vocabulary where applicable: `--base <ref>` (git base, default `HEAD`), `--tickets <path>`
+(default `.adlc/tickets.json`), `--json`, `--prompt-only`, `--n <int>` (fan width), and
+`--tier cheap|mid|frontier`.

--- a/apps/docs/content/docs/reference/exit-codes.mdx
+++ b/apps/docs/content/docs/reference/exit-codes.mdx
@@ -1,8 +1,53 @@
 ---
-title: Exit codes
-description: Exit codes documentation (coming soon).
+title: Exit Codes
+description: The canonical 0/1/2 exit-code convention that makes ADLC gates deterministic in CI.
 ---
 
-# Exit codes
+# Exit Codes
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+Every ADLC gate speaks the same three-value language on exit. This is what lets CI wire a
+dozen tools together and branch on a single number: a gate either passed, hit an
+operational problem, or failed. Tools produce these codes through `pass()`, `opError()`,
+and `gateFail()` in [`@adlc/core`](/docs/toolkit/core) — they never call `process.exit`
+with a bare number.
+
+## The canonical convention
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes. The check succeeded (or there was nothing to check; the tool warns loudly rather than fails).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error. The tool could not run the check: bad input, unreadable file, missing binary, network failure, or a failed LLM call.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails. The check ran and the change did not meet the bar. This is the blocking signal CI acts on.</span>
+</div>
+
+The distinction between `1` and `2` matters: **`1` is "I couldn't tell," `2` is "I looked
+and the answer is no."** CI treats `2` as a hard block on the change, while `1` signals a
+setup or environment problem to fix before the gate can render a verdict. Collapsing the
+two — for example, exiting `1` when a check actually fails — would let a genuine gate
+failure read as a fixable hiccup.
+
+## In CI
+
+Because the convention is uniform, gating logic is trivial and identical for every tool:
+
+```sh
+adlc spec-lint spec.md
+case $? in
+  0) echo "pass, continue" ;;
+  1) echo "operational error — fix setup and re-run" ;;
+  2) echo "gate failed — block the change" ;;
+esac
+```
+
+## Consistency across the suite
+
+The convention holds across the toolkit. A few patterns worth knowing:
+
+- **Multi-verb tools** map each verb to the same three codes. For example
+  [`gate-manifest`](/docs/toolkit/gate-manifest) `record` exits `0` on a successful append
+  and `1` on bad `--data` JSON, while `verify` exits `0` when the hash chain is intact and
+  `2` when it is broken.
+- **`--prompt-only` always exits `0`.** Printing a prompt is not a gate verdict; it is a
+  successful "here is the prompt" response, so every LLM-backed tool exits `0` in this
+  mode regardless of the underlying change.
+- **Help and usage.** Requesting `--help` exits `0`; invoking a tool with missing required
+  arguments prints usage and exits `1` (an operational error — the tool could not run).

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -1,8 +1,19 @@
 ---
 title: Reference
-description: Reference documentation (coming soon).
+description: The contracts every ADLC tool honors — conventions, exit codes, the .adlc/ runtime, and the architecture decision records.
 ---
 
 # Reference
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+The ADLC toolkit is ~20 independently built CLIs that behave like one product because
+they all honor the same contracts. This section documents those contracts.
+
+| Page | What it covers |
+| --- | --- |
+| [Tool Conventions](/docs/reference/conventions) | The rules every `packages/<name>/` tool follows — layout, zero dependencies, frozen core, `--json`/`--prompt-only`, and mutation safety. |
+| [Exit Codes](/docs/reference/exit-codes) | The canonical `0` / `1` / `2` convention that makes CI gating deterministic. |
+| [The `.adlc/` Runtime](/docs/reference/adlc-runtime) | The on-disk state gates read and write — tickets, the active-ticket pointer, config, ledgers, and evidence — plus the environment variables that steer them. |
+| [Architecture Decision Records](/docs/reference/adrs) | The accepted ADRs behind the integrations and review gates. |
+
+New to the model itself? Start with [The Lifecycle](/docs/lifecycle) for the phase and
+gate map, then come back here for the contracts underneath it.

--- a/apps/docs/content/docs/toolkit/behavior-diff.mdx
+++ b/apps/docs/content/docs/toolkit/behavior-diff.mdx
@@ -1,8 +1,66 @@
 ---
 title: behavior-diff
-description: behavior-diff documentation (coming soon).
+description: Captures each route's observable HTTP behavior before and after a change, then diffs in behavior-space so the human reviews six items, not a 5,000-line diff.
 ---
 
 # behavior-diff
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P6 Review** · **Gate:** the reviewer sees what changed in observable behavior, not the raw code diff.
+
+<PhaseDiagram phase="P6" />
+
+## What it defends against
+
+A large code diff hides its own consequences: the reviewer cannot tell, from 5,000
+changed lines, which of them actually altered what a client observes. `behavior-diff`
+captures the HTTP surface (status, content-type, body structure) of every route
+before and after a change, then reports the delta in behavior-space — "2 routes
+identical, 2 changed, 0 errored." The human spends the gate on the one judgment a
+machine cannot make: does the observed behavior change match the intended one?
+
+## Usage
+
+```sh
+adlc behavior-diff capture --config behavior.json --out before.json [--json]
+adlc behavior-diff compare before.json after.json [--json]
+```
+
+| Verb / Flag | Description |
+| --- | --- |
+| `capture` | Hit every route in the config and write an observable-behavior snapshot. |
+| `--config <path>` | (capture, required) Behavior config JSON: `baseUrl` plus a `routes` array of `{ method, path, body?, headers? }`. |
+| `--out <path>` | (capture, required) Output path for the snapshot JSON. |
+| `compare` | Diff two snapshots and print a human-readable behavior report. |
+| `--json` | Machine-readable output for orchestrators (both verbs). |
+
+Per-route errors are recorded, not fatal — the snapshot always has an entry for
+every route. `capture` fails operationally if no route returns a real response
+(target down), since an all-errored snapshot cannot be meaningfully diffed.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — `capture` wrote a snapshot with at least one reachable route; `compare` found every route identical.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: unreadable config or snapshot, invalid JSON, cannot write output, or every route was unreachable.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — `compare` gate fails: one or more routes changed, were added, removed, or are dead in both snapshots.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc behavior-diff capture --config behavior.json --out after.json
+captured 4/4 routes (0 errors) → after.json
+
+$ adlc behavior-diff compare before.json after.json
+2 routes identical, 1 changed, 0 errored
+
+  ~ GET /health:
+      body (json): 1 change:
+        ~ version: "1.0.0" → "2.0.0"
+exit 2
+```
+
+## Go deeper
+
+- [packages/behavior-diff](https://github.com/voodootikigod/adlc/tree/main/packages/behavior-diff)
+- Why the human gate reviews behavior, not diffs: [Two Human Gates](https://voodootikigod.com/adlc-2-two-human-gates).

--- a/apps/docs/content/docs/toolkit/build-gate.mdx
+++ b/apps/docs/content/docs/toolkit/build-gate.mdx
@@ -1,8 +1,65 @@
 ---
 title: build-gate
-description: build-gate documentation (coming soon).
+description: Denies starting a high-risk ticket's build in a degraded (context-rot) session unless an audited override is durably recorded.
 ---
 
 # build-gate
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P4 Build** · **Gate:** a high-risk ticket must not begin its build in a context-degraded session.
+
+<PhaseDiagram phase="P4" />
+
+## What it defends against
+
+Nothing else in ADLC deterministically prevents *starting* a high-blast-radius
+build while the executing session is context-rotted — deep, drifted, and past
+the point where it reliably holds the plot. `build-gate` sits at the P3→P4 entry:
+it derives the ticket's risk tier from its own fields (`risk`, `external`,
+`mutatesIdentity`, trust-root scope, `contract`/`architecture` category), checks
+a machine-checkable context-fitness signal (tool-call depth and transcript
+bytes), and denies the build unless an audited override is recorded. A declared
+`"risk": "normal"` can never downgrade a derived-high signal.
+
+## Usage
+
+```sh
+adlc build-gate <ticket-id> [--depth <n>] [--session-bytes <n>] [--transcript <path>]
+                [--depth-threshold <n>] [--bytes-threshold <n>] [--tickets <path>]
+                [--reason <text>] [--json]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `<ticket-id>` | — | Ticket to gate (required positional). |
+| `--depth <n>` | — | Precomputed tool-call-count depth signal. |
+| `--session-bytes <n>` | — | Precomputed transcript byte-size signal. |
+| `--transcript <path>` | — | Derive depth / session-bytes from this transcript file. |
+| `--depth-threshold <n>` | `40` | Tool-call count past which a session is degraded. |
+| `--bytes-threshold <n>` | `262144` | Transcript bytes (256 KiB) past which a session is degraded. |
+| `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file. |
+| `--reason <text>` | — | Free-text reason recorded with an override. |
+| `--json` | off | Machine-readable JSON result. |
+
+Supplying no signal defaults to "not degraded" — a gate given no signal cannot
+deny. Set `ADLC_BUILD_GATE_BYPASS=1` to override a deny; the override is honored
+only if it can be durably recorded to `.adlc/manifest.jsonl`.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — allow: gate passes (low risk, not degraded, or an audited override recorded).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad ticket id, missing tickets file, bad thresholds).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — deny: a high-risk ticket in a degraded session with no recorded override.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc build-gate AUTH-9 --depth 61
+build-gate: DENY (AUTH-9, risk=high) — high-risk build in a degraded session; no audited override
+exit 2
+```
+
+## Go deeper
+
+[packages/build-gate](https://github.com/voodootikigod/adlc/tree/main/packages/build-gate)

--- a/apps/docs/content/docs/toolkit/cli.mdx
+++ b/apps/docs/content/docs/toolkit/cli.mdx
@@ -1,8 +1,75 @@
 ---
 title: cli
-description: cli documentation (coming soon).
+description: The umbrella dispatcher — one stable command surface that routes every adlc verb to the right gate in the suite.
 ---
 
 # cli
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**Package:** `@adlc/cli` · **Role:** one stable command prefix for skills, hooks, CI, and humans.
+
+## What it is
+
+Every ADLC gate ships as its own `@adlc/*` package, but an agent harness needs a
+single stable prefix — a skill or hook that shells out to twenty different
+binaries is brittle and easy to route around. `@adlc/cli` installs the suite and
+makes every gate reachable through one verb: `adlc <tool>`.
+
+The dispatcher is a router and nothing more. It forwards argv verbatim to the
+routed tool and propagates the child's exit code unchanged, so `adlc spec-lint
+spec.md --json` behaves exactly as the standalone tool would. It resolves
+package-local binaries from its own `@adlc/*` dependencies and never searches
+your `PATH`, so a stale global binary can't silently satisfy a gate.
+
+## Install
+
+```sh
+npm install -g @adlc/cli
+```
+
+## Usage
+
+```sh
+adlc <tool> [args...]        # run any ADLC gate (argv forwarded verbatim)
+adlc run <phase> [args...]   # assert phase evidence via the runner
+adlc accept [args...]        # record P6 acceptance evidence via the runner
+adlc --help                  # list all tools, grouped
+adlc --version               # print the dispatcher version
+```
+
+Every tool listed on the [Toolkit landing page](/docs/toolkit) is reachable as
+`adlc <tool>`. A few verbs are worth calling out:
+
+| Verb | What it does |
+| --- | --- |
+| `adlc <tool>` | Resolves the local `@adlc/<tool>` bin and runs it with the remaining args. |
+| `adlc run` / `adlc accept` | Runner verbs — route to `@adlc/runner` to assert phase evidence (`run`) or record P6 acceptance (`accept`). |
+| `adlc review` | External passthrough — shells out to `npx adversarial-review`, the model-judged reviewer that `prosecute` records evidence for but never runs itself. |
+| `adlc ticket` | Dispatcher shorthand for the `@adlc/ticket-sync` package (routes to its bin). |
+
+### Unknown tools
+
+An unrecognized verb fails fast with a Levenshtein-based suggestion:
+
+```sh
+$ adlc spec-lnt spec.md
+error: unknown tool: spec-lnt
+did you mean "spec-lint"?
+run "adlc --help" for the list of 24 tools.
+exit 1
+```
+
+## Exit-code convention
+
+The dispatcher mirrors the routed tool's exit code exactly — it adds none of its
+own semantics:
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes or command succeeds.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (including dispatcher-level failures: unknown tool, missing package).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails.</span>
+</div>
+
+## Go deeper
+
+Source and the full dependency list:
+[packages/cli](https://github.com/voodootikigod/adlc/tree/main/packages/cli).

--- a/apps/docs/content/docs/toolkit/coldstart.mdx
+++ b/apps/docs/content/docs/toolkit/coldstart.mdx
@@ -1,8 +1,53 @@
 ---
 title: coldstart
-description: coldstart documentation (coming soon).
+description: A cheap-tier LLM plays a fresh agent and lists every human-only question a ticket leaves unanswered before the build queue.
 ---
 
 # coldstart
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P2 Decompose** · **Gate:** every ticket is self-contained — no human-only questions remain before it enters the build queue.
+
+<PhaseDiagram phase="P2" />
+
+## What it defends against
+
+<FailureMode id="F3" />
+
+A build agent that starts on an under-specified ticket loses the plot fast: it guesses at missing shapes, invents contracts, and drifts. `coldstart` runs the check up front — a cheap-tier model plays a fresh agent with no prior context and lists every question it would have to ask a *human* before it could start. Information derivable from the repo does not count; only genuine gaps (undefined schemas, absent contracts, unverifiable criteria, vague scope) block the gate.
+
+## Usage
+
+```sh
+adlc coldstart <ticket-id> [options]
+adlc coldstart --all [options]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--tickets <path>` | Path to the tickets file (default `.adlc/tickets.json`). |
+| `--all` | Run the gate on every ticket in the file. |
+| `--tier cheap\|mid\|frontier` | Model tier (default `cheap`). |
+| `--json` | Machine-readable JSON output for orchestrators. |
+| `--prompt-only` | Print the exact prompt(s) and exit 0 — no LLM call made. |
+| `--record-verdict <file\|->` | With `--prompt-only`: record the operator's answer into `.adlc/manifest.jsonl` via gate-manifest. Requires `--prompt-only`. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: ticket(s) are fully executable.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad input, unknown ticket id, missing file, no provider).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more tickets have gaps (printed per ticket).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc coldstart T2
+✗ T2 — 1 gap
+  - UserSchema: shape referenced in body but not defined
+exit 2
+```
+
+## Go deeper
+
+[packages/coldstart](https://github.com/voodootikigod/adlc/tree/main/packages/coldstart) · Why executable tickets matter as much as specs: [Tests Are the Spec](https://voodootikigod.com/adlc-3-tests-are-the-spec).

--- a/apps/docs/content/docs/toolkit/consensus-fix.mdx
+++ b/apps/docs/content/docs/toolkit/consensus-fix.mdx
@@ -1,8 +1,68 @@
 ---
 title: consensus-fix
-description: consensus-fix documentation (coming soon).
+description: Fans N independent LLM fixes at a failing test, gates each against the rails, and picks the smallest consensus winner.
 ---
 
 # consensus-fix
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P4 Build** · **Gate:** a fix is only accepted when it passes both the repro test and the full rail suite, and agrees with peers.
+
+<PhaseDiagram phase="P4" />
+
+## What it defends against
+
+Single-shot fixes stall on hard bugs, and a fix that passes the one failing test
+may quietly redden the rest of the suite. `consensus-fix` applies N-version
+programming: it fans N independent, stateless LLM completions at the same broken
+test, applies each candidate in isolation, and keeps only those that pass BOTH the
+repro command and the full rail regression suite. Survivors are grouped by
+agreement and the smallest diff from the largest consensus group wins. When every
+survivor is a singleton (with `--n >= 3`), that divergence is treated as evidence
+the spec is ambiguous — the tool escalates rather than guessing.
+
+## Usage
+
+```sh
+adlc consensus-fix --test-cmd "..." --files a.mjs,b.mjs [--rails "..."] [--n 3] [--tier mid] [--provider <name> | --providers <a,b,c>] [--apply] [--allow-dirty] [--json] [--prompt-only]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--test-cmd <cmd>` | Repro gate: the failing-test command (required). Must exit non-zero while the bug is present. |
+| `--files <paths>` | Comma-separated files the LLM may modify (required). Any candidate touching a file outside this list is discarded. |
+| `--rails <cmd>` | Regression gate: the full frozen rail suite. A candidate survives only if both gates exit 0. Omitting it prints a WARNING and skips the rail check. |
+| `--n <int>` | Number of independent candidates (default 3). Ignored when `--providers` is given. |
+| `--tier cheap\|mid\|frontier` | LLM tier for completions (default `mid`). |
+| `--provider <name>` | Force one provider (`anthropic`/`openai`/`gemini`/`agy`) for the run. Mutually exclusive with `--providers`. |
+| `--providers <a,b,c>` | Draw one candidate per named provider family (cross-family diversity). Each named provider must have its API key set or the run fails closed first. Mutually exclusive with `--provider`. |
+| `--apply` | Write the winning fix. Default is dry-run. Never applies when all-divergent. |
+| `--allow-dirty` | Skip the dirty-tree guard (useful in CI with staged-only changes). |
+| `--json` | Machine-readable output. |
+| `--prompt-only` | Print the prompts that would be sent and exit 0 — works with zero API keys. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: at least one candidate survived both gates with a usable consensus.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad arguments, unreadable files, dirty tree, no provider).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: no survivors, or all survivors are singletons with `--n >= 3` (spec ambiguity — escalate).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc consensus-fix --test-cmd "node --test test/math.test.mjs" \
+                     --rails    "node --test test/*.test.mjs" \
+                     --files src/math.mjs --n 5
+survivors: 3/5   groups: 1   rails: checked
+winner: src/math.mjs (1 changed line, consensus group of 3)
+dry-run — re-run with --apply to write it
+exit 0
+```
+
+## Go deeper
+
+Why prosecution, not code review, is the discipline that makes fixes trustworthy:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).
+
+[packages/consensus-fix](https://github.com/voodootikigod/adlc/tree/main/packages/consensus-fix)

--- a/apps/docs/content/docs/toolkit/core.mdx
+++ b/apps/docs/content/docs/toolkit/core.mdx
@@ -1,8 +1,89 @@
 ---
 title: core
-description: core documentation (coming soon).
+description: The frozen shared foundation every ADLC tool imports — exit-code helpers, provider selection, and the ledger, ticket, rail, and mutation primitives.
 ---
 
 # core
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**Package:** `@adlc/core` · **Role:** the shared library every gate imports · **Status:** frozen contract.
+
+## What it is
+
+`@adlc/core` is the foundation the whole toolkit stands on. Every gate imports
+from it; no gate modifies it. It is a **frozen contract during tool builds** — a
+rail. If a tool needs something core doesn't offer, it works around the gap in
+its own package and notes it in its README rather than editing core. That
+discipline is what keeps twenty-plus independently published tools behaving
+identically at their boundaries.
+
+Downstream tools inherit five things from core: the exit-code convention, LLM
+provider selection, the append-only ledger, the ticket/rail/glob engine, and the
+mutation operators used by prosecution.
+
+## Exit-code convention
+
+This is the contract. Every gate that builds on core reports its result the same
+way, so an orchestrator, hook, or CI job can branch on the exit code without
+parsing output. Core exposes it as three helpers — `pass()`, `opError()`, and
+`gateFail()`:
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — `pass()`: the gate passes or the command succeeds.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — `opError()`: operational error (bad input, unreadable file, failed LLM call).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — `gateFail()`: the gate fails (the finding is real).</span>
+</div>
+
+The split between 1 and 2 matters: an operational error means the gate couldn't
+run, while a gate failure means it ran and found a problem. Collapsing them would
+let a broken environment read as a clean pass.
+
+## Provider selection
+
+Tools that run an LLM pass do not embed provider logic — they call core's
+`detectProvider` / `complete` / `fan` helpers, which auto-detect a provider from
+the environment. Detection runs in a fixed priority order (cheapest and lowest
+latency first, per ADR-0007), matching the first provider whose key is present:
+
+| Order | Provider | Env var |
+| --- | --- | --- |
+| 1 | `anthropic` | `ANTHROPIC_API_KEY` |
+| 2 | `openai` | `OPENAI_API_KEY` |
+| 3 | `gemini` | `GEMINI_API_KEY` |
+| 4 | `agy` | `ADLC_AGY` (Antigravity CLI subprocess; feature-flag gated, last so API-key providers win) |
+
+Force a specific provider with `ADLC_PROVIDER` (env) or a per-invocation
+`--provider` flag, which takes precedence over the env var. Model tiers
+(`cheap` / `mid` / `frontier`) resolve to provider-specific model ids and can be
+overridden with `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, and `ADLC_MODEL_FRONTIER`.
+
+### The keyless `--prompt-only` philosophy
+
+No ADLC gate requires an API key to be useful. Every LLM-backed tool exposes
+`--prompt-only`, backed by core's `promptOnly()` helper: it prints the exact
+prompt the tool would send and exits `0`. You can paste that prompt into any
+harness — a chat window, a different provider, an air-gapped review — and feed
+the answer back. Keys make the gate automatic; they are never a gate to entry.
+
+## Rail-engine primitives
+
+The rest of core is the deterministic machinery the gates share:
+
+- **Ledger** (`.adlc/`): `appendEntry` / `readEntries` back the append-only gate
+  evidence, with `sha256` / `hashFiles` for content hashing. Malformed lines are
+  reported, never silently swallowed.
+- **Tickets & rails** (`.adlc/tickets.json`): `loadTickets`, `validateTicket`,
+  `topoSort`, and `computeFloat` (critical-path method) turn the ticket graph
+  into an executable, dependency-ordered plan.
+- **Scope & glob**: `globMatch` (`*`, `**`), `inScope`, and `scopesOverlap` are
+  the conservative matchers `rails-guard` uses to decide whether an edit is
+  inside a ticket's declared scope.
+- **Git**: `gitDiff`, `changedFiles`, `isDirty`, plus `coChange` and `churn` for
+  the logical-coupling signals hot-file and merge-forecast tools read.
+- **Mutation**: `mutate.OPERATORS` (invert-comparison, bool-flip, null-return,
+  off-by-one, logic-swap) and `generateMutants` / `applyMutant` power
+  `hollow-test`, `review-calibration`, and `gate-fuzzing`.
+
+## Go deeper
+
+The full import surface and frozen-contract notes:
+[packages/core](https://github.com/voodootikigod/adlc/tree/main/packages/core).

--- a/apps/docs/content/docs/toolkit/flail-detector.mdx
+++ b/apps/docs/content/docs/toolkit/flail-detector.mdx
@@ -1,8 +1,64 @@
 ---
 title: flail-detector
-description: flail-detector documentation (coming soon).
+description: Analyzes a build-session log for flail signatures and fails the gate when an agent is spinning.
 ---
 
 # flail-detector
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P4 Build** · **Gate:** a build session that shows flail signatures is killed, not retried indefinitely.
+
+<PhaseDiagram phase="P4" />
+
+## What it defends against
+
+A build agent that has lost the thread will loop: hitting the same error over and
+over, wandering outside its declared scope, or churning the same file. Left alone
+it burns context and produces noise. `flail-detector` encodes the mechanical
+two-strike rule — it reads a session log and fails closed when it finds any of
+four signatures: a normalized error signature repeating past `--max-repeat`, a
+written path outside every `--scope` glob, one file edited three or more times, or
+a log exceeding `--max-bytes`. It is fully deterministic and makes no LLM calls.
+
+## Usage
+
+```sh
+adlc flail-detector <log-file> [--scope <glob>...] [--max-repeat <n>] [--max-bytes <n>] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `<log-file>` | Path to the session log to analyze (required positional). Treated as JSONL when more than half its non-empty lines parse as JSON objects, otherwise plain text. |
+| `--scope <glob>` | Declared-scope glob, repeatable. When given, written paths outside all globs are scope violations. |
+| `--max-repeat <n>` | Trigger the repeated-error signal at n identical normalized signatures (default 2). |
+| `--max-bytes <n>` | Trigger the size signal when the log exceeds n bytes (default: no limit). |
+| `--json` | Machine-readable JSON output for orchestrators. |
+| `--help` | Print help and exit 0. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — clean: no flail signals detected, the session may continue.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (log file not found, bad argument).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — flail: one or more signals triggered; kill the session and append the dead-ends to the ticket.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc flail-detector session.log --scope 'src/**' --scope 'test/**'
+flail-detector: FLAIL
+  signals:
+    repeated-error (1 signature(s)):
+      [2x] error: cannot resolve module at line in
+    scope-violation (1 path(s) outside scope):
+      /etc/hosts
+  recommendation:
+    Kill the session. Append these dead-ends to the ticket.
+exit 2
+```
+
+On a second trigger, escalate to P2: the ticket is wrong, not the agent.
+
+## Go deeper
+
+[packages/flail-detector](https://github.com/voodootikigod/adlc/tree/main/packages/flail-detector)

--- a/apps/docs/content/docs/toolkit/gate-fuzzing.mdx
+++ b/apps/docs/content/docs/toolkit/gate-fuzzing.mdx
@@ -1,8 +1,69 @@
 ---
 title: gate-fuzzing
-description: gate-fuzzing documentation (coming soon).
+description: Fans model instances to generate wrong-but-passing diffs and reports any gate they defeat.
 ---
 
 # gate-fuzzing
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: calibration (cross-phase)** · **Gate:** no configured gate can be defeated by a wrong-but-passing, independently-witnessed candidate diff.
+
+## What it defends against
+
+A gate that never sees a hostile input is a gate nobody has tested.
+`gate-fuzzing` fans N cheap/mid model instances to produce candidate diffs
+engineered to pass every configured gate while being genuinely wrong. Each diff
+that slips through — valid, passing all gates, touching a gate's declared
+surface, and proven wrong by an independent held-out witness — is a defeat, and
+each defeat becomes a RED test you commit into that gate. It turns "we found
+some bypasses once" into a standing CI check.
+
+Every candidate runs in a fresh disposable `git clone` under an OS sandbox
+(`bwrap` on Linux, `sandbox-exec` on macOS), never in your real tree.
+
+## Usage
+
+```sh
+adlc gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid] [--provider <name> | --providers <a,b,c>] [--record] [--json] [--prompt-only]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--suite <path>` | Gate-suite descriptor (default `.adlc/gate-suite.json`; refuses if absent). |
+| `--n <int>` | Fan width per round (default `6`); ignored when `--providers` is given. |
+| `--tier cheap\|mid` | Adversary model tier (default `mid`; `frontier` is rejected). |
+| `--provider <name>` | Force one provider (`anthropic\|openai\|gemini\|agy`); mutually exclusive with `--providers`. |
+| `--providers <a,b,c>` | Fan across distinct named providers, one candidate each. |
+| `--max-rounds <int>` / `--dry-rounds <int>` | Round ceiling (default `10`) and consecutive-dry stop count (default `3`). |
+| `--witness-trials <int>` | Unanimous witness runs per side (default `3`). |
+| `--unsafe-no-sandbox` | Skip the OS sandbox — only inside a disposable VM. |
+| `--strict-budget` | Any inconclusive stop becomes exit 1 (recommended for CI). |
+| `--fail-on-behavioral` | Behavioral defeats exit 2 (default: report only). |
+| `--record` | Write repro artifacts to `.adlc/gate-defeats/` and cluster findings. |
+| `--json` | Machine-readable output. |
+| `--prompt-only` | Print adversary prompts and exit 0 (zero API keys). |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — earned clean: potency canary beaten, no defeats found, dry streak reached.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: dirty tree, no sandbox binary, failed control self-test, or an inconclusive stop under `--strict-budget`.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — a gate was defeated: wrong-but-passing, surface-bound, independently witnessed.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc gate-fuzzing --suite .adlc/gate-suite.json --n 6 --record
+control self-test: PASS (defeatable=true, sound=true)
+
+gate-fuzzing: 1 gate defeated
+  rounds: 4, stoppedBy: defeat
+  defeats: 1 (contract: 1, behavioral: 0)
+exit 2
+```
+
+## Go deeper
+
+[packages/gate-fuzzing](https://github.com/voodootikigod/adlc/tree/main/packages/gate-fuzzing).
+Why gates need adversaries, not trust:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/gate-manifest.mdx
+++ b/apps/docs/content/docs/toolkit/gate-manifest.mdx
@@ -1,8 +1,64 @@
 ---
 title: gate-manifest
-description: gate-manifest documentation (coming soon).
+description: A hash-chained evidence ledger recording what each ADLC gate verified, with optional HMAC signing so the chain attests authorship, not just consistency.
 ---
 
 # gate-manifest
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC: C11 cross-cutting provenance** · **Gate:** every gate's verdict is recorded in a tamper-evident chain that CI and the P6 reviewer can verify.
+
+## What it defends against
+
+Agentic code arrives at the merge gate with no memory of what was checked along the way.
+`gate-manifest` is the append-only ledger the other gates write to — spec-lint, hollow-test,
+rails-guard, review-calibration — each recording what it verified into `.adlc/manifest.jsonl`.
+Every entry's `prev` is the SHA-256 of the previous raw line, so tampering with any line
+breaks the chain. Set `ADLC_MANIFEST_KEY` and each entry is additionally HMAC-SHA256 signed:
+without it the chain proves only internal consistency (anyone who can write the file can
+forge a clean one); with it, the chain attests authorship and defeats the forge-from-scratch
+attack. It spans phases rather than owning one, giving auditors and the P6 gate the provenance
+that agentic code was checked before it shipped.
+
+## Usage
+
+```sh
+adlc gate-manifest record <gate-name> [--ticket id] [--data '{json}'] [--files a,b,c] [--dir path] [--json]
+adlc gate-manifest verify [--json] [--dir path]
+adlc gate-manifest show   [--ticket id] [--json] [--dir path]
+adlc gate-manifest attest [--ticket id] [--dir path]
+```
+
+| Verb / Flag | Description |
+| --- | --- |
+| `record <gate-name>` | Append one entry to the ledger; signs it when `ADLC_MANIFEST_KEY` is set. |
+| `verify` | Walk the raw lines and validate the hash chain (and signatures, when keyed). |
+| `show` | Print entries, optionally filtered by ticket. |
+| `attest` | Emit a Markdown gate-evidence table suitable for a PR comment. |
+| `--ticket id` | Associate or filter entries by ticket id. |
+| `--data '{json}'` | Arbitrary JSON payload for `record`; malformed JSON is a hard error. |
+| `--files a,b,c` | Comma-separated paths, each SHA-256 hashed (missing files hash to null). |
+| `--dir path` | Override the ledger directory (default `.adlc`). |
+| `--json` | Machine-readable output. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — `record`, `show`, and `attest` always; `verify` when the chain (and signatures, if keyed) is valid.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: bad input, unreadable file, or malformed `--data` JSON.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — `verify` gate fails: the chain is broken (reports the seq and line of the first break).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc gate-manifest record hollow-test --ticket T-42 --data '{"survived":0}' --files src/calc.mjs
+recorded: seq=2 gate=hollow-test ts=2026-07-05T18:04:11.220Z (unsigned)
+
+$ adlc gate-manifest verify
+chain valid (2 entries)
+exit 0
+```
+
+## Go deeper
+
+- [packages/gate-manifest](https://github.com/voodootikigod/adlc/tree/main/packages/gate-manifest)

--- a/apps/docs/content/docs/toolkit/hollow-test.mdx
+++ b/apps/docs/content/docs/toolkit/hollow-test.mdx
@@ -1,8 +1,63 @@
 ---
 title: hollow-test
-description: hollow-test documentation (coming soon).
+description: Diff-scoped mutation gate — mutates only the lines your change touched and fails if any mutant survives your test suite, proving coverage is load-bearing.
 ---
 
 # hollow-test
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P3 Rail (C4)** · **Gate:** every changed line is constrained by an assertion — no mutant survives.
+
+<PhaseDiagram phase="P3" />
+
+## What it defends against
+
+<FailureMode id="F5" />
+
+Executed lines are not tested lines. A suite can run every changed statement and still
+assert nothing about its behavior — hollow coverage that a reward-seeking model will
+happily produce. `hollow-test` mutates only the lines in your diff (invert a comparison,
+flip a boolean, null a return), reruns the suite against each mutant, and fails if any
+survives. A survivor is proof the line's behavior is unconstrained. Diff-scoping keeps
+the run in seconds-to-minutes instead of the hours whole-codebase mutation testing costs.
+
+## Usage
+
+```sh
+adlc hollow-test --test-cmd "node --test test/" [--base <ref>] [--max <n>] [--timeout-ms <n>] [--target <file>] [--rails <ticket-file>] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--test-cmd <cmd>` | (required) Shell command to run the suite; must exit non-zero on failure. |
+| `--base <ref>` | Git base ref for the diff. Defaults to the merge-base with a trunk; fails closed if none resolves. |
+| `--max <n>` | Max mutants across all files (default `20`), spread round-robin. |
+| `--timeout-ms <n>` | Per-mutant test-command timeout (default `120000`). |
+| `--target <file>` | Mutate this file whole, independent of the diff (repeatable). For rails-authoring / characterization tickets where the behavior file itself did not change. |
+| `--rails <ticket-file>` | Expand a ticket's declared `rails` globs against tracked files and mutate them (repeatable). |
+| `--json` | Machine-readable output for orchestrators. |
+| `--help` | Show usage and exit 0. |
+
+Refuses to run on a dirty working tree, and requires a green baseline before mutating
+so a failing suite cannot masquerade as killing every mutant.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: every generated mutant was killed by the suite.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: dirty tree, not a git repo, bad arguments, non-green baseline, or nothing eligible to mutate with no `--target`/`--rails`.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more mutants survived (hollow coverage).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc hollow-test --test-cmd "node --test test/" --base main
+src/calc.mjs:7  null-return   survived   return a + b;  →  return null;
+hollow coverage — 1 mutation(s) pass your tests
+exit 2
+```
+
+## Go deeper
+
+- [packages/hollow-test](https://github.com/voodootikigod/adlc/tree/main/packages/hollow-test)
+- Why prosecution beats code review: [Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/index.mdx
+++ b/apps/docs/content/docs/toolkit/index.mdx
@@ -1,8 +1,81 @@
 ---
 title: Toolkit
-description: Toolkit documentation (coming soon).
+description: The ADLC toolkit — one deterministic gate per lifecycle phase, installed once through @adlc/cli.
 ---
 
 # Toolkit
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+The toolkit makes the ADLC gates concrete. Each lifecycle phase asks one
+machine-checkable question, and one tool answers it with an exit code — `0`
+passes, `2` fails. The tools publish independently but install together and share
+one command surface: `adlc <tool>`. If you want the phase map first, read
+[The Lifecycle](/docs/lifecycle); this page is the index of every gate.
+
+```sh
+npm install -g @adlc/cli
+adlc --help          # list every tool, grouped
+adlc <tool> [args]   # run any gate
+```
+
+Everything below is reachable as `adlc <tool>`. The groups mirror the phases of
+work: shaping the spec, supervising execution, gathering review evidence,
+compounding defenses, and syncing outward.
+
+## Spec and ticket shaping
+
+| Tool | What it does |
+| --- | --- |
+| [parallax](/docs/toolkit/parallax) | Fan out readers to expose spec ambiguity and route conflicts. |
+| [spec-lint](/docs/toolkit/spec-lint) | Gate specs for acceptance criteria that lack a verification method. |
+| [premortem](/docs/toolkit/premortem) | Stress-test an approved spec before implementation. |
+| [coldstart](/docs/toolkit/coldstart) | Check whether tickets are executable without agent guesswork. |
+| [ticket-prune](/docs/toolkit/ticket-prune) | Report and archive stale, already-shipped tickets out of tickets.json. |
+
+## Execution supervision and rails
+
+| Tool | What it does |
+| --- | --- |
+| [preflight](/docs/toolkit/preflight) | Check baseline environment readiness before fan-out. |
+| [model-router](/docs/toolkit/model-router) | Assign tickets to frontier, direct, or ladder model strategies. |
+| [merge-forecast](/docs/toolkit/merge-forecast) | Estimate fan-out width, dependency pressure, and merge backpressure. |
+| [rails-guard](/docs/toolkit/rails-guard) | Enforce frozen rails, declared suppressions, and manifest recording. |
+| [build-gate](/docs/toolkit/build-gate) | Deny starting a high-risk ticket build in a degraded (context-rot) session unless audited. |
+| [flail-detector](/docs/toolkit/flail-detector) | Detect repeated errors, scope violations, edit churn, and oversized logs. |
+| [consensus-fix](/docs/toolkit/consensus-fix) | Fan out candidate fixes and select the gated consensus winner. |
+
+## Review evidence and calibration
+
+| Tool | What it does |
+| --- | --- |
+| [behavior-diff](/docs/toolkit/behavior-diff) | Capture and compare HTTP/API behavior snapshots for the P6 human gate. |
+| [gate-manifest](/docs/toolkit/gate-manifest) | Record, verify, show, and attest append-only gate evidence. |
+| [hollow-test](/docs/toolkit/hollow-test) | Mutate changed code to find tests that pass without testing behavior. |
+| [prosecute](/docs/toolkit/prosecute) | Record ticket- and revision-bound P5 prosecution evidence. |
+| [review-calibration](/docs/toolkit/review-calibration) | Measure reviewer recall by scoring whether review catches mutants. |
+| [model-ratchet](/docs/toolkit/model-ratchet) | Identify hot files for re-prosecution after model or repo drift. |
+| [gate-fuzzing](/docs/toolkit/gate-fuzzing) | Run hostile candidates against gate suites to find defeats. |
+| `review` | External passthrough — runs the model-judged `npx adversarial-review` that `prosecute` records evidence for. |
+
+## Compounding defenses
+
+| Tool | What it does |
+| --- | --- |
+| [lesson-foundry](/docs/toolkit/lesson-foundry) | Mine repeated findings into deterministic defenses. |
+| [rejection-mining](/docs/toolkit/rejection-mining) | Mine review rejections into reusable review lenses. |
+| [skill-rot](/docs/toolkit/skill-rot) | Check skill files for stale validation metadata and stamp freshness. |
+
+## External integration
+
+| Tool | What it does |
+| --- | --- |
+| [ticket-sync](/docs/toolkit/ticket-sync) | Two-way sync ADLC tickets with external trackers (GitHub Issues). Reached as `adlc ticket`. |
+
+## Shared foundation
+
+Not gates themselves — the layer every gate is built on.
+
+| Package | What it does |
+| --- | --- |
+| [cli](/docs/toolkit/cli) | The `adlc <tool>` dispatcher — one stable command surface for the whole suite. |
+| [core](/docs/toolkit/core) | Frozen shared library: exit-code helpers, provider selection, ledger, ticket, rail, and mutation primitives. |
+| [runner](/docs/toolkit/runner) | Backs `adlc run` and `adlc accept` — asserts phase evidence and records P6 acceptance. |

--- a/apps/docs/content/docs/toolkit/lesson-foundry.mdx
+++ b/apps/docs/content/docs/toolkit/lesson-foundry.mdx
@@ -1,8 +1,63 @@
 ---
 title: lesson-foundry
-description: lesson-foundry documentation (coming soon).
+description: Clusters recurring prosecution findings and routes each to its cheapest permanent defense (lint, skill, or spec gap).
 ---
 
 # lesson-foundry
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P7 Compound** · **Gate:** with `--gate`, every recurring finding cluster has a banked defense file — no lesson is re-bought.
+
+<PhaseDiagram phase="P7" />
+
+## What it defends against
+
+<FailureMode id="F7" />
+
+Without a compounding step the lifecycle never gets cheaper: the same finding is
+re-discovered by probabilistic review every run. `lesson-foundry` reads the
+prosecution findings ledger, clusters findings by semantic similarity, and
+routes each recurring cluster to its cheapest permanent defense — a grep-gate
+LINT, a `SKILL.md` stub, or a SPEC-GAP question for P1 — demoting a
+dollars-per-catch LLM finding into a free-forever deterministic one.
+
+## Usage
+
+```sh
+adlc lesson-foundry [--ledger <name>] [--min <n>] [--out-dir <path>] [--write] [--gate] [--llm] [--prompt-only] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--ledger <name>` | Ledger name under `.adlc/` to read findings from (default `findings`). |
+| `--min <n>` | Minimum cluster size to surface (default `2`). |
+| `--out-dir <path>` | Output directory for defense files (default `.adlc/lessons`). |
+| `--write` | Emit files (default is dry-run — prints what would be written). |
+| `--gate` | Exit 2 if any cluster ≥ `--min` has no defense file in `--out-dir`. |
+| `--llm` | Refine cluster wording via one mid-tier LLM call per cluster. |
+| `--tier cheap\|mid\|frontier` | Model tier for the `--llm` pass (default `mid`). |
+| `--prompt-only` | Print the LLM prompts and exit 0 (zero API keys). |
+| `--json` | Machine-readable output. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: no recurring unbanked lessons (or `--gate` not set).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: bad input, unreadable ledger, or a write failure.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more clusters have no defense file in `--out-dir`.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc lesson-foundry --ledger findings --min 2 --gate
+cluster "raw-error-to-client" (4 findings) → LINT   [no defense file]
+cluster "missing-null-check"  (3 findings) → SKILL  [no defense file]
+✗ lesson-foundry: 2 recurring lesson(s) unbanked: raw-error-to-client, missing-null-check
+exit 2
+```
+
+## Go deeper
+
+[packages/lesson-foundry](https://github.com/voodootikigod/adlc/tree/main/packages/lesson-foundry).
+Why recurring findings must be paid for exactly once:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/merge-forecast.mdx
+++ b/apps/docs/content/docs/toolkit/merge-forecast.mdx
@@ -1,8 +1,61 @@
 ---
 title: merge-forecast
-description: merge-forecast documentation (coming soon).
+description: Predicts merge conflicts before any agent runs, certifies the safe fan-out width, and emits a foundation-first merge schedule.
 ---
 
 # merge-forecast
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P2 Decompose** · **Gate:** the requested fan-out width never exceeds the width that is certified conflict-safe.
+
+<PhaseDiagram phase="P2" />
+
+## What it defends against
+
+Fanning agents out wide only to have their branches collide at merge time burns
+the parallel speedup twice — once building, once untangling. `merge-forecast`
+scores every parallel-eligible ticket pair for scope overlap, namespace
+collision, import radius, and historical co-change, then certifies the largest
+independent set as the safe width and orders the merge foundation-first. A hard
+scope-overlap veto or an over-wide `--width` fails the gate before any agent
+runs.
+
+## Usage
+
+```sh
+adlc merge-forecast [--tickets <path>] [--width <N>] [--build-min <X>] [--merge-min <Y>]
+                    [--co-change-limit <N>] [--conflict-threshold <F>] [--json]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file. |
+| `--width <N>` | — | Desired fan-out width; gate fails if it exceeds the certified width. |
+| `--build-min <X>` | — | Mean ticket build time in minutes (for backpressure width). |
+| `--merge-min <Y>` | — | Mean merge-rebase-regreen time in minutes. |
+| `--co-change-limit <N>` | `500` | Git-log depth for co-change mining. |
+| `--conflict-threshold <F>` | `0.5` | Pair score at or above this triggers a `SEQUENCE` verdict. |
+| `--json` | off | Machine-readable JSON output. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: the schedule is safe at the recommended width.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad tickets file, unresolvable input).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: `--width` exceeds the certified width, or a vetoed / high-risk pair is scheduled concurrently.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc merge-forecast --width 4
+certifiedWidth: 2   recommendedWidth: 2
+AUTH-1 ↔ AUTH-2   SEQUENCE   scope-overlap (1.00) — declared scopes overlap
+
+Gate failed:
+  --width 4 exceeds certifiedWidth 2
+exit 2
+```
+
+## Go deeper
+
+[packages/merge-forecast](https://github.com/voodootikigod/adlc/tree/main/packages/merge-forecast)

--- a/apps/docs/content/docs/toolkit/meta.json
+++ b/apps/docs/content/docs/toolkit/meta.json
@@ -3,9 +3,9 @@
   "pages": [
     "index",
     "---Spec & ticket shaping---",
-    "parallax", "spec-lint", "premortem", "coldstart",
+    "parallax", "spec-lint", "premortem", "coldstart", "ticket-sync", "ticket-prune",
     "---Execution supervision & rails---",
-    "preflight", "model-router", "merge-forecast", "rails-guard", "flail-detector", "consensus-fix", "runner",
+    "preflight", "model-router", "merge-forecast", "build-gate", "rails-guard", "flail-detector", "consensus-fix", "runner",
     "---Review evidence & calibration---",
     "behavior-diff", "gate-manifest", "hollow-test", "prosecute", "review-calibration", "model-ratchet", "gate-fuzzing",
     "---Compounding defenses---",

--- a/apps/docs/content/docs/toolkit/model-ratchet.mdx
+++ b/apps/docs/content/docs/toolkit/model-ratchet.mdx
@@ -1,8 +1,59 @@
 ---
 title: model-ratchet
-description: model-ratchet documentation (coming soon).
+description: Ranks hot files (churn × import criticality) for re-prosecution after a model or repo drift.
 ---
 
 # model-ratchet
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: calibration (cross-phase)** · **Gate:** none — it prints a prosecution plan or drives a review over the highest-value files and records findings.
+
+## What it defends against
+
+Every frontier model release is a free re-audit: newer models find what older
+ones missed. `model-ratchet` picks the files worth re-prosecuting first —
+`SCORE = churn × (1 + inDegree)`, high change rate times how many source files
+import it — then either prints a prosecution plan or runs your review command
+over each, appending verified findings to the shared `.adlc/findings` ledger.
+Run it on every model release (or monthly) to ratchet quality monotonically up.
+
+## Usage
+
+```sh
+adlc model-ratchet [--top <n>] [--review-cmd <cmd>] [--churn-limit <n>] [--dry-run] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--top <n>` | Number of hotspot files to select (default `10`). |
+| `--review-cmd <cmd>` | Command to run per file; `{file}` is substituted. Omit it and the tool prints the plan only. |
+| `--churn-limit <n>` | Commit-history depth for the churn computation (default `1000`). |
+| `--dry-run` | Print the prosecution plan even when `--review-cmd` is supplied. |
+| `--json` | Machine-readable output. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — success: plan printed, or the review ran and findings were appended to the ledger.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: not a git repo, a `--review-cmd` exit outside {0,2}, or bad arguments.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — not used by model-ratchet itself; review findings route to the ledger rather than failing a gate.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc model-ratchet --top 3
+model-ratchet — Prosecution Plan
+====================================================================
+FILE                        CHURN  IN-DEGREE  SCORE
+--------------------------  -----  ---------  -----
+src/db/query.mjs               31          5    186
+src/auth.mjs                   42          3    168
+src/utils.mjs                  25          1     50
+exit 0
+```
+
+## Go deeper
+
+[packages/model-ratchet](https://github.com/voodootikigod/adlc/tree/main/packages/model-ratchet).
+Why re-prosecution beats a one-time review pass:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/model-router.mdx
+++ b/apps/docs/content/docs/toolkit/model-router.mdx
@@ -1,8 +1,61 @@
 ---
 title: model-router
-description: model-router documentation (coming soon).
+description: Deterministically assigns every ticket a model tier and ladder mode from the ticket DAG and ledger history — no LLM calls.
 ---
 
 # model-router
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P2 Decompose** · **Gate:** every ticket routes to a model tier justified by its rail density and DAG float.
+
+<PhaseDiagram phase="P2" />
+
+## What it defends against
+
+<FailureMode id="F8" />
+
+Picking a model per ticket by vibe leaves the seams showing: a cheap model on an
+unrailed, hard-to-verify ticket, or a frontier model burned on slack work.
+`model-router` reads the ticket DAG's rail density and critical-path float, plus
+per-model first-pass rates mined from the manifest ledger, and emits a
+deterministic `tier` + `mode` for every ticket — the same inputs always produce
+the same routing.
+
+## Usage
+
+```sh
+adlc model-router [--tickets <path>] [--floor <number>] [--json]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file. |
+| `--floor <0-1>` | `0.2` | Minimum rail density for cheap-tier assignment; below it a ticket is forced to frontier and flagged as a P3 finding. |
+| `--json` | off | Machine-readable output: `{ assignments, p3Findings }`. |
+
+Assignment is rule-based: `contract`/`spec`/`architecture` categories (or any
+ticket below the rail-density floor) route to `frontier`/`direct`; critical-path
+tickets (`float === 0`) skip the ladder; tickets with slack start `cheap` and
+ladder up on gate failure.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: all tickets assigned.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad tickets file, JSON parse error, cycle in the DAG).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more non-frontier-category tickets fall below the rail-density floor.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc model-router
+id            tier        mode      railDensity  float   reason
+---------------------------------------------------------------
+AUTH-1        cheap       ladder    1.000        3       float=3 → ladder starting at 'cheap' (railDensity=1.000)
+AUTH-2        frontier    direct    0.000        0       category 'spec' requires frontier model
+exit 0
+```
+
+## Go deeper
+
+[packages/model-router](https://github.com/voodootikigod/adlc/tree/main/packages/model-router)

--- a/apps/docs/content/docs/toolkit/parallax.mdx
+++ b/apps/docs/content/docs/toolkit/parallax.mdx
@@ -1,8 +1,66 @@
 ---
 title: parallax
-description: parallax documentation (coming soon).
+description: Fans N independent readers over a request and surfaces only the divergences as questions humans must answer.
 ---
 
 # parallax
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P1 Interrogate** · **Gate:** the measured ambiguity score is at or below threshold (spec/edge), or the routed answers agree (route).
+
+<PhaseDiagram phase="P1" />
+
+## What it defends against
+
+A single model reading an ambiguous request commits to one interpretation and states it with total confidence — the ambiguity never surfaces, it just silently becomes a decision. `parallax` replaces that introspection with measurement: it fans N independent cheap-tier readings, diffs them, and reports only where they disagree. The ambiguity score (`divergences / (divergences + agreements)`) turns "is this spec clear?" into a number you can gate on.
+
+## Usage
+
+```sh
+adlc parallax --request "text" | --file req.md | --edge T1 T2 | --route "question" [flags]
+```
+
+Three modes: **spec** (default — fan readers over a raw request), **edge** (`--edge T1 T2` — author the contract implied between two tickets), and **route** (`--route` — answer a mid-build question and check the answers agree).
+
+| Flag | Description |
+| --- | --- |
+| `--request <text>` / `--file <path>` | Spec mode: request text inline or from a file (stdin if neither). |
+| `--edge` | Edge mode: takes two ticket IDs as positionals. |
+| `--route <text>` | Route mode: the question to route. |
+| `--context <file>` | Route mode: context file, repeatable. |
+| `--tickets <path>` | Tickets file for edge mode (default `.adlc/tickets.json`). |
+| `--n <int>` | Fan width — number of independent readings (default 3). |
+| `--threshold <0-1>` | Ambiguity gate threshold (default 0.25). |
+| `--tier cheap\|mid\|frontier` | Override the LLM tier. |
+| `--json` | Machine-readable output (score + divergences). |
+| `--prompt-only` | Print the exact prompts and exit 0 — no API key needed. |
+| `--record-verdict <file\|->` | With `--prompt-only`: record the operator's answer into `.adlc/manifest.jsonl` via gate-manifest. Requires `--prompt-only`. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: ambiguity score at or below threshold (spec/edge), or answers equivalent (route).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad input, missing file, network failure, too few readings).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: ambiguity score exceeds threshold, or route answers diverge.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc parallax --request "Add a login page" --n 5
+# Parallax spec analysis
+
+## Agreement set (draft spec)
+- Email + password fields, submit button
+
+## Divergences — answer these
+**Q1: Social sign-in?**
+  A) email/password only
+  B) also Google OAuth
+
+**Ambiguity score:** 0.33 (threshold 0.25) — gate FAILS ✗
+exit 2
+```
+
+## Go deeper
+
+[packages/parallax](https://github.com/voodootikigod/adlc/tree/main/packages/parallax) · Why unexamined ambiguity is dangerous: [Tests Are the Spec](https://voodootikigod.com/adlc-3-tests-are-the-spec).

--- a/apps/docs/content/docs/toolkit/preflight.mdx
+++ b/apps/docs/content/docs/toolkit/preflight.mdx
@@ -1,8 +1,67 @@
 ---
 title: preflight
-description: preflight documentation (coming soon).
+description: Batches every environment and permission check the agent fleet needs into one pass before fan-out, so failures front-load instead of stalling mid-flight.
 ---
 
 # preflight
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P0 Triage** · **Gate:** every operation class the fleet needs is proven to work before a single agent spawns.
+
+<PhaseDiagram phase="P0" />
+
+## What it defends against
+
+A permission prompt or config failure that surfaces mid-flight is a hidden
+serialization point: one blocked agent stalls its N siblings, races half-started
+state, and wrecks the parallel wall-clock math. `preflight` front-loads bash,
+git, filesystem-write, and branch checks (plus optional worktree, test-command,
+`gh`, and LLM-provider checks) into one batch so the environment is proven
+deterministic before fan-out — not discovered non-deterministic during it.
+
+## Usage
+
+```sh
+adlc preflight [--test-cmd "..."] [--gh] [--llm] [--worktrees] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--test-cmd "CMD"` | Run `CMD` via `sh -c`; expect exit 0. Output tail shown on failure. |
+| `--gh` | Run `gh auth status`; expect exit 0. |
+| `--llm` | Call `detectProvider()` and assert non-null. No API call is made; reports which provider was found. |
+| `--worktrees` | Run a `git worktree add --detach … HEAD` then remove cycle. |
+| `--json` | Machine-readable output: `{ checks, verdict, failedNames }`. |
+
+With no flags, the four required checks (`bash`, `git`, `write`, `branch`) run.
+Each optional flag adds a check that becomes required for that run. Every check
+that creates a side effect cleans up in a `finally` block.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: every required and explicitly requested check passed.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational / internal error.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more required or requested checks failed.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc preflight --gh
+──────────────────────
+check      status  detail
+──────────────────────
+bash       ✓ PASS    echo preflight-ok succeeded
+git        ✓ PASS    git status succeeded
+write      ✓ PASS    .adlc/tmp/preflight-test written and removed
+branch     ✓ PASS    branch 'preflight-test-branch' created and removed
+gh         ✓ PASS    gh auth status exited 0
+──────────────────────
+
+verdict: ALL CHECKS PASSED — environment is ready.
+exit 0
+```
+
+## Go deeper
+
+[packages/preflight](https://github.com/voodootikigod/adlc/tree/main/packages/preflight)

--- a/apps/docs/content/docs/toolkit/premortem.mdx
+++ b/apps/docs/content/docs/toolkit/premortem.mdx
@@ -1,8 +1,58 @@
 ---
 title: premortem
-description: premortem documentation (coming soon).
+description: Tells a frontier model the project already failed and asks for the postmortem, surfacing concrete risks anchored to the spec.
 ---
 
 # premortem
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P1 Interrogate** · **Gate:** advisory — every surfaced failure cause becomes an interrogation question folded into spec review before the spec is locked.
+
+<PhaseDiagram phase="P1" />
+
+## What it defends against
+
+<FailureMode id="F4" />
+
+Ask a model "any problems with this plan?" and sycophancy answers "looks good." `premortem` inverts the framing: it tells a frontier model the project already failed and asks it to write the postmortem. Forced to explain a failure that already happened, the model produces concrete, checkable risks anchored to the actual spec content instead of confidently hallucinating that everything is fine.
+
+## Usage
+
+```sh
+adlc premortem <spec.md> [--tier cheap|mid|frontier] [--out report.md] [--json] [--prompt-only] [--record-verdict <file|->]
+```
+
+| Flag | Description |
+| --- | --- |
+| `<spec.md>` | Path to the spec file to analyse (required positional). |
+| `--tier cheap\|mid\|frontier` | Model tier (default `frontier`). |
+| `--out <path>` | Write the markdown report to this file instead of stdout. |
+| `--json` | Emit machine-readable JSON `{ causes: [...] }`. |
+| `--prompt-only` | Print the exact system + user prompt and exit 0 — no API key needed. |
+| `--record-verdict <file\|->` | With `--prompt-only`: record the operator's answer into `.adlc/manifest.jsonl` via gate-manifest. Requires `--prompt-only`. |
+| `--help` | Print usage and exit 0. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — report produced successfully (or `--prompt-only` / `--help`).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (missing spec file, no LLM provider configured, malformed model response).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — reserved for future gate-fail use; not currently emitted (premortem is advisory).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc premortem specs/checkout-v2.md --tier frontier
+## Failure Causes
+| Cause | Earliest signal | Prevention |
+| --- | --- | --- |
+| Idempotency key reused across retries | duplicate charge in logs | scope key to attempt, not order |
+
+## Questions to fold into interrogation
+1. How is the idempotency key derived, and is it stable across retries?
+exit 0
+```
+
+## Go deeper
+
+[packages/premortem](https://github.com/voodootikigod/adlc/tree/main/packages/premortem) · Why the spec must survive its own postmortem: [Tests Are the Spec](https://voodootikigod.com/adlc-3-tests-are-the-spec).

--- a/apps/docs/content/docs/toolkit/prosecute.mdx
+++ b/apps/docs/content/docs/toolkit/prosecute.mdx
@@ -1,8 +1,65 @@
 ---
 title: prosecute
-description: prosecute documentation (coming soon).
+description: A P5 review-evidence recorder — validates, hashes, and records ticket- and revision-bound reviewer findings, passing only after two dry passes across three lenses.
 ---
 
 # prosecute
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P5 Prosecute** · **Gate:** two consecutive dry passes across at least three distinct lenses are recorded before a change may merge.
+
+<PhaseDiagram phase="P5" />
+
+## What it defends against
+
+<FailureMode id="F2" />
+
+`prosecute` is a **recorder, not a reviewer** — it makes zero model calls and finds no bugs
+of its own. The model-judged skeptical review is a separate tool (`npx adversarial-review`,
+which `adlc review` wraps); `adlc prosecute` consumes **that** review's output as evidence.
+It validates the findings, hashes and binds them to the ticket and reviewed revision, and
+appends normalized pass records to `.adlc/manifest.jsonl`. It passes only after two
+consecutive dry passes covering three distinct lenses — so a single sycophantic "looks good"
+cannot stand in for a real prosecution, and the recorded evidence is what P6 later checks.
+
+Note the binary is `adlc-prosecute` (registry `binName`) but it dispatches as `adlc prosecute`.
+
+## Usage
+
+```sh
+adlc-prosecute --input <passes.json> --ticket id [--target label] [--revision rev] [--dir .adlc] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--input <passes.json>` | (required) Normalized reviewer-produced pass evidence to record. |
+| `--ticket id` | (required) Ticket the evidence is bound to; must be referenced by the transcript. |
+| `--target label` | Human-readable label for what was reviewed (e.g. `feature branch`). |
+| `--revision rev` | Reviewed revision string; defaults to `git-worktree:<hash>`. |
+| `--dir path` | Ledger directory (default `.adlc`). |
+| `--json` | Machine-readable result. |
+| `--help` | Show usage and exit 0. |
+
+Evidence files (transcript, prompt, inputs) that resolve inside the worktree must live under
+`.adlc/` or `.omo/evidence/`, and the transcript must reference both the ticket and the
+resolved revision — a trust-boundary control against faked review evidence.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — two consecutive dry passes were recorded.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (unreadable input, missing `--ticket`, bad evidence path).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — verified or needs-human findings remain, or the convergence budget ended before two dry passes.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc-prosecute --input p5-passes.json --ticket T1 --dir .adlc
+recorded 2 consecutive dry passes across 3 lenses (security, correctness, tests)
+exit 0
+```
+
+## Go deeper
+
+- [packages/prosecute](https://github.com/voodootikigod/adlc/tree/main/packages/prosecute)
+- Why prosecution beats code review: [Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/rails-guard.mdx
+++ b/apps/docs/content/docs/toolkit/rails-guard.mdx
@@ -1,8 +1,64 @@
 ---
 title: rails-guard
-description: rails-guard documentation (coming soon).
+description: Blocks builder edits to frozen rail paths and greps added diff lines for undeclared suppression markers.
 ---
 
 # rails-guard
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P4 Build** · **Gate:** frozen rails stay untouched and no added line hides an undeclared suppression marker.
+
+<PhaseDiagram phase="P4" />
+
+## What it defends against
+
+During P4 a builder can quietly edit the very tests, contract types, or CI config
+that are supposed to hold it accountable — or slip a `.skip(`, `.only(`,
+`@ts-ignore`, or `# noqa` into the diff to turn a red gate green. `rails-guard`
+enforces two invariants on the diff: declared rail globs must not be touched, and
+any newly added suppression marker is blocked unless the active ticket body
+carries a matching `allow-suppression:` declaration. Prose files (`.md`,
+`.markdown`) are exempt from the marker scan; `.mdx` is not, because it compiles
+to executable JSX.
+
+## Usage
+
+```sh
+adlc rails-guard [--base <ref>] [--ticket <id>] [--tickets <path>] [--rails <glob>...] [--record] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--base <ref>` | Freeze baseline to diff against. When omitted, resolves to the merge-base of HEAD with trunk (`main`/`master`/`origin/main`/`origin/master`) and **fails closed if no trunk ref is found** — it never defaults to HEAD, which would hide already-committed rail edits. |
+| `--ticket <id>` | Load rail globs and `allow-suppression` declarations from this ticket. |
+| `--tickets <path>` | Path to the tickets file (default `.adlc/tickets.json`). |
+| `--rails <glob>` | Frozen-path glob, repeatable. Overrides `ticket.rails` when supplied. |
+| `--record` | On a clean pass, append a `rails-check` proof (with SHA-256 of every rail-matching file) to `.adlc/manifest.jsonl`. |
+| `--json` | Emit a machine-readable result for orchestrators. |
+| `--help` | Print help and exit 0. |
+
+Rails resolve from `--rails` when given, otherwise from `--ticket`; with neither, the run is an operational error.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: no rail edits and no undeclared suppression markers.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (not a git repo, bad input, no rails resolvable, no trunk baseline).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more violations found (list printed to stderr / JSON).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc rails-guard --rails "test/**" --ticket T42 --base origin/main
+rails-guard: 2 violation(s) found
+  [rail-edit]   test/auth.test.ts  (matched globs: test/**)
+  [suppression] src/foo.ts:12  marker: @ts-ignore
+exit 2
+```
+
+## Go deeper
+
+The frozen-rails discipline and why builders must not touch their own tests:
+[Tests Are the Spec](https://voodootikigod.com/adlc-3-tests-are-the-spec).
+
+[packages/rails-guard](https://github.com/voodootikigod/adlc/tree/main/packages/rails-guard)

--- a/apps/docs/content/docs/toolkit/rejection-mining.mdx
+++ b/apps/docs/content/docs/toolkit/rejection-mining.mdx
@@ -1,8 +1,66 @@
 ---
 title: rejection-mining
-description: rejection-mining documentation (coming soon).
+description: Mines human PR review objections into reusable prosecution lenses so recurring "no"s are caught pre-submit.
 ---
 
 # rejection-mining
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P7 Compound** · **Gate:** none — it authors prosecution lens files from clustered PR objections for `adversarial-review` to reuse.
+
+<PhaseDiagram phase="P7" />
+
+## What it defends against
+
+Institutional reviewers reject the same classes of change over and over — the
+"nights of no" that cost days in queue. `rejection-mining` fetches PR review
+threads via the GitHub CLI, filters for negative-signal language, clusters
+similar objections, and authors each cluster into a lens file with a
+prosecution charter and anonymized example quotes. "Would security reject this?"
+becomes a seconds-long pre-flight check instead of a days-long round trip.
+
+## Usage
+
+```sh
+adlc rejection-mining [--limit <n>] [--min <n>] [--out-dir <path>] [--write] [--llm] [--prompt-only] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--limit <n>` | Maximum number of PRs to fetch (default `50`). |
+| `--min <n>` | Minimum cluster size to author a lens (default `2`). |
+| `--out-dir <path>` | Directory to write lens files into (default `.adlc/lenses`). |
+| `--write` | Emit lens files (default is dry-run). |
+| `--llm` | Sharpen each lens title and charter via one mid-tier LLM call per cluster. |
+| `--tier cheap\|mid\|frontier` | Model tier for the `--llm` pass (default `mid`). |
+| `--prompt-only` | Print the LLM prompts and exit 0 (zero API keys). |
+| `--json` | Machine-readable output. |
+
+Requires the `gh` CLI installed and authenticated (`gh auth login`).
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — success: mining complete (lenses printed, or written with `--write`).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: `gh` missing, auth failure, no PRs found, or bad arguments.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — reserved for a gate-fail; not currently emitted by this tool.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc rejection-mining --limit 100 --min 3 --write
+rejection-mining results
+═══════════════════════
+  PRs scanned:   47
+  Signals found: 23
+  Lenses:        2
+  wrote: .adlc/lenses/lens-error-expose-raw.md
+  wrote: .adlc/lenses/lens-hardcode-credentials.md
+exit 0
+```
+
+## Go deeper
+
+[packages/rejection-mining](https://github.com/voodootikigod/adlc/tree/main/packages/rejection-mining).
+Why review objections belong in the prosecution loop:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/review-calibration.mdx
+++ b/apps/docs/content/docs/toolkit/review-calibration.mdx
@@ -1,8 +1,63 @@
 ---
 title: review-calibration
-description: review-calibration documentation (coming soon).
+description: Measures reviewer recall by planting bugs and scoring whether the review command catches them.
 ---
 
 # review-calibration
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: calibration (cross-phase)** · **Gate:** the reviewer catches at least `--min-recall` of planted bugs, proven against a controlled scorer.
+
+## What it defends against
+
+<FailureMode id="F6" />
+
+"We do adversarial review" is a vibe until it is a number. `review-calibration`
+plants real bugs into files changed by a commit, runs your review command, and
+scores recall — with a built-in echo control that scores ~0 and an oracle
+control that scores 1.0, so the recall figure is trustworthy rather than gamed
+by a reviewer that merely echoes changed lines.
+
+## Usage
+
+```sh
+adlc review-calibration --review-cmd "cmd with {base} placeholder" [options]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--review-cmd <cmd>` | Required. Command that runs the reviewer; `{base}` is substituted with the commit ref. |
+| `--commit <ref>` | Commit whose changed files are the plant targets (default `HEAD`). |
+| `--plants <n>` | Number of bugs to plant (default `8`). |
+| `--min-recall <f>` | Minimum recall fraction to pass, 0–1 (default `0.5`). |
+| `--min-precision <f>` | Optional minimum precision to also require. |
+| `--scorer judge\|string` | `judge` (default) is cheap-model semantic match; `string` is the gameable legacy location-only fallback (warns). |
+| `--files <list>` | Comma-separated fallback file list when the commit has no eligible code. |
+| `--plants-file <path>` | JSON array of authored plants `[{file,line,original,mutated,category?,defect?,witness?}]`. |
+| `--tier cheap\|mid\|frontier` | Model tier for the LLM judge (default `cheap`). |
+| `--review-provider <name>` | Provider family `--review-cmd` runs on; compared against the judge for independence. |
+| `--strict` | Gate-fail instead of warn when `--review-provider` matches the judge's provider. |
+| `--json` | Machine-readable output. |
+| `--prompt-only` | Print a representative judge prompt and exit 0 (no API key or git repo needed). |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: recall (and precision, if set) meet the thresholds.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: dirty tree, no plants generatable, review command crashed (exit not in {0,2}), no judge provider, or a control self-test failed.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: recall/precision below the thresholds, or a `--strict` provider match.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc review-calibration --review-cmd "adversarial-review --base {base} --json" --plants 8 --min-recall 0.6
+recall 62.5% (5/8 caught) · precision 83%
+✗ gate fails — recall 62.5% (min 60.0%)
+exit 2
+```
+
+## Go deeper
+
+[packages/review-calibration](https://github.com/voodootikigod/adlc/tree/main/packages/review-calibration).
+Why the review itself must be prosecuted:
+[Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/toolkit/runner.mdx
+++ b/apps/docs/content/docs/toolkit/runner.mdx
@@ -1,8 +1,64 @@
 ---
 title: runner
-description: runner documentation (coming soon).
+description: Asserts that each ADLC phase's required manifest evidence is present, failing closed when reviewed content changes.
 ---
 
 # runner
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: cross-phase (P3–P6 assertions)** · **Gate:** a phase is only complete when its required manifest evidence exists and still matches the reviewed content.
+
+## What it defends against
+
+"A command ran" is not a gate. An orchestrator can call a tool, ignore its result,
+and march on — or edit the code after it was reviewed. The runner refuses that: it
+reads `.adlc/manifest.jsonl` and asserts the specific evidence each phase requires,
+scoped to a ticket for P3–P6. P5 and P6 bind to the current content fingerprint and
+fail closed if reviewed content changes after the fact, so committing the exact
+content reviewed at P5 keeps P6 green while any tampering turns it red. It gives CI
+and Codex skills one stable command for asserting phase completion.
+
+## Usage
+
+The runner ships as the `adlc-runner` binary and also dispatches through the
+umbrella CLI as `adlc run` and `adlc accept`.
+
+```sh
+adlc run <phase> [--dir .adlc] [--ticket <id>] [--revision <rev>] [--json]
+adlc accept --ticket <id> --packet .adlc/packet.json [--before .adlc/before.json] [--after .adlc/after.json] [--dir .adlc] [--revision <rev>] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--dir <path>` | ADLC control directory (default `.adlc`). |
+| `--ticket <id>` | Ticket to scope evidence to. Required for phases p3, p4, p5, p6. |
+| `--revision <rev>` | Offline selector for recorded manifest/artifact evidence; verifies recorded hashes without comparing against the live worktree. Omit for normal worktree use. |
+| `--packet <path>` | (`accept`) Path to the P6 acceptance packet to record. Must live under `.adlc/` or `.omo/evidence/`. |
+| `--before <path>` / `--after <path>` | (`accept`) Behavior snapshot paths recorded and re-verified at P6. |
+| `--json` | Machine-readable result. |
+| `--help` | Print help and exit 0. |
+
+Phases run p1 through p7; p3–p6 require `--ticket`.
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — required phase evidence is present (and still matches the reviewed content).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (unknown phase, missing `--ticket`, bad input).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — required phase evidence is missing.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc run p5 --ticket T1 --dir .adlc
+adlc p5: missing evidence: prosecution-transcript
+exit 2
+
+$ adlc run p6 --ticket T1
+adlc p6: required evidence present
+exit 0
+```
+
+## Go deeper
+
+[packages/runner](https://github.com/voodootikigod/adlc/tree/main/packages/runner)

--- a/apps/docs/content/docs/toolkit/skill-rot.mdx
+++ b/apps/docs/content/docs/toolkit/skill-rot.mdx
@@ -1,8 +1,57 @@
 ---
 title: skill-rot
-description: skill-rot documentation (coming soon).
+description: Verifies the checkable claims inside SKILL.md files still hold against the current repo and stamps fresh ones.
 ---
 
 # skill-rot
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: calibration (cross-phase)** · **Gate:** every skill's verifiable claims (commands, paths, scripts) still resolve against the current repo.
+
+## What it defends against
+
+Skills are caches, and a stale cache delivers misinformation with the authority
+of an expert — worse than no skill at all. `skill-rot` walks each `SKILL.md`,
+extracts the claims it can actually check (command names, file paths, and
+`npm`/`npx`/`pnpm`/`yarn` script references), and verifies them against the
+repo. Verifiable-but-failing claims are `stale` and fail the gate; claims it
+cannot adjudicate (URLs, missing `package.json`) are `unverifiable` and never
+counted against you. Run it weekly in CI to keep the skill corpus honest.
+
+## Usage
+
+```sh
+adlc skill-rot [path ...] [--write] [--json]
+```
+
+Positional paths override the default search roots (`.claude/skills`,
+`.agents/skills`, `skills`), which are searched only when they exist.
+
+| Flag | Description |
+| --- | --- |
+| `--write` | When every claim in a skill is ok, upsert `last-verified: <YYYY-MM-DD>` into its frontmatter. Skills with stale claims are never stamped. |
+| `--json` | Machine-readable output with `skills[]` and a `summary`. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: all skills clean.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: no `SKILL.md` files found, or bad input.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: at least one skill has stale claims.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc skill-rot .claude/skills
+SKILL                          OK  STALE  UNVERIFIABLE
+-----------------------------  --  -----  ------------
+.claude/skills/build/SKILL.md   7      1             2
+✗ 1 skill has stale claims (command `pnpm turbo` no longer resolves)
+exit 2
+```
+
+## Go deeper
+
+[packages/skill-rot](https://github.com/voodootikigod/adlc/tree/main/packages/skill-rot).
+See the [toolkit overview](/docs/lifecycle) for how skill freshness feeds the
+calibration loop.

--- a/apps/docs/content/docs/toolkit/spec-lint.mdx
+++ b/apps/docs/content/docs/toolkit/spec-lint.mdx
@@ -19,12 +19,13 @@ turns unverifiable criteria into blocking failures.
 ## Usage
 
 ```sh
-adlc spec-lint <spec.md> [--llm] [--json] [--prompt-only]
+adlc spec-lint <spec.md> [--llm] [--tier cheap|mid|frontier] [--json] [--prompt-only]
 ```
 
 | Flag | Description |
 | --- | --- |
-| `--llm` | Cheap-tier LLM pass on VERIFIED criteria to catch vacuous methods ("works correctly", "run tests"). Demoted criteria become WISH. Requires a provider env var (see core). |
+| `--llm` | LLM pass on VERIFIED criteria to catch vacuous methods ("works correctly", "run tests"). Demoted criteria become WISH. Requires a provider env var (see core). |
+| `--tier` | Model tier for the `--llm` pass: `cheap` (default), `mid`, or `frontier`. |
 | `--json` | Machine-readable output for orchestrators. All other output is suppressed. |
 | `--prompt-only` | Print the exact LLM prompt and exit 0 — works with zero API keys; paste into any harness. |
 

--- a/apps/docs/content/docs/toolkit/ticket-prune.mdx
+++ b/apps/docs/content/docs/toolkit/ticket-prune.mdx
@@ -1,8 +1,50 @@
 ---
 title: ticket-prune
-description: ticket-prune documentation (coming soon).
+description: Reports and archives stale, already-shipped tickets out of .adlc/tickets.json so live work is not buried under leftovers.
 ---
 
 # ticket-prune
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: maintenance / cross-phase (C12)** · **Gate:** none — advisory report; `--write` archives stale tickets, never deletes.
+
+## What it defends against
+
+`.adlc/tickets.json` is a mutable scratchpad, and nothing else prunes it after a ticket ships. Completed tickets accumulate and masquerade as an open backlog — you can't tell live work from leftovers without cross-checking deliverables and merged PRs by hand. `ticket-prune` reports (and, with `--write`, archives) the tickets it can determine are stale, so the backlog reflects what is actually open.
+
+A ticket is stale when it carries an explicit terminal `status` (`done` / `closed` / `complete` / `completed` / `archived` / `shipped`, case-insensitive), or — absent a status — when it declares at least one `scope` glob and every glob resolves to a file tracked at `--base-ref`. A ticket with no scope and no status is never inferred stale.
+
+## Usage
+
+```sh
+adlc ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [--json]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--tickets <path>` | Ticket file to read (default `.adlc/tickets.json`). |
+| `--archive <path>` | Archive file written under `--write` (default `.adlc/tickets.archive.json`, gitignored). |
+| `--base-ref <ref>` | Git ref to check `scope` globs against (default `HEAD`). Point at `origin/main` to audit a branch's tickets against trunk. |
+| `--write` | Archive stale tickets — move them out of `--tickets` into `--archive` (append/upsert by id; never clobbered, never deleted). |
+| `--json` | Machine-readable `{ baseRef, write, stale[], active[], archived[] }`. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — report or archive succeeded, regardless of how many stale tickets were found. Advisory, not a merge blocker.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, or the write lock could not be acquired).</span>
+</div>
+
+## Example
+
+```sh
+$ adlc ticket-prune --base-ref origin/main
+stale (2): T3 (status: shipped), T7 (scope shipped on origin/main)
+active (4): T9, T10, T11, T12
+
+Dry run — re-run with --write to archive.
+exit 0
+```
+
+## Go deeper
+
+[packages/ticket-prune](https://github.com/voodootikigod/adlc/tree/main/packages/ticket-prune)

--- a/apps/docs/content/docs/toolkit/ticket-sync.mdx
+++ b/apps/docs/content/docs/toolkit/ticket-sync.mdx
@@ -1,8 +1,57 @@
 ---
 title: ticket-sync
-description: ticket-sync documentation (coming soon).
+description: Two-way sync between ADLC tickets and an external tracker (GitHub Issues), dry-run by default and failing closed on conflict.
 ---
 
 # ticket-sync
 
-This page is being written. In the meantime, see the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory).
+**ADLC phase: P0 Triage (external integration)** · **Gate:** a non-clean pull fails closed (exit 2) rather than overwriting the local ticket store.
+
+<PhaseDiagram phase="P0" />
+
+## What it defends against
+
+The ticket backlog and its external tracker drift apart the moment either is edited alone — issues closed on GitHub still look open in `.adlc/tickets.json`, and locally-authored tickets never reach the tracker. `ticket-sync` reconciles both directions through the `gh` CLI. It is dry-run by default, and a `pull` that hits an unresolvable conflict aborts before any write (and before any `push`), so an unreconciled sync can never clobber the rails trust root. Sync bookkeeping lives in a gitignored, rebuildable sidecar; a stable sentinel key plus a pre-create adoption scan make `create` idempotent, so a re-run never duplicates an issue.
+
+## Usage
+
+```sh
+adlc ticket <pull|push|sync|doctor> [--write] [--force] [--allow-rail-narrowing] [--json]
+```
+
+The standalone binary is `adlc-ticket-sync`; the same command dispatches through the umbrella as `adlc ticket`.
+
+| Command / Flag | Description |
+| --- | --- |
+| `pull` | Import issues into `.adlc/tickets.json` (3-way reconcile; unions; fails closed on conflict). |
+| `push` | Write tickets back — update synced issues, idempotent create for local-only tickets, display-only status. |
+| `sync` | `pull` then `push`; a non-clean pull aborts before push. |
+| `doctor` | Read-only, offline health checks (config / tickets / schema drift / sidecar / stale lock). |
+| `--write` | Apply changes (dry-run without it). |
+| `--force` | Override a blocked pull. |
+| `--allow-rail-narrowing` | Permit a pull that narrows declared rails. |
+| `--json` | Machine-readable output on all commands. |
+
+## Exit codes
+
+<div style={{ display: 'grid', gap: '0.25rem' }}>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0** — ok: command completed (or produced a clean dry-run plan).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad config, `gh` failure, unknown flag or subcommand).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2** — blocked: a conflict the sync refuses to resolve automatically.</span>
+</div>
+
+## Example
+
+```sh
+$ adlc ticket pull
+[dry-run] would plan:
+  import	gh:voodootikigod/adlc#39
+  reconcile	T4 (union)
+
+Dry run — re-run with --write to apply.
+exit 0
+```
+
+## Go deeper
+
+[packages/ticket-sync](https://github.com/voodootikigod/adlc/tree/main/packages/ticket-sync)

--- a/apps/docs/test/integrations-antigravity.test.mjs
+++ b/apps/docs/test/integrations-antigravity.test.mjs
@@ -66,29 +66,13 @@ test('index.mdx is a real landing page (no "coming soon" stub) enumerating all s
   }
 });
 
-test('index.mdx discloses that the stub harness pages (codex, opencode, pi) are still being written', () => {
-  const p = path.join(integrationsDir, 'index.mdx');
-  const content = readFileSync(p, 'utf8');
+test('every harness page is real content, and index.mdx carries no "still being written" disclosure', () => {
+  const indexContent = readFileSync(path.join(integrationsDir, 'index.mdx'), 'utf8');
 
-  const STUB_HARNESSES = ['codex', 'opencode', 'pi'];
-  const WRITTEN_HARNESSES = ['claude-code', 'antigravity', 'cursor'];
-
-  for (const harness of STUB_HARNESSES) {
-    const bulletMatch = content.match(
-      new RegExp(`- \\*\\*\\[[^\\]]+\\]\\(/docs/integrations/${harness}\\)\\*\\*[\\s\\S]*?(?=\\n- \\*\\*|\\n\\nSee)`)
-    );
-    assert.ok(bulletMatch, `index.mdx should have a bullet for ${harness}`);
-    assert.match(
-      bulletMatch[0],
-      /full walkthrough still being written/,
-      `the ${harness} bullet should disclose that its full walkthrough is still being written`
-    );
-  }
-
-  // The two harnesses with real, complete pages must NOT carry the disclosure —
-  // otherwise it would misleadingly undersell finished documentation.
-  for (const harness of WRITTEN_HARNESSES) {
-    const bulletMatch = content.match(
+  // All six pages are written now; a disclosure anywhere would misleadingly
+  // undersell finished documentation.
+  for (const harness of HARNESSES) {
+    const bulletMatch = indexContent.match(
       new RegExp(`- \\*\\*\\[[^\\]]+\\]\\(/docs/integrations/${harness}\\)\\*\\*[\\s\\S]*?(?=\\n- \\*\\*|\\n\\nSee)`)
     );
     assert.ok(bulletMatch, `index.mdx should have a bullet for ${harness}`);
@@ -96,6 +80,18 @@ test('index.mdx discloses that the stub harness pages (codex, opencode, pi) are 
       bulletMatch[0],
       /still being written/,
       `the ${harness} bullet documents a finished page and should not claim it is still being written`
+    );
+
+    const pageContent = readFileSync(path.join(integrationsDir, `${harness}.mdx`), 'utf8');
+    assert.doesNotMatch(
+      pageContent,
+      /coming soon|This page is being written/i,
+      `${harness}.mdx should be real content, not a stub`
+    );
+    assert.match(
+      pageContent,
+      /rails-guard|rails-guard-ci\.mjs/,
+      `${harness}.mdx should document rail enforcement`
     );
   }
 });

--- a/apps/docs/test/toolkit-usage-dispatcher.test.mjs
+++ b/apps/docs/test/toolkit-usage-dispatcher.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Getting Started tells users to install ONLY the @adlc/cli dispatcher, so every
+// command a toolkit page shows must go through `adlc <tool>` — a bare tool binary
+// (`hollow-test …`, `$ premortem …`) is "command not found" on a machine that
+// followed the quickstart. This guard was distilled from an adversarial-review
+// finding; see the review notes on the 2026-07-05 docs fan-out.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const toolkitDir = path.join(__dirname, '..', 'content', 'docs', 'toolkit');
+
+// Pages that document the dispatcher/foundation itself, not a dispatched tool.
+const NON_TOOL_PAGES = new Set(['index', 'cli', 'core']);
+
+const slugs = readdirSync(toolkitDir)
+  .filter((f) => f.endsWith('.mdx'))
+  .map((f) => f.replace(/\.mdx$/, ''))
+  .filter((slug) => !NON_TOOL_PAGES.has(slug));
+
+function shBlocks(content) {
+  const blocks = [];
+  const re = /```sh\n([\s\S]*?)```/g;
+  let m;
+  while ((m = re.exec(content)) !== null) blocks.push(m[1]);
+  return blocks;
+}
+
+// A block with `$ ` lines is an example transcript: only the `$ ` lines are
+// commands (the rest is program output). A block without them is a usage
+// synopsis: every non-empty line is a command.
+function commandLines(block) {
+  const lines = block.split('\n');
+  const dollar = lines.filter((l) => l.startsWith('$ '));
+  if (dollar.length > 0) return dollar.map((l) => l.slice(2));
+  return lines.filter((l) => l.trim() !== '');
+}
+
+test('every toolkit-page command dispatches through `adlc <tool>` — no bare tool binaries', () => {
+  const violations = [];
+
+  for (const file of readdirSync(toolkitDir).filter((f) => f.endsWith('.mdx'))) {
+    const content = readFileSync(path.join(toolkitDir, file), 'utf8');
+    for (const block of shBlocks(content)) {
+      for (const cmd of commandLines(block)) {
+        const firstToken = cmd.trim().split(/\s+/)[0];
+        if (slugs.includes(firstToken)) {
+          violations.push(`${file}: "${cmd.trim()}" — use \`adlc ${firstToken} …\``);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `bare tool binaries in toolkit docs (Getting Started installs only @adlc/cli):\n  ${violations.join('\n  ')}`
+  );
+});
+
+test('the guard itself detects a planted bare binary (self-test)', () => {
+  const planted = '```sh\nhollow-test --test-cmd "npm test"\n```';
+  const block = shBlocks(planted)[0];
+  const cmds = commandLines(block);
+  assert.ok(
+    cmds.some((c) => slugs.includes(c.trim().split(/\s+/)[0])),
+    'a bare `hollow-test` command must be recognized as a violation'
+  );
+});

--- a/docs/adr/0009-universal-install-via-plugins.md
+++ b/docs/adr/0009-universal-install-via-plugins.md
@@ -1,0 +1,68 @@
+# ADR 0009: Universal install via the `plugins` installer — accepted supply-chain tradeoff
+
+**Status:** **Accepted.** `npx plugins add voodootikigod/adlc` is the documented,
+preferred install path for ADLC's harness integrations wherever the [`plugins`
+package](https://www.npmjs.com/package/plugins) supports the target harness. The
+supply-chain exposure inherent in `npx`-executing a third-party installer is a
+**consciously accepted residual risk**, not an oversight. Reviewers (human or model)
+flagging this instruction should be pointed at this ADR rather than re-litigating it.
+
+**Date:** 2026-07-05
+**Deciders:** Chris Williams (prompted by an adversarial-review CRITICAL finding against
+the docs-site getting-started page; the finding was triaged as accepted-risk, not a defect).
+
+> Related: [ADR-0003](./0003-adlc-claude-code-plugin.md) ships the Claude Code plugin the
+> installer targets; [ADR-0006](./0006-adlc-cursor-integration.md) covers the Cursor
+> integration (not yet published, see Scope). This ADR governs only the **install
+> instruction** the project recommends, not what any plugin does once installed.
+
+---
+
+## Context
+
+ADLC integrates with six agent harnesses, each with its own native install mechanism
+(Claude Code marketplace, Cursor scaffolder, opencode plugin registration, `pi
+--extension`, `agy plugin install`). Documenting six divergent flows as the *first* step
+of adoption is a real onboarding cost. The `plugins` npm package is a vendor-neutral
+installer that detects the agent tools present on a machine and installs a repo's plugin
+into each, collapsing the first step to one line:
+
+```sh
+npx plugins add voodootikigod/adlc
+```
+
+An adversarial review of the documentation site flagged this instruction as a CRITICAL
+supply-chain finding: `npx` downloads and executes the `plugins` package, which is
+third-party code outside this project's control. The finding is technically accurate —
+that is what `npx` does — and applies equally to every `npx <tool>` instruction in any
+README anywhere.
+
+## Decision
+
+1. **Keep `npx plugins add voodootikigod/adlc` as the recommended install path** in the
+   README, the docs site, and the marketing site, for harnesses the installer actually
+   supports.
+2. **Accept the supply-chain risk explicitly.** The `plugins` package is executed with
+   the user's normal npm trust posture; we treat it the same way we treat `npx
+   adversarial-review` or any other CLI this project recommends. Compromise of the npm
+   package would be a supply-chain incident upstream of this project; we do not build
+   bespoke mitigations for it.
+3. **Do not version-pin the installer in docs** (`plugins@x.y.z`). Pinning trades a
+   narrow integrity window for permanent maintenance drag and stale-installer bugs; the
+   unpinned form is the deliberate choice.
+4. **Docs must only claim harness coverage the installer actually has.** Where a
+   harness's plugin is not yet published/wired for the installer, the docs say so and
+   give the native path instead (see each integration page's Install section).
+5. **Native install paths remain documented** on every integration page as the
+   fallback, so no adopter is forced through the universal installer.
+
+## Consequences
+
+- Adversarial reviews of docs changes will keep surfacing this instruction; the response
+  is a citation of this ADR, not a doc change. (If the reviewer supports focus text,
+  include: "`npx plugins add` is accepted per ADR-0009".)
+- If the `plugins` package is ever compromised, renamed, or abandoned, this ADR is the
+  single place recording why we depend on it — revisit the decision there, then update
+  README + getting-started + integration pages together.
+- Claim accuracy is now a documented obligation (Decision 4): expanding the "auto-detects
+  X" claim requires the X plugin to actually be installable by the installer first.

--- a/packages/rails-guard/bin/rails-guard.mjs
+++ b/packages/rails-guard/bin/rails-guard.mjs
@@ -18,8 +18,11 @@ import {
   ADLC_DIR,
 } from '@adlc/core';
 
+import { readFileSync } from 'node:fs';
+
 import { runChecks } from '../lib/check.mjs';
 import { formatViolations, buildResult } from '../lib/output.mjs';
+import { computeFencedLines, isMdxFile } from '../lib/suppressions.mjs';
 
 const { values } = parseArgs({
   options: {
@@ -114,9 +117,28 @@ try {
   opError(`git error: ${err.message}`);
 }
 
+// --- authoritative `.mdx` fenced-code lookup ---
+// Compute fenced-block membership from the FULL working-tree file (HEAD content is
+// exactly what MDX compiles), memoized per file. Fails CLOSED: any file that cannot
+// be read yields an empty set, so its markers are scanned rather than skipped.
+const fenceCache = new Map();
+function isFenced(file, lineNo) {
+  if (!isMdxFile(file)) return false;
+  let fenced = fenceCache.get(file);
+  if (fenced === undefined) {
+    try {
+      fenced = computeFencedLines(readFileSync(file, 'utf8'));
+    } catch {
+      fenced = new Set(); // unreadable → fail closed (scan every line)
+    }
+    fenceCache.set(file, fenced);
+  }
+  return fenced.has(lineNo);
+}
+
 // --- run checks ---
 const { railGlobs, railGlobError, violations, railsDiffEmpty, suppressionsClean } =
-  runChecks({ changedFiles: files, diffText: diff, cliRails, ticket });
+  runChecks({ changedFiles: files, diffText: diff, cliRails, ticket, isFenced });
 
 const result = buildResult({
   violations,

--- a/packages/rails-guard/lib/check.mjs
+++ b/packages/rails-guard/lib/check.mjs
@@ -12,6 +12,9 @@ import { parseAddedLines, findSuppressions, isMarkerAllowed } from './suppressio
  * @param {string}    opts.diffText      - raw git diff output
  * @param {string[]}  opts.cliRails      - globs from --rails flags (may be empty)
  * @param {object|null} opts.ticket      - loaded ticket object or null
+ * @param {(file: string, lineNo: number) => boolean} [opts.isFenced]
+ *        Authoritative `.mdx` fenced-code predicate (see findSuppressions). Omitted
+ *        in pure/unit contexts, where it fails closed.
  *
  * @returns {{
  *   railGlobs: string[],
@@ -25,7 +28,7 @@ import { parseAddedLines, findSuppressions, isMarkerAllowed } from './suppressio
  *   { file, type: 'rail-edit', globs }          — froze path was edited
  *   { file, type: 'suppression', marker, lineNo }  — unapproved marker added
  */
-export function runChecks({ changedFiles, diffText, cliRails, ticket }) {
+export function runChecks({ changedFiles, diffText, cliRails, ticket, isFenced }) {
   const { globs: railGlobs, error: railGlobError } = resolveRailGlobs(cliRails, ticket);
 
   const violations = [];
@@ -40,7 +43,7 @@ export function runChecks({ changedFiles, diffText, cliRails, ticket }) {
 
   // CHECK 2: suppression markers in added lines
   const addedLines = parseAddedLines(diffText);
-  const suppressions = findSuppressions(addedLines);
+  const suppressions = findSuppressions(addedLines, { isFenced });
   const ticketBody = ticket?.body ?? '';
 
   for (const s of suppressions) {

--- a/packages/rails-guard/lib/suppressions.mjs
+++ b/packages/rails-guard/lib/suppressions.mjs
@@ -66,6 +66,80 @@ export function parseAddedLines(diffText) {
 }
 
 /**
+ * Match a fenced-code OPENER: up to 3 spaces of indent, then a run of ≥3 backticks
+ * or ≥3 tildes, then an optional info string. Returns { char, len } or null.
+ * A backtick opener whose info string contains a backtick is NOT a valid fence
+ * (CommonMark) — that guards against inline ```` ``` ```` runs being read as openers.
+ */
+function matchFenceOpen(line) {
+  const m = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  if (!m) return null;
+  const char = m[1][0];
+  if (char === '`' && m[2].includes('`')) return null;
+  return { char, len: m[1].length };
+}
+
+/**
+ * True when `line` CLOSES an open fence of `char`/`len`: same fence character, a
+ * run at least as long as the opener, up to 3 spaces of indent, and nothing after
+ * the run but whitespace (CommonMark forbids an info string on a closer). A run
+ * that is too short — e.g. a ```` ``` ```` line inside a ```` ```` ```` fence — does
+ * NOT close it and stays interior content. This is what makes the scan authoritative
+ * rather than a naive toggle that desyncs on nested fences of differing lengths.
+ */
+function isFenceClose(line, char, len) {
+  const m = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
+  return Boolean(m) && m[1][0] === char && m[1].length >= len;
+}
+
+/**
+ * Compute the set of 1-based line numbers that fall INSIDE a Markdown fenced code
+ * block, given the FULL file content, using CommonMark fenced-code semantics (a
+ * closer must match the opener's fence character and be at least as long). This is
+ * authoritative for `.mdx` FENCED blocks: MDX compiles fenced code to inert
+ * `<pre><code>` text, and follows these same rules. NOTE: only fenced blocks are
+ * exempted — INDENTED code blocks are deliberately NOT, because MDX disables them
+ * (indentation is JSX there), so a 4-space-indented marker can be operative.
+ *
+ * Fence-delimiter lines are NOT included (they carry no marker); only the inert
+ * interior lines are. An unclosed fence extends to end-of-file.
+ *
+ * Line endings are normalized: lines are split on `\n` (to keep 1-based numbers in
+ * lockstep with the `\n`-based diff parser) and a trailing `\r` is stripped, so a
+ * CRLF fence closer is recognized (`` ```\r `` still closes) — MDX/micromark treat
+ * `\r\n` as a line ending, and a `\r` clinging to a delimiter must not defeat the
+ * anchors. A pathological EMBEDDED `\r` (a bare CR mid-line, which git does not
+ * treat as a line break but micromark does) fails CLOSED: the fence is force-closed
+ * and the line is scanned, never silently treated as inert.
+ *
+ * @param {string} content  full file text
+ * @returns {Set<number>}
+ */
+export function computeFencedLines(content) {
+  const fenced = new Set();
+  if (typeof content !== 'string' || content === '') return fenced;
+  const lines = content.split('\n');
+  let fence = null; // { char, len } while inside a fence, else null
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/\r+$/, ''); // normalize CRLF / trailing CR run
+    if (line.includes('\r')) {
+      fence = null; // embedded bare CR — cannot reason about MDX line breaks; fail closed
+      continue;
+    }
+    if (fence === null) {
+      fence = matchFenceOpen(line); // opener line itself is not marked
+      continue;
+    }
+    if (isFenceClose(line, fence.char, fence.len)) {
+      fence = null; // closer line itself is not marked
+      continue;
+    }
+    fenced.add(i + 1); // interior line, 1-based
+  }
+  return fenced;
+}
+
+/**
  * Documentation file extensions (lowercase, leading dot). Suppression markers are
  * code constructs; prose documentation legitimately names them (an integration
  * guide, this package's own README). A marker in a prose doc is never an executed
@@ -94,16 +168,68 @@ export function isDocFile(file) {
 }
 
 /**
+ * True when `file`'s final extension is `.mdx`. MDX is scanned like code (it
+ * compiles to JSX/TS), but its Markdown code CONTEXTS — inline spans and fenced
+ * blocks — render as literal text and cannot carry an operative suppression, so
+ * markers there are prose, not escape hatches. Uses the same true-suffix logic as
+ * isDocFile so a code file like `x.mdx.ts` is not treated as MDX.
+ */
+export function isMdxFile(file) {
+  if (typeof file !== 'string' || file === '') return false;
+  const base = file.slice(file.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) return false;
+  return base.slice(dot).toLowerCase() === '.mdx';
+}
+
+/**
+ * Remove Markdown inline-code spans (`` `…` ``) from a line so their contents are
+ * not matched as suppressions. Backticks are paired left-to-right; an unmatched
+ * trailing backtick leaves the rest of the line intact (scanned).
+ *
+ * A backtick region that contains a `${` interpolation is a JS/JSX template literal
+ * whose interpolated expression is OPERATIVE code (a test-focus call inside the
+ * interpolation actually runs), NOT an inert Markdown code span — it is preserved
+ * verbatim so its markers are still scanned. This fails closed: a genuine prose span
+ * that happens to contain a literal `${` is scanned too (a false positive), never
+ * silently skipped.
+ */
+export function stripInlineCode(line) {
+  return line.replace(/`[^`]*`/g, (span) => (span.includes('${') ? span : ''));
+}
+
+/**
  * Find suppression markers in added lines.
  * Returns [ { file, lineNo, marker, content } ].
- * Documentation files (see isDocFile) are skipped — prose is not executed code.
+ *
+ * Skips:
+ *   - prose docs (isDocFile: `.md`/`.markdown`) — never executed code;
+ *   - `.mdx` lines inside a fenced code block — inert display text;
+ *   - marker occurrences inside `.mdx` inline-code spans — inert display text.
+ * A marker in the MDX ESM/JSX layer (outside spans and fences) is still scanned,
+ * so real, operative type/lint suppressions in MDX remain caught.
+ *
+ * @param {Array} addedLines  [ { file, lineNo, content } ]
+ * @param {object} [opts]
+ * @param {(file: string, lineNo: number) => boolean} [opts.isFenced]
+ *        Authoritative "is this `.mdx` line inside a fenced code block?" predicate,
+ *        computed from full file content by the caller. Defaults to always-false,
+ *        which FAILS CLOSED: an `.mdx` fenced marker the caller could not classify
+ *        is scanned (a false positive), never silently skipped.
  */
-export function findSuppressions(addedLines) {
+export function findSuppressions(addedLines, { isFenced = () => false } = {}) {
   const found = [];
   for (const { file, lineNo, content } of addedLines) {
     if (isDocFile(file)) continue;
+
+    let scanText = content;
+    if (isMdxFile(file)) {
+      if (isFenced(file, lineNo)) continue; // inside a fenced code block — inert prose
+      scanText = stripInlineCode(content); // strip inline-code spans — inert prose
+    }
+
     for (const marker of SUPPRESSION_MARKERS) {
-      if (content.includes(marker)) {
+      if (scanText.includes(marker)) {
         found.push({ file, lineNo, marker, content });
         break; // one violation per line is enough
       }

--- a/packages/rails-guard/test/suppressions.test.mjs
+++ b/packages/rails-guard/test/suppressions.test.mjs
@@ -2,7 +2,7 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseAddedLines, findSuppressions, isMarkerAllowed, isDocFile } from '../lib/suppressions.mjs';
+import { parseAddedLines, findSuppressions, isMarkerAllowed, isDocFile, computeFencedLines } from '../lib/suppressions.mjs';
 
 describe('parseAddedLines', () => {
   test('extracts added lines with correct file and line numbers', () => {
@@ -173,6 +173,143 @@ describe('findSuppressions', () => {
     // A code file whose name merely contains ".md" is NOT a doc — only the final extension counts.
     const lines = [{ file: 'src/render.md.mjs', lineNo: 1, content: `x${SKIP}` }];
     assert.equal(findSuppressions(lines).length, 1);
+  });
+
+  // --- MDX prose code-contexts: markers inside Markdown inline-code spans and fenced
+  //     code blocks render as literal text and can never be an operative suppression.
+  //     They are exempt for .mdx; a marker in the MDX ESM/JSX layer stays scanned.
+  test('does NOT flag a marker inside an .mdx inline-code span (prose false positive)', () => {
+    const lines = [{ file: 'apps/docs/x.mdx', lineNo: 24, content: `markers (\`${TSIG}\`, \`${SKIP}\`, …) are reverted` }];
+    assert.deepEqual(findSuppressions(lines), []);
+  });
+
+  test('DOES flag a real marker OUTSIDE the inline-code span on the same .mdx line', () => {
+    // First occurrence is prose in a span; a second, bare occurrence is operative ESM.
+    const lines = [{ file: 'apps/docs/x.mdx', lineNo: 5, content: `see \`${TSIG}\` — then const a = 1; ${TSIG}` }];
+    assert.equal(findSuppressions(lines).length, 1);
+  });
+
+  test('DOES flag a call-marker hidden in a template-literal interpolation (HIT 3)', () => {
+    // A test-focus call inside a ${...} interpolation is operative JS, not an inert
+    // Markdown span, so it must not be stripped. (Marker assembled to avoid self-trip.)
+    const only = '.on' + 'ly(';
+    const lines = [{ file: 'apps/docs/x.mdx', lineNo: 9, content: '<X>{`${describe' + only + 't)}`}</X>' }];
+    assert.equal(findSuppressions(lines).length, 1);
+  });
+
+  test('does NOT flag a marker on an .mdx line the isFenced predicate marks as fenced', () => {
+    const lines = [{ file: 'apps/docs/rails-guard.mdx', lineNo: 55, content: `  [suppression] src/foo.ts:12  marker: ${TSIG}` }];
+    const isFenced = (file, lineNo) => file === 'apps/docs/rails-guard.mdx' && lineNo === 55;
+    assert.deepEqual(findSuppressions(lines, { isFenced }), []);
+  });
+
+  test('DOES flag a real .mdx marker on a line the isFenced predicate marks NOT fenced', () => {
+    const lines = [{ file: 'apps/docs/x.mdx', lineNo: 80, content: `export const meta = {}; // ${TSIG}` }];
+    const isFenced = () => false; // outside any fence
+    assert.equal(findSuppressions(lines, { isFenced }).length, 1);
+  });
+
+  test('isFenced predicate does NOT apply to code files (only .mdx is prose)', () => {
+    // Even if a predicate lied about a .ts line, findSuppressions never consults it for code.
+    const lines = [{ file: 'src/a.ts', lineNo: 10, content: `// ${TSIG}` }];
+    const isFenced = () => true;
+    assert.equal(findSuppressions(lines, { isFenced }).length, 1);
+  });
+
+  test('fails CLOSED: a fenced .mdx marker is scanned when no isFenced predicate is supplied', () => {
+    const lines = [{ file: 'apps/docs/x.mdx', lineNo: 5, content: `bare operative ${TSIG}` }];
+    assert.equal(findSuppressions(lines).length, 1);
+  });
+});
+
+describe('computeFencedLines', () => {
+  const fence = '```';
+  const TSIG = '@ts-' + 'ignore';
+
+  test('marks interior lines of a fenced block, not the delimiters', () => {
+    const content = [
+      'intro prose',       // 1
+      `${fence}sh`,        // 2  opener
+      `marker ${TSIG}`,    // 3  interior — fenced
+      'more output',       // 4  interior — fenced
+      `${fence}`,          // 5  closer
+      'trailing prose',    // 6
+    ].join('\n');
+    const fenced = computeFencedLines(content);
+    assert.deepEqual([...fenced].sort((a, b) => a - b), [3, 4]);
+  });
+
+  test('an unclosed fence extends to end of file (fails closed by marking everything inside)', () => {
+    const content = ['before', `${fence}`, 'a', 'b'].join('\n');
+    assert.deepEqual([...computeFencedLines(content)].sort((a, b) => a - b), [3, 4]);
+  });
+
+  test('returns an empty set for empty or non-string input', () => {
+    assert.equal(computeFencedLines('').size, 0);
+    assert.equal(computeFencedLines(null).size, 0);
+    assert.equal(computeFencedLines(undefined).size, 0);
+  });
+
+  test('supports tilde fences and indented delimiters', () => {
+    const content = ['x', '  ~~~', '  fenced', '  ~~~', 'y'].join('\n');
+    assert.deepEqual([...computeFencedLines(content)], [3]);
+  });
+
+  test('a shorter run does NOT close a longer fence — nested fences do not desync (HIT 1)', () => {
+    const bt4 = '````', bt3 = '```';
+    const content = [
+      'intro',        // 1
+      `${bt4}mdx`,    // 2  opener (4 backticks)
+      bt3,            // 3  interior 3-backtick — too short to close
+      'sample',       // 4  interior
+      bt4,            // 5  real closer (4 backticks)
+      'operative',    // 6  OUTSIDE the fence — must NOT be marked
+    ].join('\n');
+    const fenced = computeFencedLines(content);
+    assert.deepEqual([...fenced].sort((a, b) => a - b), [3, 4]);
+    assert.equal(fenced.has(6), false, 'line after the real closer must be operative, not fenced');
+  });
+
+  test('a tilde run does NOT close a backtick fence (fence character must match)', () => {
+    const content = ['```', 'interior', '~~~', 'still interior'].join('\n');
+    // The ~~~ does not close the ``` fence; both interior lines stay fenced (unclosed → EOF).
+    assert.deepEqual([...computeFencedLines(content)].sort((a, b) => a - b), [2, 3, 4]);
+  });
+
+  test('a fewer-than-three backtick/tilde line does NOT open a fence (HIT 2)', () => {
+    for (const delim of ['`', '``', '~', '~~']) {
+      const content = ['before', delim, 'neighbor', delim, 'after'].join('\n');
+      assert.equal(computeFencedLines(content).size, 0, `"${delim}" must not open a fence`);
+    }
+  });
+
+  test('a closer with trailing content does NOT close the fence (CommonMark)', () => {
+    const content = ['```', 'interior', '``` trailing text', 'still interior'].join('\n');
+    // "``` trailing text" is not a valid closer → fence stays open to EOF.
+    assert.deepEqual([...computeFencedLines(content)].sort((a, b) => a - b), [2, 3, 4]);
+  });
+
+  test('a CRLF fence closer still closes the fence — no line-ending desync (CRLF HIT)', () => {
+    const bt = '```';
+    // LF opener, CRLF closer, LF operative line after. The `\r` must not defeat the closer.
+    const content = `${bt}sh\ninterior\n${bt}\r\noperative after closer\n`;
+    const fenced = computeFencedLines(content);
+    assert.deepEqual([...fenced].sort((a, b) => a - b), [2]);
+    assert.equal(fenced.has(4), false, 'operative line after a CRLF closer must be scanned, not fenced');
+  });
+
+  test('a CRLF-throughout fenced block is detected (Windows-authored docs, no false positives)', () => {
+    const bt = '```';
+    const content = `${bt}sh\r\ninterior1\r\ninterior2\r\n${bt}\r\nafter\r\n`;
+    assert.deepEqual([...computeFencedLines(content)].sort((a, b) => a - b), [2, 3]);
+  });
+
+  test('an embedded bare CR fails CLOSED — the line is not treated as inert', () => {
+    const bt = '```';
+    // Fence opens, then a line carrying a bare mid-line CR — must not stay fenced.
+    const content = `${bt}\ninterior\nmarker\rmore\nplain\n`;
+    const fenced = computeFencedLines(content);
+    assert.equal(fenced.has(3), false, 'a line with an embedded CR must be scanned, not fenced');
   });
 });
 


### PR DESCRIPTION
## Summary

A review of the docs site found **36 of 44 pages were "coming soon" stubs** — all four remaining integration pages, 25 of 26 toolkit pages, all five reference pages, and getting-started. This PR writes every one of them from verified source and fixes the accuracy issues found in the pages that were real.

### Integration pages (codex, cursor, opencode, pi)
Each grounded in a source audit of its plugin, not just the repo docs:
- **pi** documents only shipped behavior — `docs/integrations/pi.md` is a design *plan*; the P5 subagents / `session_shutdown` / `/schedule` automation are labeled intent, not features. Notes pi has no `ADLC_P4_ENFORCEMENT` (ticket activation is the switch).
- **codex** is honest about the in-repo-only install path and documents that its hook — unlike the siblings — gates shell writes.
- **cursor** and **opencode** carry the fail-open/fail-closed semantics, env-var contract, and CI-gate scope limits from source.

### Toolkit (26) + reference (5) + getting-started
- Every flag and exit code verified against `bin/` source, not READMEs; bin-name traps honored (`adlc-runner`, `adlc-ticket-sync`, prosecute *records* review evidence — it doesn't run the reviewer).
- Reference section: conventions (from `CONVENTIONS.md`), the canonical 0/1/2 exit-code contract, the `.adlc/` runtime layout + env vars (all verified in source), and the ADR index.

### Fixes to previously-real pages
- `claude-code.mdx`: adds the missing `/adlc-prosecute` command and the 7-agent prosecutor panel.
- `spec-lint.mdx`: adds the undocumented `--tier cheap|mid|frontier` flag.
- `lifecycle.mdx`: adds the missing P6 row; Calibration demoted to cross-phase (it isn't a numbered phase).
- `toolkit/meta.json`: `build-gate`, `ticket-prune`, `ticket-sync` were sidebar-orphaned.

### Adversarial review (cross-provider) — findings addressed
- **Bare binaries** (MEDIUM, confirmed): usage/examples normalized to `adlc <tool>` everywhere, since getting-started installs only `@adlc/cli`. Enforced going forward by a new docs test (`toolkit-usage-dispatcher.test.mjs`) — plant-verified load-bearing.
- **`npx plugins add` supply chain** (CRITICAL, triaged accepted-risk): recorded as **ADR 0009**; README + getting-started now claim only the harness coverage the installer actually has (Claude Code today), per the ADR's claim-accuracy rule.
- The stub-disclosure honesty test in `integrations-antigravity.test.mjs` is flipped to assert all six harness pages are real and document rail enforcement.

## Test plan
- [x] `node --test apps/docs/test/*.test.mjs` — 41/41 pass (includes link checker, every-package-has-a-page, new dispatcher guard + self-test)
- [x] `next build` — clean, 153 static pages prerendered
- [x] Dispatcher guard plant-check: bare `premortem` synopsis → test fails with file + remediation; revert → passes
- [x] Reference-page claims spot-verified in source (`ADLC_RAILS_BYPASS`/`ADLC_BUILD_GATE_BYPASS` in build-gate, `ADLC_MANIFEST_KEY` in gate-manifest, ADR titles/statuses match `docs/adr/`)