### PR TITLE
feat(opencode): enforce-by-default rails guard, live deny proof, native skills (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,23 @@ jobs:
       - name: Test
         run: npm test
 
+      # AC7 — OpenCode live deny proof (ADR 0004 amendment 2026-07-05).
+      # Folded into the REQUIRED test job (not a separate optional job) on
+      # purpose: on a private free-plan repo new required checks can't be added
+      # (403), and an optional live-deny job would let a refactor silently kill
+      # the enforcement throw and still merge — the exact regression class the
+      # adversarial design review flagged. Runs on one matrix leg to keep CI
+      # time bounded; --require makes a missing opencode binary a hard failure.
+      # PINNED to the version the plugin contract is verified against (ADR 0004
+      # amendment) so upstream releases can't flake or mask regressions in a
+      # required job; bump deliberately alongside the peerDependency. A separate
+      # non-required job may track latest.
+      - name: OpenCode live deny proof (AC7)
+        if: matrix.node-version == 20
+        run: |
+          npm install -g opencode-ai@1.17.13
+          node scripts/opencode-live-deny.mjs --require
+
   pre-ga-gate:
     # Explicit CI gate that fails with a clear message while either of the two
     # unverified Pre-GA assumptions documented in docs/adr/0003-adlc-claude-code-plugin.md

--- a/docs/adr/0004-adlc-opencode-integration.md
+++ b/docs/adr/0004-adlc-opencode-integration.md
@@ -1,6 +1,8 @@
 # ADR: OpenCode integration — rails-guard plugin MVP
 
-**Status:** **Accepted — MVP shipped (P3 rail guard); Phases A/B/C/E follow-on.**
+**Status:** **Accepted — MVP shipped (P3 rail guard); Phases A/B/C/E follow-on.
+Amended 2026-07-05: enforcement contract verified against `@opencode-ai/plugin`
+v1.17.13 — the hook now ENFORCES BY DEFAULT (see Amendment).**
 The detailed design is the [OpenCode integration plan](../integrations/../opencode-integration-plan.md);
 this ADR records the decisions for the first shippable increment (ticket T1) and
 the verified facts the build rests on.
@@ -81,18 +83,56 @@ added in #15) so the rail set and recovery key can't be quietly rewritten.
 
 ## Unverified / follow-on
 
-- **`input.args.filePath` vs `output.args.filePath`** — official docs and the
-  community gist disagree; the handler reads `input` first and falls back to
-  `output`. Pinning this against a captured real payload is pending a live install.
-- **Live deny proof (AC7)** — a maintainer-only end-to-end test against a real
-  OpenCode binary remains the GA gate.
+- ~~**`input.args.filePath` vs `output.args.filePath`**~~ — **RESOLVED (2026-07-05):**
+  verified against `@opencode-ai/plugin` v1.17.13 source: the mutable args live on
+  `output.args`; `input` carries only `{ tool, sessionID, callID }`. The handler
+  reads `output.args` first (with an `input.args` tolerance fallback for older hosts).
+- ~~**Live deny proof (AC7)**~~ — **RESOLVED (2026-07-05):**
+  `scripts/opencode-live-deny.mjs` drives a real `opencode` binary with a mock
+  OpenAI-compatible provider: a control run proves the write executes when
+  enforcement is off; the treatment run proves the write is aborted and the deny
+  reason reaches the model. Wired into the required CI `test` job (private-repo
+  fallback per `docs/ci/rails-guard.yml`).
 - **TS + bundled `dist/index.js`** — the MVP ships plain `.mjs` (no build step);
   the plan's bundled-distribution form is a follow-on.
 - **Phases A/B/C/E** — command suite, keyless bridge, advisory hooks, prosecutor
   lenses (follow-on tickets T2–T5).
 
+## Amendment — 2026-07-05: enforce by default (opencode-native-flush Phase 1)
+
+The July-2026 verification of OpenCode's extension surface
+(`@opencode-ai/plugin` v1.17.13, opencode.ai/docs `plugins.mdx`) answered the
+open questions this ADR had left gated:
+
+1. **A thrown error in `tool.execute.before` ABORTS the tool call** — documented
+   host behavior, no longer an assumption. The capability probe
+   (`probeEnforcementCapability`) and its `ADLC_OPENCODE_ENFORCES` flag are
+   therefore **retired**; the hook enforces by default. The only downgrade is the
+   explicit operator escape hatch `ADLC_ALLOW_ADVISORY_HOOKS=1` (surface, don't
+   block). The retired probe was also structurally unreachable — the plugin never
+   captured the SDK `client` object — which the amendment fixes: `client` is now
+   threaded into the hooks.
+2. **Deny visibility**: denials and advisory warnings now surface via
+   `client.tui.showToast` and `client.app.log` (stderr retained as fallback), so
+   the advisory layer is visible in the TUI, not only in a log nobody watches.
+3. **Fail closed on unextractable targets**: `patch`/`multiedit`/`apply_patch`
+   (and any unknown tool) whose target path cannot be extracted from its args are
+   DENIED while rails are in force, instead of silently allowed — closing the
+   arg-shape bypass. Multi-file shapes (`files[]`, `edits[]`) are extracted and
+   each target checked; tool names are normalized before classification.
+4. **Canonical plural layout**: the scaffolder deploys native Agent Skills
+   (`.opencode/skills/<name>/SKILL.md`) and migrates the legacy flat
+   `.opencode/skill/*.md` deployment.
+
+The pinned API block above is superseded accordingly: peerDependency
+`>=1.17.13`, edited path on `output.args`, deny mechanism `throw` (documented,
+regression-tested by the live deny proof).
+
 ## Consequences
 
 Rail enforcement is real in OpenCode for the common structured-edit path, with the
-rail engine delegated to a single source of truth. The advisory/CI two-layer model
-is honest about what the in-session hook can and cannot guarantee.
+rail engine delegated to a single source of truth. In-session enforcement is now
+default-on (documented host contract + live regression proof), with the CI gate
+remaining the unbypassable backstop for shell-driven writes and hostile
+environments. The advisory/CI two-layer framing survives for the explicitly
+downgraded mode only.

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -11,19 +11,27 @@ discovery skill.
 
 ## Status
 
-Shipping so far: the rails-guard plugin (`plugins/adlc-opencode/`, plan Phase D),
-the discovery skill, the **Phase A command surface** — `/adlc-init`,
+Shipping so far: the rails-guard plugin (`plugins/adlc-opencode/`, plan Phase D —
+**enforcing by default** since the 2026-07-05 amendment, see ADR 0004), the
+discovery skill (deployed as a native Agent Skill,
+`.opencode/skills/adlc/SKILL.md`), the **Phase A command surface** — `/adlc-init`,
 `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`, `/adlc-decompose` plus the
-gate-bin dependency mapping and deterministic `/adlc-init` scaffolding — and the
-**Phase B keyless gate bridge** (`lib/keyless-bridge.mjs`): run any LLM-backed gate
-in `--prompt-only` mode, route the prompt(s) to the host model, no API key — and
-the **Phase C advisory session hooks** (`session.created` preflight,
-`session.idle` gate-manifest audit), and the **Phase E prosecution surface** — the
-G4 build gate (`/adlc-verify-build`), the five P5 prosecution subagents
-(`@prosecutor-correctness|security|contract|diff|tests`) plus the
+gate-bin dependency mapping and deterministic `/adlc-init` scaffolding — the
+**Phase C advisory session hooks** (`session.created` preflight, `session.idle`
+gate-manifest audit — both surfaced as TUI toasts), and the **Phase E prosecution
+surface** — the G4 build gate (`/adlc-verify-build`), the five P5 prosecution
+subagents (`@prosecutor-correctness|security|contract|diff|tests`) plus the
 `@prosecutor-verifier`, the `/adlc-prosecute` fan-out/verify/loop-until-dry
-command, and `/adlc-distill` (P7). With Phase F's CI backstop (merged earlier),
-all six plan phases (A–F) now ship.
+command, and `/adlc-distill` (P7). Phase F's CI backstop merged earlier.
+
+**Honesty note on Phase B and the P5 helpers:** `lib/keyless-bridge.mjs`
+(extract a gate's prompts, ask, thread answers) and the `lib/prosecutor.mjs`
+decision helpers are implemented and unit-tested but **not yet wired into a
+runtime path** — today the commands instruct the model to run gates via
+`adlc <gate> --prompt-only` and reason over the printed output itself. Wiring
+them to the now-available SDK (`client.session.create` + `session.prompt`) is
+the `opencode-native-flush` plan's Phase 4
+([spec](../specs/opencode-native-flush.md)).
 
 > **Session hooks — event-name note.** The plan specified `session.created` +
 > `session.ended`, but OpenCode has no `session.ended`; the end-of-work signal is
@@ -32,11 +40,12 @@ all six plan phases (A–F) now ship.
 > ADLC-initialized.
 
 > **Keyless bridge — SDK dependency (plan §6.4).** The bridge's protocol (extract
-> a gate's prompts, ask, thread answers) is implemented and tested, but the
-> isolated-sub-context model call depends on a proposed OpenCode SDK extension. The
-> `ask` function is capability-gated: it uses the SDK isolated-prompt API when
-> present, optionally degrades to the active session model, and otherwise returns
-> `null` so callers fail closed rather than silently skip a gate.
+> a gate's prompts, ask, thread answers) is implemented and tested, and the SDK
+> capability it was waiting for now exists (`client.session.create` +
+> `session.prompt` with structured output, verified on `@opencode-ai/plugin`
+> v1.17.13). Wiring `makeAsk` to it is Phase 4 of the
+> [`opencode-native-flush` plan](../specs/opencode-native-flush.md); until then
+> `makeAsk` returns `null` so callers fail closed rather than silently skip a gate.
 
 ## Commands
 
@@ -67,7 +76,8 @@ the enforcing hook only runs once the plugin package is registered.) Phase A com
 
 The plugin ships in this repo at `plugins/adlc-opencode/`. The
 `@adlc/opencode-package` package is **not yet published to npm**, so install from
-source for now (peer dependency: `@opencode-ai/plugin` >= 1.17.11).
+source for now (peer dependency: `@opencode-ai/plugin` >= 1.17.13 — the version
+whose documented hook contract the enforce-by-default posture is pinned against).
 
 **1. Install the gate toolkit** — the plugin shells out to the `adlc` binary:
 
@@ -117,18 +127,25 @@ verification — see [ADR 0004](../adr/0004-adlc-opencode-integration.md).
 
 ## Rail enforcement — two layers
 
-The integration enforces frozen rails at two layers, and **the in-session layer is
-deliberately advisory**:
+The integration enforces frozen rails at two layers:
 
-1. **In-session hook (advisory).** The plugin's `tool.execute.before` hook denies
-   structured `edit`/`write` to a frozen rail declared by the active ticket. It
-   only *actually blocks* when the host OpenCode SDK honors a thrown denial
-   (`onFailure: deny`); a runtime capability probe gates this. When the capability
-   is unproven the hook runs advisory (it surfaces the violation but cannot block)
-   unless `ADLC_ALLOW_ADVISORY_HOOKS=1` is set — otherwise it fails closed. The
-   hook also no-ops unless the repo is ADLC-initialized and `ADLC_P4_ENFORCEMENT=1`.
-   It is inherently bypassable (the agent controls its own environment and the
-   active-ticket selector), so it is **not** the real control.
+1. **In-session hook (enforcing by default).** The plugin's `tool.execute.before`
+   hook denies structured mutations to a frozen rail declared by the active
+   ticket: a thrown error in the hook **aborts the tool call** — documented host
+   behavior on `@opencode-ai/plugin` >= 1.17.13, regression-tested end-to-end by
+   `scripts/opencode-live-deny.mjs`. Every extractable target path is checked
+   (`filePath`, `files[]`, `edits[]`); a mutating or *unknown* tool whose target
+   cannot be extracted is denied while rails are in force (fail closed — a
+   deliberate tradeoff: an unrecognized third-party write tool must not slip
+   past on arg shape; a benign no-target tool a railed build needs can be
+   explicitly opted out via `ADLC_UNGATED_TOOLS="tool_a,tool_b"`, which still
+   gets the frozen-rail-target spoof guard). Denials and advisory warnings
+   surface as TUI toasts (`client.tui.showToast`) with stderr as fallback. The
+   only enforcement downgrade is the explicit escape hatch
+   `ADLC_ALLOW_ADVISORY_HOOKS=1` (surface, don't block). The hook no-ops unless
+   the repo is ADLC-initialized and `ADLC_P4_ENFORCEMENT=1`. It remains
+   inherently bypassable by a hostile agent (which controls its own environment
+   and the active-ticket selector), so it is still **not** the real control.
 2. **Commit-time CI gate (mandatory, unbypassable).** The real control is
    [`../ci/rails-guard.yml`](../ci/rails-guard.yml) driving `scripts/rails-guard-ci.mjs`
    — a harness-agnostic diff gate that reads the frozen rail set from the trusted
@@ -163,7 +180,7 @@ glob/ticket logic to `@adlc/core`:
 | P0 Triage | **Yes** | `/adlc-ticket` (Phase A) |
 | P1 Interrogate | **Yes** | `/adlc-spec` + `/adlc-approve-spec` (Phase A) + the `adlc` skill |
 | P2 Decompose | **Yes** | `/adlc-decompose` (Phase A) |
-| P3 Rail | **MVP** | the in-session rails-guard hook (this plugin) + CI gate |
+| P3 Rail | **Yes** | the in-session rails-guard hook (enforcing by default, live-deny-proofed) + CI gate |
 | P4 Build | Partial | rails-guard hook + `session.created` advisory preflight; flail-detection is follow-on |
 | P5 Prosecute | **Yes** | `/adlc-verify-build` (G4) + 5 prosecutor lenses + verifier + `/adlc-prosecute` |
 | P6 Integrate | Partial | `session.idle` advisory gate-manifest audit; the human gate is by design |
@@ -171,19 +188,28 @@ glob/ticket logic to `@adlc/core`:
 
 ## Gaps
 
-1. **In-session enforcement depends on host SDK capability.** Until OpenCode's
-   plugin SDK is confirmed to honor a thrown denial (`onFailure: deny`), the hook
-   is advisory; the CI gate is the real control.
-2. **Bash-driven writes are not gated in-session** (Turing-complete shell) — caught
-   by the CI diff gate, mirroring the Claude Code posture.
-3. **Phase-E orchestration is model-driven.** `/adlc-prosecute` describes the
+1. **Bash-driven writes are not gated in-session** (Turing-complete shell) — caught
+   by the CI diff gate, mirroring the Claude Code posture. In-session shell gating
+   is Phase 2 of the [`opencode-native-flush` plan](../specs/opencode-native-flush.md).
+2. **Phase-E orchestration is model-driven.** `/adlc-prosecute` describes the
    fan-out → dedupe → verify → loop-until-dry protocol (the decision helpers in
    `lib/prosecutor.mjs` are unit-tested), but the loop itself is executed by the
    model invoking the subagents, not a deterministic first-party runner — the same
-   gap the Codex path documents for P5.
-4. **Live deny proof pending.** A maintainer-only end-to-end check against a real
-   OpenCode binary (driving an actual edit-to-rail and asserting the block) is the
-   remaining GA gate — see ADR 0004.
+   gap the Codex path documents for P5. A native-tool deterministic runner is
+   plan Phase 4.
+3. **The keyless bridge is unwired** (see the honesty note under Status) — plan
+   Phase 4.
+4. **Tool-name-independent backstop pending** — the guard keys off tool names and
+   arg shapes (unknown ones fail closed, and an *ungated* tool whose args carry a
+   frozen-rail target is denied rather than allowed by name); the residual class —
+   a co-installed plugin registering a writing tool under a *read-only* name — is
+   closed by the `file.edited`-event backstop in plan Phase 2.5, and at commit
+   time by the CI gate.
+
+Resolved 2026-07-05 (formerly Gaps 1/4): in-session enforcement no longer depends
+on an unproven SDK capability — a thrown denial is documented host behavior and
+the live deny proof (`scripts/opencode-live-deny.mjs`, required CI) regression-tests
+it. See ADR 0004's amendment.
 
 ## Boundary
 

--- a/docs/specs/opencode-native-flush.md
+++ b/docs/specs/opencode-native-flush.md
@@ -1,0 +1,183 @@
+# OpenCode Native Flush — making adlc-opencode robust, feature-complete, and native-feeling
+
+Status: PROPOSED (plan for review)
+Branch: `opencode-native-flush`
+Inputs: full plugin audit, six-integration capability benchmark, and a verified inventory of
+OpenCode's extension surface as of `@opencode-ai/plugin` v1.17.13 (July 2026).
+
+## Why now
+
+The integration was designed against an *assumed* OpenCode SDK (ADR 0004 lists the open
+questions). The July-2026 surface answers nearly all of them, in our favor:
+
+| Old assumption (in code/docs today) | Verified reality (v1.17.13) |
+| --- | --- |
+| Throwing in `tool.execute.before` may not block ("capability unproven") | **Throwing blocks the tool call.** Documented, verbatim example in plugins.mdx. |
+| `input.args` vs `output.args` ambiguity | Args are on **`output.args`** only; `input` = `{tool, sessionID, callID}`. |
+| Keyless bridge needs a "proposed SDK extension" | `client.session.create({parentID})` + `session.prompt` (with `outputFormat` JSON-schema structured output and `noReply`) exists today. |
+| Warnings can only go to `console.error` | `client.tui.showToast`, `client.app.log`, plus a full **TUI plugin surface** (toasts, dialogs, persistent UI slots, OS notifications). |
+| Commands/agents markdown is the only extension shape | Plugins can register **native model-callable tools** (`tool` hook / `.opencode/tools/`), a **`permission.ask`** programmatic allow/deny hook, `tool.definition` rewriting, `experimental.chat.system.transform`, and more. |
+| `.opencode/command/`, `skill/adlc.md` layout | **Plural dirs are canonical** (`commands/ agents/ skills/ tools/ plugins/`); native skills are `skills/<name>/SKILL.md` discovered via a `skill` tool. |
+
+## Where we stand (audit + benchmark synthesis)
+
+adlc-opencode is the **second-most-complete** of the six integrations (after claude-code):
+richest explicit phase-command surface (8 commands), 5 prosecutor lenses + verifier,
+self-registering idempotent scaffold, 71/71 unit tests, CI backstop wired.
+
+But the audit found the native seam is thin — one hook plus two session events — and four
+material defects the docs don't admit:
+
+1. **Dead code shipped as capability.** `lib/keyless-bridge.mjs`, `gate-bins.mjs`, and the
+   decision half of `lib/prosecutor.mjs` are imported only by their own tests. "Phase B/E
+   ship" describes tested-but-unwired libraries.
+2. **The SDK-capability probe is structurally unreachable.** `index.mjs:20` destructures
+   `{directory, worktree, project}` and **discards `client`**; `probeEnforcementCapability`
+   then checks `.capabilities` on the wrong object. Enforcement today is env-var-only.
+3. **`patch`/`multiedit`/`apply_patch` silently bypass the guard.** Only `args.filePath` is
+   read; tools without that field return early → the write is allowed with zero signal,
+   contradicting the ADR threat model.
+4. **The advisory layer may be invisible.** Everything goes to `console.error`; TUI
+   visibility was never established. The default fail-closed deny path emits *nothing* if a
+   throw were swallowed.
+
+Benchmark gaps vs best sibling (ranked): blocking rails (CC/codex/pi), build-gate
+context-rot backstop (CC), shell-mutation gating (codex/pi), flail detection (CC),
+`adlc-maintain` + maintenance cron (CC), `prosecutor` meta-agent (CC/agy), TUI statusline
+(pi), per-turn ticket-context injection (pi), suppression-marker revert + scope
+enforcement (pi).
+
+## The plan
+
+Phases ordered by risk-reduction per unit effort. Each phase is independently shippable
+and prosecutable (P5) before the next begins.
+
+### Phase 1 — Fix the hook we already have (correctness, small diffs)
+
+1.1 **Capture `client` and `$` from `PluginInput`** in `index.mjs`; thread `client` into the
+    hook closures and session hooks.
+1.2 **Pin the payload contract**: read args from `output.args` (keep a tolerant fallback),
+    extract `filePath` for edit/write and `command` for bash. Delete the
+    `input.args`-first guess and the ADR "pinning pending" caveat.
+1.3 **Enforce by default.** Throwing blocks — retire `probeEnforcementCapability` and the
+    `ADLC_OPENCODE_ENFORCES` opt-in; keep `ADLC_ALLOW_ADVISORY_HOOKS` only as an explicit
+    downgrade escape hatch. Update ADR 0004 + docs/integrations/opencode.md (the
+    "advisory until proven" posture, Gap 1, and the Status overstatements from audit §3.1).
+1.4 **Fail closed on unextractable paths from mutating tools.** If `tool` is mutating
+    (patch/multiedit/apply_patch/…) and no path can be extracted, deny with a clear
+    message instead of silently allowing. Add arg-shape handling for multi-file payloads
+    (`files[]`, patch body paths) as they're pinned against real payloads. Keep the
+    existing unknown-tool-name fail-closed posture, and add a test that registers a
+    **synthetic unknown write tool** and proves the deny path fires for it.
+1.5 **Normalize tool names** (`toLowerCase()`) before allowlist/mutator checks.
+1.6 **Deny visibly.** On every deny (and every advisory warning), call
+    `client.tui.showToast({variant:'error'|'warning'})` with `console.error` retained as
+    fallback; route audit trails through `client.app.log`.
+1.7 **Scaffold to canonical plural layout**: `commands/`, `agents/`, and native skill shape
+    `.opencode/skills/adlc/SKILL.md` (frontmatter `name` + `description` so the `skill`
+    tool discovers it). Migrate idempotently; leave back-compat copies out.
+1.8 Hygiene: fix the dangling `/adlc-rail-write` reference in `adlc-decompose.md`; add
+    `agent/*.md` to the manual-install fallback in `adlc-init.md`.
+
+Exit: live deny proof (ADR 0004 AC7) now automatable — script an `opencode` server via
+`@opencode-ai/sdk`, drive an edit to a frozen rail, assert the block and the toast.
+This becomes `scripts/opencode-live-deny.test.mjs` and is wired as a **required CI
+gate**, not an optional job — a refactor of the `output.args` read path must not be
+able to silently kill the deny throw and still merge. On the private-repo free plan
+(where required checks 403), fold it into the existing required job, mirroring the
+rails-guard CI fallback. Follow-on: run it against a small **version matrix** of
+OpenCode releases (current + latest) to catch upstream hook-contract drift.
+
+### Phase 2 — Enforcement depth (close the benchmark's top gaps)
+
+2.1 **`permission.ask` second lever.** Register the hook; when the permission targets a
+    frozen rail, set `output.status='deny'`. Belt-and-braces with the throw, and it covers
+    permission-mediated paths the tool hook doesn't see.
+2.2 **In-session shell gating.** Port adlc-codex's shell parser (fail-closed on opaque
+    commands) into `tool.execute.before` for `bash` via `output.args.command`. Same
+    posture as codex: parseable mutating command against a rail → deny; unparseable +
+    rail-relevant heuristics → deny with explanation (CI gate remains the backstop).
+2.3 **Build-gate context-rot backstop** (port CC issue #48): a second enforcing check in
+    `tool.execute.before` that denies structured edits on high-risk tickets when the
+    session's context-fitness degrades. Signals available natively: `session.compacted`
+    events, `experimental.compaction.autocontinue`, message counts via `client.state`.
+2.4 **Suppression-marker + scope enforcement (pi parity):** `tool.execute.after` +
+    `file.edited` event watcher that flags/reverts unapproved `@ts-ignore` /
+    `eslint-disable` / `.skip(` introductions and edits outside the active ticket's
+    `scope`, using `$` (Bun shell) for the git revert. Advisory first, opt-in enforcing.
+
+2.5 **Tool-name-independent rail backstop.** The pre-write guards in 1.x/2.1/2.2 key off
+    tool names and arg shapes — but OpenCode lets *any other plugin* register new
+    model-callable write tools (e.g. a third-party `write_file`) that our lists have
+    never seen. Close the class, not the instance: (a) subscribe to the `file.edited`
+    event and, when the edited path resolves to a frozen rail, revert via git and toast
+    loudly — enforcement that holds regardless of which tool performed the write; (b)
+    register `permission.ask` at global scope so any permission whose target resolves
+    to a frozen rail is denied no matter which tool raised it. Test with a synthetic
+    third-party write tool registered alongside the plugin (shares the 1.4 fixture).
+
+### Phase 3 — Native feel & visibility
+
+3.1 **Per-turn ticket-context injection** via `experimental.chat.system.transform`:
+    append active ticket id, scope, and frozen rails to the system prompt each turn
+    (pi's F1/F3 context-rot defense).
+3.2 **`tool.definition` annotation**: rewrite the `edit`/`write` tool descriptions to name
+    the currently frozen rails, so the model is warned *before* attempting a violation.
+3.3 **Flail/churn detection** (port CC's PostToolUse advisory) via `tool.execute.after`
+    over a bounded window; surface via toast.
+3.4 **TUI plugin module** (separate `tui` export — a module is server XOR tui, so ship
+    `plugins/adlc-opencode/tui.mjs` registered alongside): persistent slot
+    (`session_prompt_right` or `sidebar_footer`) showing active ticket + enforcement
+    state; `DialogConfirm` for `/adlc-approve-spec` so the G1 human gate is a real modal;
+    `api.attention.notify` on gate failures.
+
+### Phase 4 — Wire the dead code (keyless bridge + deterministic P5)
+
+4.1 **Keyless bridge goes live.** `makeAsk` gets a real implementation:
+    `client.session.create({parentID: current})` → `session.prompt` with
+    `outputFormat` (JSON-schema structured verdicts) → thread answers per the existing
+    tested protocol. Delete the "proposed SDK extension" caveat.
+4.2 **Native `adlc_gate` custom tool** (plugin `tool` hook): the model calls
+    `adlc_gate({gate, args})` instead of being prose-instructed to shell out; execute()
+    runs the CLI (or keyless bridge for LLM-backed gates) and returns structured
+    `{title, output, metadata}`. `gate-bins.mjs` becomes the tool's dispatch table
+    (dead code → live).
+4.3 **Deterministic P5 runner**: native `adlc_prosecute` tool whose execute() drives
+    fan-out → dedupe → verify → loop-until-dry *in first-party code* using the already-
+    tested `lib/prosecutor.mjs` helpers, spawning lens/verifier child sessions via the
+    SDK with structured output. `/adlc-prosecute` command becomes a thin invoker. This
+    closes the "model-driven orchestration" gap CC itself still has — opencode would
+    leapfrog to the most deterministic P5 of all six.
+
+### Phase 5 — Parity ports & distribution
+
+5.1 `/adlc-maintain` command + `docs/ci/adlc-maintenance.yml` weekly cron (CC parity).
+5.2 `prosecutor` meta-agent (7th agent: hollow-test / behavior-diff / review-calibration
+    deterministic gates), port from CC/agy.
+5.3 **Publish `@adlc/opencode-package` to npm** so install is
+    `"plugin": ["@adlc/opencode-package"]` in opencode.json; scaffolder registers the npm
+    name instead of a source path. Fold into the lockstep `/release` flow.
+5.4 Docs truth pass: rewrite Status/Gaps in `docs/integrations/opencode.md` to match
+    reality (no phase claimed shipped without a runtime caller), refresh ADR 0004
+    (answered questions → decisions), update the smoke script for the new surface.
+
+## Risks / open questions
+
+- **v1 vs v2 plugin API**: a v2 API exists in-source but undocumented; build on v1.17.x,
+  isolate hook wiring so a v2 migration is one adapter file.
+- **Arg shapes for patch/multiedit**: fail-closed default lands first (Phase 1.4);
+  precise multi-file extraction is pinned against captured real payloads.
+- **`session.prompt` cost**: keyless-bridge child sessions bill the user's configured
+  model; keep per-gate calls bounded and surface which model answered.
+- **TUI plugin is a second module**: server XOR tui — scaffolder must register both and
+  the smoke test must cover both.
+
+## Ticket slicing (P2 sketch)
+
+Phase 1 → 1 ticket (hook correctness + scaffold layout + docs truth), rails: CI gate
+config, `.adlc/*` trust roots. Phase 2 → 3 tickets (permission.ask+shell gating;
+build-gate; suppression/scope + tool-name-independent backstop, which share the
+watcher plumbing). Phase 3 → 2 tickets (server-side context/visibility;
+TUI module). Phase 4 → 2 tickets (keyless bridge + adlc_gate tool; deterministic P5).
+Phase 5 → 2 tickets (maintain+meta-agent; npm publish + docs). Each gated by
+`/adlc-prosecute` before merge per house rules.

--- a/plugins/adlc-opencode/command/adlc-decompose.md
+++ b/plugins/adlc-opencode/command/adlc-decompose.md
@@ -27,4 +27,7 @@ close any gaps that would block a fresh agent.
 
 ## 4. Summarize
 Report the ticket DAG (waves + merge order), each ticket's coldstart verdict, and
-the routing hints. Point the user at `/adlc-rail-write` (P3) for the first ticket.
+the routing hints. For P3, remind the user: declare the first ticket's `rails` in
+`.adlc/tickets.json`, set it active (`.adlc/current-ticket.json` or `ADLC_TICKET`),
+and export `ADLC_P4_ENFORCEMENT=1` — the in-session rails-guard hook and the CI
+rail-freeze gate then enforce the frozen rails during the build.

--- a/plugins/adlc-opencode/command/adlc-init.md
+++ b/plugins/adlc-opencode/command/adlc-init.md
@@ -21,16 +21,18 @@ npm install -g @adlc/cli
 - Create `.adlc/` if missing.
 - If `.adlc/tickets.json` is absent, create it as `{ "tickets": [] }`. If present, leave it.
 - Run the deterministic scaffolder to create `.adlc/config.json` (defaults, no
-  clobber), deploy this plugin's `command/` and `skill/` into `.opencode/`, ensure
-  `.gitignore` tracks the ticket + specs contracts, and exclude `.adlc/` from any
-  detected repo formatter/linter:
+  clobber), deploy this plugin's `command/`, `agent/`, and `skill/` into
+  `.opencode/` (commands/, agents/, skills/<name>/SKILL.md), ensure `.gitignore`
+  tracks the ticket + specs contracts, and exclude `.adlc/` from any detected
+  repo formatter/linter:
 
   !`node "$(dirname "$(node -e "process.stdout.write(require.resolve('@adlc/opencode-package/package.json'))" 2>/dev/null || echo .)")/lib/scaffold-cli.mjs" .`
 
   (If the helper is unavailable, scaffold manually: create `.adlc/config.json`
   with `{"securityMode":"unsigned-fallback"}`, copy the plugin's `command/*.md`
-  into `.opencode/commands/` and `skill/*.md` into `.opencode/skill/`, then do
-  steps 3 and 4 below by hand.)
+  into `.opencode/commands/`, `agent/*.md` into `.opencode/agents/`, and each
+  `skill/<name>.md` to `.opencode/skills/<name>/SKILL.md`, then do steps 3 and 4
+  below by hand.)
 
 ## 3. Separate the contract from runtime evidence in git
 

--- a/plugins/adlc-opencode/index.mjs
+++ b/plugins/adlc-opencode/index.mjs
@@ -5,50 +5,77 @@
 // gate. The deny path imports only Node builtins + @adlc/core (first-party,
 // zero third-party dependency).
 //
-// Enforcement-capability gate (integration-plan Phase D): a thrown error in
-// `tool.execute.before` only blocks the write if the host SDK honors it
-// (onFailure:deny). When the capability is unproven, the hook runs ADVISORY
-// (surfaces the violation, does not claim to block) unless the operator opts into
-// advisory mode; otherwise it signals that preflight should fail closed.
+// Enforcement contract (pinned against @opencode-ai/plugin v1.17.13): a thrown
+// error in `tool.execute.before` ABORTS the tool call — this is documented host
+// behavior, so the hook ENFORCES BY DEFAULT. The mutable tool args live on the
+// second hook parameter (`output.args`); `input` carries only
+// { tool, sessionID, callID }. The only downgrade is the explicit operator
+// escape hatch ADLC_ALLOW_ADVISORY_HOOKS=1 (surface, don't block) — there is no
+// capability probe anymore, because the capability is documented, and the live
+// deny proof (scripts/opencode-live-deny.mjs) regression-tests it against a real
+// opencode binary.
 
-import { checkRail, probeEnforcementCapability } from './rails-checker.mjs';
+import { checkToolCall } from './rails-checker.mjs';
 import { checkPreflight, auditGateManifest, auditAdversarialReview } from './lib/session-hooks.mjs';
 
 /** @typedef {import('@opencode-ai/plugin').Plugin} Plugin */
 
+/**
+ * Surface a message to the operator. Best-effort on every channel, never
+ * throws, never blocks the caller: the OpenCode TUI toast (the channel a TUI
+ * user actually sees), the server log, and stderr as the always-available
+ * fallback.
+ */
+function makeNotify(client) {
+  return (message, variant = 'error') => {
+    console.error(message);
+    const deliveries = [];
+    try {
+      const toast = client?.tui?.showToast?.({ body: { title: 'ADLC', message, variant } });
+      if (toast?.catch) deliveries.push(toast.catch(() => {}));
+    } catch { /* toast channel unavailable — stderr already carried it */ }
+    try {
+      const log = client?.app?.log?.({ body: { service: 'adlc-opencode', level: variant === 'error' ? 'error' : 'warn', message } });
+      if (log?.catch) deliveries.push(log.catch(() => {}));
+    } catch { /* log channel unavailable */ }
+    return Promise.all(deliveries).then(() => undefined);
+  };
+}
+
 /** @type {Plugin} */
-export const adlcRailsGuard = async ({ directory, worktree, project } = {}) => {
+export const adlcRailsGuard = async ({ directory, worktree, project, client } = {}) => {
   // The repo root used to locate .adlc/ and to canonicalize edited paths.
   const root = worktree ?? directory ?? project?.worktree ?? process.cwd();
-  const enforces = probeEnforcementCapability({ directory, worktree, project });
-  const advisoryAllowed = process.env.ADLC_ALLOW_ADVISORY_HOOKS === '1';
+  const advisoryOnly = process.env.ADLC_ALLOW_ADVISORY_HOOKS === '1';
+  const notify = makeNotify(client);
 
   return {
     'tool.execute.before': async (input, output) => {
       const tool = input?.tool;
-      // Sources disagree on whether the edited path is on input.args or
-      // output.args; read input first, fall back to output. (ADR 0004 tracks
-      // pinning this against a captured real payload.)
-      const filePath = input?.args?.filePath ?? output?.args?.filePath;
-      if (!filePath || !tool) return;
+      if (!tool) return;
+      // Pinned contract (v1.17.13): args are on output.args. The input.args
+      // fallback is tolerance for older hosts, not the primary read.
+      const args = output?.args ?? input?.args ?? {};
 
-      const verdict = checkRail({ filePath, tool, root, env: process.env });
+      const verdict = checkToolCall({ tool, args, root, env: process.env });
       if (verdict.decision !== 'deny') return;
 
-      const message = `ADLC rails-guard: blocked edit to ${verdict.reason}`;
-      if (enforces || !advisoryAllowed) {
-        // Enforcing (or refusing to silently downgrade): throw to abort the tool.
-        throw new Error(message);
+      const message = `ADLC rails-guard: blocked ${tool} — ${verdict.reason}`;
+      if (advisoryOnly) {
+        // Explicit operator downgrade: surface loudly without claiming to block.
+        await notify(`${message} [ADVISORY — ADLC_ALLOW_ADVISORY_HOOKS=1; the CI rail-freeze gate remains authoritative]`, 'warning');
+        return;
       }
-      // Advisory mode: cannot abort, so surface loudly without claiming to block.
-      console.error(`${message} [ADVISORY — host SDK does not honor deny; rely on the CI rail-freeze gate]`);
+      // Enforcing (default): notify fire-and-forget, then throw to abort the tool.
+      notify(message, 'error');
+      throw new Error(message);
     },
 
     // session.created (Phase C): advisory environment preflight. Never throws.
     'session.created': async () => {
       try {
         const { skipped, warnings } = checkPreflight(root, { env: process.env });
-        if (!skipped) for (const w of warnings) console.error(`ADLC preflight: ${w}`);
+        if (!skipped) for (const w of warnings) await notify(`ADLC preflight: ${w}`, 'warning');
       } catch { /* advisory: swallow */ }
     },
 
@@ -58,7 +85,7 @@ export const adlcRailsGuard = async ({ directory, worktree, project } = {}) => {
     'session.idle': async () => {
       try {
         const { warning } = auditGateManifest(root);
-        if (warning) console.error(`ADLC gate-manifest audit: ${warning}`);
+        if (warning) await notify(`ADLC gate-manifest audit: ${warning}`, 'warning');
       } catch { /* advisory: swallow */ }
 
       // Mechanical adversarial-review trigger (issue #59): deterministic,
@@ -66,7 +93,7 @@ export const adlcRailsGuard = async ({ directory, worktree, project } = {}) => {
       // only — session.idle has no blocking contract in OpenCode.
       try {
         const { warning } = auditAdversarialReview(root, { env: process.env });
-        if (warning) console.error(`ADLC adversarial-review audit: ${warning}`);
+        if (warning) await notify(`ADLC adversarial-review audit: ${warning}`, 'warning');
       } catch { /* advisory: swallow */ }
     },
   };

--- a/plugins/adlc-opencode/lib/scaffold.mjs
+++ b/plugins/adlc-opencode/lib/scaffold.mjs
@@ -9,7 +9,7 @@
 // Pure-ish: every function takes explicit roots, so it is unit-testable against
 // a temp dir without touching the real environment.
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 // The .gitignore stanza + formatter-ignore hygiene logic (issue #97) is shared
 // with plugins/adlc-cursor via @adlc/core, which this package already
@@ -80,21 +80,56 @@ export function ensurePluginRegistered(root, pkgName = '@adlc/opencode-package')
 }
 
 /**
+ * Deploy the plugin's skill/*.md sources as NATIVE OpenCode Agent Skills:
+ * .opencode/skills/<name>/SKILL.md (the shape the `skill` tool discovers).
+ * Also migrates away the legacy flat deployment (.opencode/skill/<name>.md)
+ * that pre-dated native skill support — a legacy file is removed ONLY when its
+ * content is pristine (byte-identical to what this plugin deploys), so a
+ * user-customized copy is never silently destroyed; the legacy dir is dropped
+ * only when left empty. Idempotent; returns { deployed, preservedLegacy }.
+ */
+export function deploySkills(pkgRoot, destRoot) {
+  const srcDir = join(pkgRoot, 'skill');
+  if (!existsSync(srcDir)) return { deployed: [], preservedLegacy: [] };
+  const deployed = [];
+  const preservedLegacy = [];
+  const legacyDir = join(destRoot, '.opencode', 'skill');
+  for (const name of readdirSync(srcDir)) {
+    if (!name.endsWith('.md')) continue;
+    const source = readFileSync(join(srcDir, name), 'utf8');
+    const skillName = name.slice(0, -'.md'.length);
+    const outDir = join(destRoot, '.opencode', 'skills', skillName);
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, 'SKILL.md'), source);
+    deployed.push(`${skillName}/SKILL.md`);
+    const legacy = join(legacyDir, name);
+    if (existsSync(legacy)) {
+      if (readFileSync(legacy, 'utf8') === source) rmSync(legacy);
+      else preservedLegacy.push(`.opencode/skill/${name}`); // user-modified — keep it
+    }
+  }
+  if (existsSync(legacyDir) && readdirSync(legacyDir).length === 0) {
+    rmSync(legacyDir, { recursive: true });
+  }
+  return { deployed, preservedLegacy };
+}
+
+/**
  * Full scaffold: ensure config, REGISTER the plugin (so the rails-guard hook
  * loads), deploy command/, agent/, and skill/ into .opencode/, ensure the
  * .gitignore contract stanza, and exclude .adlc/ from any detected repo
- * formatter/linter. OpenCode discovers project commands under
- * .opencode/commands/, subagents under .opencode/agents/, and skills under
- * .opencode/skill/; the plugin ships them under command/, agent/, and skill/
- * respectively. Returns a summary.
+ * formatter/linter. OpenCode's canonical project layout is PLURAL:
+ * commands under .opencode/commands/, subagents under .opencode/agents/, and
+ * native skills under .opencode/skills/<name>/SKILL.md; the plugin ships its
+ * sources under command/, agent/, and skill/ respectively. Returns a summary.
  */
 export function scaffold(root, pkgRoot) {
   const config = ensureConfig(root);
   const plugin = ensurePluginRegistered(root);
   const commands = deployDir(pkgRoot, root, 'command', 'commands');
   const agents = deployDir(pkgRoot, root, 'agent', 'agents');
-  const skills = deployDir(pkgRoot, root, 'skill', 'skill');
+  const { deployed: skills, preservedLegacy: preservedLegacySkills } = deploySkills(pkgRoot, root);
   const gitignore = ensureGitignore(root);
   const formatterIgnores = ensureFormatterIgnores(root);
-  return { config, plugin, commands, agents, skills, gitignore, formatterIgnores };
+  return { config, plugin, commands, agents, skills, preservedLegacySkills, gitignore, formatterIgnores };
 }

--- a/plugins/adlc-opencode/package.json
+++ b/plugins/adlc-opencode/package.json
@@ -12,7 +12,7 @@
     "skill": "./skill/"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.17.11"
+    "@opencode-ai/plugin": ">=1.17.13"
   },
   "dependencies": {
     "@adlc/core": "^1.1.0"

--- a/plugins/adlc-opencode/rails-checker.mjs
+++ b/plugins/adlc-opencode/rails-checker.mjs
@@ -23,9 +23,14 @@ export const MUTATING_TOOLS = ['edit', 'write', 'patch', 'multiedit', 'apply_pat
 
 // Known read-only tools that may carry a file path but never mutate it. The gate
 // fails CLOSED: only these are skipped; any other structured tool that reaches the
-// checker (i.e. carries a filePath) — including unrecognized mutation tools — is
-// checked against the rail set rather than silently allowed.
-export const READONLY_TOOLS = ['read', 'grep', 'glob', 'list', 'ls', 'webfetch'];
+// checker — including unrecognized mutation tools — is checked against the rail
+// set rather than silently allowed.
+export const READONLY_TOOLS = ['read', 'grep', 'glob', 'list', 'ls', 'webfetch', 'websearch', 'codebase_search', 'lsp', 'todoread'];
+
+// First-party tools with no single-file mutation semantics, deliberately not
+// gated in-session (bash falls to the CI diff gate; the rest don't write files).
+// Anything NOT in this list or READONLY_TOOLS is treated as potentially mutating.
+export const UNGATED_TOOLS = ['bash', 'task', 'skill', 'todowrite', 'question'];
 
 /** Canonicalize a path to a forward-slash path relative to the repo root (lexical). */
 export function canonicalizePath(filePath, root) {
@@ -83,68 +88,142 @@ export function resolveActiveTicketId(root, env) {
 }
 
 /**
- * Decide whether a structured edit/write should be allowed or denied.
- * Pure and fail-safe: returns { decision: 'allow' | 'deny', reason }.
- *
- * Enforcement contract (identical to the sibling hooks):
- *  - only the structured mutating tools are gated;
- *  - enforcement is phase-scoped to ADLC_P4_ENFORCEMENT === '1';
- *  - no-op when the repo is not ADLC-initialized;
- *  - the active ticket is the SINGLE source of declared rails; a conflicting
- *    active-ticket signal fails closed;
- *  - rails in force = active ticket's declared rails PLUS the trust-root rails.
+ * Resolve whether rails are currently IN FORCE and, if so, the effective rail
+ * set. Shared by the single-path check and the whole-tool-call check so the
+ * gating ladder (phase flag → initialized → active ticket → rails) exists once.
+ * Returns one of:
+ *   { active: false, reason }                          — nothing to enforce
+ *   { active: true, conflict: true, reason }           — tamper signal, fail closed
+ *   { active: true, conflict: false, ticketId, rails } — rails in force
  */
-export function checkRail({ filePath, tool, root = process.cwd(), env = process.env }) {
-  if (READONLY_TOOLS.includes(tool)) {
-    return { decision: 'allow', reason: `tool "${tool}" is read-only` };
-  }
-  // Everything else that reached here carries a file path: known mutators AND any
-  // unrecognized structured tool are checked (fail closed), so a new mutation tool
-  // name can't slip an edit past the guard.
+export function resolveRailsInForce(root, env) {
   if (env.ADLC_P4_ENFORCEMENT !== '1') {
-    return { decision: 'allow', reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
+    return { active: false, reason: 'enforcement inactive (ADLC_P4_ENFORCEMENT !== "1")' };
   }
   const ticketsPath = join(root, '.adlc', 'tickets.json');
   if (!existsSync(ticketsPath)) {
-    return { decision: 'allow', reason: 'repo not ADLC-initialized (no .adlc/tickets.json)' };
+    return { active: false, reason: 'repo not ADLC-initialized (no .adlc/tickets.json)' };
   }
-
   const active = resolveActiveTicketId(root, env);
   if (active.conflict) {
-    return { decision: 'deny', reason: 'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json)' };
+    return { active: true, conflict: true, reason: 'conflicting active-ticket signal (ADLC_TICKET vs .adlc/current-ticket.json)' };
   }
   if (!active.id) {
-    return { decision: 'allow', reason: 'no active ticket resolved' };
+    return { active: false, reason: 'no active ticket resolved' };
   }
-
   const { tickets } = loadTickets(ticketsPath);
   const ticket = tickets.find((t) => t.id === active.id);
-  const declaredRails = ticket?.rails ?? [];
-  const rails = [...declaredRails, ...TRUST_ROOT_RAILS];
-
-  // Match BOTH the lexical path (normal case) and the symlink-resolved real path
-  // (so a symlink alias whose target is a frozen rail can't slip past a name check).
-  const candidates = new Set([canonicalizePath(filePath, root), resolveRailPath(filePath, root)]);
-  for (const path of candidates) {
-    const hit = rails.find((rail) => rail === path || globMatch(rail, path));
-    if (hit) {
-      return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${active.id})` };
-    }
-  }
-  return { decision: 'allow', reason: 'path is not a frozen rail' };
+  return { active: true, conflict: false, ticketId: active.id, rails: [...(ticket?.rails ?? []), ...TRUST_ROOT_RAILS] };
 }
 
 /**
- * Probe whether the host OpenCode SDK can actually ENFORCE a denial (abort the
- * tool via a thrown error / onFailure:deny). Per integration-plan Phase D, the
- * in-session hook must not be treated as enforcing unless this is true; otherwise
- * it is advisory and preflight should fail closed unless advisory hooks are
- * explicitly allowed. We cannot introspect the SDK contract portably, so we treat
- * an explicit capability flag as the signal and default to "unknown".
+ * Extract every candidate target path from a tool call's args. Tolerant across
+ * the arg shapes the structured mutators use: a single `filePath`/`path`/`file`
+ * string, a `files` array (strings or objects), or an `edits` array of objects.
+ * Returns [] when nothing path-like is found — the caller decides whether that
+ * fails closed (mutating/unknown tool while rails are in force) or is benign.
  */
-export function probeEnforcementCapability(api, env = process.env) {
-  if (env.ADLC_OPENCODE_ENFORCES === '1') return true;
-  if (env.ADLC_OPENCODE_ENFORCES === '0') return false;
-  // The SDK may advertise the capability; absent that, enforcement is unproven.
-  return Boolean(api?.capabilities?.toolExecuteBeforeDeny);
+export function extractTargets(args) {
+  if (!args || typeof args !== 'object') return [];
+  const targets = [];
+  const push = (v) => { if (typeof v === 'string' && v.trim()) targets.push(v); };
+  push(args.filePath); push(args.path); push(args.file);
+  for (const list of [args.files, args.edits]) {
+    if (!Array.isArray(list)) continue;
+    for (const entry of list) {
+      if (typeof entry === 'string') push(entry);
+      else if (entry && typeof entry === 'object') { push(entry.filePath); push(entry.path); push(entry.file); }
+    }
+  }
+  return targets;
+}
+
+function railHit(target, rails, root) {
+  // Match BOTH the lexical path (normal case) and the symlink-resolved real path
+  // (so a symlink alias whose target is a frozen rail can't slip past a name check).
+  const candidates = new Set([canonicalizePath(target, root), resolveRailPath(target, root)]);
+  for (const path of candidates) {
+    const hit = rails.find((rail) => rail === path || globMatch(rail, path));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Decide whether a whole tool call should be allowed or denied. This is the
+ * hook-facing entry point. Pure and fail-safe: returns
+ * { decision: 'allow' | 'deny', reason }.
+ *
+ * Enforcement contract (identical to the sibling hooks):
+ *  - tool names are normalized (lowercased) before classification;
+ *  - known read-only tools and the deliberately-ungated first-party tools
+ *    (bash et al — CI diff gate covers them) are allowed;
+ *  - enforcement is phase-scoped to ADLC_P4_ENFORCEMENT === '1';
+ *  - no-op when the repo is not ADLC-initialized or no active ticket resolves;
+ *  - a conflicting active-ticket signal fails closed;
+ *  - rails in force = active ticket's declared rails PLUS the trust-root rails;
+ *  - EVERY extractable target path is checked; a mutating or UNKNOWN tool whose
+ *    target cannot be extracted is DENIED while rails are in force (fail closed —
+ *    an unrecognized third-party write tool must not slip past on arg shape).
+ */
+export function checkToolCall({ tool, args, root = process.cwd(), env = process.env }) {
+  const name = String(tool ?? '').toLowerCase();
+  if (READONLY_TOOLS.includes(name)) {
+    // Reading a rail is legitimate; allow by name. Residual risk: a hostile
+    // co-installed plugin could register a WRITING tool under a read-only name —
+    // that class is closed by the tool-name-independent file.edited backstop
+    // (opencode-native-flush plan Phase 2.5) and, at commit time, the CI gate.
+    return { decision: 'allow', reason: `tool "${name}" is read-only` };
+  }
+  // Operators can extend the ungated list for benign third-party tools that a
+  // railed build legitimately needs (e.g. ADLC_UNGATED_TOOLS="symbols_index").
+  // An explicit opt-out per tool keeps the DEFAULT fail-closed for unknown
+  // tools (an unrecognized write tool must not slip past on arg shape) without
+  // hard-blocking benign no-target tools forever. Extended entries get the same
+  // spoof guard as the built-in ungated list.
+  const ungated = UNGATED_TOOLS.concat(
+    String(env.ADLC_UNGATED_TOOLS ?? '').split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+  );
+  if (ungated.includes(name)) {
+    // Not gated by design (bash et al fall to the CI diff gate) — BUT a benign
+    // ungated tool never carries a file-path arg, so if this call DOES carry an
+    // extractable target that resolves to a frozen rail, treat the name as
+    // spoofed/abused and deny rather than allow purely by name.
+    const force = resolveRailsInForce(root, env);
+    if (force.active && !force.conflict) {
+      for (const target of extractTargets(args)) {
+        const hit = railHit(target, force.rails, root);
+        if (hit) {
+          return { decision: 'deny', reason: `ungated tool "${name}" carries a frozen-rail target — frozen rail "${hit}" (active ticket ${force.ticketId})` };
+        }
+      }
+    }
+    return { decision: 'allow', reason: `tool "${name}" is not gated in-session (CI diff gate covers it)` };
+  }
+  const force = resolveRailsInForce(root, env);
+  if (!force.active) return { decision: 'allow', reason: force.reason };
+  if (force.conflict) return { decision: 'deny', reason: force.reason };
+
+  const targets = extractTargets(args);
+  if (targets.length === 0) {
+    return {
+      decision: 'deny',
+      reason: `mutating/unknown tool "${name}" carries no extractable target path — failing closed while rails are in force (active ticket ${force.ticketId})`,
+    };
+  }
+  for (const target of targets) {
+    const hit = railHit(target, force.rails, root);
+    if (hit) {
+      return { decision: 'deny', reason: `frozen rail "${hit}" (active ticket ${force.ticketId})` };
+    }
+  }
+  return { decision: 'allow', reason: 'no target is a frozen rail' };
+}
+
+/**
+ * Single-path convenience used by tests and sibling callers: the same contract
+ * as checkToolCall for a tool call whose one target is `filePath`.
+ */
+export function checkRail({ filePath, tool, root = process.cwd(), env = process.env }) {
+  return checkToolCall({ tool, args: { filePath }, root, env });
 }

--- a/plugins/adlc-opencode/test/rails-checker.test.mjs
+++ b/plugins/adlc-opencode/test/rails-checker.test.mjs
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { checkRail, resolveActiveTicketId, probeEnforcementCapability } from '../rails-checker.mjs';
+import { checkRail, checkToolCall, extractTargets, resolveActiveTicketId } from '../rails-checker.mjs';
 import { adlcRailsGuard } from '../index.mjs';
 
 function repo({ tickets, current } = {}) {
@@ -118,48 +118,188 @@ test('g: conflicting ADLC_TICKET vs current-ticket.json → deny (fail closed)',
   assert.equal(resolveActiveTicketId(dir, {}).conflict, false); // sanity: no env, dir gone is fine
 });
 
-// ---- (h) capability gate: advisory vs fail-closed via the REAL handler ----
-test('h: handler throws to enforce when SDK honors deny', async () => {
+// ---- (h) the REAL handler: enforce by default, pinned payload shape ----
+// v1.17.13 contract: hook receives (input={tool,sessionID,callID}, output={args}).
+const IN = (tool) => ({ tool, sessionID: 's_1', callID: 'c_1' });
+const OUT = (args) => ({ args });
+
+/** A fake SDK client capturing toast/log calls, mirroring @opencode-ai/sdk's shape. */
+function fakeClient() {
+  const calls = { toasts: [], logs: [] };
+  return {
+    calls,
+    tui: { showToast: async (req) => { calls.toasts.push(req.body); } },
+    app: { log: async (req) => { calls.logs.push(req.body); } },
+  };
+}
+
+test('h: handler throws to enforce BY DEFAULT (no env opt-in needed)', async () => {
   const dir = repo({ tickets: T1_RAILED });
   const saved = { ...process.env };
   try {
     process.env.ADLC_P4_ENFORCEMENT = '1';
     process.env.ADLC_TICKET = 'T1';
-    process.env.ADLC_OPENCODE_ENFORCES = '1';
     delete process.env.ADLC_ALLOW_ADVISORY_HOOKS;
-    const hooks = await adlcRailsGuard({ worktree: dir });
-    await assert.rejects(() => hooks['tool.execute.before']({ tool: 'edit', args: { filePath: 'test/x.mjs' } }));
+    delete process.env.ADLC_OPENCODE_ENFORCES; // retired flag must not be needed
+    const client = fakeClient();
+    const hooks = await adlcRailsGuard({ worktree: dir, client });
+    await assert.rejects(
+      () => hooks['tool.execute.before'](IN('edit'), OUT({ filePath: 'test/x.mjs' })),
+      /ADLC rails-guard: blocked/,
+    );
+    // The deny is surfaced in the TUI, not only stderr (fire-and-forget → settle).
+    await new Promise((r) => setImmediate(r));
+    assert.equal(client.calls.toasts.length, 1);
+    assert.equal(client.calls.toasts[0].variant, 'error');
+    assert.match(client.calls.toasts[0].message, /blocked edit/);
   } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
 });
 
-test('h: no deny capability + advisory NOT allowed → fail closed (handler throws)', async () => {
+test('h: args read from output.args (input carries only tool/session/call ids)', async () => {
   const dir = repo({ tickets: T1_RAILED });
   const saved = { ...process.env };
   try {
     process.env.ADLC_P4_ENFORCEMENT = '1';
     process.env.ADLC_TICKET = 'T1';
-    process.env.ADLC_OPENCODE_ENFORCES = '0';
     delete process.env.ADLC_ALLOW_ADVISORY_HOOKS;
     const hooks = await adlcRailsGuard({ worktree: dir });
-    await assert.rejects(() => hooks['tool.execute.before']({ tool: 'edit', args: { filePath: 'test/x.mjs' } }));
+    // Same payload but the target is NOT a rail → resolves.
+    await hooks['tool.execute.before'](IN('edit'), OUT({ filePath: 'src/ok.mjs' }));
   } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
 });
 
-test('h: no deny capability + advisory ALLOWED → advisory (handler does not throw)', async () => {
+test('h: explicit advisory downgrade → no throw, warning toast instead', async () => {
   const dir = repo({ tickets: T1_RAILED });
   const saved = { ...process.env };
   try {
     process.env.ADLC_P4_ENFORCEMENT = '1';
     process.env.ADLC_TICKET = 'T1';
-    process.env.ADLC_OPENCODE_ENFORCES = '0';
     process.env.ADLC_ALLOW_ADVISORY_HOOKS = '1';
-    const hooks = await adlcRailsGuard({ worktree: dir });
-    await hooks['tool.execute.before']({ tool: 'edit', args: { filePath: 'test/x.mjs' } }); // resolves, no throw
+    const client = fakeClient();
+    const hooks = await adlcRailsGuard({ worktree: dir, client });
+    await hooks['tool.execute.before'](IN('edit'), OUT({ filePath: 'test/x.mjs' })); // resolves, no throw
+    assert.equal(client.calls.toasts.length, 1);
+    assert.equal(client.calls.toasts[0].variant, 'warning');
+    assert.match(client.calls.toasts[0].message, /ADVISORY/);
   } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
 });
 
-test('h: probeEnforcementCapability honors explicit flags', () => {
-  assert.equal(probeEnforcementCapability(null, { ADLC_OPENCODE_ENFORCES: '1' }), true);
-  assert.equal(probeEnforcementCapability(null, { ADLC_OPENCODE_ENFORCES: '0' }), false);
-  assert.equal(probeEnforcementCapability(null, {}), false);
+test('h: handler survives a client with no tui/app surface (stderr fallback)', async () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const saved = { ...process.env };
+  try {
+    process.env.ADLC_P4_ENFORCEMENT = '1';
+    process.env.ADLC_TICKET = 'T1';
+    delete process.env.ADLC_ALLOW_ADVISORY_HOOKS;
+    const hooks = await adlcRailsGuard({ worktree: dir, client: {} });
+    await assert.rejects(() => hooks['tool.execute.before'](IN('edit'), OUT({ filePath: 'test/x.mjs' })));
+  } finally { Object.assign(process.env, saved); rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (i) fail closed on unextractable / synthetic third-party mutators ----
+test('i: mutating tool with NO extractable path while rails in force → deny', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkToolCall({ tool: 'apply_patch', args: { patch: '*** Begin Patch ...' }, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'deny');
+    assert.match(r.reason, /no extractable target path/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('i: synthetic third-party write tool (unknown name, unknown args) → deny', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkToolCall({ tool: 'write_file', args: { destination: 'test/x.mjs', contents: 'x' }, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'deny'); // unknown arg shape → fail closed
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('i: unextractable path but rails NOT in force → allow (no false deny outside ADLC)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'oc-rails-'));
+  try {
+    const r = checkToolCall({ tool: 'apply_patch', args: { patch: '...' }, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow'); // not ADLC-initialized
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('i: multi-file arg shapes are all checked (edits[] / files[])', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const env = { ...ON, ADLC_TICKET: 'T1' };
+  try {
+    assert.equal(checkToolCall({ tool: 'multiedit', args: { edits: [{ filePath: 'src/ok.mjs' }, { filePath: 'test/x.mjs' }] }, root: dir, env }).decision, 'deny');
+    assert.equal(checkToolCall({ tool: 'multiedit', args: { edits: [{ filePath: 'src/ok.mjs' }] }, root: dir, env }).decision, 'allow');
+    assert.equal(checkToolCall({ tool: 'patch', args: { files: ['test/x.mjs'] }, root: dir, env }).decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('i: extractTargets covers the tolerated shapes', () => {
+  assert.deepEqual(extractTargets({ filePath: 'a' }), ['a']);
+  assert.deepEqual(extractTargets({ path: 'b', files: ['c', { filePath: 'd' }], edits: [{ path: 'e' }] }), ['b', 'c', 'd', 'e']);
+  assert.deepEqual(extractTargets({ patch: 'not a path field' }), []);
+  assert.deepEqual(extractTargets(undefined), []);
+});
+
+// ---- (j) tool-name normalization + ungated first-party tools ----
+test('j: capitalized tool names are normalized (Read allowed, Edit gated)', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const env = { ...ON, ADLC_TICKET: 'T1' };
+  try {
+    assert.equal(checkToolCall({ tool: 'Read', args: { filePath: 'test/x.mjs' }, root: dir, env }).decision, 'allow');
+    assert.equal(checkToolCall({ tool: 'Edit', args: { filePath: 'test/x.mjs' }, root: dir, env }).decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('j: bash is deliberately not gated in-session (CI diff gate covers it)', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkToolCall({ tool: 'bash', args: { command: 'echo x > test/x.mjs' }, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (k) ungated-name spoofing: an "ungated" tool carrying a rail target is denied ----
+// A benign bash/todowrite/question never carries a file-path arg; if one does and it
+// resolves to a frozen rail, allowing purely by name would hand a co-installed
+// plugin a bypass. (Read-only names stay allowed — reading rails is legitimate;
+// that residual class falls to the Phase 2.5 file.edited backstop + CI gate.)
+for (const tool of ['todowrite', 'question', 'bash']) {
+  test(`k: ungated "${tool}" carrying a frozen-rail filePath → deny (spoof guard)`, () => {
+    const dir = repo({ tickets: T1_RAILED });
+    try {
+      const r = checkToolCall({ tool, args: { filePath: 'test/x.mjs' }, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+      assert.equal(r.decision, 'deny');
+      assert.match(r.reason, /ungated tool/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+}
+
+test('k: ungated tool with a NON-rail target stays allowed', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkToolCall({ tool: 'todowrite', args: { filePath: 'src/ok.mjs' }, root: dir, env: { ...ON, ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('k: ungated tool with rail target but enforcement OFF → allow (no false denies)', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  try {
+    const r = checkToolCall({ tool: 'todowrite', args: { filePath: 'test/x.mjs' }, root: dir, env: { ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---- (l) operator escape valve: ADLC_UNGATED_TOOLS extends the ungated list ----
+test('l: unknown no-target tool is denied by default, allowed when operator-ungated', () => {
+  const dir = repo({ tickets: T1_RAILED });
+  const base = { ...ON, ADLC_TICKET: 'T1' };
+  try {
+    // Default: fail closed (an unrecognized write tool must not slip past on arg shape).
+    assert.equal(checkToolCall({ tool: 'symbols_index', args: { query: 'foo' }, root: dir, env: base }).decision, 'deny');
+    // Operator opt-out: explicitly ungated → allowed.
+    const env = { ...base, ADLC_UNGATED_TOOLS: 'symbols_index, other_tool' };
+    assert.equal(checkToolCall({ tool: 'symbols_index', args: { query: 'foo' }, root: dir, env }).decision, 'allow');
+    // The spoof guard still applies to operator-ungated tools.
+    assert.equal(checkToolCall({ tool: 'symbols_index', args: { filePath: 'test/x.mjs' }, root: dir, env }).decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
 });

--- a/plugins/adlc-opencode/test/scaffold.test.mjs
+++ b/plugins/adlc-opencode/test/scaffold.test.mjs
@@ -92,8 +92,49 @@ test('scaffold deploys the real command files into .opencode/commands', () => {
     assert.ok(out.commands.includes('adlc-init.md'), 'adlc-init.md deployed');
     assert.ok(out.commands.includes('adlc-ticket.md'), 'adlc-ticket.md deployed');
     assert.ok(existsSync(join(root, '.opencode', 'commands', 'adlc-spec.md')));
-    assert.ok(existsSync(join(root, '.opencode', 'skill', 'adlc.md')));
+    // Native Agent Skill shape: .opencode/skills/<name>/SKILL.md (plural dir)
+    assert.ok(existsSync(join(root, '.opencode', 'skills', 'adlc', 'SKILL.md')));
+    assert.ok(out.skills.includes('adlc/SKILL.md'));
     assert.equal(out.config.created, true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('scaffold migrates a PRISTINE legacy flat skill deployment (.opencode/skill/adlc.md)', () => {
+  const root = mkroot();
+  try {
+    // Simulate a pre-native deployment: pristine legacy file + an unrelated file.
+    const source = readFileSync(join(PKG, 'skill', 'adlc.md'), 'utf8');
+    mkdirSync(join(root, '.opencode', 'skill'), { recursive: true });
+    writeFileSync(join(root, '.opencode', 'skill', 'adlc.md'), source);
+    writeFileSync(join(root, '.opencode', 'skill', 'users-own.md'), 'keep me');
+    const out = scaffold(root, PKG);
+    assert.ok(existsSync(join(root, '.opencode', 'skills', 'adlc', 'SKILL.md')));
+    assert.ok(!existsSync(join(root, '.opencode', 'skill', 'adlc.md')), 'pristine legacy copy removed');
+    assert.ok(existsSync(join(root, '.opencode', 'skill', 'users-own.md')), 'unrelated file untouched');
+    assert.deepEqual(out.preservedLegacySkills, []);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('scaffold PRESERVES a user-modified legacy skill file (no silent data loss)', () => {
+  const root = mkroot();
+  try {
+    mkdirSync(join(root, '.opencode', 'skill'), { recursive: true });
+    writeFileSync(join(root, '.opencode', 'skill', 'adlc.md'), 'team-customized content');
+    const out = scaffold(root, PKG);
+    assert.ok(existsSync(join(root, '.opencode', 'skills', 'adlc', 'SKILL.md')), 'native skill still deployed');
+    assert.equal(readFileSync(join(root, '.opencode', 'skill', 'adlc.md'), 'utf8'), 'team-customized content');
+    assert.deepEqual(out.preservedLegacySkills, ['.opencode/skill/adlc.md']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('scaffold removes the legacy skill dir when migration leaves it empty', () => {
+  const root = mkroot();
+  try {
+    const source = readFileSync(join(PKG, 'skill', 'adlc.md'), 'utf8');
+    mkdirSync(join(root, '.opencode', 'skill'), { recursive: true });
+    writeFileSync(join(root, '.opencode', 'skill', 'adlc.md'), source);
+    scaffold(root, PKG);
+    assert.ok(!existsSync(join(root, '.opencode', 'skill')), 'empty legacy dir removed');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -76,8 +76,24 @@ else {
   if (/no integration exists yet/.test(doc)) fail("opencode.md still has the 'no integration exists yet' stub banner");
   else ok('stub banner removed');
   if (!/ci\/rails-guard\.yml/.test(doc)) fail('opencode.md does not point at the mandatory CI gate (docs/ci/rails-guard.yml)'); else ok('links the unbypassable CI gate');
-  if (!/advisor/i.test(doc)) fail('opencode.md does not frame the in-session hook as advisory'); else ok('frames in-session hook as advisory');
+  if (!/enforcing by default/i.test(doc)) fail('opencode.md does not document the enforce-by-default posture'); else ok('documents enforce-by-default in-session hook');
+  if (!/ADLC_ALLOW_ADVISORY_HOOKS/.test(doc)) fail('opencode.md does not document the explicit advisory downgrade'); else ok('documents the advisory escape hatch');
 }
+
+// ---- Enforce-by-default wiring (2026-07-05 amendment): no capability probe,
+// client captured, args pinned to output.args, deny fails closed on unextractable ----
+{
+  const idx = read(indexPath);
+  const chk = read(checkerPath);
+  if (/probeEnforcementCapability|ADLC_OPENCODE_ENFORCES/.test(idx + chk)) fail('retired capability probe (ADLC_OPENCODE_ENFORCES) still referenced'); else ok('capability probe retired (enforce by default)');
+  if (!/client/.test(idx) || !/showToast/.test(idx)) fail('index.mjs does not surface denials via the SDK client (tui.showToast)'); else ok('denials surfaced via client.tui.showToast');
+  if (!/output\?\.args/.test(idx)) fail('index.mjs does not read the pinned output.args payload'); else ok('args pinned to output.args (v1.17.13 contract)');
+  if (!/checkToolCall/.test(idx)) fail('index.mjs does not use the whole-tool-call checker (multi-target + fail-closed extraction)'); else ok('uses checkToolCall (multi-target, fail-closed extraction)');
+}
+
+// ---- AC7: live deny proof script present (runs in CI with --require) ----
+if (!existsSync(join(ROOT, 'scripts', 'opencode-live-deny.mjs'))) fail('scripts/opencode-live-deny.mjs missing (AC7 live deny proof)');
+else ok('AC7 live deny proof script present (scripts/opencode-live-deny.mjs)');
 
 // ---- Phase A (T2): command suite + gate-bin dependency mapping ----
 const pkg2 = existsSync(pkgPath) ? JSON.parse(read(pkgPath)) : {};
@@ -133,9 +149,9 @@ for (const c of ['adlc-verify-build.md', 'adlc-prosecute.md', 'adlc-distill.md']
 }
 if (!existsSync(join(PLUGIN, 'lib', 'prosecutor.mjs'))) fail('lib/prosecutor.mjs missing'); else ok('prosecutor registry/helpers present');
 
-// AC7 (live deny proof against the real opencode binary) is the remaining GA gate;
-// it requires a disposable OpenCode install and is tracked in ADR 0004.
-console.log('  note — AC7 live-binary deny proof is a maintainer/CI follow-up (no opencode binary here).');
+// AC7 (live deny proof) runs separately — scripts/opencode-live-deny.mjs drives a
+// real opencode binary; CI runs it with --require. This smoke stays binary-free.
+console.log('  note — AC7 live deny proof: run `node scripts/opencode-live-deny.mjs` (CI: --require).');
 
 if (failures) { console.error(`\nopencode-install-smoke: ${failures} failure(s)`); process.exit(2); }
 console.log('\nopencode-install-smoke: PASS');

--- a/scripts/opencode-live-deny.mjs
+++ b/scripts/opencode-live-deny.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+// opencode-live-deny.mjs — AC7: the LIVE deny proof for the ADLC OpenCode plugin.
+//
+// Drives a REAL `opencode` binary end-to-end and proves the enforcement contract
+// the plugin relies on: a thrown error in `tool.execute.before` aborts the tool
+// call. No real model is needed — a local mock OpenAI-compatible server plays
+// the model and always asks for a `write` to a frozen-rail path.
+//
+// Two runs, both against the same temp project:
+//   1. CONTROL   (enforcement off): the write MUST land. This proves the mock
+//      provider + tool loop actually executes the write — without it, a broken
+//      harness would make the treatment run pass hollowly.
+//   2. TREATMENT (ADLC_P4_ENFORCEMENT=1): the rail file MUST be unchanged AND
+//      the tool result the model receives (captured by the mock server on the
+//      follow-up request) MUST contain the rails-guard deny message.
+//
+// The TUI toast channel is unit-tested (test/rails-checker.test.mjs section h);
+// `opencode run` is headless, so this proof asserts the deny through the two
+// channels headless mode has: the aborted write and the tool-result error text.
+//
+// Exit codes: 0 = pass, 1 = fail, 3 = skipped (no `opencode` binary and not
+// --require). CI passes --require so a missing binary can never silently skip.
+
+import { spawn, spawnSync, execSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PLUGIN_INDEX = join(REPO, 'plugins', 'adlc-opencode', 'index.mjs');
+const REQUIRE = process.argv.includes('--require');
+const KEEP = process.argv.includes('--keep');
+const RAIL_ORIGINAL = 'export const frozen = true;\n';
+
+const log = (m) => console.log(`opencode-live-deny: ${m}`);
+
+/** Dump the newest opencode server log from the isolated home (failure diagnosis). */
+function dumpOpencodeLogs(home) {
+  try {
+    const logDir = join(home, '.local', 'share', 'opencode', 'log');
+    if (!existsSync(logDir)) { console.error('  (no opencode log dir found)'); return; }
+    const newest = readdirSync(logDir)
+      .map((f) => join(logDir, f))
+      .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)[0];
+    if (newest) {
+      console.error(`--- opencode log (${newest}) ---`);
+      const lines = readFileSync(newest, 'utf8').split('\n');
+      console.error(lines.slice(-80).join('\n'));
+    }
+  } catch (e) { console.error(`  (could not read opencode logs: ${e})`); }
+}
+
+let failHome = null;
+const fail = (m) => {
+  console.error(`opencode-live-deny: FAIL — ${m}`);
+  if (failHome) dumpOpencodeLogs(failHome);
+  process.exit(1);
+};
+
+// ---- preconditions ----
+const which = spawnSync('opencode', ['--version'], { encoding: 'utf8' });
+if (which.error || which.status !== 0) {
+  if (REQUIRE) fail('`opencode` binary not found but --require was set (install: npm i -g opencode-ai)');
+  log('SKIP — no `opencode` binary on PATH (run with --require to make this fatal)');
+  process.exit(3);
+}
+log(`opencode ${String(which.stdout || '').trim()}`);
+
+// ---- mock OpenAI-compatible provider ----
+// Every conversation: first call → tool_call write(test/x.mjs), any call whose
+// messages already carry a tool result → plain "done". Tool results are
+// captured per run so the treatment run can assert on the deny text the model saw.
+function sse(res, events) {
+  res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+  for (const e of events) res.write(`data: ${JSON.stringify(e)}\n\n`);
+  res.write('data: [DONE]\n\n');
+  res.end();
+}
+const chunk = (delta, finish = null) => ({
+  id: 'mock-1', object: 'chat.completion.chunk', created: 1, model: 'deny-driver',
+  choices: [{ index: 0, delta, finish_reason: finish }],
+});
+const usage = () => ({
+  id: 'mock-1', object: 'chat.completion.chunk', created: 1, model: 'deny-driver',
+  choices: [], usage: { prompt_tokens: 10, completion_tokens: 10, total_tokens: 20 },
+});
+
+let toolResults = []; // reset per run
+const server = createServer((req, res) => {
+  if (!req.url.endsWith('/chat/completions')) { res.writeHead(404); res.end(); return; }
+  let body = '';
+  req.on('data', (d) => { body += d; });
+  req.on('end', () => {
+    let payload = {};
+    try { payload = JSON.parse(body); } catch { /* keep {} */ }
+    const messages = payload.messages ?? [];
+    const hasTools = Array.isArray(payload.tools) && payload.tools.length > 0;
+    const results = messages.filter((m) => m.role === 'tool');
+    if (KEEP) console.error(`  [mock] request: tools=${hasTools} toolResults=${results.length} roles=${messages.map((m) => m.role).join(',')}`);
+    if (!hasTools) {
+      // Utility calls (e.g. title generation) carry no tools — answer with text.
+      sse(res, [chunk({ role: 'assistant', content: 'live deny proof' }), chunk({}, 'stop'), usage()]);
+      return;
+    }
+    if (results.length === 0) {
+      sse(res, [
+        chunk({ role: 'assistant', tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'write', arguments: JSON.stringify({ filePath: 'test/x.mjs', content: 'OVERWRITTEN BY MODEL\n' }) } }] }),
+        chunk({}, 'tool_calls'),
+        usage(),
+      ]);
+      return;
+    }
+    for (const r of results) toolResults.push(typeof r.content === 'string' ? r.content : JSON.stringify(r.content));
+    sse(res, [chunk({ role: 'assistant', content: 'done' }), chunk({}, 'stop'), usage()]);
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const PORT = server.address().port;
+log(`mock provider listening on 127.0.0.1:${PORT}`);
+
+// ---- temp project + isolated opencode home ----
+const work = mkdtempSync(join(tmpdir(), 'oc-live-deny-'));
+const project = join(work, 'project');
+const home = join(work, 'home');
+mkdirSync(join(project, '.adlc'), { recursive: true });
+mkdirSync(join(project, 'test'), { recursive: true });
+mkdirSync(join(project, '.opencode', 'plugins'), { recursive: true });
+mkdirSync(home, { recursive: true });
+failHome = home;
+
+writeFileSync(join(project, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', rails: ['test/**'] }] }, null, 2));
+writeFileSync(join(project, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T1' }));
+writeFileSync(join(project, 'test', 'x.mjs'), RAIL_ORIGINAL);
+// Load the real plugin from this repo via a shim (project-local plugin file).
+writeFileSync(join(project, '.opencode', 'plugins', 'adlc.js'),
+  `export { adlcRailsGuard } from ${JSON.stringify('file://' + PLUGIN_INDEX)};\n`);
+writeFileSync(join(project, '.opencode', 'opencode.json'), JSON.stringify({
+  $schema: 'https://opencode.ai/config.json',
+  provider: {
+    mock: {
+      npm: '@ai-sdk/openai-compatible',
+      name: 'Mock',
+      options: { baseURL: `http://127.0.0.1:${PORT}/v1`, apiKey: 'mock' },
+      models: { 'deny-driver': { name: 'deny-driver', tool_call: true } },
+    },
+  },
+  permission: { edit: 'allow', bash: 'allow' },
+}, null, 2));
+try {
+  execSync('git init -q && git add -A && git -c user.email=t@t -c user.name=t commit -qm init', { cwd: project });
+} catch { /* git optional — plugin falls back to directory */ }
+
+async function runOpencode(extraEnv) {
+  toolResults = [];
+  // MINIMAL child env — deliberately NOT ...process.env:
+  //  - a stale PWD would make opencode root the session at the CALLER's project
+  //    (observed on 1.16.2), silently testing the wrong directory;
+  //  - inherited *_API_KEY vars would register real providers next to the mock.
+  // ASYNC spawn, not spawnSync: this script IS the mock provider's event loop —
+  // a sync wait would block the HTTP server and hang every model stream.
+  const child = spawn('opencode', ['run', '-m', 'mock/deny-driver', 'Overwrite test/x.mjs please'], {
+    cwd: project,
+    env: {
+      PATH: process.env.PATH,
+      TERM: process.env.TERM ?? 'xterm-256color',
+      LANG: process.env.LANG ?? 'C.UTF-8',
+      NO_COLOR: '1',
+      PWD: project,
+      HOME: home,
+      XDG_DATA_HOME: join(home, '.local', 'share'),
+      XDG_CONFIG_HOME: join(home, '.config'),
+      XDG_CACHE_HOME: join(home, '.cache'),
+      XDG_STATE_HOME: join(home, '.local', 'state'),
+      OPENCODE_DISABLE_AUTOUPDATE: '1',
+      ...extraEnv,
+    },
+  });
+  child.stdin.end(); // signal EOF — `opencode run` waits on piped stdin otherwise
+  let stdout = '', stderr = '';
+  child.stdout.on('data', (d) => { stdout += d; });
+  child.stderr.on('data', (d) => { stderr += d; });
+  const started = Date.now();
+  let timedOut = false;
+  const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, 180_000);
+  const status = await new Promise((resolveExit) => {
+    child.on('close', (code) => { clearTimeout(timer); resolveExit(code); });
+    child.on('error', () => { clearTimeout(timer); resolveExit(1); });
+  });
+  return { status, timedOut, seconds: Math.round((Date.now() - started) / 1000), stdout, stderr, toolResults: [...toolResults] };
+}
+
+let exitCode = 1;
+try {
+  // ---- run 1: CONTROL (enforcement off) — the write must actually land ----
+  log('control run (enforcement off)…');
+  const control = await runOpencode({ ADLC_P4_ENFORCEMENT: '0' });
+  const afterControl = readFileSync(join(project, 'test', 'x.mjs'), 'utf8');
+  if (afterControl === RAIL_ORIGINAL) {
+    fail(`CONTROL run did not write the file — the harness never executed the write, so the deny proof would be hollow.\nexit=${control.status} timedOut=${control.timedOut} after ${control.seconds}s\nstdout:\n${control.stdout}\nstderr:\n${control.stderr}`);
+  }
+  log('control: write landed (harness genuinely executes the tool)');
+
+  // restore the rail file for the treatment run
+  writeFileSync(join(project, 'test', 'x.mjs'), RAIL_ORIGINAL);
+
+  // ---- run 2: TREATMENT (enforcement on) — the write must be BLOCKED ----
+  log('treatment run (ADLC_P4_ENFORCEMENT=1)…');
+  const treatment = await runOpencode({ ADLC_P4_ENFORCEMENT: '1' });
+  const afterTreatment = readFileSync(join(project, 'test', 'x.mjs'), 'utf8');
+  const sawDeny = treatment.toolResults.some((t) => t.includes('ADLC rails-guard: blocked')) ||
+    `${treatment.stdout}\n${treatment.stderr}`.includes('ADLC rails-guard: blocked');
+
+  if (afterTreatment !== RAIL_ORIGINAL) {
+    fail(`TREATMENT run WROTE to the frozen rail — tool.execute.before throw did NOT abort the tool.\nstdout:\n${treatment.stdout}\nstderr:\n${treatment.stderr}`);
+  }
+  if (!sawDeny) {
+    fail(`rail file unchanged but no rails-guard deny message reached the model or the output — cannot attribute the block to the plugin.\ntool results: ${JSON.stringify(treatment.toolResults, null, 2)}\nstdout:\n${treatment.stdout}\nstderr:\n${treatment.stderr}`);
+  }
+  log('treatment: write blocked AND the deny reason reached the model');
+  log('PASS — live deny proof holds (AC7)');
+  exitCode = 0;
+} finally {
+  server.close();
+  if (KEEP) log(`--keep: temp project retained at ${work}`);
+  else rmSync(work, { recursive: true, force: true });
+}
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

Phase 1 of the **opencode-native-flush** plan (`docs/specs/opencode-native-flush.md` — included in this PR), making the ADLC OpenCode integration genuinely enforcing and native. Grounded in a three-way review: a deep audit of the existing plugin, a capability benchmark across all six harness integrations, and a verified inventory of OpenCode's extension surface (`@opencode-ai/plugin` v1.17.13).

### Enforcement correctness
- **Enforce by default**: a thrown `tool.execute.before` error is documented host behavior that aborts the tool call, so the (structurally unreachable) capability probe and `ADLC_OPENCODE_ENFORCES` flag are retired. `ADLC_ALLOW_ADVISORY_HOOKS=1` remains the only explicit downgrade.
- **SDK client captured**; denials/advisory warnings surface via `client.tui.showToast` + `client.app.log` with stderr fallback — the advisory layer is no longer invisible in the TUI.
- **Args pinned to `output.args`** (v1.17.13 contract; `input` carries only tool/session/call ids), with a tolerance fallback.
- **Fail closed on unextractable targets**: `patch`/`multiedit`/`apply_patch` or any unknown tool whose target path can't be extracted is denied while rails are in force — closing a silent bypass where such writes were allowed with zero signal. Multi-shape extraction (`filePath`/`path`/`files[]`/`edits[]`), tool-name normalization.
- **Ungated-name spoof guard**: an ungated tool (`bash`/`todowrite`/`question`…) whose args carry a frozen-rail target is denied rather than allowed by name. `ADLC_UNGATED_TOOLS` gives operators a per-tool opt-out (still spoof-guarded).

### Live deny proof (ADR 0004 AC7 — resolved)
`scripts/opencode-live-deny.mjs` drives a **real `opencode` binary** with a mock OpenAI-compatible provider: the control run proves the write genuinely executes; the treatment run proves the plugin aborts the write **and** the deny reason reaches the model. Validated on opencode **1.16.2 and 1.17.13**; wired into the **required CI test job** (pinned `opencode-ai@1.17.13`, folded into `test` per the private-repo required-check caveat).

### Native layout + hygiene
- Scaffold deploys **native Agent Skills** (`.opencode/skills/adlc/SKILL.md`) with content-aware legacy migration (never deletes a user-modified file; reports `preservedLegacySkills`).
- Fixed dangling `/adlc-rail-write` reference; manual-install fallback now includes agents.
- Docs truth pass: ADR 0004 amendment, `opencode.md` enforce-by-default posture, honest note that the keyless bridge is tested-but-unwired (Phase 4), peer dep `>=1.17.13`, smoke script updated.

## Review / prosecution
- Plan adversarially reviewed twice (GPT-5, `--verify`): 2 design findings folded in (tool-name-independent backstop → Phase 2.5; live deny proof → required CI gate).
- Implementation prosecuted twice (GPT-5, `--verify`), both gate-APPROVE; round-1 findings fixed (spoof guard, CI pin, migration safety). Round-2's "allow unknown no-target tools" was rejected as contradicting the mandated fail-closed posture; resolved with the `ADLC_UNGATED_TOOLS` escape valve instead.

## Test plan
- [x] 87/87 plugin unit tests (`node --test plugins/adlc-opencode/test/*.test.mjs`)
- [x] `node scripts/opencode-install-smoke.mjs .` → PASS
- [x] `node scripts/opencode-live-deny.mjs` → PASS on opencode 1.16.2 and 1.17.13
- [x] Full `npm test` → exit 0 (re-verified after rebase onto 39b1eab)
- [ ] CI: live deny proof runs on the node-20 leg via pinned `opencode-ai@1.17.13`

Follow-on phases (2–5: permission.ask + shell gating + watcher backstop, TUI module + context injection, keyless-bridge wiring + deterministic P5 runner, adlc-maintain + npm publish) are specced in `docs/specs/opencode-native-flush.md`.