### PR TITLE
docs(review-lenses): text-scanning-gate boundary lens (P7 distill)

### DIFF
--- a/docs/review-lenses/text-scanning-gates.md
+++ b/docs/review-lenses/text-scanning-gates.md
@@ -1,0 +1,68 @@
+# Review lens — text-scanning gates (operative vs inert boundary)
+
+A **review lens** is a set of questions a reviewer (or a P5 prosecutor) asks of a
+change. This one is distilled by [`lesson-foundry`](../tools/lesson-foundry.md)
+(P7) from three same-class defects, and graduated out of the local
+`.adlc/lessons/` staging area to here so it is versioned and shared.
+
+Apply it in **P1** (spec) and **P5** (prosecution) to **any gate that scans
+source text for "operative" markers** and exempts inert prose/display context —
+e.g. `rails-guard`'s suppression scan, secret scanners, banned-API / bare-command
+guards, TODO/FIXME gates, or license-header checks.
+
+## Where it came from
+
+The `rails-guard` `.mdx` suppression scan (PR #103) exempts markers that appear in
+Markdown *code contexts* (inline spans, fenced blocks) because they render as
+inert text. A three-round adversarial prosecution found **three different bypasses
+of one root failure** — the detector *approximated* the operative-vs-inert
+boundary instead of deriving it authoritatively:
+
+1. **Naive delimiter toggle desynced from the real grammar.** A `` ``` `` line
+   inside a ```` ```` ```` block flipped the fence state, so operative code after
+   the *real* closer was judged inert. Fix: implement the actual CommonMark rule —
+   a closer must match the opener's fence character **and be at least as long**.
+2. **Blanket-stripping a delimiter pair ate operative code.** `stripInlineCode`
+   removed everything between back-ticks, including an operative `${…}` template
+   interpolation. Fix: preserve regions that are operative in the target language
+   (interpolations, JSX expressions).
+3. **A regex anchor ran before line endings were normalized.** A CRLF closer
+   (`` ```\r ``) left a `\r` that defeated `$`, so the fence never "closed" and
+   operative lines were judged inert. Fix: normalize `\r\n` / lone `\r` / BOM
+   *before* anchoring.
+
+Each of these shipped past initial unit tests and was only caught by adversarial
+prosecution — which is why they belong in a lens, not just a changelog.
+
+## The lens
+
+- [ ] **Authoritative source, not an approximation.** Does the detector judge
+      operative-vs-inert from the *same artifact the compiler/runtime consumes*
+      (the full file), rather than a diff window, a single line, or a summary? A
+      per-line or per-hunk view cannot see enclosing context and *will* desync.
+- [ ] **Real grammar, not a lookalike toggle.** If it parses a structured format
+      (Markdown fences, quotes, comments, heredocs, brackets), does it implement
+      the actual closing/escaping rules, rather than flip state on any delimiter
+      that *looks* like a boundary?
+- [ ] **Normalize before anchoring.** Are line endings (`\r\n`, lone `\r`), BOM,
+      and surrounding whitespace normalized *before* regex anchors (`^`/`$`) run?
+- [ ] **Strip only provably-inert regions.** When exempting "prose" (inline code,
+      fenced blocks, comments), does the exemption exclude constructs that are
+      *operative* in the target language (template interpolations, JSX
+      expressions, here-doc substitutions)? Never blanket-strip a delimiter pair.
+- [ ] **Fail closed on every ambiguity.** When context cannot be resolved
+      (unreadable file, pathological input, an unparseable region), does the gate
+      *scan* the line — risking a false positive — rather than *skip* it, which
+      risks a silent bypass?
+- [ ] **Adversarially prosecuted, with evasions as regression tests.** Was the
+      exemption logic attacked by a skeptic trying to smuggle an operative marker
+      through each inert channel, and was every demonstrated evasion turned into a
+      permanent regression test?
+
+## Related
+
+- [`lesson-foundry`](../tools/lesson-foundry.md) — mines repeated findings into
+  defenses like this lens (P7).
+- [`rejection-mining`](../tools/rejection-mining.md) — mines human PR objections
+  into review lenses (P7).
+- [`prosecute`](../tools/prosecute.md) — the P5 gate this lens feeds.

--- a/docs/toolkit.md
+++ b/docs/toolkit.md
@@ -62,7 +62,10 @@ statement.
    blind spots (see [ADR-0007](./adr/0007-multimodel-adversarial-review.md)). Use
    [`adlc review-calibration`](./tools/review-calibration.md) to decide, on evidence, when one model's recall is too low to trust alone.
 7. After review, use [`adlc lesson-foundry`](./tools/lesson-foundry.md) and [`adlc rejection-mining`](./tools/rejection-mining.md) to convert repeated review
-   findings into deterministic lint checks, skills, or spec-gap templates.
+   findings into deterministic lint checks, skills, or spec-gap templates. Lenses
+   that generalize past one site graduate out of the local `.adlc/lessons/` staging
+   area into [`docs/review-lenses/`](./review-lenses/) — e.g.
+   [text-scanning gates](./review-lenses/text-scanning-gates.md).
 8. On a schedule or after model changes, use [`adlc model-ratchet`](./tools/model-ratchet.md), [`adlc review-calibration`](./tools/review-calibration.md),
    [`adlc skill-rot`](./tools/skill-rot.md), [`adlc ticket-prune`](./tools/ticket-prune.md), and [`adlc gate-fuzzing`](./tools/gate-fuzzing.md) to re-check assumptions that can decay over time.
 


### PR DESCRIPTION
## What

Graduates a `lesson-foundry`-distilled **review lens** out of the local,
gitignored `.adlc/lessons/` staging area into a versioned, team-facing home:
`docs/review-lenses/text-scanning-gates.md`. Linked from the P7 step in
`docs/toolkit.md`.

## Why

Distilled (P7) from the `rails-guard` `.mdx` suppression-scan hardening in #103.
A three-round adversarial prosecution found **three bypasses of one root
failure** — the detector *approximated* the operative-vs-inert boundary instead
of deriving it authoritatively:

1. naive nested-fence toggle desynced from real CommonMark grammar;
2. `stripInlineCode` blanket-stripped an operative `${…}` template interpolation;
3. a CRLF closer defeated a `$`-anchored regex.

The lens turns that class into six questions to ask in **P1** (spec) and **P5**
(prosecution) of *any* gate that scans source text for operative markers
(suppressions, secrets, banned APIs, bare-command guards, license headers):
authoritative full-file source, real grammar, normalize line endings before
anchoring, strip only provably-inert regions, fail closed on ambiguity, and turn
demonstrated evasions into regression tests.

## Notes

- Establishes the convention: `.adlc/lessons/` = local staging output;
  `docs/review-lenses/` = committed, generalized lenses.
- Docs-only (`.md`); no code change. `rails-guard` gate passes.