### PR TITLE
feat(pi): Phase 3 native flush — /adlc command surface, live widget, message renderers (T24+T25)

### DIFF
--- a/plugins/adlc-pi/lib/commands.mjs
+++ b/plugins/adlc-pi/lib/commands.mjs
@@ -1,0 +1,254 @@
+// commands.mjs — the interactive `/adlc-*` command trio for pi (spec Phase 3.1).
+//
+// These are registerCommand handlers (signature `(args, ctx)` per the pi
+// v0.80.3 contract), NOT agent tools. That distinction is load-bearing: the
+// rail trust-root freeze governs the AGENT acting through tool_call events —
+// it does not govern a human driving these command handlers, so /adlc-ticket
+// may write `.adlc/current-ticket.json` directly (the privileged path the spec
+// calls out) while an agent write to the same file is denied by the gate.
+//
+// Every dialog result is checked for `undefined`/false so the commands degrade
+// cleanly in non-TUI modes (rpc/json/print): pi's dialogs resolve undefined
+// there (ctx.hasUI === false in print/json), and a command must notify + return
+// rather than hang or throw.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import { loadTickets, sha256 } from '@adlc/core';
+import { ensureGitignore, ensureFormatterIgnores } from '@adlc/core';
+import { record } from '@adlc/gate-manifest/lib/record.mjs';
+import { recordGateEvent } from './evidence.mjs';
+
+/**
+ * Register the interactive command trio on a pi ExtensionAPI.
+ *
+ * @param {object} pi - the ExtensionAPI (registerCommand, exec, appendEntry)
+ * @param {object} deps
+ * @param {object} deps.env - environment (ADLC_TICKETS override)
+ * @param {(cwd: string) => object} deps.reload - the extension's reload path;
+ *   called after activation so the NEXT tool_call gates the new ticket without
+ *   waiting for a turn boundary (spec AC2).
+ * @param {() => {ticketId: string|null}} deps.getActive - current active ticket.
+ * @param {() => string} deps.getCwd - the extension's live cwd, for the
+ *   completion callback (which pi calls without a ctx).
+ */
+export function registerCommands(pi, { env = process.env, reload, getActive, getCwd } = {}) {
+  const ticketsPathFor = (cwd) => env.ADLC_TICKETS ?? join(cwd, '.adlc', 'tickets.json');
+  const ticketLabel = (t) => (t.title ? `${t.id} — ${t.title}` : t.id);
+
+  // =====================================================================
+  // /adlc-init — scaffold .adlc/ + hygiene ignores. Idempotent; never clobbers.
+  // =====================================================================
+  pi.registerCommand('adlc-init', {
+    description: 'Bootstrap the ADLC runtime (.adlc/) and hygiene ignores in this repo',
+    async handler(_args, ctx) {
+      const root = ctx.cwd;
+
+      // Never scaffold a workspace whose gates cannot run: a missing/failing
+      // `adlc` CLI stops here with the install command (spec AC5). pi.exec may
+      // reject (ENOENT) or resolve with a non-zero code — treat either as
+      // missing.
+      let cliOk = true;
+      try {
+        const res = await pi.exec('adlc', ['--version']);
+        if (res && typeof res.code === 'number' && res.code !== 0) cliOk = false;
+      } catch {
+        cliOk = false;
+      }
+      if (!cliOk) {
+        ctx.ui.notify('ADLC CLI not found. Install it first: npm install -g @adlc/cli', 'error');
+        return;
+      }
+
+      const adlcDir = join(root, '.adlc');
+      const ticketsPath = join(adlcDir, 'tickets.json');
+      let ticketsCreated = false;
+      try {
+        mkdirSync(adlcDir, { recursive: true });
+        if (!existsSync(ticketsPath)) {
+          writeFileSync(ticketsPath, JSON.stringify({ tickets: [] }, null, 2) + '\n');
+          ticketsCreated = true;
+        }
+      } catch (err) {
+        ctx.ui.notify(`ADLC init failed to scaffold .adlc/: ${err.message}`, 'error');
+        return;
+      }
+
+      // Track the contract, ignore the runtime; exclude .adlc/ from whatever
+      // formatter/linter the repo already uses. Both core helpers are
+      // idempotent — a second run changes nothing (spec AC5).
+      let gi;
+      let fmt;
+      try {
+        gi = ensureGitignore(root);
+        fmt = ensureFormatterIgnores(root);
+      } catch (err) {
+        ctx.ui.notify(`ADLC init: hygiene step failed: ${err.message}`, 'error');
+        return;
+      }
+
+      const giMsg = gi.changed
+        ? `.gitignore updated (${gi.added.length ? gi.added.join(', ') : 'ordering fix'})`
+        : '.gitignore already correct';
+      const fmtChanged = Object.entries(fmt)
+        .filter(([, r]) => r && r.changed)
+        .map(([tool]) => tool);
+      const fmtMsg = fmtChanged.length
+        ? `formatter/linter ignores updated: ${fmtChanged.join(', ')}`
+        : 'formatter/linter ignores unchanged';
+
+      ctx.ui.notify(
+        `ADLC init complete. ` +
+          `${ticketsCreated ? 'Created .adlc/tickets.json' : '.adlc/tickets.json already present'}. ` +
+          `${giMsg}. ${fmtMsg}.`,
+        'info'
+      );
+    },
+  });
+
+  // =====================================================================
+  // /adlc-ticket [id] — activate a ticket (picker or by id) + reload.
+  // =====================================================================
+  pi.registerCommand('adlc-ticket', {
+    description: 'Activate an ADLC ticket (picker or by id) and reload enforcement',
+    // Completes ticket ids. pi invokes this WITHOUT a ctx, so cwd comes from
+    // the extension's live accessor; any failure degrades to no completions.
+    getArgumentCompletions(prefix) {
+      try {
+        const cwd = typeof getCwd === 'function' ? getCwd() : process.cwd();
+        const { tickets } = loadTickets(ticketsPathFor(cwd));
+        const items = tickets
+          .filter((t) => typeof t.id === 'string' && t.id.startsWith(prefix ?? ''))
+          .map((t) => ({ value: t.id, label: ticketLabel(t) }));
+        return items.length > 0 ? items : null;
+      } catch {
+        return null;
+      }
+    },
+    async handler(args, ctx) {
+      const root = ctx.cwd;
+      const { tickets, errors } = loadTickets(ticketsPathFor(root));
+      // Only hard-fail when there is nothing selectable: an unreadable/missing
+      // file yields empty tickets + errors; soft per-ticket validation warnings
+      // on an otherwise-populated file must not block activating a valid id.
+      if (tickets.length === 0) {
+        const why = errors && errors.length ? errors[0] : 'no tickets found';
+        ctx.ui.notify(`ADLC: ${why}. Run /adlc-init or author a ticket first.`, errors && errors.length ? 'error' : 'warning');
+        return;
+      }
+
+      const requested = (args ?? '').trim();
+      let chosenId;
+      if (requested) {
+        const match = tickets.find((t) => t.id === requested);
+        if (!match) {
+          ctx.ui.notify(`ADLC: ticket "${requested}" not found in the tickets file.`, 'error');
+          return;
+        }
+        chosenId = match.id;
+      } else {
+        // No id → interactive picker. In non-TUI modes select() resolves
+        // undefined, so require an explicit id there instead of prompting.
+        if (!ctx.hasUI) {
+          ctx.ui.notify('ADLC: /adlc-ticket needs a ticket id in non-interactive mode (e.g. /adlc-ticket T1).', 'warning');
+          return;
+        }
+        const options = tickets.map(ticketLabel);
+        const picked = await ctx.ui.select('Select the active ADLC ticket', options);
+        if (picked === undefined) {
+          // Cancelled / timed out — leave state untouched (spec AC3).
+          ctx.ui.notify('ADLC: ticket selection cancelled — active ticket unchanged.', 'info');
+          return;
+        }
+        const idx = options.indexOf(picked);
+        if (idx < 0) {
+          ctx.ui.notify('ADLC: selection did not match a known ticket — active ticket unchanged.', 'warning');
+          return;
+        }
+        chosenId = tickets[idx].id;
+      }
+
+      // Activate: write the pointer DIRECTLY. This is the human acting through
+      // a command handler, not the agent through a tool — the trust-root freeze
+      // governs agent tool_call events, not this privileged path.
+      const currentPath = join(root, '.adlc', 'current-ticket.json');
+      try {
+        mkdirSync(join(root, '.adlc'), { recursive: true });
+        writeFileSync(currentPath, JSON.stringify({ id: chosenId }, null, 2) + '\n');
+      } catch (err) {
+        ctx.ui.notify(`ADLC: failed to write current-ticket.json: ${err.message}`, 'error');
+        return;
+      }
+
+      // Evidence rail (best-effort; never blocks the switch).
+      recordGateEvent({ pi, ctx, root, ticketId: chosenId, type: 'ticket-switch', detail: { to: chosenId } });
+
+      // Reload NOW so the very next tool_call gates against the new ticket —
+      // no turn boundary needed (spec AC2).
+      if (typeof reload === 'function') reload(root);
+      ctx.ui.notify(`ADLC: active ticket set to ${chosenId}. Enforcement reloaded.`, 'info');
+    },
+  });
+
+  // =====================================================================
+  // /adlc-approve-spec <spec-path> — the G1 human gate as a real confirm modal.
+  // =====================================================================
+  pi.registerCommand('adlc-approve-spec', {
+    description: 'Record human spec approval (P1 Gate 1) as a confirm modal',
+    async handler(args, ctx) {
+      const root = ctx.cwd;
+      const specArg = (args ?? '').trim();
+      if (!specArg) {
+        ctx.ui.notify('ADLC: /adlc-approve-spec needs a spec path (e.g. /adlc-approve-spec .adlc/specs/foo.md).', 'error');
+        return;
+      }
+      const specPath = isAbsolute(specArg) ? specArg : join(root, specArg);
+
+      // Missing/unreadable spec → error notify, NO dialog (spec AC4).
+      let bytes;
+      try {
+        bytes = readFileSync(specPath);
+      } catch (err) {
+        ctx.ui.notify(`ADLC: cannot read spec "${specArg}": ${err.message}. Nothing recorded.`, 'error');
+        return;
+      }
+
+      // G1 is a human decision — the model cannot self-approve, and there is no
+      // dialog to prompt with in non-TUI modes. Record nothing and say so.
+      if (!ctx.hasUI) {
+        ctx.ui.notify('ADLC: spec approval requires interactive confirmation (G1 is a human gate) — nothing recorded.', 'warning');
+        return;
+      }
+
+      const approved = await ctx.ui.confirm(
+        'Approve spec (P1 G1)',
+        `Record your human approval of "${specArg}"? This is the G1 gate — the model cannot self-approve.`
+      );
+      if (!approved) {
+        // Declined or timed out (confirm resolves false) → record nothing.
+        ctx.ui.notify('ADLC: spec approval declined — nothing recorded.', 'info');
+        return;
+      }
+
+      const hash = sha256(bytes);
+      const active = typeof getActive === 'function' ? getActive() : null;
+      const ticketId = active && active.ticketId ? active.ticketId : undefined;
+      try {
+        // Chain-valid manifest entry naming the spec + its sha256 (spec AC4).
+        record({
+          gate: 'spec-approval',
+          ticket: ticketId,
+          rawData: JSON.stringify({ spec: specArg, sha256: hash, verdict: 'approved' }),
+          dir: join(root, '.adlc'),
+        });
+      } catch (err) {
+        ctx.ui.notify(`ADLC: failed to record spec approval: ${err.message}`, 'error');
+        return;
+      }
+      ctx.ui.notify(
+        `ADLC: recorded spec approval for "${specArg}" (sha256 ${hash.slice(0, 12)}…)${ticketId ? ' on ticket ' + ticketId : ''}.`,
+        'info'
+      );
+    },
+  });
+}

--- a/plugins/adlc-pi/lib/extension.mjs
+++ b/plugins/adlc-pi/lib/extension.mjs
@@ -432,7 +432,9 @@ export function createExtension({ env = process.env } = {}) {
 
     pi.registerCommand('ticket', {
       description: 'Display the active ADLC ticket and scope constraints',
-      async handler(ctx) {
+      // pi command handlers receive (args, ctx) — the ctx-first shape was a
+      // latent crash on live /ticket invocations (caught in T24 review).
+      async handler(_args, ctx) {
         reload(ctx.cwd);
 
         if (!active.ticketId) {

--- a/plugins/adlc-pi/lib/extension.mjs
+++ b/plugins/adlc-pi/lib/extension.mjs
@@ -33,6 +33,7 @@ import { parseAddedLines } from '@adlc/rails-guard/lib/suppressions.mjs';
 import { appendToSystemPrompt, buildTicketDoctrine, buildErrorDoctrine } from './doctrine.mjs';
 import { createFitnessTracker, checkBuildGate } from './build-gate.mjs';
 import { createFlailTracker } from './flail.mjs';
+import { registerCommands } from './commands.mjs';
 
 // Bound the pending-snapshot map: a blocked call never gets a tool_result, so
 // stale entries are evicted oldest-first well past any realistic concurrency.
@@ -450,6 +451,16 @@ export function createExtension({ env = process.env } = {}) {
           'info'
         );
       },
+    });
+
+    // Interactive `/adlc-*` command surface (spec Phase 3.1). Handlers act on
+    // behalf of the human, so /adlc-ticket writes the trust-root pointer
+    // directly and calls reload() so the next tool_call gates the new ticket.
+    registerCommands(pi, {
+      env,
+      reload,
+      getActive: () => active,
+      getCwd: () => activeCwd,
     });
 
     // Exposed for tests only (not part of the pi extension contract).

--- a/plugins/adlc-pi/lib/extension.mjs
+++ b/plugins/adlc-pi/lib/extension.mjs
@@ -34,6 +34,8 @@ import { appendToSystemPrompt, buildTicketDoctrine, buildErrorDoctrine } from '.
 import { createFitnessTracker, checkBuildGate } from './build-gate.mjs';
 import { createFlailTracker } from './flail.mjs';
 import { registerCommands } from './commands.mjs';
+import { renderWidgetLines } from './widget.mjs';
+import { createRenderers } from './renderers.mjs';
 
 // Bound the pending-snapshot map: a blocked call never gets a tool_result, so
 // stale entries are evicted oldest-first well past any realistic concurrency.
@@ -48,12 +50,83 @@ export function createExtension({ env = process.env } = {}) {
     const fitness = createFitnessTracker();
     const flail = createFlailTracker();
     const unvettedSeen = new Set();
+    // Most recent gate event, summarized for the live widget (line 3).
+    let lastGateEvent = null;
+    // TUI-only message renderers, isolated so this module stays loadable under
+    // `node --test` (no top-level @earendil-works/pi-tui import).
+    const renderers = createRenderers();
 
     // ctx.getContextUsage() is TUI/SDK-provided; degrade to null when absent
     // (a missing signal must not crash the gate — compaction still covers it).
     function safeUsage(ctx) {
       try { return typeof ctx?.getContextUsage === 'function' ? ctx.getContextUsage() : null; }
       catch { return null; }
+    }
+
+    // =====================================================================
+    // Live widget + gate-notice choke point (spec 3.2 / 3.3)
+    // =====================================================================
+
+    // Refresh the above-editor widget from live state. Shown ONLY while a
+    // ticket resolves; cleared with undefined otherwise. All ui access is
+    // guarded (setWidget is absent on older/fake ctx) — the widget is cosmetic
+    // and must never break a gate (AC4).
+    function refreshWidget(ctx) {
+      const setWidget = ctx?.ui?.setWidget;
+      if (typeof setWidget !== 'function') return;
+      try {
+        if (!active.ticketId) {
+          setWidget.call(ctx.ui, 'adlc', undefined);
+          return;
+        }
+        const usage = safeUsage(ctx);
+        const lines = renderWidgetLines({
+          ticketId: active.ticketId,
+          ticketTitle: active.ticket?.title ?? null,
+          enforcement: active.ticket ? 'active' : 'error',
+          contextPercent: usage?.percent ?? null,
+          degraded: fitness.isCompacted(),
+          lastGateEvent,
+        });
+        setWidget.call(ctx.ui, 'adlc', lines.length ? lines : undefined);
+      } catch {
+        // A widget failure must never affect enforcement.
+      }
+    }
+
+    // A short path-ish token for the widget's "last gate" line and the notice.
+    function gateSummary(detail) {
+      return detail?.path || detail?.paths?.[0] || detail?.tool || '';
+    }
+
+    // Deny/revert events render as structured 'adlc-gate-notice' messages in
+    // addition to the per-site ctx.ui.notify (which stays the fallback).
+    function shouldNoticeGate(type) {
+      return /-deny$|-revert$/.test(type);
+    }
+
+    function emitGateNotice(type, detail) {
+      try {
+        const summary = gateSummary(detail);
+        pi.sendMessage({
+          customType: 'adlc-gate-notice',
+          content: `ADLC ${type}${summary ? `: ${summary}` : ''}${detail?.reason ? ` — ${detail.reason}` : ''}`,
+          display: true,
+          details: { type, ticketId: active.ticketId, ...detail },
+        });
+      } catch {
+        // Structured channel is best-effort; ctx.ui.notify already fired.
+      }
+    }
+
+    // ONE choke point for every gate event: persist evidence, update the live
+    // widget, and (for denies/reverts) emit the structured TUI notice. Call
+    // sites pass only { ctx, type, detail }; pi/root/ticketId are filled here.
+    function noteGate({ ctx, type, detail = {} }) {
+      lastGateEvent = { type, summary: gateSummary(detail) };
+      recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type, detail });
+      refreshWidget(ctx);
+      if (shouldNoticeGate(type)) emitGateNotice(type, detail);
     }
 
     function steerFlailAdvisories(filePath, ctx) {
@@ -105,6 +178,16 @@ export function createExtension({ env = process.env } = {}) {
       return stdout;
     }
 
+    // Structured renderers for our custom message types (spec 3.3). Registered
+    // at load; guarded because registerMessageRenderer is absent on fake/older
+    // pi (the notify fallback still covers those).
+    try {
+      pi.registerMessageRenderer?.('adlc-flail-advisory', renderers.flailAdvisory);
+      pi.registerMessageRenderer?.('adlc-gate-notice', renderers.gateNotice);
+    } catch {
+      // Renderer registration is cosmetic — never fail extension load.
+    }
+
     // =====================================================================
     // Lifecycle
     // =====================================================================
@@ -114,6 +197,8 @@ export function createExtension({ env = process.env } = {}) {
       fitness.reset();
       flail.reset();
       unvettedSeen.clear();
+      lastGateEvent = null;
+      refreshWidget(ctx);
       if (!active.ticketId) return;
       if (active.error) {
         ctx.ui.setStatus('adlc-ticket', `🎟️ Ticket: \x1b[31m${active.ticketId} (ERROR)\x1b[0m`);
@@ -126,12 +211,17 @@ export function createExtension({ env = process.env } = {}) {
 
     pi.on('turn_start', async (_event, ctx) => {
       maybeReload(ctx?.cwd);
+      // Picks up a mid-session ticket switch AND clears the widget with
+      // undefined once a ticket deactivates (AC2).
+      refreshWidget(ctx);
     });
 
     // A threshold/overflow compaction marks the session context-degraded for
     // the build gate; a manual /compact does not.
-    pi.on('session_compact', async (event, _ctx) => {
+    pi.on('session_compact', async (event, ctx) => {
       fitness.markCompaction(event.reason);
+      // Surface the degraded flag in the widget immediately.
+      refreshWidget(ctx);
     });
 
     // Append (never replace) the ADLC doctrine to the turn's system prompt.
@@ -172,7 +262,7 @@ export function createExtension({ env = process.env } = {}) {
         const verdict = checkStructuredWrite(filePath, active.ticket, activeCwd);
         if (verdict.decision === 'deny') {
           ctx.ui.notify(`Blocked ${event.toolName}: ${verdict.reason}`, 'error');
-          recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'rail-deny', detail: { tool: event.toolName, path: filePath, reason: verdict.reason } });
+          noteGate({ ctx, type: 'rail-deny', detail: { tool: event.toolName, path: filePath, reason: verdict.reason } });
           return { block: true, reason: `Blocked ${event.toolName}: ${verdict.reason} (ticket ${active.ticketId})` };
         }
         // Build-gate backstop (spec 2.1): a high-risk ticket in a degraded
@@ -186,7 +276,7 @@ export function createExtension({ env = process.env } = {}) {
         });
         if (gate.decision === 'deny') {
           ctx.ui.notify(`Build gate: ${gate.reason}`, 'error');
-          recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'build-gate-deny', detail: { tool: event.toolName, path: filePath, reason: gate.reason } });
+          noteGate({ ctx, type: 'build-gate-deny', detail: { tool: event.toolName, path: filePath, reason: gate.reason } });
           return { block: true, reason: `Blocked ${event.toolName} by the ADLC build gate: ${gate.reason} (ticket ${active.ticketId})` };
         }
         // Flail advisory (spec 2.2): never blocks.
@@ -205,7 +295,7 @@ export function createExtension({ env = process.env } = {}) {
         const verdict = checkShellCommand(command, active.ticket, activeCwd);
         if (verdict.decision === 'deny') {
           ctx.ui.notify(`Blocked shell command: ${verdict.reason}`, 'error');
-          recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'shell-deny', detail: { reason: verdict.reason } });
+          noteGate({ ctx, type: 'shell-deny', detail: { reason: verdict.reason } });
           return { block: true, reason: `Blocked command: ${verdict.reason} (ticket ${active.ticketId})` };
         }
         if (verdict.mutating) {
@@ -228,13 +318,13 @@ export function createExtension({ env = process.env } = {}) {
       const custom = checkCustomTool(event.toolName, event.input, active.ticket, activeCwd);
       if (custom.decision === 'deny') {
         ctx.ui.notify(`Blocked ${event.toolName}: ${custom.reason}`, 'error');
-        recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'custom-tool-deny', detail: { tool: event.toolName, reason: custom.reason } });
+        noteGate({ ctx, type: 'custom-tool-deny', detail: { tool: event.toolName, reason: custom.reason } });
         return { block: true, reason: `Blocked ${event.toolName}: ${custom.reason} (ticket ${active.ticketId})` };
       }
       if (custom.unvetted && !unvettedSeen.has(event.toolName)) {
         // Once per tool name per session — evidence, not noise.
         unvettedSeen.add(event.toolName);
-        recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'unvetted-tool', detail: { tool: event.toolName } });
+        noteGate({ ctx, type: 'unvetted-tool', detail: { tool: event.toolName } });
       }
       return undefined;
     });
@@ -252,7 +342,7 @@ export function createExtension({ env = process.env } = {}) {
       // stay silent: warning a human about every build command is noise.
       if (verdict.decision === 'deny' && verdict.mutating) {
         ctx.ui.notify(`ADLC: the agent would be denied this command under ticket ${active.ticketId} (${verdict.reason}) — running anyway (human override), recorded to evidence`, 'warning');
-        recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'user-bash-rail-override', detail: { command: event.command, reason: verdict.reason } });
+        noteGate({ ctx, type: 'user-bash-rail-override', detail: { command: event.command, reason: verdict.reason } });
       }
       return undefined;
     });
@@ -279,7 +369,7 @@ export function createExtension({ env = process.env } = {}) {
 
       const restored = restoreSnapshot(activeCwd, snap);
       ctx.ui.notify(`Blocked unallowed suppression marker: ${violations[0].marker}`, 'error');
-      recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'suppression-revert', detail: { path, markers: violations.map((v) => v.marker), restored } });
+      noteGate({ ctx, type: 'suppression-revert', detail: { path, markers: violations.map((v) => v.marker), restored } });
       return {
         isError: true,
         content: [
@@ -329,7 +419,7 @@ export function createExtension({ env = process.env } = {}) {
 
       if (railViolations.length > 0) {
         ctx.ui.notify(`Blocked modifications to frozen rails: ${railViolations.join(', ')}`, 'error');
-        recordGateEvent({ pi, ctx, root: activeCwd, ticketId: active.ticketId, type: 'bash-rail-revert', detail: { paths: railViolations, unrestorable, degraded: entry.degraded === true } });
+        noteGate({ ctx, type: 'bash-rail-revert', detail: { paths: railViolations, unrestorable, degraded: entry.degraded === true } });
         return {
           isError: true,
           content: [

--- a/plugins/adlc-pi/lib/renderers.mjs
+++ b/plugins/adlc-pi/lib/renderers.mjs
@@ -1,0 +1,75 @@
+// renderers.mjs — TUI-only custom message renderers (spec Phase 3.3).
+//
+// registerMessageRenderer wants a SYNCHRONOUS (message, options, theme) =>
+// Component | undefined, and a Component can only be built from
+// @earendil-works/pi-tui. That package is a peer supplied by the pi runtime;
+// it is NOT resolvable under `node --test` (and may be absent in non-TUI
+// modes). So this module isolates the pi-tui dependency: it kicks off a single
+// dynamic import at factory time and every renderer degrades to `undefined`
+// until (or unless) that module resolves. extension.mjs never imports pi-tui
+// at module top level, staying loadable under a plain `node --test`.
+//
+// The specifier is assembled at runtime so the TypeScript nodenext resolver in
+// CI (`tsc --allowJs` over index.ts) does not try to resolve the nested,
+// runtime-only package.
+const PI_TUI_SPECIFIER = ['@earendil-works', 'pi-tui'].join('/');
+
+let tuiPromise;
+async function loadTui() {
+  if (tuiPromise === undefined) {
+    // A rejection (module absent) resolves to null so callers degrade quietly.
+    tuiPromise = import(PI_TUI_SPECIFIER).catch(() => null);
+  }
+  return tuiPromise;
+}
+
+/**
+ * Build the ADLC message renderers. Each returned function is safe to hand to
+ * pi.registerMessageRenderer immediately: before pi-tui loads (or if it never
+ * does) it returns undefined and pi falls back to its default text rendering,
+ * keeping the ctx.ui.notify channel as the visible fallback.
+ *
+ * @param {{ loader?: () => Promise<any> }} [opts] - loader override for tests.
+ * @returns {{ gateNotice: Function, flailAdvisory: Function }}
+ */
+export function createRenderers({ loader = loadTui } = {}) {
+  let tui = null;
+  // Fire-and-forget: cache the module when/if it resolves. Any failure leaves
+  // tui null and every renderer degrades — a cosmetic renderer must never
+  // throw into pi's render loop.
+  Promise.resolve()
+    .then(loader)
+    .then((mod) => { if (mod) tui = mod; })
+    .catch(() => { /* degrade: renderers stay undefined */ });
+
+  function box(text, bgKey, theme) {
+    try {
+      const { Box, Text } = tui;
+      const bg = new Box(1, 1, (t) => theme.bg(bgKey, t));
+      bg.addChild(new Text(text, 0, 0));
+      return bg;
+    } catch {
+      return undefined;
+    }
+  }
+
+  function gateNotice(message, options, theme) {
+    if (!tui) return undefined;
+    const details = message?.details ?? {};
+    const type = typeof details.type === 'string' ? details.type : 'gate';
+    const prefix = theme.fg('error', `[ADLC ${type}]`);
+    let text = `${prefix} ${message?.content ?? ''}`;
+    if (options?.expanded && details.ticketId) {
+      text += `\n${theme.fg('dim', `  ticket ${details.ticketId}`)}`;
+    }
+    return box(text, 'customMessageBg', theme);
+  }
+
+  function flailAdvisory(message, _options, theme) {
+    if (!tui) return undefined;
+    const prefix = theme.fg('warning', '[ADLC flail]');
+    return box(`${prefix} ${message?.content ?? ''}`, 'customMessageBg', theme);
+  }
+
+  return { gateNotice, flailAdvisory };
+}

--- a/plugins/adlc-pi/lib/widget.mjs
+++ b/plugins/adlc-pi/lib/widget.mjs
@@ -1,0 +1,59 @@
+// widget.mjs — pure widget line rendering (spec Phase 3.2). No pi imports.
+//
+// renderWidgetLines(state) turns the live enforcement state into 1–3 short,
+// theme-agnostic plain-text lines for ctx.ui.setWidget('adlc', …). Kept pure
+// and free of ANSI so line length is honest (the ≤80-char truncation counts
+// visible characters) and so it can be unit-tested without a TUI. The status
+// pill keeps its color; the widget conveys state through words, not escapes.
+
+/** Max visible characters per widget line. */
+export const WIDGET_MAX_LINE = 80;
+
+const ELLIPSIS = '…';
+
+function truncate(text, max = WIDGET_MAX_LINE) {
+  if (typeof text !== 'string') return '';
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + ELLIPSIS;
+}
+
+/**
+ * @param {object} state
+ * @param {string|null} [state.ticketId]
+ * @param {string|null} [state.ticketTitle]
+ * @param {'active'|'error'|'inert'} [state.enforcement]
+ * @param {number|null} [state.contextPercent] - percent (0–100) or null/absent
+ * @param {boolean} [state.degraded]
+ * @param {{ type:string, summary?:string }|null} [state.lastGateEvent]
+ * @returns {string[]} 0 lines (no ticket) up to 3 short lines
+ */
+export function renderWidgetLines(state = {}) {
+  const { ticketId, ticketTitle, enforcement, contextPercent, degraded, lastGateEvent } = state;
+
+  // The widget exists only while a ticket is resolved; the caller passes the
+  // empty result to setWidget as `undefined` to clear it.
+  if (typeof ticketId !== 'string' || ticketId.trim() === '') return [];
+
+  const label = enforcement === 'error' ? 'error' : enforcement === 'inert' ? 'inert' : 'active';
+  let head = `ADLC ▸ ${ticketId} (${label})`;
+  // Missing/NaN percent is omitted entirely — never rendered as 'NaN%'.
+  if (typeof contextPercent === 'number' && Number.isFinite(contextPercent)) {
+    head += ` · ctx ${Math.round(contextPercent)}%`;
+  }
+  if (degraded) head += ' · degraded';
+
+  const lines = [truncate(head)];
+
+  if (typeof ticketTitle === 'string' && ticketTitle.trim() !== '') {
+    lines.push(truncate(ticketTitle.trim()));
+  }
+
+  if (lastGateEvent && typeof lastGateEvent.type === 'string') {
+    const summary = typeof lastGateEvent.summary === 'string' && lastGateEvent.summary !== ''
+      ? ` ${lastGateEvent.summary}`
+      : '';
+    lines.push(truncate(`last gate: ${lastGateEvent.type}${summary}`));
+  }
+
+  return lines;
+}

--- a/plugins/adlc-pi/package.json
+++ b/plugins/adlc-pi/package.json
@@ -10,6 +10,9 @@
     ],
     "skills": [
       "./skills/"
+    ],
+    "prompts": [
+      "./prompts"
     ]
   },
   "peerDependencies": {

--- a/plugins/adlc-pi/prompts/adlc-decompose.md
+++ b/plugins/adlc-pi/prompts/adlc-decompose.md
@@ -1,0 +1,37 @@
+---
+description: Slice an approved spec into executable ticket partitions (P2) and forecast the merge.
+argument-hint: "[ticket-or-request]"
+---
+
+# /adlc-decompose — decompose into tickets (P2)
+
+Turn an approved spec into a set of small, independently-executable tickets with
+explicit ordering, then forecast how they merge. Target: `$ARGUMENTS` (default to
+the active ticket). See the `adlc-spec` skill for the command reference.
+
+## 1. Slice
+Break the work into tickets small enough for one fresh agent context. For each,
+follow the `/adlc-ticket` contract (self-contained body, concrete acceptance
+criteria, `scope`, `rails`, `edges`, `duration`). Wire `edges` as prerequisite→
+dependent; tickets that touch the same scope should be serialized to avoid
+concurrent merge conflicts.
+
+## 2. Check executability — `coldstart`
+For each new ticket run `adlc coldstart <id> --json` (or `--prompt-only` to answer
+the audit yourself — in pi you are the working model), and close any gaps that
+would block a fresh agent. Add `--record-verdict <file|->` to capture the verdict
+into `.adlc/manifest.jsonl` so executability is auditable.
+
+## 3. Forecast — `merge-forecast` + `model-router`
+- Run `adlc merge-forecast --json`: confirm a clean DAG (no cycles, no high-risk
+  concurrent same-scope pairs). Serialize with edges if it flags conflicts.
+- Run `adlc model-router --json` (deterministic — no `--prompt-only` mode; flags
+  are `--tickets`/`--floor`/`--json`) to get a tier/route hint per ticket
+  (cheap / mid / frontier).
+
+## 4. Summarize
+Report the ticket DAG (waves + merge order), each ticket's coldstart verdict, and
+the routing hints. The next phase is P3: declare the ticket's `rails` (the frozen
+paths) and verify them with `adlc rails-guard`; then build under
+`/adlc-verify-build` (P4). Note: the pi extension enforces those rails in-session
+once the ticket is active — see the `adlc-rail-build` skill.

--- a/plugins/adlc-pi/prompts/adlc-distill.md
+++ b/plugins/adlc-pi/prompts/adlc-distill.md
@@ -1,0 +1,51 @@
+---
+description: Distill repeated review findings and PR rejections into permanent, deterministic defenses (P7).
+argument-hint: "[scope]"
+---
+
+# /adlc-distill — turn findings into defenses (P7)
+
+P7 is where the lifecycle compounds: repeated findings become deterministic
+defenses (lint checks, skills, spec-gap templates, review lenses) so the same
+class of defect can't recur. This is idle-time work — run it after a batch of
+reviews. Target scope: `$ARGUMENTS` (default to recent history). See the
+`adlc-distill` skill for the command reference.
+
+These LLM-backed gates run against your configured provider (`--json`); add
+`--prompt-only` to answer the printed prompt yourself (keyless — you are the
+working model). Prerequisite: `adlc --version` works (else `npm i -g @adlc/cli`).
+
+## 1. Lesson foundry — mine repeated findings (C9)
+Run `adlc lesson-foundry --json` (or `--prompt-only`).
+- `(no clusters to refine)` → not enough repeated findings in
+  `.adlc/findings.jsonl` yet; report that and stop here.
+- Otherwise, decide the cheapest *deterministic* defense that would have caught
+  the whole cluster — a lint rule, a skill, or a spec-gap template — preferring a
+  machine-checkable gate over a prose reminder.
+- After the user approves, materialize with
+  `adlc lesson-foundry --write --out-dir .adlc/lessons` (dry-run by default),
+  then edit the scaffolded files to match the defenses you decided — `--write`
+  alone does not apply your refinement.
+
+## 2. Rejection mining — mine human PR objections (C13)
+Run `adlc rejection-mining --json` first (deterministic, keyless: it fetches
+recent PR review rejections via the `gh` CLI and clusters them). If it errors
+with a `gh`/auth/repo message, note that this gate was skipped and why, then
+continue. CAUTION: do not use `--prompt-only` for the fetch — it exits BEFORE any
+`gh` call with a placeholder built from fake sample data, so answering it looks
+like a completed gate while mining nothing real. Use `--prompt-only` only as the
+lens-writing template AFTER the real clusters are in hand.
+- Turn each repeated human objection into a reusable **review lens** (a question
+  a future prosecutor should ask). Materialize with `--write` only after
+  approval.
+
+## 3. Check skill decay
+Run `adlc skill-rot --json` (deterministic — it scans skill files' validation
+metadata; no LLM/`--prompt-only` mode) and flag any skills with stale validation
+metadata for re-validation.
+
+## Summarize
+Report: the finding clusters and rejection lenses found, the concrete defenses
+proposed, which were written (if any), and which gates were skipped (e.g.
+rejection-mining without `gh`) so the coverage stays honest. Point the user at
+`/adlc-maintain` for the decay-driven checks.

--- a/plugins/adlc-pi/prompts/adlc-maintain.md
+++ b/plugins/adlc-pi/prompts/adlc-maintain.md
@@ -1,0 +1,57 @@
+---
+description: Run the decay-driven ADLC maintenance checks — stale skills, hot files to re-prosecute, stale tickets, and gate calibration (C10/C12).
+---
+
+# /adlc-maintain — fight decay (C10 / C12 + calibration)
+
+Some assumptions rot over time or after a model/repo change: skill cache metadata
+goes stale, files churn enough to deserve re-prosecution, shipped tickets linger
+in the contract, and gates that once held may now be defeatable. This command
+runs those checks. It is idle-time work — run it on a schedule or after a model
+upgrade. See the `adlc-distill` skill for the maintenance command reference.
+
+Prerequisite: `adlc --version` works (else `npm i -g @adlc/cli`). Report a single
+honest summary at the end, including any check that did not apply.
+
+## 1. Skill rot — stale validation metadata (C10)
+Run `adlc skill-rot <skill-dir-or-glob> --json`.
+- Exit `0`: skills are fresh.
+- Exit `2`: stale validation metadata — list the skills and recommend
+  re-validating (then `--write` to stamp freshness once re-checked).
+- Exit `1` with `nothing to verify`: informational, not a failure. Note it.
+
+## 2. Model ratchet — hot files to re-prosecute (C12)
+Run `adlc model-ratchet --dry-run --json`.
+- Lists the highest-churn / highest-dependency files (`score`) — the best
+  candidates to re-prosecute after model or repo drift. This is a *plan*, not a
+  gate. Report the top files and suggest running `/adlc-prosecute` (or
+  `npx adversarial-review`) against them.
+- With a `--review-cmd`, model-ratchet can run a review over those files and
+  append findings to `.adlc/findings.jsonl` (which later feeds `/adlc-distill`).
+
+## 3. Ticket prune — stale ticket hygiene
+Run `adlc ticket-prune --json`.
+- Dry-run by default (this call never writes): reports tickets that look already
+  shipped — an explicit done-shaped status, or every declared `scope` glob
+  resolving to a file already tracked on `HEAD`. Exit `0` either way; exit `1`
+  only on an operational error.
+- List the stale tickets and recommend confirming them by hand, then re-running
+  with `adlc ticket-prune --write` to archive them into the gitignored
+  `.adlc/tickets.archive.json` (never deletes outright). Treat `--write` as a
+  human-confirmed action — `.adlc/tickets.json` is the shared rail trust root,
+  and the commit-time CI gate hard-denies removing a base-ref ticket in a PR, so
+  a prune of already-merged tickets can only land through the protected-base
+  ceremony, not a normal PR.
+
+## 4. Gate fuzzing — can hostile candidates defeat the gates? (calibration)
+Only if a gate suite exists at `.adlc/gate-suite.json` (without one the tool
+exits `1` — note that calibration was skipped):
+`adlc gate-fuzzing --suite .adlc/gate-suite.json --json` (or `--prompt-only` to
+play the adversary yourself against each gate). A gate you can defeat is a
+**calibration gap** — report it.
+
+## Summarize
+Report: stale skills (if any), the top hot files to re-prosecute, stale tickets
+found (and whether they were archived), gate-fuzzing result or why it was
+skipped, and recommended next actions. Repeated findings surfaced here flow into
+`/adlc-distill`.

--- a/plugins/adlc-pi/prompts/adlc-prosecute.md
+++ b/plugins/adlc-pi/prompts/adlc-prosecute.md
@@ -1,0 +1,184 @@
+---
+description: Prosecute a change before merge (P5) — run the five prosecution lenses sequentially, verify each finding, loop until dry, run the deterministic gates, and record the verdict.
+argument-hint: "[ticket-or-request]"
+---
+
+# /adlc-prosecute — hostile pre-merge review (P5)
+
+Prosecute the change for the active ticket. Requires a clean G4 build
+(`/adlc-verify-build`). Target: `$ARGUMENTS` (default to the active ticket in
+`.adlc/current-ticket.json`). See the `adlc-prosecute` skill for the evidence
+recording reference.
+
+**How this differs from the fan-out integrations — read before trusting the
+verdict.** In this Phase-3 command the five prosecution lenses below run
+SEQUENTIALLY in this one context, worked by the same model that reads this
+command. Sequential same-context lenses have **weaker independence** than a
+fresh-context subagent fan-out: conclusions from an earlier lens can anchor a
+later one, and a blind spot in this session repeats across all five passes. Do
+not treat this loop as equivalent to an independent review. For the cross-model
+risk gate, run `npx adversarial-review --providers <a,b>` (two distinct
+providers) — step 6 below — so at least one genuinely different model examines
+the change. (The pi extension's deterministic fresh-context prosecutor is a
+later phase; until it ships, this sequential loop plus the cross-model gate is
+the P5 flow.)
+
+This command is self-contained: everything the loop needs (lens briefs, dedupe
+rule, verification rule, stop rule) is defined below.
+
+## 0. Collect the evidence
+
+Precondition: a CLEAN working tree — commit (or stash) everything first. The
+hollow-test gate in step 5 mutates files in place and refuses to run on a dirty
+tree (exit 1: "commit or stash first"), so an uncommitted change cannot complete
+this prosecution.
+
+Establish the target ticket (its `scope`, spec, and acceptance criteria from
+`.adlc/tickets.json`) and the change under prosecution:
+`git diff <base-branch>...HEAD`. Every lens reviews this same diff plus whatever
+surrounding code it needs to read. Lenses are read-only reviewers: while
+prosecuting, do not edit files or run state-changing commands — a reviewer that
+can rewrite the evidence is not a reviewer.
+
+## 1. Run the five lenses, sequentially
+
+Work through each lens below **in order, one at a time**. Before starting each
+lens, deliberately set aside the previous lens's conclusions and re-read the diff
+from scratch under the new lens's mandate only — this is the closest a single
+context can get to independent reviewers, and it is imperfect (see the caveat
+above).
+
+Every lens uses the same stance and output shape:
+
+> You are a hostile pre-merge reviewer. Your only job is to **break confidence in
+> the change**, not validate it. For each finding, produce an object with:
+> `severity` (critical|high|medium|low), `file`, `line_start`, `line_end`
+> (post-change line numbers; 0,0 = file-level), `title`, `body`, `evidence`
+> (quoted verbatim from the diff), and `recommendation`. Output a JSON array of
+> findings (empty if none). Do not soften or speculate beyond the evidence — a
+> finding you cannot ground in the diff does not belong.
+
+### Lens 1 — Correctness
+Hunt specifically for: logic errors, off-by-one and boundary mistakes, broken
+invariants, incorrect results, mishandled error/empty/null cases, and state that
+can desync.
+
+### Lens 2 — Security
+Hunt specifically for: auth and trust-boundary holes, injection
+(SQL/shell/path), secrets in code or logs, SSRF, unsafe deserialization, missing
+input validation at boundaries, and who-controls-the-control bypasses.
+
+### Lens 3 — Contract conformance
+Hunt specifically for: API/schema/type drift, backwards-incompatible changes,
+undocumented response shape changes, and violations of the ticket's declared
+contract or shared types.
+
+### Lens 4 — Spec-vs-implementation diff
+Hunt specifically for: places where the implementation diverges from the
+spec/acceptance criteria, behavior changes not reflected in the spec, and scope
+creep beyond the ticket.
+
+### Lens 5 — Test audit
+Hunt specifically for: tests that assert nothing meaningful, mock-only
+verifications, tests that would pass against a broken implementation, missing
+coverage of the change's core behavior, and suppressed/skipped assertions.
+
+Collect every finding from every lens into one list.
+
+## 2. Dedupe
+
+Merge findings across lenses, deduping by **file + line range + normalized
+title** (trim, lowercase, collapse internal whitespace). When two lenses report
+the same defect, keep the **highest severity** (critical > high > medium > low).
+Dedupe only on that key — do not drop a finding because it "sounds like" another
+one.
+
+## 3. Verifier pass — adversarially re-examine each finding
+
+For each deduped finding, run the verifier brief:
+
+> You are given ONE prosecution finding. Try to **refute it**, not to agree.
+> Steps: (1) re-read the finding's evidence in context; (2) construct the most
+> concrete reproduction or counterexample you can; (3) decide: REAL (a genuine
+> defect a maintainer should act on — you built a concrete repro or mechanism),
+> REFUTED (you built a concrete counterexample, or proved it is already handled),
+> or CANNOT-DECIDE (neither succeeded). Be specific and mechanistic; "looks fine"
+> is not a reason.
+
+**Honesty note on the verification semantics:** here there is one model (you)
+re-examining its own findings in the same context, which is weaker than the
+fan-out integrations' strict majority of independent verifier votes. Adapt the
+contract honestly:
+
+- REAL, with a concrete repro or mechanism → the finding **survives**.
+- REFUTED, with a concrete counterexample or proof it is already handled → the
+  finding is **dropped**. A vague "probably fine" does not refute anything.
+- Cannot decide (evidence unclear, cannot trace the code path) → the finding
+  **survives as an unverified blocker**. A pre-merge gate fails closed: never
+  silently drop a finding because verification did not complete.
+
+## 4. Loop until dry
+
+Repeat steps 1–3 until **two consecutive rounds surface no new confirmed
+findings** (a round is dry when it contributes zero net-new surviving findings
+versus the running set). Cap the loop at 5 rounds; if it is cut off before going
+dry, report that as a finding itself ("convergence did not complete").
+
+## 5. Deterministic gates
+
+These are mechanical, not judgment:
+
+- **Hollow-test** (always) — are the tests load-bearing? Run
+  `adlc hollow-test --test-cmd "<the project's test command>"`. It mutates the
+  changed code to find tests that pass without actually testing the behavior
+  (hence the clean-tree precondition in step 0 — it mutates in place and
+  restores). On a clone with no resolvable `main`/`master`, pass an explicit
+  `--base <ref>`. Exit `2` = hollow tests found; fix them before merging.
+- **Behavior-diff** (only for HTTP-observable services) — is the change visible?
+  The capture tool probes a RUNNING HTTP target: `behavior.json` must declare
+  `baseUrl` plus a non-empty `routes` array of `{method, path}` entries. There is
+  no base-branch mode — to get a "before" snapshot, check out and run the base
+  yourself, then capture. Run
+  `adlc behavior-diff capture --config behavior.json --out before.json`, repeat
+  for `after.json` on the change, then
+  `adlc behavior-diff compare before.json after.json`. For projects with no HTTP
+  surface (CLIs, libraries), skip this gate and note the skip in the verdict.
+
+## 6. Cross-model adversarial review (the risk gate)
+
+Run `npx adversarial-review --providers <a,b>` (≥2 distinct providers on the risk
+gate) — a fresh-context, cross-model ship/no-ship review. Given the
+weaker-independence caveat above, this step carries the cross-model weight for
+this flow; do not skip it for risk-gated changes (auth/trust boundaries, deny
+paths, secrets, destructive data operations, schema migrations, CI/CD/supply
+chain). The default invocation is single-shot: fix its findings and re-run until
+it exits 0 (`exit 0 = SHIP`). If no API keys are configured, use
+`npx adversarial-review --prompt-only` and answer the review prompt yourself, but
+prefer a genuinely different model for security-critical changes.
+
+When the review passes, record it so the risk-tier stop-audit has a satisfiable
+record instead of nagging unconditionally:
+
+```
+adlc gate-manifest record adversarial-review --ticket <id> --files <risk-gated paths> --data '{"providers":"<a,b>","verdict":"SHIP"}'
+```
+
+`--ticket <id>` scopes the record to THIS ticket — a ticketless entry satisfies
+the stop-audit for ANY later ticket touching the same files. `--files` is a
+comma-separated list of repo-root-relative paths and must cover the risk-gated
+changed paths the review actually examined (a space-separated list silently
+records only the first path).
+
+## 7. Record + verdict
+
+Report the surviving findings (severity, file, evidence, recommendation) and a
+ship/no-ship verdict. On CLEAR, record the prosecution evidence:
+
+```
+adlc gate-manifest record prosecution --ticket <id> --files <changed files>
+```
+
+(`--files` here too: comma-separated, repo-root-relative.)
+
+Material (surviving, non-refuted) findings block the merge — including unverified
+blockers, until they are verified or refuted.

--- a/plugins/adlc-pi/prompts/adlc-spec.md
+++ b/plugins/adlc-pi/prompts/adlc-spec.md
@@ -1,0 +1,39 @@
+---
+description: Shape and stress-test a spec (P1 Interrogate) with parallax, spec-lint, and premortem.
+argument-hint: "[ticket-or-request]"
+---
+
+# /adlc-spec — interrogate the spec (P1)
+
+Turn a ticket or rough request into an executable spec and stress it before
+decomposition. Target ticket / request: `$ARGUMENTS` (default to the active
+ticket in `.adlc/current-ticket.json` when empty).
+
+These gates are LLM-backed. In pi you drive a configured model, so you can run
+each gate against your provider (`--json`) or answer it yourself with
+`--prompt-only` (keyless — you are the working model). `parallax` and `premortem`
+also support `--record-verdict <file|->` so the verdict lands in
+`.adlc/manifest.jsonl` instead of vanishing with the session. See the `adlc-spec`
+skill for the full command reference.
+
+## 1. Measure ambiguity — `parallax`
+Run `adlc parallax --file <spec-or-request> --record-verdict <file>` (add
+`--prompt-only` to answer it yourself). Produce the N independent readings, then
+the divergence analysis. Every divergence above the threshold is an ambiguity you
+must resolve (ask the user or research) before proceeding. Write the converged
+spec to a file under `.adlc/specs/`.
+
+## 2. Lint acceptance criteria — `spec-lint`
+Run `adlc spec-lint <spec.md> --json` (or `--prompt-only`) and answer the
+vacuousness audit: every acceptance criterion needs a concrete, runnable
+verification (command, test file, or assertion). Rewrite any vacuous criterion.
+
+## 3. Failure-first — `premortem`
+Run `adlc premortem <spec.md> --record-verdict <file>` (add `--prompt-only` to
+answer it yourself) and produce 5–10 concrete, mechanism-specific failure causes.
+Fold the material ones back into the spec / acceptance criteria.
+
+## 4. Summarize
+Report the converged spec, the resolved ambiguities, and the premortem causes you
+folded in. When the spec is clean, point the user at `/adlc-approve-spec` (P1 G1)
+and then `/adlc-decompose` (P2).

--- a/plugins/adlc-pi/prompts/adlc-verify-build.md
+++ b/plugins/adlc-pi/prompts/adlc-verify-build.md
@@ -1,0 +1,38 @@
+---
+description: Assert the deterministic build gate (G4/P4) — build, lint, targeted tests, and flail detection must be clean before prosecution.
+argument-hint: "[ticket]"
+---
+
+# /adlc-verify-build — deterministic build gate (G4, P4)
+
+Before a change can be prosecuted (P5), the build must be clean. This gate runs
+the project's build/lint/test commands, checks the build session for flail, and
+records a G4/P4 build record. Target ticket: `$ARGUMENTS` (default to the active
+ticket in `.adlc/current-ticket.json`). See the `adlc-rail-build` skill for the
+command reference.
+
+## Steps
+1. Run the configured build, lint, and test commands (from `.adlc/config.json` or
+   the project's `package.json`). Capture exit codes and keep the output in a
+   log file.
+2. Run a **targeted** test pass for the active ticket: the test files covering
+   the ticket's `scope` globs (e.g. `node --test <matching test files>`), so a
+   green full suite can't mask a skipped local suite.
+3. Check the session for flail: `adlc flail-detector <log-file> --scope <glob>`
+   (use the ticket's `scope` globs). It flags repeated errors, scope violations,
+   edit churn, and oversized logs — exit `2` means the build session itself is
+   unhealthy; investigate before proceeding.
+4. If any of the above fail, STOP — report the failures; the change is not
+   eligible for P5.
+5. On success, record the build evidence:
+   `adlc gate-manifest record p4-build --ticket <id> --files <changed files>
+   --data '{"tests":"<command run>","result":"green","flail":"<verdict>"}'`.
+   (Note: `adlc run p4` is a read-only ASSERTION requiring
+   `rails-green`/`rails-check`/`flail-check` manifest entries — of which the
+   current toolkit only ever emits `rails-check` (via `adlc rails-guard
+   --record`) — so it exits 2 even after this step. The `p4-build` record above
+   IS the P4 evidence.)
+
+## Summarize
+Report each command's result, the flail verdict, and what was recorded. When
+green, point the user at `/adlc-prosecute` (P5).

--- a/plugins/adlc-pi/test/build-gate-flail.test.mjs
+++ b/plugins/adlc-pi/test/build-gate-flail.test.mjs
@@ -211,7 +211,10 @@ test('F4 regression: a rails-denied edit never counts toward churn', async () =>
       const denied = await pi.handlers.tool_call(writeCall('test/contracts/auth.test.ts', `d${i}`), ctx);
       assert.equal(denied.block, true);
     }
-    assert.equal(pi.steers.length, 0, 'denied edits are not churn — flail runs after the deny returns');
+    // The sendMessage channel now also carries 'adlc-gate-notice' for denies
+    // (T25); the flail claim is specifically that NO churn advisory fires.
+    const flail = pi.steers.filter((s) => s.msg.customType === 'adlc-flail-advisory');
+    assert.equal(flail.length, 0, 'denied edits are not churn — flail runs after the deny returns');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-pi/test/commands.test.mjs
+++ b/plugins/adlc-pi/test/commands.test.mjs
@@ -323,6 +323,23 @@ test('AC5: /adlc-init on a bare repo creates .adlc/tickets.json + gitignore entr
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('P5 follow-up: /adlc-init never clobbers a POPULATED tickets.json (byte-identical after run)', async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-init-pop-')));
+  try {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    const ticketsPath = join(root, '.adlc', 'tickets.json');
+    const populated = JSON.stringify({ tickets: [{ id: 'T1', title: 'Real work', body: 'precious' }] }, null, 2) + '\n';
+    writeFileSync(ticketsPath, populated);
+
+    const pi = fakePi();
+    createExtension({ env: {} })(pi);
+    const ctx = fakeCtx(root);
+    await pi.commands['adlc-init'].handler('', ctx);
+
+    assert.equal(readFileSync(ticketsPath, 'utf8'), populated, 'existing tickets must be byte-identical after init');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('AC5: /adlc-init with the adlc CLI missing notifies the install command and does not scaffold', async () => {
   const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-init-')));
   try {

--- a/plugins/adlc-pi/test/commands.test.mjs
+++ b/plugins/adlc-pi/test/commands.test.mjs
@@ -1,0 +1,349 @@
+// T24 tests: the /adlc-* command surface (spec Phase 3.1).
+//
+// AC1 asserts the six prompt templates + manifest field. AC2–AC5 drive the real
+// registerCommand handlers through the same fake-pi harness the other wiring
+// tests use, so a regression in the command wiring fails here. The extension is
+// booted end-to-end (createExtension()(pi)) so /adlc-ticket exercises the real
+// reload path shared with the gate.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, realpathSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createExtension } from '../lib/extension.mjs';
+import { verify } from '@adlc/gate-manifest/lib/verify.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, '..');
+
+const T1 = {
+  id: 'T1', title: 'First ticket', body: 'Do the first thing',
+  scope: ['src/**'], rails: ['test/contracts/**'], edges: [], duration: 1, category: 'feature',
+};
+const T2 = {
+  id: 'T2', title: 'Second ticket', body: 'Do the second thing',
+  scope: ['lib/**'], rails: ['test/contracts/**'], edges: [], duration: 1, category: 'feature',
+};
+
+function makeRepo({ tickets = [T1, T2], current = 'T1' } = {}) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-cmd-')));
+  mkdirSync(join(root, '.adlc'), { recursive: true });
+  writeFileSync(join(root, '.adlc', 'tickets.json'), JSON.stringify({ tickets }, null, 2));
+  if (current !== null) {
+    writeFileSync(join(root, '.adlc', 'current-ticket.json'), JSON.stringify({ id: current }));
+  }
+  return root;
+}
+
+// A fake pi with the surface the command handlers touch: on/registerCommand,
+// exec (configurable), and appendEntry for the evidence rail.
+function fakePi({ exec } = {}) {
+  const handlers = {};
+  const commands = {};
+  const entries = [];
+  return {
+    on(name, fn) { handlers[name] = fn; },
+    registerCommand(name, def) { commands[name] = def; },
+    async exec(cmd, args) {
+      if (typeof exec === 'function') return exec(cmd, args);
+      return { stdout: '', stderr: '', code: 0 };
+    },
+    appendEntry(customType, data) { entries.push({ customType, data }); },
+    handlers, commands, entries,
+  };
+}
+
+// ctx with configurable dialogs. select/confirm default to a resolved value;
+// hasUI defaults true (TUI). Records dialog invocations for degradation asserts.
+function fakeCtx(cwd, { hasUI = true, select, confirm } = {}) {
+  const notices = [];
+  const calls = { select: 0, confirm: 0 };
+  return {
+    cwd,
+    hasUI,
+    ui: {
+      setStatus() {},
+      notify(msg, level) { notices.push({ msg, level }); },
+      async select(title, options) {
+        calls.select += 1;
+        return typeof select === 'function' ? select(title, options) : options[0];
+      },
+      async confirm(title, message) {
+        calls.confirm += 1;
+        return typeof confirm === 'function' ? confirm(title, message) : true;
+      },
+    },
+    notices,
+    calls,
+  };
+}
+
+async function boot(root, { env = {}, exec } = {}) {
+  const pi = fakePi({ exec });
+  createExtension({ env })(pi);
+  const ctx = fakeCtx(root);
+  await pi.handlers.session_start({ type: 'session_start', reason: 'startup' }, ctx);
+  return { pi };
+}
+
+// Minimal frontmatter reader: the block between the first two '---' fences.
+function readFrontmatter(file) {
+  const text = readFileSync(file, 'utf8');
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const fields = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z-]+):\s*(.*)$/);
+    if (kv) fields[kv[1]] = kv[2];
+  }
+  return fields;
+}
+
+// =========================================================================
+// AC1 — six prompt templates with frontmatter + the pi.prompts manifest field
+// =========================================================================
+
+test('AC1: six prompt templates exist with frontmatter description; pi.prompts manifest points at ./prompts', () => {
+  const expected = [
+    'adlc-spec', 'adlc-decompose', 'adlc-verify-build',
+    'adlc-prosecute', 'adlc-distill', 'adlc-maintain',
+  ];
+  for (const name of expected) {
+    const file = join(PLUGIN_ROOT, 'prompts', `${name}.md`);
+    assert.ok(existsSync(file), `prompt template missing: ${name}.md`);
+    const fm = readFrontmatter(file);
+    assert.ok(fm, `no frontmatter block in ${name}.md`);
+    assert.ok(fm.description && fm.description.trim().length > 0, `no description in ${name}.md`);
+  }
+  // argument-hint is present on the templates that accept a target argument.
+  for (const name of ['adlc-spec', 'adlc-decompose', 'adlc-verify-build', 'adlc-prosecute', 'adlc-distill']) {
+    const fm = readFrontmatter(join(PLUGIN_ROOT, 'prompts', `${name}.md`));
+    assert.ok(fm['argument-hint'] && fm['argument-hint'].trim().length > 0, `no argument-hint in ${name}.md`);
+  }
+  const pkg = JSON.parse(readFileSync(join(PLUGIN_ROOT, 'package.json'), 'utf8'));
+  assert.ok(Array.isArray(pkg.pi.prompts), 'package.json pi.prompts must be an array');
+  assert.ok(pkg.pi.prompts.includes('./prompts'), 'pi.prompts must include "./prompts"');
+});
+
+// =========================================================================
+// AC2 — /adlc-ticket <id> writes the pointer, records evidence, and the NEXT
+// tool_call gates against the new ticket with no turn boundary
+// =========================================================================
+
+test('AC2: /adlc-ticket <id> activates immediately — next tool_call gates the new ticket', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root);
+
+    // Under T1 (scope src/**), a write to src/ is in-scope; a lib/ write is not.
+    const beforeSrc = await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'a', input: { path: 'src/x.ts', content: 'x' } }, ctx);
+    assert.equal(beforeSrc, undefined, 'src write allowed under T1');
+
+    await pi.commands['adlc-ticket'].handler('T2', ctx);
+
+    // Pointer rewritten to T2.
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T2');
+    // Evidence recorded (session entry + chained manifest line).
+    assert.ok(pi.entries.some((e) => e.data.type === 'ticket-switch'), 'session evidence for the switch');
+    assert.match(readFileSync(join(root, '.adlc', 'manifest.jsonl'), 'utf8'), /pi-ticket-switch/);
+
+    // No turn boundary: the very next tool_call must gate against T2 (scope
+    // lib/**), so the previously-allowed src/ write is now out of scope and a
+    // lib/ write is allowed.
+    const afterSrc = await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'b', input: { path: 'src/x.ts', content: 'x' } }, ctx);
+    assert.equal(afterSrc.block, true, 'src write now blocked under T2');
+    assert.match(afterSrc.reason, /scope/);
+    const afterLib = await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'c', input: { path: 'lib/y.ts', content: 'y' } }, ctx);
+    assert.equal(afterLib, undefined, 'lib write allowed under T2');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC2: /adlc-ticket <unknown-id> notifies an error and leaves the pointer unchanged', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root);
+    await pi.commands['adlc-ticket'].handler('T999', ctx);
+    assert.ok(ctx.notices.some((n) => n.level === 'error' && /not found/.test(n.msg)));
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T1', 'pointer unchanged on unknown id');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC2: /adlc-ticket getArgumentCompletions completes ticket ids by prefix', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const all = pi.commands['adlc-ticket'].getArgumentCompletions('');
+    assert.deepEqual(all.map((i) => i.value).sort(), ['T1', 'T2']);
+    const none = pi.commands['adlc-ticket'].getArgumentCompletions('Z');
+    assert.equal(none, null, 'no matches returns null');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
+// AC3 — /adlc-ticket with no args surfaces ui.select; undefined leaves state
+// =========================================================================
+
+test('AC3: /adlc-ticket with no args offers one option per ticket and activates the choice', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    let offered = null;
+    const ctx = fakeCtx(root, { select: (_title, options) => { offered = options; return options[1]; } });
+    await pi.commands['adlc-ticket'].handler('', ctx);
+    assert.equal(ctx.calls.select, 1, 'select was surfaced');
+    assert.equal(offered.length, 2, 'one option per ticket');
+    assert.ok(offered[0].startsWith('T1'), 'option carries the id');
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T2', 'chose the second ticket');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC3: /adlc-ticket select returning undefined (non-TUI cancel) leaves state unchanged and notifies', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root, { select: () => undefined });
+    await pi.commands['adlc-ticket'].handler('', ctx);
+    assert.ok(ctx.notices.some((n) => /cancelled/.test(n.msg)), 'notifies the cancel');
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T1', 'pointer unchanged after cancel');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC3: /adlc-ticket with no args in non-TUI mode requires an id (no hang, no prompt)', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root, { hasUI: false });
+    await pi.commands['adlc-ticket'].handler('', ctx);
+    assert.equal(ctx.calls.select, 0, 'no dialog attempted without a UI');
+    assert.ok(ctx.notices.some((n) => /non-interactive/.test(n.msg)));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
+// AC4 — /adlc-approve-spec: confirm=true records a chain-valid entry; false
+// records nothing; missing path errors without a dialog
+// =========================================================================
+
+test('AC4: /adlc-approve-spec on an existing file with confirm=true appends a chain-valid entry naming the spec', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    mkdirSync(join(root, '.adlc', 'specs'), { recursive: true });
+    const specRel = '.adlc/specs/feature.md';
+    writeFileSync(join(root, specRel), '# Spec\nacceptance criteria\n');
+    const ctx = fakeCtx(root, { confirm: () => true });
+
+    await pi.commands['adlc-approve-spec'].handler(specRel, ctx);
+
+    const manifest = readFileSync(join(root, '.adlc', 'manifest.jsonl'), 'utf8');
+    assert.match(manifest, /spec-approval/);
+    assert.match(manifest, /feature\.md/, 'entry names the spec path');
+    const verdict = verify(join(root, '.adlc'));
+    assert.equal(verdict.valid, true, `manifest chain must verify: ${JSON.stringify(verdict)}`);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC4: /adlc-approve-spec with confirm=false records nothing', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const specRel = '.adlc/specs/feature.md';
+    mkdirSync(join(root, '.adlc', 'specs'), { recursive: true });
+    writeFileSync(join(root, specRel), '# Spec\n');
+    const ctx = fakeCtx(root, { confirm: () => false });
+    await pi.commands['adlc-approve-spec'].handler(specRel, ctx);
+    assert.equal(existsSync(join(root, '.adlc', 'manifest.jsonl')), false, 'no manifest written on decline');
+    assert.ok(ctx.notices.some((n) => /declined/.test(n.msg)));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC4: /adlc-approve-spec on a nonexistent path errors without opening a dialog', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root, { confirm: () => true });
+    await pi.commands['adlc-approve-spec'].handler('.adlc/specs/missing.md', ctx);
+    assert.equal(ctx.calls.confirm, 0, 'no dialog opened for a missing spec');
+    assert.ok(ctx.notices.some((n) => n.level === 'error' && /cannot read/.test(n.msg)));
+    assert.equal(existsSync(join(root, '.adlc', 'manifest.jsonl')), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC4: /adlc-approve-spec with no path errors without a dialog', async () => {
+  const root = makeRepo({ current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root, { confirm: () => true });
+    await pi.commands['adlc-approve-spec'].handler('', ctx);
+    assert.equal(ctx.calls.confirm, 0);
+    assert.ok(ctx.notices.some((n) => n.level === 'error'));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
+// AC5 — /adlc-init scaffolds a bare repo, is idempotent, and refuses to
+// scaffold when the adlc CLI is missing
+// =========================================================================
+
+test('AC5: /adlc-init on a bare repo creates .adlc/tickets.json + gitignore entries and is idempotent', async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-init-')));
+  try {
+    const pi = fakePi();
+    createExtension({ env: {} })(pi);
+    const ctx = fakeCtx(root);
+
+    await pi.commands['adlc-init'].handler('', ctx);
+
+    const ticketsPath = join(root, '.adlc', 'tickets.json');
+    assert.ok(existsSync(ticketsPath), 'tickets.json created');
+    assert.deepEqual(JSON.parse(readFileSync(ticketsPath, 'utf8')), { tickets: [] });
+    const gitignore = readFileSync(join(root, '.gitignore'), 'utf8');
+    assert.match(gitignore, /^\.adlc\/\*$/m, '.adlc/* ignore added');
+    assert.match(gitignore, /^!\.adlc\/tickets\.json$/m, 'tickets.json negation added');
+
+    // Idempotent: a second run changes nothing on disk.
+    const beforeTickets = readFileSync(ticketsPath, 'utf8');
+    const beforeGitignore = readFileSync(join(root, '.gitignore'), 'utf8');
+    await pi.commands['adlc-init'].handler('', ctx);
+    assert.equal(readFileSync(ticketsPath, 'utf8'), beforeTickets, 'tickets.json unchanged on second run');
+    assert.equal(readFileSync(join(root, '.gitignore'), 'utf8'), beforeGitignore, '.gitignore unchanged on second run');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC5: /adlc-init with the adlc CLI missing notifies the install command and does not scaffold', async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-init-')));
+  try {
+    // pi.exec rejects (command not found) — the guard must fail closed.
+    const pi = fakePi({ exec: async () => { throw new Error('spawn adlc ENOENT'); } });
+    createExtension({ env: {} })(pi);
+    const ctx = fakeCtx(root);
+    await pi.commands['adlc-init'].handler('', ctx);
+    assert.ok(ctx.notices.some((n) => n.level === 'error' && /npm install -g @adlc\/cli/.test(n.msg)));
+    assert.equal(existsSync(join(root, '.adlc')), false, 'no .adlc/ scaffolded when the CLI is missing');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC5: /adlc-init with the adlc CLI returning non-zero also refuses to scaffold', async () => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-init-')));
+  try {
+    const pi = fakePi({ exec: async () => ({ stdout: '', stderr: 'nope', code: 127 }) });
+    createExtension({ env: {} })(pi);
+    const ctx = fakeCtx(root);
+    await pi.commands['adlc-init'].handler('', ctx);
+    assert.ok(ctx.notices.some((n) => n.level === 'error' && /npm install -g @adlc\/cli/.test(n.msg)));
+    assert.equal(existsSync(join(root, '.adlc')), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/plugins/adlc-pi/test/extension.test.mjs
+++ b/plugins/adlc-pi/test/extension.test.mjs
@@ -197,11 +197,11 @@ test('tool_call: inert without a ticket', async () => {
 // /ticket command
 // =========================================================================
 
-test('/ticket command reports the active ticket', async () => {
+test('/ticket command reports the active ticket (real pi signature: args, ctx)', async () => {
   const root = makeRepo();
   try {
     const { pi, ctx } = await boot(root);
-    await pi.commands.ticket.handler(ctx);
+    await pi.commands.ticket.handler('', ctx);
     assert.ok(ctx.notices.some((n) => n.msg.includes('Active Ticket: T1')));
   } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/plugins/adlc-pi/test/renderers.test.mjs
+++ b/plugins/adlc-pi/test/renderers.test.mjs
@@ -1,0 +1,68 @@
+// P5 follow-up (Phase 3 finding 1): exercise the renderer CONSTRUCTION path
+// with an injected fake pi-tui, so the TUI branch is proven, not just the
+// degraded one.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRenderers } from '../lib/renderers.mjs';
+
+// Minimal pi-tui stand-ins matching the constructor shapes renderers.mjs uses.
+class FakeBox {
+  constructor(px, py, bgFn) { this.px = px; this.py = py; this.bgFn = bgFn; this.children = []; }
+  addChild(c) { this.children.push(c); }
+}
+class FakeText {
+  constructor(text, x, y) { this.text = text; this.x = x; this.y = y; }
+}
+const fakeTui = { Box: FakeBox, Text: FakeText };
+const fakeTheme = {
+  fg: (color, text) => `<${color}>${text}</${color}>`,
+  bg: (key, _t) => `bg:${key}`,
+};
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test('renderers construct real components once the (injected) pi-tui loads', async () => {
+  const r = createRenderers({ loader: async () => fakeTui });
+  await tick(); // let the fire-and-forget loader resolve
+
+  const gate = r.gateNotice(
+    { content: 'ADLC rail-deny: src/x.ts', details: { type: 'rail-deny', ticketId: 'T9' } },
+    { expanded: true },
+    fakeTheme
+  );
+  assert.ok(gate instanceof FakeBox, 'gateNotice builds a Box');
+  assert.equal(gate.children.length, 1);
+  assert.ok(gate.children[0] instanceof FakeText);
+  assert.match(gate.children[0].text, /<error>\[ADLC rail-deny\]<\/error>/);
+  assert.match(gate.children[0].text, /ticket T9/, 'expanded view names the ticket');
+  assert.equal(gate.bgFn(null), 'bg:customMessageBg');
+
+  const flail = r.flailAdvisory({ content: 'edited 3 times' }, {}, fakeTheme);
+  assert.ok(flail instanceof FakeBox);
+  assert.match(flail.children[0].text, /<warning>\[ADLC flail\]<\/warning> edited 3 times/);
+});
+
+test('renderers degrade to undefined before load and when the loader fails', async () => {
+  const failing = createRenderers({ loader: async () => { throw new Error('no tui'); } });
+  await tick();
+  assert.equal(failing.gateNotice({ content: 'x', details: {} }, {}, fakeTheme), undefined);
+  assert.equal(failing.flailAdvisory({ content: 'x' }, {}, fakeTheme), undefined);
+
+  // Pre-load window: renderer called before the loader resolves.
+  let release;
+  const gated = createRenderers({ loader: () => new Promise((res) => { release = res; }) });
+  await tick(); // the factory invokes the loader on a microtask — let it start
+  assert.equal(gated.gateNotice({ content: 'x', details: {} }, {}, fakeTheme), undefined, 'undefined before load');
+  release(fakeTui);
+  await tick();
+  assert.ok(gated.gateNotice({ content: 'x', details: {} }, {}, fakeTheme) instanceof FakeBox, 'constructs after load');
+});
+
+test('a constructor-time failure degrades instead of throwing into the render loop', async () => {
+  const hostileTheme = { fg: () => 'ok', bg: () => { throw new Error('theme boom'); } };
+  const brokenTui = { Box: class { constructor() { throw new Error('ctor boom'); } }, Text: FakeText };
+  const r = createRenderers({ loader: async () => brokenTui });
+  await tick();
+  assert.equal(r.gateNotice({ content: 'x', details: {} }, {}, hostileTheme), undefined);
+});

--- a/plugins/adlc-pi/test/widget-wiring.test.mjs
+++ b/plugins/adlc-pi/test/widget-wiring.test.mjs
@@ -1,0 +1,231 @@
+// AC2–AC5 — drive the real extension handlers through a fake pi/ctx harness to
+// prove the live widget wiring, inert-session silence, minimal-ctx crash
+// safety, renderer registration, and the gate-notice message emission.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createExtension } from '../lib/extension.mjs';
+
+const TICKET = {
+  id: 'T24',
+  title: 'Command surface',
+  body: 'Do the thing',
+  scope: ['src/**'],
+  rails: ['test/contracts/**'],
+};
+const HIGH_RISK = { id: 'T7', title: 'Dangerous', body: 'risky', risk: 'high', scope: ['src/**'], rails: ['test/contracts/**'] };
+
+function makeRepo({ tickets = [TICKET], current = 'T24' } = {}) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'adlc-pi-widget-')));
+  mkdirSync(join(root, '.adlc'), { recursive: true });
+  writeFileSync(join(root, '.adlc', 'tickets.json'), JSON.stringify({ tickets }, null, 2));
+  if (current !== null) writeFileSync(join(root, '.adlc', 'current-ticket.json'), JSON.stringify({ id: current }));
+  mkdirSync(join(root, 'src'), { recursive: true });
+  return root;
+}
+
+function fakePi() {
+  const handlers = {};
+  const commands = {};
+  const renderers = {};
+  const messages = [];
+  const entries = [];
+  return {
+    on(name, fn) { handlers[name] = fn; },
+    registerCommand(name, def) { commands[name] = def; },
+    registerMessageRenderer(type, fn) { renderers[type] = fn; },
+    sendMessage(msg, opts) { messages.push({ msg, opts }); },
+    appendEntry(customType, data) { entries.push({ customType, data }); },
+    async exec() { return { stdout: '', stderr: '', code: 0 }; },
+    handlers, commands, renderers, messages, entries,
+  };
+}
+
+// A full-featured ctx that captures setWidget content and serves a percent.
+function fakeCtx(cwd, { percent = 12 } = {}) {
+  const widgets = [];
+  const notices = [];
+  return {
+    cwd,
+    ui: {
+      setStatus() {},
+      notify(m, l) { notices.push({ m, l }); },
+      setWidget(key, content) { widgets.push({ key, content }); },
+    },
+    getContextUsage: () => ({ tokens: 100, contextWindow: 1000, percent }),
+    widgets, notices,
+  };
+}
+
+// AC4 shape: an older/RPC ctx with NO setWidget and NO getContextUsage.
+function minimalCtx(cwd) {
+  const notices = [];
+  return { cwd, ui: { setStatus() {}, notify(m, l) { notices.push({ m, l }); } }, notices };
+}
+
+async function boot(root, { env = {}, ctx } = {}) {
+  const pi = fakePi();
+  createExtension({ env })(pi);
+  const useCtx = ctx ?? fakeCtx(root);
+  await pi.handlers.session_start({ type: 'session_start', reason: 'startup' }, useCtx);
+  return { pi, ctx: useCtx };
+}
+
+const lastWidget = (ctx) => ctx.widgets[ctx.widgets.length - 1];
+
+// =========================================================================
+// AC2 — widget refresh on session_start, rail deny, and deactivation clear
+// =========================================================================
+
+test('AC2: session_start with an active ticket sets a widget naming the ticket', async () => {
+  const root = makeRepo();
+  try {
+    const { ctx } = await boot(root);
+    const w = lastWidget(ctx);
+    assert.equal(w.key, 'adlc');
+    assert.ok(Array.isArray(w.content), 'content is the line array');
+    assert.match(w.content[0], /T24/, 'first line names the ticket');
+    assert.match(w.content[0], /\(active\)/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC2: a rail deny refreshes the widget with the gate event', async () => {
+  const root = makeRepo();
+  try {
+    const { pi, ctx } = await boot(root);
+    const before = ctx.widgets.length;
+    const denied = await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'c1', input: { path: 'test/contracts/x.test.ts', content: 'x' } },
+      ctx
+    );
+    assert.equal(denied.block, true);
+    assert.ok(ctx.widgets.length > before, 'widget refreshed after the deny');
+    const w = lastWidget(ctx);
+    assert.ok(w.content.some((l) => l.includes('rail-deny')), `gate event present: ${JSON.stringify(w.content)}`);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC2: deactivating the ticket (pointer removed + turn_start) clears the widget', async () => {
+  const root = makeRepo();
+  try {
+    const { pi, ctx } = await boot(root);
+    assert.ok(Array.isArray(lastWidget(ctx).content), 'active initially');
+    // Remove the pointer, then a turn boundary re-resolves to inert.
+    rmSync(join(root, '.adlc', 'current-ticket.json'));
+    await pi.handlers.turn_start({ type: 'turn_start' }, ctx);
+    const w = lastWidget(ctx);
+    assert.equal(w.key, 'adlc');
+    assert.equal(w.content, undefined, 'cleared with undefined');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC2: a threshold compaction refreshes the widget with the degraded flag', async () => {
+  const root = makeRepo();
+  try {
+    const { pi, ctx } = await boot(root);
+    await pi.handlers.session_compact({ type: 'session_compact', reason: 'overflow' }, ctx);
+    assert.match(lastWidget(ctx).content[0], /degraded/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
+// AC3 — an inert session never renders a content-bearing widget
+// =========================================================================
+
+test('AC3: inert session (no ticket) never calls setWidget with content', async () => {
+  const root = makeRepo({ current: null });
+  try {
+    const { pi, ctx } = await boot(root);
+    await pi.handlers.turn_start({ type: 'turn_start' }, ctx);
+    await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'c1', input: { path: 'anything.ts', content: 'x' } },
+      ctx
+    );
+    const withContent = ctx.widgets.filter((w) => w.content !== undefined);
+    assert.equal(withContent.length, 0, `no content widget in an inert session: ${JSON.stringify(ctx.widgets)}`);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
+// AC4 — a ctx without setWidget/getContextUsage crashes no handler
+// =========================================================================
+
+test('AC4: the full deny path runs on a minimal ctx (no setWidget/getContextUsage)', async () => {
+  const root = makeRepo();
+  try {
+    const pi = fakePi();
+    createExtension({ env: {} })(pi);
+    const ctx = minimalCtx(root);
+    // session_start, a rail deny, and turn_start must all survive.
+    await pi.handlers.session_start({ type: 'session_start', reason: 'startup' }, ctx);
+    const denied = await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'c1', input: { path: 'test/contracts/x.test.ts', content: 'x' } },
+      ctx
+    );
+    assert.equal(denied.block, true, 'the gate still blocks');
+    await pi.handlers.turn_start({ type: 'turn_start' }, ctx);
+    await pi.handlers.session_compact({ type: 'session_compact', reason: 'overflow' }, ctx);
+    // gate-notice still emitted despite no widget surface.
+    assert.ok(pi.messages.some((m) => m.msg.customType === 'adlc-gate-notice'));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
+// AC5 — renderer registration + gate-notice emission alongside notify
+// =========================================================================
+
+test('AC5: both custom message renderers are registered at extension load', async () => {
+  const pi = fakePi();
+  createExtension({ env: {} })(pi);
+  assert.equal(typeof pi.renderers['adlc-flail-advisory'], 'function');
+  assert.equal(typeof pi.renderers['adlc-gate-notice'], 'function');
+});
+
+test('AC5: a rail deny emits an adlc-gate-notice message in addition to notify', async () => {
+  const root = makeRepo();
+  try {
+    const { pi, ctx } = await boot(root);
+    await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'c1', input: { path: 'test/contracts/x.test.ts', content: 'x' } },
+      ctx
+    );
+    const notice = pi.messages.find((m) => m.msg.customType === 'adlc-gate-notice');
+    assert.ok(notice, 'gate-notice emitted');
+    assert.equal(notice.msg.display, true);
+    assert.match(notice.msg.content, /rail-deny/);
+    assert.equal(notice.msg.details.type, 'rail-deny');
+    // The notify fallback still fired.
+    assert.ok(ctx.notices.some((n) => /Blocked/.test(n.m)));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC5: the build-gate deny path emits an adlc-gate-notice', async () => {
+  const root = makeRepo({ tickets: [HIGH_RISK], current: 'T7' });
+  try {
+    const { pi, ctx } = await boot(root, { ctx: fakeCtx(realpathSync(join(root)), { percent: 95 }) });
+    const denied = await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'write', toolCallId: 'c1', input: { path: 'src/a.ts', content: 'x' } },
+      ctx
+    );
+    assert.equal(denied.block, true);
+    assert.match(denied.reason, /build gate/i);
+    const notice = pi.messages.find((m) => m.msg.customType === 'adlc-gate-notice' && m.msg.details.type === 'build-gate-deny');
+    assert.ok(notice, `build-gate-deny notice emitted: ${JSON.stringify(pi.messages.map((m) => m.msg.details?.type))}`);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('AC5: an advisory gate (unvetted tool) does NOT emit a gate-notice', async () => {
+  const root = makeRepo();
+  try {
+    const { pi, ctx } = await boot(root);
+    // An unknown tool with no path-like arg is recorded as unvetted, not denied.
+    await pi.handlers.tool_call(
+      { type: 'tool_call', toolName: 'weather_lookup', toolCallId: 'c1', input: { city: 'NYC' } },
+      ctx
+    );
+    assert.ok(!pi.messages.some((m) => m.msg.customType === 'adlc-gate-notice'), 'no notice for a non-deny event');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/plugins/adlc-pi/test/widget.test.mjs
+++ b/plugins/adlc-pi/test/widget.test.mjs
@@ -1,0 +1,107 @@
+// AC1 — renderWidgetLines is a pure function: no pi imports, deterministic,
+// and it never emits 'NaN%', over-long lines, or a widget for an inert session.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderWidgetLines, WIDGET_MAX_LINE } from '../lib/widget.mjs';
+
+test('AC1: active ticket with percent → header names ticket, state, ctx%', () => {
+  const lines = renderWidgetLines({
+    ticketId: 'T24',
+    ticketTitle: 'Command surface',
+    enforcement: 'active',
+    contextPercent: 41,
+    degraded: false,
+    lastGateEvent: null,
+  });
+  assert.equal(lines[0], 'ADLC ▸ T24 (active) · ctx 41%');
+  assert.equal(lines[1], 'Command surface');
+  assert.equal(lines.length, 2);
+});
+
+test('AC1: error enforcement renders (error), not (active)', () => {
+  const lines = renderWidgetLines({ ticketId: 'T9', enforcement: 'error', contextPercent: null });
+  assert.equal(lines[0], 'ADLC ▸ T9 (error)');
+});
+
+test('AC1: missing percent is omitted, never "NaN%"', () => {
+  for (const bad of [null, undefined, NaN, Infinity, -Infinity]) {
+    const lines = renderWidgetLines({ ticketId: 'T1', enforcement: 'active', contextPercent: bad });
+    assert.ok(!lines[0].includes('NaN'), `no NaN for ${bad}`);
+    assert.ok(!/ctx/.test(lines[0]), `ctx omitted for ${bad}: ${lines[0]}`);
+  }
+});
+
+test('AC1: percent is rounded', () => {
+  const lines = renderWidgetLines({ ticketId: 'T1', enforcement: 'active', contextPercent: 40.7 });
+  assert.match(lines[0], /ctx 41%/);
+});
+
+test('AC1: degraded flag surfaces on the header line', () => {
+  const lines = renderWidgetLines({ ticketId: 'T1', enforcement: 'active', contextPercent: 50, degraded: true });
+  assert.match(lines[0], /· degraded/);
+});
+
+test('AC1: last gate event becomes a trailing line', () => {
+  const lines = renderWidgetLines({
+    ticketId: 'T1',
+    enforcement: 'active',
+    contextPercent: 10,
+    lastGateEvent: { type: 'rail-deny', summary: 'src/x.ts' },
+  });
+  assert.equal(lines[lines.length - 1], 'last gate: rail-deny src/x.ts');
+});
+
+test('AC1: gate event without a summary still renders the type', () => {
+  const lines = renderWidgetLines({
+    ticketId: 'T1',
+    enforcement: 'active',
+    lastGateEvent: { type: 'shell-deny', summary: '' },
+  });
+  assert.equal(lines[lines.length - 1], 'last gate: shell-deny');
+});
+
+test('AC1: no ticket id → no widget (empty array to clear)', () => {
+  assert.deepEqual(renderWidgetLines({ ticketId: null }), []);
+  assert.deepEqual(renderWidgetLines({ ticketId: '' }), []);
+  assert.deepEqual(renderWidgetLines({}), []);
+});
+
+test('AC1: at most three lines', () => {
+  const lines = renderWidgetLines({
+    ticketId: 'T1',
+    ticketTitle: 'A title',
+    enforcement: 'active',
+    contextPercent: 12,
+    degraded: true,
+    lastGateEvent: { type: 'suppression-revert', summary: 'src/a.ts' },
+  });
+  assert.ok(lines.length <= 3, `got ${lines.length}`);
+});
+
+test('AC1: long title is truncated to ≤ WIDGET_MAX_LINE with an ellipsis', () => {
+  const longTitle = 'x'.repeat(200);
+  const lines = renderWidgetLines({ ticketId: 'T1', ticketTitle: longTitle, enforcement: 'active' });
+  const titleLine = lines[1];
+  assert.ok(titleLine.length <= WIDGET_MAX_LINE, `title line ${titleLine.length} chars`);
+  assert.ok(titleLine.endsWith('…'), 'truncated with ellipsis');
+});
+
+test('AC1: a long ticket id/gate line stays ≤ WIDGET_MAX_LINE', () => {
+  const lines = renderWidgetLines({
+    ticketId: 'T1',
+    enforcement: 'active',
+    contextPercent: 12,
+    lastGateEvent: { type: 'bash-rail-revert', summary: 'a/'.repeat(120) + 'file.ts' },
+  });
+  for (const line of lines) {
+    assert.ok(line.length <= WIDGET_MAX_LINE, `line over cap: ${line.length}`);
+  }
+});
+
+test('AC1: purity — same input, same output, input not mutated', () => {
+  const state = Object.freeze({ ticketId: 'T1', enforcement: 'active', contextPercent: 33 });
+  const a = renderWidgetLines(state);
+  const b = renderWidgetLines(state);
+  assert.deepEqual(a, b);
+});


### PR DESCRIPTION
## Summary

Phase 3 of [docs/specs/pi-native-flush.md](docs/specs/pi-native-flush.md), built as ADLC tickets **T24/T25**, P5-prosecuted fresh-context (**SHIP**; 8/9 planted defect classes caught by named tests, the ninth double-guarded), with both follow-up coverage gaps closed pre-merge.

### T24 — /adlc command surface (12c59a5)
- **Six prompt templates** (`prompts/`, registered via `pi.prompts`): adlc-spec / decompose / verify-build / prosecute / distill / maintain — ported from the cursor/opencode command suites, reframed for pi, cross-referencing the existing skills.
- **Interactive trio** (`lib/commands.mjs`): `/adlc-init` (CLI probe → idempotent scaffold + hygiene ignores; refuses when `adlc` is missing), `/adlc-ticket` (id or `ui.select` picker, ticket-id completions, **immediate** enforcement reload, evidence entry), `/adlc-approve-spec` (real `ui.confirm` modal → chain-valid manifest record; decline records nothing). Full non-TUI degradation.
- **Security note (prosecuted)**: the trust-root exemption for these handlers is safe — pi 0.80.3's dispatch only routes slash commands from `interactive`/`rpc` input sources; `sendUserMessage` (`source:"extension"`) skips command dispatch entirely, and the model has no tool that reaches `prompt()`. Verified against pi's own `agent-session.js`.

### Fix uncovered during review (1730b66)
`/ticket` used `handler(ctx)` but pi's contract is `(args, ctx)` — live invocations would have crashed; the old test enshrined the wrong shape. Fixed both.

### T25 — live widget + renderers (3140e5e)
- `lib/widget.mjs` pure `renderWidgetLines`; above-editor widget showing ticket, enforcement state, context %, degraded flag, and the last gate event — refreshed through **one choke point** (`noteGate`) shared with evidence recording and structured `adlc-gate-notice` messages; cleared when no ticket resolves; every UI call guarded so a minimal ctx can't break enforcement.
- `lib/renderers.mjs`: TUI message renderers for `adlc-flail-advisory`/`adlc-gate-notice`, isolated behind a degrading dynamic-import factory (extension stays `node --test`-loadable; pi falls back to default rendering when absent).

### P5 follow-ups closed (this PR's last commit)
- Renderer **construction** path now exercised via an injected fake pi-tui (was degraded in every CI environment — the exact dead-code-as-capability pattern this spec exists to kill).
- `/adlc-init` clobber guard pinned: a populated `tickets.json` is byte-identical after init.

## Test plan
- [x] 112 pi tests; full root `npm test` green; `scripts/pi-live-deny.mjs` PASS
- [x] `adlc rails-guard` exit 0 + recorded for T24 (vs main) and T25 (per-ticket)
- [x] Fresh-context P5 prosecution: SHIP; prompt-template audit clean; frozen opencode suite untouched (192 pass)