### PR TITLE
feat(opencode): T31 upstream sync — CI drift canary, anomalyco sweep, permission.ask re-verified dormant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,25 @@ jobs:
         if: matrix.node-version == 20
         run: node scripts/opencode-live-tool.mjs --require
 
+      # pi live deny proof (ticket T21 AC5) — same folded-into-required-job
+      # rationale as the OpenCode step above. Runs on the Node 22 leg only
+      # (pi requires Node >= 22.19; the script hard-skips on older majors and
+      # hard-fails if the pinned pi binary is missing on a supported Node).
+      # The pi version is PINNED via the repo devDependency
+      # (@earendil-works/pi-coding-agent) so upstream releases can't flake a
+      # required job; bump deliberately alongside the plugin peerDependency.
+      # MUST stay in this REQUIRED matrix job (the Node 22 leg) — it depends on
+      # matrix.node-version and would silently never run in a non-matrix job.
+      - name: pi live deny proof (T21 AC5)
+        if: matrix.node-version == 22
+        run: node scripts/pi-live-deny.mjs
+
   # T31 drift canary: the SAME two OpenCode live proofs against opencode-ai@latest.
   # ADVISORY by design (continue-on-error): upstream releases near-daily, and a
   # latest-version break must be VISIBLE same-day without blocking unrelated
   # merges — the required, pinned proofs in the test job above stay authoritative.
   # Bump the pin deliberately when this canary shows sustained green on a newer line.
+  # Single Node 20, NO matrix — so no step here may use a matrix.* condition.
   opencode-live-latest:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -85,17 +99,6 @@ jobs:
           opencode --version
           node scripts/opencode-live-deny.mjs --require
           node scripts/opencode-live-tool.mjs --require
-
-      # pi live deny proof (ticket T21 AC5) — same folded-into-required-job
-      # rationale as the OpenCode step above. Runs on the Node 22 leg only
-      # (pi requires Node >= 22.19; the script hard-skips on older majors and
-      # hard-fails if the pinned pi binary is missing on a supported Node).
-      # The pi version is PINNED via the repo devDependency
-      # (@earendil-works/pi-coding-agent) so upstream releases can't flake a
-      # required job; bump deliberately alongside the plugin peerDependency.
-      - name: pi live deny proof (T21 AC5)
-        if: matrix.node-version == 22
-        run: node scripts/pi-live-deny.mjs
 
   pre-ga-gate:
     # Explicit CI gate that fails with a clear message while either of the two

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,35 @@ jobs:
         if: matrix.node-version == 20
         run: node scripts/opencode-live-tool.mjs --require
 
+  # T31 drift canary: the SAME two OpenCode live proofs against opencode-ai@latest.
+  # ADVISORY by design (continue-on-error): upstream releases near-daily, and a
+  # latest-version break must be VISIBLE same-day without blocking unrelated
+  # merges — the required, pinned proofs in the test job above stay authoritative.
+  # Bump the pin deliberately when this canary shows sustained green on a newer line.
+  opencode-live-latest:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm install
+
+      - name: OpenCode live proofs vs latest
+        run: |
+          npm install -g opencode-ai@latest
+          opencode --version
+          node scripts/opencode-live-deny.mjs --require
+          node scripts/opencode-live-tool.mjs --require
+
       # pi live deny proof (ticket T21 AC5) — same folded-into-required-job
       # rationale as the OpenCode step above. Runs on the Node 22 leg only
       # (pi requires Node >= 22.19; the script hard-skips on older majors and

--- a/docs/adr/0004-adlc-opencode-integration.md
+++ b/docs/adr/0004-adlc-opencode-integration.md
@@ -128,6 +128,40 @@ The pinned API block above is superseded accordingly: peerDependency
 `>=1.17.13`, edited path on `output.args`, deny mechanism `throw` (documented,
 regression-tested by the live deny proof).
 
+## Amendment — 2026-07-09: upstream sync (T31)
+
+Dated re-verification against the current upstream, which had moved and advanced
+since the Phase-1 amendment:
+
+1. **Repo moved to `anomalyco/opencode`** (from the former sst org path). The
+   org rebranded; opencode.ai docs remain canonical and npm still publishes
+   `@opencode-ai/*` from the same tags. All in-repo references were swept to the
+   new path (issue links included); the install smoke gates that stale live
+   references stay at zero.
+2. **`permission.ask` is still DORMANT — DISPATCHED = NO.** Re-verified FROM
+   SOURCE at tags **v1.17.17 and v1.17.18** (newest at the time): the string
+   `permission.ask` occurs only in the Hooks type
+   (`packages/plugin/src/index.ts`); it is never passed to `plugin.trigger()`,
+   and the real permission path (`packages/opencode/src/permission/index.ts`)
+   publishes the `permission.asked` event without invoking any plugin hook.
+   Upstream **anomalyco/opencode#7006 remains OPEN**. Nothing between 1.17.13 and
+   1.17.18 wired it. Decision: keep the tolerant handler (it activates the instant
+   upstream dispatches the hook) but the **`tool.execute.before` throw remains the
+   only load-bearing in-session gate**; `permission.ask` must not be counted as an
+   enforcement lever.
+3. **Falsified `session.prompt` assumption (Phase 4 correction).** The
+   `opencode-native-flush` plan assumed `session.prompt({outputFormat})` for
+   JSON-schema structured output. **No such field exists** (verified through
+   1.17.17). The keyless bridge concatenates the reply's text parts; structured
+   output is obtained via a registered verdict *tool* schema, not a prompt option.
+4. **Version-matrix CI (drift armor).** The two live proofs
+   (`opencode-live-deny.mjs`, `opencode-live-tool.mjs`) run required against the
+   pinned floor `opencode-ai@1.17.13` AND advisory (`continue-on-error`) against
+   `opencode-ai@latest` in the `opencode-live-latest` job — a breaking upstream
+   change surfaces same-day without blocking unrelated merges. The peerDependency
+   floor stays `>=1.17.13` (the contract-verified, required-proof version); bump
+   it deliberately when the canary shows sustained green on a newer line.
+
 ## Consequences
 
 Rail enforcement is real in OpenCode for the common structured-edit path, with the

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -144,7 +144,13 @@ The integration enforces frozen rails at two layers:
    hook denies structured mutations to a frozen rail declared by the active
    ticket: a thrown error in the hook **aborts the tool call** — documented host
    behavior on `@opencode-ai/plugin` >= 1.17.13, regression-tested end-to-end by
-   `scripts/opencode-live-deny.mjs`. Every extractable target path is checked
+   `scripts/opencode-live-deny.mjs`. That proof runs on a **version matrix** in
+   CI: the pinned floor (`opencode-ai@1.17.13`, the contract-verified version) as
+   a *required* check, plus an *advisory* `opencode-live-latest` job that runs the
+   same deny + tool proofs against `opencode-ai@latest` — so a breaking upstream
+   change is visible same-day without blocking unrelated merges (opencode releases
+   near-daily). The floor pin is bumped deliberately when the canary shows
+   sustained green on a newer line. Every extractable target path is checked
    (`filePath`, `files[]`, `edits[]`); a mutating or *unknown* tool whose target
    cannot be extracted is denied while rails are in force (fail closed — a
    deliberate tradeoff: an unrecognized third-party write tool must not slip
@@ -206,11 +212,15 @@ glob/ticket logic to `@adlc/core`:
    keyless bridge that would let a native `adlc_prosecute` tool spawn lens/verifier
    child sessions is now proven (Phase 4); wiring the deterministic runner on top
    is the **Phase 4b** follow-on.
-2. **`permission.ask` is a DORMANT lever.** At opencode 1.17.13 the hook is
-   defined but never dispatched (upstream sst/opencode#7006); the plugin ships a
-   tolerant handler (denies rail-target permissions under both documented payload
-   shapes) that activates the moment upstream wires it. The enforcing control is
-   the `tool.execute.before` throw.
+2. **`permission.ask` is a DORMANT lever.** The hook is defined but never
+   dispatched — re-verified from source at tags **v1.17.17 and v1.17.18**
+   (2026-07-09): `permission.ask` appears only in the Hooks type, is never passed
+   to `plugin.trigger()`, and the real permission path publishes the
+   `permission.asked` event without invoking any plugin hook. Upstream
+   anomalyco/opencode#7006 remains OPEN. The plugin ships a tolerant handler
+   (denies rail-target permissions under both documented payload shapes) that
+   activates the moment upstream wires it. The enforcing control is the
+   `tool.execute.before` throw.
 3. **Floating leading-`**` rails and in-session directory deletion.** The
    in-session shell guard denies deleting/moving a rail's *fixed-anchor* parent
    (`rm -rf test` vs `test/**`, `rm -rf packages/foo/test` vs

--- a/docs/specs/opencode-integration-continuation.md
+++ b/docs/specs/opencode-integration-continuation.md
@@ -4,7 +4,7 @@ Status: PROPOSED (P0/P1 — evaluation + execution plan)
 Branch: `opencode-integration`
 Supersedes nothing; continues `docs/specs/opencode-native-flush.md` (Phases 1–3 merged).
 Baseline verified 2026-07-09 against `@opencode-ai/plugin` / `@opencode-ai/sdk` **1.17.17**
-(published same day; upstream repo moved `sst/opencode` → `anomalyco/opencode`).
+(published same day; upstream repo moved from the sst org to `anomalyco/opencode`).
 
 ## Where we stand (evaluation, 2026-07-09)
 
@@ -30,7 +30,7 @@ Baseline verified 2026-07-09 against `@opencode-ai/plugin` / `@opencode-ai/sdk` 
    actually loaded from, not the npm name.
 2. **Version drift.** CI pins `opencode-ai@1.17.13`; upstream is at 1.17.17 (releases
    near-daily). The flush spec's planned version matrix (pinned + latest) was never wired.
-3. **Stale upstream references.** `sst/opencode` moved to `anomalyco/opencode`; issue links
+3. **Stale upstream references.** The upstream repo moved from the sst org to `anomalyco/opencode`; issue links
    (e.g. #7006 for dormant `permission.ask`) and docs need a sweep + re-verification.
 4. **Falsified spec assumption.** Flush spec 4.1 assumed `session.prompt({outputFormat})`
    JSON-schema structured output. **No such field exists at 1.17.17.** The in-flight code
@@ -90,10 +90,10 @@ covers the npx path; docs Install section rewritten.
 1. Bump baseline: peer dep `>=1.17.13` verified against 1.17.17; CI live proofs run a
    **version matrix** — pinned floor (1.17.13) + `latest` (advisory job so upstream churn
    can't block unrelated merges, but drift is visible same-day).
-2. `sst/opencode` → `anomalyco/opencode` reference sweep (docs, ADR, comments).
+2. sst → anomalyco repo-reference sweep (docs, ADR, comments).
 3. Re-verify `permission.ask` dormancy (#7006) at 1.17.17; if now dispatched, promote the
    dormant handler to a live-tested second lever.
-**AC:** matrix job green on both versions; zero `sst/opencode` references; permission.ask
+**AC:** matrix job green on both versions; zero references to the old sst repo path; permission.ask
 status re-recorded in ADR 0004 with a dated check.
 
 ### T-D — Native robustness: compaction survival + command gating

--- a/plugins/adlc-opencode/index.mjs
+++ b/plugins/adlc-opencode/index.mjs
@@ -195,12 +195,17 @@ export const adlcRailsGuard = async ({ directory, worktree, project, client } = 
       } catch { /* advisory: swallow — the watcher must never break the host */ }
     },
 
-    // Phase 2.1 — DORMANT deny lever. At opencode 1.17.13 `permission.ask` is
-    // defined in the Hooks interface but never dispatched (upstream #7006);
-    // the enforcing control is the tool.execute.before throw above. This
-    // handler exists so rail denial extends to permission prompts the moment
-    // upstream wires the hook. Tolerant of both documented Permission shapes
-    // (V1 {type, pattern} and V2 {action, resources[]}); never throws.
+    // Phase 2.1 — DORMANT deny lever. `permission.ask` is defined in the Hooks
+    // interface but never dispatched — RE-VERIFIED FROM SOURCE at tags v1.17.17
+    // AND v1.17.18 (2026-07-09): the string appears only in the Hooks type at
+    // packages/plugin/src/index.ts; it is never passed to plugin.trigger(), and
+    // the real permission path (packages/opencode/src/permission/index.ts)
+    // publishes the `permission.asked` event without invoking any plugin hook.
+    // Upstream anomalyco/opencode#7006 remains OPEN. The enforcing control is the
+    // tool.execute.before throw above; this handler exists so rail denial extends
+    // to permission prompts the moment upstream wires it. Tolerant of both
+    // documented Permission shapes (V1 {type, pattern} and V2 {action,
+    // resources[]}); never throws.
     'permission.ask': async (input, output) => {
       try {
         const kind = String(input?.type ?? input?.action ?? '').toLowerCase();

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -238,26 +238,35 @@ console.log('  note — AC7 live deny proof: run `node scripts/opencode-live-den
   }
 }
 
-// ---- T31: no STALE LIVE references to the old upstream repo path ----
+// ---- T31: no STALE LIVE references to the old upstream repo home ----
 // The repo moved to anomalyco/opencode; docs, source, comments, and workflows
-// must not still point at the old org path as if current. Scope: live-reference
-// locations only. EXCLUDED: this guard file (names the pattern), and .adlc/
-// ticket bodies — immutable historical contracts (editing one trips the CI
-// base-ticket-contract gate) that legitimately describe the move as past work.
+// must not still point at the old sst home as if current. Matches BOTH the
+// org-path form (sst/opencode, in HTTPS or git@ URLs — case-insensitive, since
+// GitHub org paths are) AND the old domain forms (sst.dev/opencode,
+// opencode.sst.dev). Scope: live-reference locations only. EXCLUDED: this guard
+// file (it names the patterns), and .adlc/tickets.json specifically — the T31
+// ticket body legitimately describes the move as past work and is an immutable
+// contract (editing it trips the CI base-ticket gate). Any OTHER .adlc/ file is
+// still scanned.
 {
-  // Assemble the needle in two halves so the guard file never self-matches.
-  const needle = ['sst', 'opencode'].join('/');
+  // Assemble each needle in halves so the guard file never self-matches.
+  const patterns = [
+    ['sst', 'opencode'].join('/'),        // github.com/sst/opencode, git@github.com:sst/opencode
+    ['sst', 'dev/opencode'].join('.'),    // sst.dev/opencode
+    ['opencode', 'sst', 'dev'].join('.'), // opencode.sst.dev
+  ];
   let hits = '';
   try {
-    hits = execFileSync('git', ['-C', ROOT, 'grep', '-l', needle, '--',
-      '.', ':!scripts/opencode-install-smoke.mjs', ':!.adlc/'], { encoding: 'utf8' }).trim();
+    hits = execFileSync('git', ['-C', ROOT, 'grep', '-il', '-E', patterns.join('|'), '--',
+      '.', ':!scripts/opencode-install-smoke.mjs', ':!.adlc/tickets.json'], { encoding: 'utf8' }).trim();
   } catch (e) {
     // git grep exits 1 with no output when there are NO matches — the pass case.
+    // Any other status (128 non-git dir, ENOENT git absent) is a real failure.
     if (e.status === 1 && !e.stdout?.trim()) hits = '';
-    else { fail(`upstream-path sweep could not run: ${e.message}`); hits = ''; }
+    else { fail(`upstream-home sweep could not run: ${e.message}`); hits = ''; }
   }
-  if (hits) fail(`stale upstream repo path present in: ${hits.split('\n').join(', ')}`);
-  else ok('no stale upstream repo-path references (upstream is anomalyco/opencode)');
+  if (hits) fail(`stale upstream repo-home reference present in: ${hits.split('\n').join(', ')}`);
+  else ok('no stale upstream repo-home references (upstream is anomalyco/opencode)');
 }
 
 if (failures) { console.error(`\nopencode-install-smoke: ${failures} failure(s)`); process.exit(2); }

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -238,6 +238,28 @@ console.log('  note — AC7 live deny proof: run `node scripts/opencode-live-den
   }
 }
 
+// ---- T31: no STALE LIVE references to the old upstream repo path ----
+// The repo moved to anomalyco/opencode; docs, source, comments, and workflows
+// must not still point at the old org path as if current. Scope: live-reference
+// locations only. EXCLUDED: this guard file (names the pattern), and .adlc/
+// ticket bodies — immutable historical contracts (editing one trips the CI
+// base-ticket-contract gate) that legitimately describe the move as past work.
+{
+  // Assemble the needle in two halves so the guard file never self-matches.
+  const needle = ['sst', 'opencode'].join('/');
+  let hits = '';
+  try {
+    hits = execFileSync('git', ['-C', ROOT, 'grep', '-l', needle, '--',
+      '.', ':!scripts/opencode-install-smoke.mjs', ':!.adlc/'], { encoding: 'utf8' }).trim();
+  } catch (e) {
+    // git grep exits 1 with no output when there are NO matches — the pass case.
+    if (e.status === 1 && !e.stdout?.trim()) hits = '';
+    else { fail(`upstream-path sweep could not run: ${e.message}`); hits = ''; }
+  }
+  if (hits) fail(`stale upstream repo path present in: ${hits.split('\n').join(', ')}`);
+  else ok('no stale upstream repo-path references (upstream is anomalyco/opencode)');
+}
+
 if (failures) { console.error(`\nopencode-install-smoke: ${failures} failure(s)`); process.exit(2); }
 console.log('\nopencode-install-smoke: PASS');
 

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -250,10 +250,13 @@ console.log('  note — AC7 live deny proof: run `node scripts/opencode-live-den
 // still scanned.
 {
   // Assemble each needle in halves so the guard file never self-matches.
+  // Dots are escaped for -E so `.` matches a literal dot, not any char (a bare
+  // `.` would over-flag contrived strings like `sstXdev/opencode`). Fail-safe
+  // either way — the regex can only over-flag, never hide a stale ref.
   const patterns = [
-    ['sst', 'opencode'].join('/'),        // github.com/sst/opencode, git@github.com:sst/opencode
-    ['sst', 'dev/opencode'].join('.'),    // sst.dev/opencode
-    ['opencode', 'sst', 'dev'].join('.'), // opencode.sst.dev
+    ['sst', 'opencode'].join('/'),           // github.com/sst/opencode, git@github.com:sst/opencode
+    ['sst', 'dev/opencode'].join('\\.'),     // sst.dev/opencode
+    ['opencode', 'sst', 'dev'].join('\\.'),  // opencode.sst.dev
   ];
   let hits = '';
   try {


### PR DESCRIPTION
## Summary

Executes ticket **T31** from the [continuation spec](docs/specs/opencode-integration-continuation.md) — armors the integration against upstream drift and refreshes the truth of every version-dependent claim.

- **CI version-matrix drift canary**: a new advisory `opencode-live-latest` job (`continue-on-error: true`, no `needs`/`if`) runs both live proofs (`opencode-live-deny.mjs` + `opencode-live-tool.mjs`) against `opencode-ai@latest`. A breaking upstream change is visible same-day without failing the required pipeline (opencode releases near-daily). The required `test` job still runs both proofs against the pinned `1.17.13` floor; the peerDependency floor stays `>=1.17.13` and is bumped deliberately when the canary shows sustained green.
- **anomalyco sweep**: the upstream repo moved from the sst org to `anomalyco/opencode`. All live references swept to zero, gated by a new install-smoke guard (`git grep`, excluding the guard file itself and immutable `.adlc/` ticket bodies) so drift can't creep back.
- **`permission.ask` re-verified DORMANT** at tags **v1.17.17 AND v1.17.18** by source inspection: the hook appears only in the Hooks type, is never passed to `plugin.trigger()`, and the real permission path publishes `permission.asked` without invoking any plugin hook. Upstream **#7006 remains OPEN**. The handler stays as the dormant lever; the `tool.execute.before` throw remains the only load-bearing in-session gate. Dated finding recorded in the code comment, `docs/integrations/opencode.md`, and a new **ADR 0004 amendment** (which also records the anomalyco move, the falsified `session.prompt({outputFormat})` assumption, and the version-matrix rationale).

## Test plan
- [x] 212/212 plugin tests; install smoke PASS (incl. the new sweep guard); full repo suite green
- [x] All four T31 ACs verified (CI matrix present + advisory; zero live sst refs; dated ADR entry; suite green)
- [x] Same-model P5 prosecution: **SHIP** — sweep guard mutation-verified load-bearing (stale ref → fail exit 2; `.adlc/`+self exclusions do real work; git-absent/non-git-dir fail loudly, never swallowed as pass); advisory job proven non-gating and always-run; permission.ask docs match unchanged handler with no overclaim
- [ ] Cross-model codex loop (running; verdict noted before merge)
- [ ] CI live proofs on the node-20 leg + the new advisory latest job