### PR TITLE
feat(opencode): T33 deterministic P5 runner — native adlc_prosecute tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,15 @@ jobs:
       - name: OpenCode compaction registration+behavior proof (T32)
         run: node scripts/opencode-live-compaction.mjs
 
+      # T33 deterministic P5 proof: the shipped adlc_prosecute tool drives the
+      # fan-out → verify → loop-until-dry loop in first-party code over
+      # WRITE-DISABLED child sessions, converging a seeded defect to NO-SHIP.
+      # Runs against a real-shaped mock SDK client (a full multi-lens loop isn't
+      # deterministically forcible through a real binary) — registration on the
+      # real binary is proven by the live-tool step above. REQUIRED.
+      - name: OpenCode deterministic prosecute proof (T33)
+        run: node scripts/opencode-live-prosecute.mjs
+
       # pi live deny proof (ticket T21 AC5) — same folded-into-required-job
       # rationale as the OpenCode step above. Runs on the Node 22 leg only
       # (pi requires Node >= 22.19; the script hard-skips on older majors and

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -203,16 +203,27 @@ glob/ticket logic to `@adlc/core`:
 | P6 Integrate | Partial | `session.idle` advisory gate-manifest audit; the human gate is by design |
 | P7 Distill | **Yes** | `/adlc-distill` (Phase E) |
 
+Resolved 2026-07-09 (T33 / Phase 4b): **deterministic P5 runner.** The native
+**`adlc_prosecute`** tool drives the fan-out → dedupe → verify → loop-until-dry
+protocol in FIRST-PARTY code (`lib/prosecute-runner.mjs` `runProsecution`, over
+the tested `@adlc/core` helpers), not by prose-instructing the model to
+orchestrate. Each lens and the verifier run in an isolated child session
+(`client.session.create({parentID})` + `session.prompt`) carrying the agent's
+prompt as a per-call `system` override and a **write-disabled `tools` map** (a
+`false` map over every mutating + shell tool — a lens reads the diff, it cannot
+edit). Structured verdicts come back as fenced JSON (there is no server-side
+`outputFormat` at 1.17.x); an unparseable verdict is **fail-closed** — the
+finding is kept as a blocker and flagged unverified, never silently dropped. The
+loop is hard-bounded (max rounds / max child sessions) and reports the bound it
+hit. `/adlc-prosecute` calls the tool first and keeps the prose protocol as the
+fallback when the tool is unavailable. Proven end-to-end by
+`scripts/opencode-live-prosecute.mjs` (seeded-defect convergence + write-disable,
+CI-required) and `scripts/opencode-live-tool.mjs` (real-binary registration).
+This makes OpenCode's P5 the most deterministic of the six integrations.
+
 ## Gaps
 
-1. **P5 orchestration is still model-driven.** `/adlc-prosecute` describes the
-   fan-out → dedupe → verify → loop-until-dry protocol (the decision helpers in
-   `lib/prosecutor.mjs` are unit-tested), but the loop itself is executed by the
-   model invoking the subagents, not a deterministic first-party runner. The
-   keyless bridge that would let a native `adlc_prosecute` tool spawn lens/verifier
-   child sessions is now proven (Phase 4); wiring the deterministic runner on top
-   is the **Phase 4b** follow-on.
-2. **`permission.ask` is a DORMANT lever.** The hook is defined but never
+1. **`permission.ask` is a DORMANT lever.** The hook is defined but never
    dispatched — re-verified from source at tags **v1.17.17 and v1.17.18**
    (2026-07-09): `permission.ask` appears only in the Hooks type, is never passed
    to `plugin.trigger()`, and the real permission path publishes the
@@ -221,7 +232,7 @@ glob/ticket logic to `@adlc/core`:
    (denies rail-target permissions under both documented payload shapes) that
    activates the moment upstream wires it. The enforcing control is the
    `tool.execute.before` throw.
-3. **Floating leading-`**` rails and in-session directory deletion.** The
+2. **Floating leading-`**` rails and in-session directory deletion.** The
    in-session shell guard denies deleting/moving a rail's *fixed-anchor* parent
    (`rm -rf test` vs `test/**`, `rm -rf packages/foo/test` vs
    `packages/*/test/**`, `rm -rf .`). A rail with a *leading* `**` (e.g.

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -209,13 +209,25 @@ protocol in FIRST-PARTY code (`lib/prosecute-runner.mjs` `runProsecution`, over
 the tested `@adlc/core` helpers), not by prose-instructing the model to
 orchestrate. Each lens and the verifier run in an isolated child session
 (`client.session.create({parentID})` + `session.prompt`) carrying the agent's
-prompt as a per-call `system` override and a **write-disabled `tools` map** (a
-`false` map over every mutating + shell tool — a lens reads the diff, it cannot
-edit). Structured verdicts come back as fenced JSON (there is no server-side
+prompt as a per-call `system` override and a **fail-closed read-only `tools`
+allowlist**. That map is `{ "*": false, <read-only tools>: true }` — the
+wildcard-deny-first shape opencode's own `explore`/`compaction` agents use:
+opencode compiles the map to permission rules (`findLast` wins), so `"*": false`
+denies everything and only the read-only tools re-allow themselves. Any unlisted
+tool — `edit`/`write`/`apply_patch`, the `task` sub-agent spawner, MCP tools, or
+any future tool — matches only `"*"` and is **hard-denied**. (A denylist would
+fail OPEN here, since the SDK `tools` map is a sparse override where absent =
+the agent default = enabled.) So a lens reads the diff and *cannot* mutate the
+repo, even via a sub-agent or a prompt-injection in the untrusted diff.
+Structured verdicts come back as fenced JSON (there is no server-side
 `outputFormat` at 1.17.x); an unparseable verdict is **fail-closed** — the
-finding is kept as a blocker and flagged unverified, never silently dropped. The
-loop is hard-bounded (max rounds / max child sessions) and reports the bound it
-hit. `/adlc-prosecute` calls the tool first and keeps the prose protocol as the
+finding is kept as a blocker and flagged unverified, never silently dropped. A
+lens whose reply doesn't parse likewise surfaces a blocker (an all-garbage round
+can't masquerade as a clean pass), a bounded/incomplete run is reported
+`NO-SHIP (INCOMPLETE)` (only a *converged* zero-findings run SHIPs), and a
+`git diff` capture failure fails closed rather than reading as an empty change.
+The loop is hard-bounded (max rounds / max child sessions) and reports the bound
+it hit. `/adlc-prosecute` calls the tool first and keeps the prose protocol as the
 fallback when the tool is unavailable. Proven end-to-end by
 `scripts/opencode-live-prosecute.mjs` (seeded-defect convergence + write-disable,
 CI-required) and `scripts/opencode-live-tool.mjs` (real-binary registration).

--- a/plugins/adlc-opencode/command/adlc-prosecute.md
+++ b/plugins/adlc-opencode/command/adlc-prosecute.md
@@ -7,6 +7,15 @@ description: Prosecute a change before merge (P5) — fan out the 5 lenses, veri
 Prosecute the change for the active ticket. Requires a clean G4 build
 (`/adlc-verify-build`). Target: **$ARGUMENTS** (default to the active ticket).
 
+## 0. Prefer the deterministic runner
+If the native **`adlc_prosecute`** tool is available, call it first —
+`adlc_prosecute({ base: "<base ref>" })`. It drives the entire fan-out → dedupe →
+verify → loop-until-dry protocol below in **first-party code** over isolated,
+**write-disabled** child sessions (lenses can read the diff, never mutate), and
+returns the confirmed findings + a ship/no-ship verdict deterministically. Report
+its result and skip to step 5. Only fall back to the manual prose protocol
+(steps 1–4) when the tool is unavailable (no session API / older host).
+
 ## 1. Fan out the lenses
 Invoke the five prosecution subagents independently, each on the change diff:
 `@prosecutor-correctness`, `@prosecutor-security`, `@prosecutor-contract`,

--- a/plugins/adlc-opencode/index.mjs
+++ b/plugins/adlc-opencode/index.mjs
@@ -22,6 +22,7 @@ import { handleFileEdited, createWatcherState } from './lib/watcher.mjs';
 import { buildSystemContext, buildToolRailNotice, buildStatusLine } from './lib/context-inject.mjs';
 import { createFlailTracker, flailMessage } from './lib/flail.mjs';
 import { buildGateTool } from './lib/gate-tool.mjs';
+import { buildProsecuteTool } from './lib/prosecute-tool.mjs';
 import { buildCompactionContext, decideAutocontinue } from './lib/compaction.mjs';
 import { checkCommandOrder, checkCommandTamper } from './lib/command-gate.mjs';
 import { fileURLToPath } from 'node:url';
@@ -142,12 +143,16 @@ export const adlcRailsGuard = async ({ directory, worktree, project, client } = 
   try {
     const { tool } = await import('@opencode-ai/plugin');
     if (tool?.schema) {
-      toolHook = buildGateTool(tool.schema, { root, client });
+      // adlc_gate (Phase 4.2) + adlc_prosecute (T33: deterministic P5 runner).
+      toolHook = {
+        ...buildGateTool(tool.schema, { root, client }),
+        ...buildProsecuteTool(tool.schema, { root, pkgRoot: PKG_ROOT, client }),
+      };
     } else {
-      console.error('[adlc] @opencode-ai/plugin exposes no tool.schema — adlc_gate tool NOT registered');
+      console.error('[adlc] @opencode-ai/plugin exposes no tool.schema — adlc_gate/adlc_prosecute tools NOT registered');
     }
   } catch (err) {
-    console.error(`[adlc] adlc_gate tool NOT registered (@opencode-ai/plugin unavailable: ${err?.message ?? err})`);
+    console.error(`[adlc] native tools NOT registered (@opencode-ai/plugin unavailable: ${err?.message ?? err})`);
   }
 
   return {

--- a/plugins/adlc-opencode/lib/keyless-bridge.mjs
+++ b/plugins/adlc-opencode/lib/keyless-bridge.mjs
@@ -128,7 +128,11 @@ export function makeAsk(client, { parentID, model, timeoutMs = PROMPT_TIMEOUT_MS
           path: { id: childId },
           body: {
             ...(model ? { model } : {}),
-            tools: {}, // no tools — a pure question/answer turn
+            // A pure Q/A turn needs NO tools. `tools: {}` is NOT "no tools" —
+            // opencode treats an empty map as "no overrides" → all tools inherit
+            // the base agent default (`"*": "allow"`) = ALL ENABLED. Deny
+            // everything with the wildcard rule so the gate child can't act.
+            tools: { '*': false },
             parts: [{ type: 'text', text }],
           },
         }),

--- a/plugins/adlc-opencode/lib/prosecute-runner.mjs
+++ b/plugins/adlc-opencode/lib/prosecute-runner.mjs
@@ -61,11 +61,11 @@ export function parseFindings(text) {
   const v = parseFenced(text);
   if (Array.isArray(v)) return { findings: v.filter((f) => f && typeof f === 'object'), parsed: true };
   if (v && Array.isArray(v.findings)) return { findings: v.findings.filter((f) => f && typeof f === 'object'), parsed: true };
-  // Nothing parseable. Distinguish a genuinely empty reply from garbage: an
-  // empty/whitespace reply is a clean "no findings"; any other unparseable
-  // content is a parse FAILURE that must surface.
-  const clean = typeof text !== 'string' || text.trim() === '';
-  return { findings: [], parsed: clean };
+  // Nothing parseable → parse FAILURE. A well-behaved lens with nothing to say
+  // returns an explicit empty array (`[]`), which parses cleanly above. An
+  // EMPTY/whitespace or garbage reply is anomalous — fail closed (parsed:false),
+  // symmetric with a null/no-reply, so a silent lens can't read as "found nothing".
+  return { findings: [], parsed: false };
 }
 
 /** Normalize a verifier reply into a {real:boolean} vote, or null if unparseable. */

--- a/plugins/adlc-opencode/lib/prosecute-runner.mjs
+++ b/plugins/adlc-opencode/lib/prosecute-runner.mjs
@@ -1,0 +1,171 @@
+// prosecute-runner.mjs — T33: the DETERMINISTIC P5 prosecution loop, in
+// first-party code. Instead of prose-instructing the host model to orchestrate
+// fan-out → dedupe → verify → loop-until-dry, the native `adlc_prosecute` tool
+// calls runProsecution(), which drives that protocol itself using the tested
+// @adlc/core helpers (via lib/prosecutor.mjs) and spawns lens/verifier work as
+// isolated, WRITE-DISABLED child sessions.
+//
+// Everything here is pure + injectable: runProsecution takes an `ask` function
+// (real → child session; test → mock), so the control flow is unit-testable
+// offline. The session wiring (makeLensAsk) is proven end-to-end by the live
+// harness against a real opencode.
+
+import {
+  LENSES, VERIFIER, findingKey, dedupeFindings, survivesVerification, shouldContinue,
+} from './prosecutor.mjs';
+import { MUTATING_TOOLS, SHELL_TOOLS } from '../rails-checker.mjs';
+import { PROMPT_TIMEOUT_MS } from './keyless-bridge.mjs';
+
+// A lens/verifier session must be able to READ but never MUTATE. Disabling by
+// an explicit false map (not an allowlist) means a write tool the host adds
+// later still can't be enabled here without a code change.
+export const WRITE_TOOLS = [...MUTATING_TOOLS, ...SHELL_TOOLS];
+
+/** The tools disable-map handed to a lens/verifier child session.prompt. */
+export function lensToolsMap(extra = []) {
+  const map = {};
+  for (const t of [...WRITE_TOOLS, ...extra]) map[t] = false;
+  return map;
+}
+
+/**
+ * Extract a fenced JSON payload from a reply. Findings/verdicts are requested
+ * as a ```json block. Returns the parsed value, or null on absence/parse
+ * failure — the caller decides the fail-closed behavior (never silently drop).
+ */
+export function parseFenced(text) {
+  if (typeof text !== 'string') return null;
+  const m = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const body = (m ? m[1] : text).trim();
+  if (!body) return null;
+  try { return JSON.parse(body); } catch { return null; }
+}
+
+/** Normalize a lens reply into a findings array (fail-closed to []). */
+export function parseFindings(text) {
+  const v = parseFenced(text);
+  if (Array.isArray(v)) return v.filter((f) => f && typeof f === 'object');
+  if (v && Array.isArray(v.findings)) return v.findings.filter((f) => f && typeof f === 'object');
+  return [];
+}
+
+/** Normalize a verifier reply into a {real:boolean} vote, or null if unparseable. */
+export function parseVerdict(text) {
+  const v = parseFenced(text);
+  if (v && typeof v.real === 'boolean') return { real: v.real, reason: typeof v.reason === 'string' ? v.reason : undefined };
+  return null;
+}
+
+/**
+ * Build the real lens/verifier `ask` from the host SDK client: each call spins
+ * up an isolated child session (parentID = active session) with a per-call
+ * SYSTEM override (the agent prompt) and the WRITE-DISABLED tools map, returns
+ * the reply text, and best-effort deletes the child. Returns null when the
+ * client lacks the session API (caller falls back to the prose protocol).
+ * Mirrors keyless-bridge makeAsk, adding `system` + the tools disable-map.
+ */
+export function makeLensAsk(client, { parentID, model, timeoutMs = PROMPT_TIMEOUT_MS, withTimeout } = {}) {
+  const session = client?.session;
+  if (typeof session?.create !== 'function' || typeof session?.prompt !== 'function') return null;
+  const race = withTimeout ?? ((p) => p);
+  return async ({ system, prompt }) => {
+    const created = await race(
+      session.create({ body: { ...(parentID ? { parentID } : {}), title: 'adlc-prosecute' } }),
+      timeoutMs, 'prosecute: child session.create timed out');
+    const childId = created?.data?.id ?? created?.id;
+    try {
+      const res = await race(
+        session.prompt({
+          path: { id: childId },
+          body: {
+            ...(model ? { model } : {}),
+            ...(system ? { system } : {}),
+            tools: lensToolsMap(),
+            parts: [{ type: 'text', text: prompt }],
+          },
+        }),
+        timeoutMs, 'prosecute: child session.prompt timed out');
+      const parts = res?.data?.parts ?? res?.parts ?? [];
+      return parts.filter((p) => p?.type === 'text').map((p) => p.text).join('') || '';
+    } finally {
+      try { if (childId && typeof session.delete === 'function') await session.delete({ path: { id: childId } }); }
+      catch { /* best-effort cleanup */ }
+    }
+  };
+}
+
+const DEFAULTS = { maxRounds: 4, maxSessions: 40, maxDry: 2, verifierVotes: 1 };
+
+/**
+ * Drive the deterministic P5 loop.
+ *
+ * @param {object} opts
+ * @param {(req:{agent:string,system:string,prompt:string}) => Promise<string>} opts.ask
+ *   lens/verifier caller (real child session or test mock).
+ * @param {(agent:string) => string} opts.agentPrompt  system prompt for an agent key.
+ * @param {string} opts.diff   the change under prosecution (lens/verifier context).
+ * @param {object} [opts.bounds]  { maxRounds, maxSessions, maxDry, verifierVotes }
+ * @returns {Promise<{confirmed:object[], unverified:object[], rounds:number, sessionsUsed:number, hitBound:string|null}>}
+ */
+export async function runProsecution({ ask, agentPrompt, diff, bounds = {} } = {}) {
+  const { maxRounds, maxSessions, maxDry, verifierVotes } = { ...DEFAULTS, ...bounds };
+  if (typeof ask !== 'function') throw new Error('runProsecution: an ask() function is required');
+
+  const seen = new Set();          // findingKey of every finding ever surfaced (dedupe across rounds)
+  const confirmed = [];
+  const unverified = [];
+  let sessionsUsed = 0;
+  let dryStreak = 0;
+  let round = 0;
+  let hitBound = null;
+  let naturalStop = false; // loop went dry (converged) rather than hitting a bound
+
+  const askOne = async (agent, prompt) => {
+    if (sessionsUsed >= maxSessions) { hitBound = 'maxSessions'; return null; }
+    sessionsUsed += 1;
+    return ask({ agent, system: agentPrompt ? agentPrompt(agent) : '', prompt });
+  };
+
+  while (round < maxRounds) {
+    round += 1;
+
+    // Fan out every lens for this round (each in its own write-disabled session).
+    const lensReplies = await Promise.all(LENSES.map(async (lens) => {
+      const text = await askOne(lens.agent, `Prosecute this change through the ${lens.focus} lens. Return findings as a fenced \`\`\`json array of {title, severity, file, detail}.\n\n${diff}`);
+      return text == null ? [] : parseFindings(text);
+    }));
+    if (hitBound) break;
+
+    const roundFindings = dedupeFindings(lensReplies.flat());
+    const fresh = roundFindings.filter((f) => !seen.has(findingKey(f)));
+    for (const f of fresh) seen.add(findingKey(f));
+
+    // Verify each fresh finding (verifierVotes independent votes). An unparseable
+    // verdict yields NO valid vote → survivesVerification keeps it (fail-closed).
+    for (const f of fresh) {
+      const votes = [];
+      let unparsedVote = false;
+      for (let i = 0; i < verifierVotes; i += 1) {
+        const text = await askOne(VERIFIER.agent, `Try to REFUTE this finding — reproduce it or prove it false. Return a fenced \`\`\`json {"real": boolean, "reason": string}.\n\nFinding: ${JSON.stringify(f)}\n\n${diff}`);
+        if (hitBound) break;
+        const v = parseVerdict(text);
+        if (v) votes.push(v); else unparsedVote = true;
+      }
+      if (hitBound) break;
+      const kept = survivesVerification(votes);
+      if (kept) {
+        confirmed.push(f);
+        if (unparsedVote && votes.length === 0) unverified.push(f); // kept but never verifiably confirmed
+      }
+    }
+    if (hitBound) break;
+
+    const step = shouldContinue({ freshThisRound: fresh.length, dryStreak, maxDry });
+    dryStreak = step.dryStreak;
+    if (!step.continue) { naturalStop = true; break; }
+  }
+  // Only a bound if we exhausted the round budget WITHOUT converging.
+  if (!hitBound && !naturalStop && round >= maxRounds) hitBound = 'maxRounds';
+
+  return { confirmed: dedupeFindings(confirmed), unverified, rounds: round, sessionsUsed, hitBound };
+}

--- a/plugins/adlc-opencode/lib/prosecute-runner.mjs
+++ b/plugins/adlc-opencode/lib/prosecute-runner.mjs
@@ -13,18 +13,27 @@
 import {
   LENSES, VERIFIER, findingKey, dedupeFindings, survivesVerification, shouldContinue,
 } from './prosecutor.mjs';
-import { MUTATING_TOOLS, SHELL_TOOLS } from '../rails-checker.mjs';
+import { READONLY_TOOLS } from '../rails-checker.mjs';
 import { PROMPT_TIMEOUT_MS } from './keyless-bridge.mjs';
 
-// A lens/verifier session must be able to READ but never MUTATE. Disabling by
-// an explicit false map (not an allowlist) means a write tool the host adds
-// later still can't be enabled here without a code change.
-export const WRITE_TOOLS = [...MUTATING_TOOLS, ...SHELL_TOOLS];
+// A lens/verifier session must READ but never MUTATE. The session.prompt `tools`
+// map compiles to opencode PERMISSION RULES (session/prompt.ts): each key → one
+// rule, `findLast` match wins, unmatched → the agent default (base `build` =
+// `"*": "allow"`). So a DENYLIST fails OPEN — a write tool not in the list
+// (`task` sub-agent spawner, MCP tools, any future tool) stays enabled.
+//
+// The fix is a wildcard-deny-first ALLOWLIST — the exact shape opencode's own
+// read-only `explore`/`compaction` agents use: `{ "*": false, <read tools>: true }`.
+// `"*": false` denies everything; the read tools re-allow themselves via a LATER
+// rule (findLast). Anything unlisted — edit/write/patch, `task`, MCP, unknown —
+// matches only `*` → HARD DENY (an explicit deny rule, enforced even in a
+// headless child with no interactive approver). ORDER IS LOAD-BEARING: `"*"`
+// MUST be the first key, or the deny wins for everything.
+export const LENS_READ_TOOLS = READONLY_TOOLS; // single source: the rail guard's read-only set
 
-/** The tools disable-map handed to a lens/verifier child session.prompt. */
-export function lensToolsMap(extra = []) {
-  const map = {};
-  for (const t of [...WRITE_TOOLS, ...extra]) map[t] = false;
+export function lensToolsMap() {
+  const map = { '*': false };            // deny-all first (insertion order preserved)
+  for (const t of LENS_READ_TOOLS) map[t] = true; // re-allow only read-only tools
   return map;
 }
 
@@ -41,12 +50,22 @@ export function parseFenced(text) {
   try { return JSON.parse(body); } catch { return null; }
 }
 
-/** Normalize a lens reply into a findings array (fail-closed to []). */
+/**
+ * Normalize a lens reply into { findings, parsed }. A CLEAN empty result
+ * (`[]` / `{findings:[]}`) is parsed:true, findings:[]. An unparseable or
+ * schema-drifted NON-EMPTY reply is parsed:false — the caller must NOT treat it
+ * as "found nothing" (fail-open); a lens that produced garbage is not a lens
+ * that cleanly cleared the change.
+ */
 export function parseFindings(text) {
   const v = parseFenced(text);
-  if (Array.isArray(v)) return v.filter((f) => f && typeof f === 'object');
-  if (v && Array.isArray(v.findings)) return v.findings.filter((f) => f && typeof f === 'object');
-  return [];
+  if (Array.isArray(v)) return { findings: v.filter((f) => f && typeof f === 'object'), parsed: true };
+  if (v && Array.isArray(v.findings)) return { findings: v.findings.filter((f) => f && typeof f === 'object'), parsed: true };
+  // Nothing parseable. Distinguish a genuinely empty reply from garbage: an
+  // empty/whitespace reply is a clean "no findings"; any other unparseable
+  // content is a parse FAILURE that must surface.
+  const clean = typeof text !== 'string' || text.trim() === '';
+  return { findings: [], parsed: clean };
 }
 
 /** Normalize a verifier reply into a {real:boolean} vote, or null if unparseable. */
@@ -132,17 +151,31 @@ export async function runProsecution({ ask, agentPrompt, diff, bounds = {} } = {
     // Fan out every lens for this round (each in its own write-disabled session).
     const lensReplies = await Promise.all(LENSES.map(async (lens) => {
       const text = await askOne(lens.agent, `Prosecute this change through the ${lens.focus} lens. Return findings as a fenced \`\`\`json array of {title, severity, file, detail}.\n\n${diff}`);
-      return text == null ? [] : parseFindings(text);
+      if (text == null) return { lens, findings: [], parsed: false }; // bound hit / no reply → fail closed
+      const p = parseFindings(text);
+      return { lens, findings: p.findings, parsed: p.parsed };
     }));
     if (hitBound) break;
 
-    const roundFindings = dedupeFindings(lensReplies.flat());
+    // A lens whose reply couldn't be parsed did NOT clear the change — surface a
+    // synthetic blocker so an all-garbage round can never masquerade as dry/SHIP.
+    const unparsedLenses = lensReplies.filter((r) => !r.parsed);
+    const parseBlockers = unparsedLenses.map((r) => ({
+      title: `unparseable lens output: ${r.lens.agent}`,
+      severity: 'high', file: '(prosecution)', detail: 'lens reply was not valid findings JSON — treated as an unverified blocker (fail-closed)',
+      _unparsed: true,
+    }));
+
+    const roundFindings = dedupeFindings([...lensReplies.flatMap((r) => r.findings), ...parseBlockers]);
     const fresh = roundFindings.filter((f) => !seen.has(findingKey(f)));
     for (const f of fresh) seen.add(findingKey(f));
 
     // Verify each fresh finding (verifierVotes independent votes). An unparseable
     // verdict yields NO valid vote → survivesVerification keeps it (fail-closed).
     for (const f of fresh) {
+      // A parse-failure blocker has nothing to refute — keep it as an unverified
+      // blocker directly (no verifier session spent, no false convergence).
+      if (f._unparsed) { confirmed.push(f); unverified.push(f); continue; }
       const votes = [];
       let unparsedVote = false;
       for (let i = 0; i < verifierVotes; i += 1) {

--- a/plugins/adlc-opencode/lib/prosecute-tool.mjs
+++ b/plugins/adlc-opencode/lib/prosecute-tool.mjs
@@ -19,11 +19,18 @@ export function makeAgentPromptReader(pkgRoot) {
   };
 }
 
-/** The change under prosecution: `git diff <base>...HEAD`. '' if git/base unavailable. */
+/**
+ * The change under prosecution: `git diff <base>...HEAD`.
+ * Returns { diff, error }. A git FAILURE (bad base ref, non-git cwd, buffer
+ * overflow) sets error — the caller must NOT treat that as an empty diff (which
+ * would falsely SHIP); a genuine clean tree returns { diff: '', error: null }.
+ */
 export function captureDiff({ base = 'main', cwd = process.cwd(), spawnImpl = execFileSync } = {}) {
   try {
-    return String(spawnImpl('git', ['diff', `${base}...HEAD`], { cwd, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }) || '');
-  } catch { return ''; }
+    return { diff: String(spawnImpl('git', ['diff', `${base}...HEAD`], { cwd, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }) || ''), error: null };
+  } catch (err) {
+    return { diff: '', error: String(err?.message ?? err) };
+  }
 }
 
 /**
@@ -58,24 +65,40 @@ export function buildProsecuteTool(schema, { root = process.cwd(), pkgRoot, clie
             metadata: { error: 'no-session-api', deterministic: false },
           };
         }
-        const diff = (diffImpl ?? captureDiff)({ base, cwd });
+        const captured = (diffImpl ?? captureDiff)({ base, cwd });
+        // Normalize: diffImpl (tests) may return a bare string; captureDiff returns {diff,error}.
+        const { diff, error } = typeof captured === 'string' ? { diff: captured, error: null } : captured;
+        if (error) {
+          // A git FAILURE is NOT "nothing to prosecute" — fail closed.
+          return {
+            title: 'adlc_prosecute: NO-SHIP (diff capture failed)',
+            output: `Could not capture \`git diff ${base}...HEAD\`: ${error}. Not treating this as an empty change — resolve the base ref / repo state and re-run.`,
+            metadata: { base, deterministic: true, verdict: 'NO-SHIP (diff-capture-failed)', error: 'diff-capture-failed', confirmed: 0 },
+          };
+        }
         if (!diff.trim()) {
           return {
             title: 'adlc_prosecute: empty diff',
             output: `\`git diff ${base}...HEAD\` produced no changes to prosecute.`,
-            metadata: { base, deterministic: true, confirmed: 0 },
+            metadata: { base, deterministic: true, confirmed: 0, empty: true },
           };
         }
         const result = await runProsecution({ ask, agentPrompt: makeAgentPromptReader(pkgRoot), diff });
         const lines = result.confirmed.map((f) =>
           `- [${f.severity ?? '?'}] ${f.title}${f.file ? ` (${f.file})` : ''}${result.unverified.includes(f) ? ' — UNVERIFIED (kept fail-closed)' : ''}`);
-        const verdict = result.confirmed.length === 0 ? 'SHIP (no confirmed findings)' : `NO-SHIP (${result.confirmed.length} confirmed)`;
+        // A bounded/incomplete run is NOT a clean pass: only a converged run with
+        // zero confirmed findings SHIPs. hitBound → NO-SHIP (INCOMPLETE).
+        const verdict = result.hitBound
+          ? `NO-SHIP (INCOMPLETE — stopped at ${result.hitBound}${result.confirmed.length ? `, ${result.confirmed.length} confirmed` : ''})`
+          : result.confirmed.length === 0
+            ? 'SHIP (no confirmed findings)'
+            : `NO-SHIP (${result.confirmed.length} confirmed)`;
         return {
           title: `adlc_prosecute: ${verdict}`,
           output: [
             `Deterministic P5 loop over ${LENSES.length} lenses + verifier.`,
-            `Rounds: ${result.rounds}, child sessions: ${result.sessionsUsed}${result.hitBound ? `, stopped at bound: ${result.hitBound}` : ''}.`,
-            result.confirmed.length ? `\nConfirmed findings:\n${lines.join('\n')}` : '\nNo findings survived verification.',
+            `Rounds: ${result.rounds}, child sessions: ${result.sessionsUsed}${result.hitBound ? `, stopped at bound: ${result.hitBound} (INCOMPLETE — not a converged pass)` : ''}.`,
+            result.confirmed.length ? `\nConfirmed findings:\n${lines.join('\n')}` : (result.hitBound ? '\nNo confirmed findings yet, but the run did NOT converge.' : '\nNo findings survived verification.'),
           ].join('\n'),
           metadata: {
             base, deterministic: true, verdict,

--- a/plugins/adlc-opencode/lib/prosecute-tool.mjs
+++ b/plugins/adlc-opencode/lib/prosecute-tool.mjs
@@ -1,0 +1,92 @@
+// prosecute-tool.mjs — T33: the native `adlc_prosecute` tool. The model calls
+// adlc_prosecute({ base? }) and execute() drives the deterministic P5 loop in
+// FIRST-PARTY code (runProsecution) — fan-out → dedupe → verify → loop-until-dry
+// across write-disabled child sessions — instead of the model orchestrating it.
+// Returns a structured result the model reports for the P6 human gate.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { LENSES, VERIFIER } from './prosecutor.mjs';
+import { runProsecution, makeLensAsk } from './prosecute-runner.mjs';
+
+/** Read an agent's system prompt from the packaged agent/<name>.md, '' if absent. */
+export function makeAgentPromptReader(pkgRoot) {
+  return (agent) => {
+    const path = join(pkgRoot, 'agent', `${agent}.md`);
+    if (!existsSync(path)) return '';
+    try { return readFileSync(path, 'utf8'); } catch { return ''; }
+  };
+}
+
+/** The change under prosecution: `git diff <base>...HEAD`. '' if git/base unavailable. */
+export function captureDiff({ base = 'main', cwd = process.cwd(), spawnImpl = execFileSync } = {}) {
+  try {
+    return String(spawnImpl('git', ['diff', `${base}...HEAD`], { cwd, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }) || '');
+  } catch { return ''; }
+}
+
+/**
+ * Build the `adlc_prosecute` tool definition map for the plugin `tool` hook.
+ * `schema` is the host zod (injected for testability). `client` is the SDK
+ * client — required for the child-session fan-out; without a usable session API
+ * the tool returns a structured "use the /adlc-prosecute prose protocol"
+ * message rather than silently doing nothing. `pkgRoot` locates the agent
+ * prompts. Returns `{ adlc_prosecute: ToolDefinition }`.
+ */
+export function buildProsecuteTool(schema, { root = process.cwd(), pkgRoot, client, diffImpl } = {}) {
+  return {
+    adlc_prosecute: {
+      description:
+        'Run the ADLC P5 prosecution loop (fan-out → dedupe → verify → ' +
+        'loop-until-dry) deterministically in first-party code over ' +
+        `${LENSES.length} lenses + the ${VERIFIER.agent}. Lens/verifier work runs ` +
+        'in isolated, WRITE-DISABLED child sessions — they read the diff and ' +
+        'return findings, they cannot edit. Prefer this over orchestrating the ' +
+        'prosecution by hand. Returns the confirmed findings for the human gate.',
+      args: {
+        base: schema.string().optional().describe('Base ref to diff against (default "main").'),
+      },
+      execute: async (a, ctx) => {
+        const base = String(a?.base ?? 'main');
+        const cwd = ctx?.directory ?? ctx?.worktree ?? root;
+        const ask = makeLensAsk(client, { parentID: ctx?.sessionID });
+        if (!ask) {
+          return {
+            title: 'adlc_prosecute: no session API',
+            output: 'The host SDK session API is unavailable, so the deterministic runner cannot spawn lens sessions. Run the /adlc-prosecute command (prose protocol) instead.',
+            metadata: { error: 'no-session-api', deterministic: false },
+          };
+        }
+        const diff = (diffImpl ?? captureDiff)({ base, cwd });
+        if (!diff.trim()) {
+          return {
+            title: 'adlc_prosecute: empty diff',
+            output: `\`git diff ${base}...HEAD\` produced no changes to prosecute.`,
+            metadata: { base, deterministic: true, confirmed: 0 },
+          };
+        }
+        const result = await runProsecution({ ask, agentPrompt: makeAgentPromptReader(pkgRoot), diff });
+        const lines = result.confirmed.map((f) =>
+          `- [${f.severity ?? '?'}] ${f.title}${f.file ? ` (${f.file})` : ''}${result.unverified.includes(f) ? ' — UNVERIFIED (kept fail-closed)' : ''}`);
+        const verdict = result.confirmed.length === 0 ? 'SHIP (no confirmed findings)' : `NO-SHIP (${result.confirmed.length} confirmed)`;
+        return {
+          title: `adlc_prosecute: ${verdict}`,
+          output: [
+            `Deterministic P5 loop over ${LENSES.length} lenses + verifier.`,
+            `Rounds: ${result.rounds}, child sessions: ${result.sessionsUsed}${result.hitBound ? `, stopped at bound: ${result.hitBound}` : ''}.`,
+            result.confirmed.length ? `\nConfirmed findings:\n${lines.join('\n')}` : '\nNo findings survived verification.',
+          ].join('\n'),
+          metadata: {
+            base, deterministic: true, verdict,
+            confirmed: result.confirmed.length,
+            unverified: result.unverified.length,
+            rounds: result.rounds,
+            sessionsUsed: result.sessionsUsed,
+            hitBound: result.hitBound,
+          },
+        };
+      },
+    },
+  };
+}

--- a/plugins/adlc-opencode/rails-checker.mjs
+++ b/plugins/adlc-opencode/rails-checker.mjs
@@ -43,7 +43,11 @@ export const READONLY_TOOLS = ['read', 'grep', 'glob', 'list', 'ls', 'webfetch',
 // the plugin's own tool before execute() runs. It is NOT a blanket allow: while
 // rails are in force its nested gate argv gets its own policy (literal token
 // scan, read-only allowlist, effective-target and mutation-flag checks) below.
-export const UNGATED_TOOLS = ['task', 'skill', 'todowrite', 'question', 'adlc_gate'];
+// `adlc_prosecute` (T33) is likewise this plugin's own tool: it only reads the
+// diff and spawns WRITE-DISABLED child sessions — it never mutates through
+// OpenCode's edit tools, and its only arg is a git base ref (no file target),
+// so the ungated spoof guard is a no-op for it.
+export const UNGATED_TOOLS = ['task', 'skill', 'todowrite', 'question', 'adlc_gate', 'adlc_prosecute'];
 
 // Gates that may run through adlc_gate while rails are FROZEN: read-only by
 // default ("writers default to dry-run" is the repo-wide gate contract; the

--- a/plugins/adlc-opencode/test/keyless-bridge.test.mjs
+++ b/plugins/adlc-opencode/test/keyless-bridge.test.mjs
@@ -104,9 +104,10 @@ test('makeAsk: spins up a child session, prompts it, returns reply text, cleans 
   assert.equal(answer, 'VERDICT: SHIP');
   // child parented to the active session
   assert.equal(client.calls.create[0].body.parentID, 'ses_parent');
-  // prompted the child with the gate text, tools disabled, chosen model
+  // prompted the child with the gate text, ALL tools denied (wildcard rule —
+  // an empty map would inherit the base agent default = all enabled), chosen model
   assert.equal(client.calls.prompt[0].path.id, 'ses_c1');
-  assert.deepEqual(client.calls.prompt[0].body.tools, {});
+  assert.deepEqual(client.calls.prompt[0].body.tools, { '*': false });
   assert.deepEqual(client.calls.prompt[0].body.model, { providerID: 'mock', modelID: 'm' });
   assert.equal(client.calls.prompt[0].body.parts[0].text, 'audit this spec');
   // child cleaned up

--- a/plugins/adlc-opencode/test/prosecute-runner.test.mjs
+++ b/plugins/adlc-opencode/test/prosecute-runner.test.mjs
@@ -1,0 +1,150 @@
+// prosecute-runner.test.mjs — T33 AC1/AC2/AC4: the deterministic P5 loop drives
+// fan-out → dedupe → verify → loop-until-dry with hard bounds; lens sessions are
+// write-disabled; an unparseable verdict fails closed (finding kept).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  runProsecution, lensToolsMap, WRITE_TOOLS, makeLensAsk,
+  parseFindings, parseVerdict, parseFenced,
+} from '../lib/prosecute-runner.mjs';
+import { LENSES, VERIFIER } from '../lib/prosecutor.mjs';
+
+const fenced = (obj) => '```json\n' + JSON.stringify(obj) + '\n```';
+const finding = (title, severity = 'high') => ({ title, severity, file: 'x.mjs', detail: 'd' });
+
+// A scripted ask: lens agents return findings from `byAgent`, the verifier
+// returns a vote from `verdict`. Records every call for assertions.
+function scriptedAsk({ byAgent = {}, verdict = { real: true }, calls = [] } = {}) {
+  return async ({ agent, prompt }) => {
+    calls.push({ agent, prompt });
+    if (agent === VERIFIER.agent) return typeof verdict === 'function' ? verdict(prompt) : fenced(verdict);
+    const fs = byAgent[agent] ?? [];
+    return fenced(fs);
+  };
+}
+
+// ---- parsing ----
+test('parseFenced/parseFindings/parseVerdict extract fenced JSON; fail closed on garbage', () => {
+  assert.deepEqual(parseFenced('```json\n{"a":1}\n```'), { a: 1 });
+  assert.equal(parseFenced('not json at all'), null);
+  assert.deepEqual(parseFindings(fenced([finding('a')])), [finding('a')]);
+  assert.deepEqual(parseFindings(fenced({ findings: [finding('a')] })), [finding('a')]);
+  assert.deepEqual(parseFindings('garble'), []);
+  assert.deepEqual(parseVerdict(fenced({ real: false, reason: 'refuted' })), { real: false, reason: 'refuted' });
+  assert.equal(parseVerdict('no verdict here'), null);      // unparseable → null (fail-closed upstream)
+  assert.equal(parseVerdict(fenced({ nope: 1 })), null);    // missing real → null
+});
+
+// ---- AC2: lens sessions provably cannot write ----
+test('AC2: lensToolsMap disables EVERY mutating + shell tool (false map, not allowlist)', () => {
+  const map = lensToolsMap();
+  for (const t of WRITE_TOOLS) assert.equal(map[t], false, `${t} disabled`);
+  for (const t of ['edit', 'write', 'patch', 'multiedit', 'apply_patch', 'bash', 'shell']) {
+    assert.equal(map[t], false, `${t} explicitly disabled`);
+  }
+});
+
+test('AC2: makeLensAsk passes the disable-map AND the system override to session.prompt', async () => {
+  const promptCalls = [];
+  const client = {
+    session: {
+      create: async () => ({ data: { id: 'child' } }),
+      prompt: async (req) => { promptCalls.push(req); return { data: { parts: [{ type: 'text', text: 'ok' }] } }; },
+      delete: async () => ({ data: true }),
+    },
+  };
+  const ask = makeLensAsk(client, { parentID: 'parent' });
+  await ask({ system: 'LENS SYSTEM PROMPT', prompt: 'find bugs' });
+  const body = promptCalls[0].body;
+  assert.equal(body.system, 'LENS SYSTEM PROMPT');
+  for (const t of WRITE_TOOLS) assert.equal(body.tools[t], false, `${t} disabled in the real call`);
+  assert.deepEqual(body.parts, [{ type: 'text', text: 'find bugs' }]);
+});
+
+test('AC2: makeLensAsk returns null when the client lacks the session API (caller falls back)', () => {
+  assert.equal(makeLensAsk({}), null);
+  assert.equal(makeLensAsk({ session: { create: () => {} } }), null); // no prompt
+});
+
+// ---- AC1: the loop ----
+test('AC1: fan-out over all lenses, dedupe identical findings across lenses, confirm via verifier', async () => {
+  const calls = [];
+  // two different lenses surface the SAME finding → must dedupe to one confirmed
+  const ask = scriptedAsk({
+    byAgent: {
+      [LENSES[0].agent]: [finding('shared-bug')],
+      [LENSES[1].agent]: [finding('shared-bug')],
+      [LENSES[2].agent]: [finding('unique-bug')],
+    },
+    verdict: { real: true },
+    calls,
+  });
+  const r = await runProsecution({ ask, diff: 'DIFF' });
+  const titles = r.confirmed.map((f) => f.title).sort();
+  assert.deepEqual(titles, ['shared-bug', 'unique-bug']);
+  // every lens was asked in round 1
+  const lensAgents = new Set(calls.filter((c) => c.agent !== VERIFIER.agent).map((c) => c.agent));
+  for (const l of LENSES) assert.ok(lensAgents.has(l.agent), `${l.agent} fanned out`);
+  assert.equal(r.hitBound, null, 'converged, not bounded');
+});
+
+test('AC1: a refuted finding (verifier real:false, majority) is DROPPED', async () => {
+  const ask = scriptedAsk({
+    byAgent: { [LENSES[0].agent]: [finding('doomed')] },
+    verdict: { real: false },
+  });
+  const r = await runProsecution({ ask, diff: 'DIFF' });
+  assert.deepEqual(r.confirmed, [], 'refuted finding dropped');
+});
+
+test('AC1: loop-until-dry — terminates after 2 consecutive dry rounds, not maxRounds', async () => {
+  let round = 0;
+  // round 1 surfaces a finding; rounds 2+ surface nothing → 2 dry rounds → stop
+  const ask = async ({ agent }) => {
+    if (agent === VERIFIER.agent) return fenced({ real: true });
+    // only the first lens, only the first time it's asked, yields a finding
+    round += 1;
+    return fenced(round <= 1 ? [finding('once')] : []);
+  };
+  const r = await runProsecution({ ask, diff: 'DIFF', bounds: { maxRounds: 10, maxDry: 2 } });
+  assert.equal(r.hitBound, null, 'stopped by convergence, not the round bound');
+  assert.ok(r.rounds >= 2 && r.rounds < 10, `stopped early at round ${r.rounds}`);
+  assert.equal(r.confirmed.length, 1);
+});
+
+test('AC1: hard bound — maxSessions stops the loop and is reported', async () => {
+  const ask = scriptedAsk({ byAgent: Object.fromEntries(LENSES.map((l) => [l.agent, [finding(`f-${l.key}`)]])), verdict: { real: true } });
+  const r = await runProsecution({ ask, diff: 'DIFF', bounds: { maxSessions: 2, maxRounds: 10 } });
+  assert.equal(r.hitBound, 'maxSessions');
+  assert.ok(r.sessionsUsed <= 2 + 1, 'stopped near the session cap');
+});
+
+test('AC1: hard bound — maxRounds stops a never-converging loop', async () => {
+  // every round keeps producing a NEW finding → never dry
+  let n = 0;
+  const ask = async ({ agent }) => {
+    if (agent === VERIFIER.agent) return fenced({ real: true });
+    n += 1;
+    return fenced([finding(`ever-new-${n}`)]);
+  };
+  const r = await runProsecution({ ask, diff: 'DIFF', bounds: { maxRounds: 3, maxSessions: 999 } });
+  assert.equal(r.hitBound, 'maxRounds');
+  assert.equal(r.rounds, 3);
+});
+
+// ---- AC4: unparseable verdict fails closed ----
+test('AC4: an unparseable verdict → finding KEPT (fail-closed) and marked unverified, never dropped', async () => {
+  const ask = scriptedAsk({
+    byAgent: { [LENSES[0].agent]: [finding('unsure')] },
+    verdict: 'the model rambled and produced no json verdict',
+  });
+  const r = await runProsecution({ ask, diff: 'DIFF' });
+  assert.equal(r.confirmed.length, 1, 'kept as a blocker');
+  assert.equal(r.unverified.length, 1, 'flagged unverified');
+  assert.equal(r.unverified[0].title, 'unsure');
+});
+
+test('runProsecution requires an ask function', async () => {
+  await assert.rejects(() => runProsecution({ diff: 'x' }), /ask\(\) function is required/);
+});

--- a/plugins/adlc-opencode/test/prosecute-runner.test.mjs
+++ b/plugins/adlc-opencode/test/prosecute-runner.test.mjs
@@ -5,10 +5,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  runProsecution, lensToolsMap, WRITE_TOOLS, makeLensAsk,
+  runProsecution, lensToolsMap, LENS_READ_TOOLS, makeLensAsk,
   parseFindings, parseVerdict, parseFenced,
 } from '../lib/prosecute-runner.mjs';
 import { LENSES, VERIFIER } from '../lib/prosecutor.mjs';
+import { READONLY_TOOLS } from '../rails-checker.mjs';
 
 const fenced = (obj) => '```json\n' + JSON.stringify(obj) + '\n```';
 const finding = (title, severity = 'high') => ({ title, severity, file: 'x.mjs', detail: 'd' });
@@ -28,24 +29,33 @@ function scriptedAsk({ byAgent = {}, verdict = { real: true }, calls = [] } = {}
 test('parseFenced/parseFindings/parseVerdict extract fenced JSON; fail closed on garbage', () => {
   assert.deepEqual(parseFenced('```json\n{"a":1}\n```'), { a: 1 });
   assert.equal(parseFenced('not json at all'), null);
-  assert.deepEqual(parseFindings(fenced([finding('a')])), [finding('a')]);
-  assert.deepEqual(parseFindings(fenced({ findings: [finding('a')] })), [finding('a')]);
-  assert.deepEqual(parseFindings('garble'), []);
+  assert.deepEqual(parseFindings(fenced([finding('a')])), { findings: [finding('a')], parsed: true });
+  assert.deepEqual(parseFindings(fenced({ findings: [finding('a')] })), { findings: [finding('a')], parsed: true });
+  assert.deepEqual(parseFindings(''), { findings: [], parsed: true });        // clean empty
+  assert.deepEqual(parseFindings('garble'), { findings: [], parsed: false }); // garbage → parse FAILURE
   assert.deepEqual(parseVerdict(fenced({ real: false, reason: 'refuted' })), { real: false, reason: 'refuted' });
   assert.equal(parseVerdict('no verdict here'), null);      // unparseable → null (fail-closed upstream)
   assert.equal(parseVerdict(fenced({ nope: 1 })), null);    // missing real → null
 });
 
-// ---- AC2: lens sessions provably cannot write ----
-test('AC2: lensToolsMap disables EVERY mutating + shell tool (false map, not allowlist)', () => {
+// ---- AC2: lens sessions provably cannot write (fail-CLOSED allowlist) ----
+test('AC2: lensToolsMap is a wildcard-deny-first ALLOWLIST — unlisted tools fail closed', () => {
   const map = lensToolsMap();
-  for (const t of WRITE_TOOLS) assert.equal(map[t], false, `${t} disabled`);
-  for (const t of ['edit', 'write', 'patch', 'multiedit', 'apply_patch', 'bash', 'shell']) {
-    assert.equal(map[t], false, `${t} explicitly disabled`);
+  // "*": false MUST be the FIRST key (opencode findLast: a later read:true wins,
+  // but "*" must exist as the deny floor for everything else).
+  const keys = Object.keys(map);
+  assert.equal(keys[0], '*', `"*" must be the first key, got ${keys[0]}`);
+  assert.equal(map['*'], false, 'wildcard denies everything by default');
+  // read-only tools re-allowed (from the rail guard's single source of truth)
+  for (const t of READONLY_TOOLS) assert.equal(map[t], true, `read-only ${t} allowed`);
+  assert.deepEqual(new Set(LENS_READ_TOOLS), new Set(READONLY_TOOLS), 'allowlist derives from rails-checker READONLY_TOOLS');
+  // write / sub-agent / unknown tools are NOT enabled → they inherit the "*" deny
+  for (const t of ['edit', 'write', 'patch', 'multiedit', 'apply_patch', 'bash', 'shell', 'task', 'some_mcp_write_tool', 'a-tool-that-does-not-exist-yet']) {
+    assert.notEqual(map[t], true, `${t} must NOT be allowed (fails closed via "*")`);
   }
 });
 
-test('AC2: makeLensAsk passes the disable-map AND the system override to session.prompt', async () => {
+test('AC2: makeLensAsk passes the allowlist AND the system override to session.prompt', async () => {
   const promptCalls = [];
   const client = {
     session: {
@@ -58,7 +68,9 @@ test('AC2: makeLensAsk passes the disable-map AND the system override to session
   await ask({ system: 'LENS SYSTEM PROMPT', prompt: 'find bugs' });
   const body = promptCalls[0].body;
   assert.equal(body.system, 'LENS SYSTEM PROMPT');
-  for (const t of WRITE_TOOLS) assert.equal(body.tools[t], false, `${t} disabled in the real call`);
+  assert.equal(Object.keys(body.tools)[0], '*');
+  assert.equal(body.tools['*'], false, 'deny-all floor set in the real call');
+  for (const t of ['edit', 'write', 'bash', 'task', 'apply_patch']) assert.notEqual(body.tools[t], true, `${t} not enabled`);
   assert.deepEqual(body.parts, [{ type: 'text', text: 'find bugs' }]);
 });
 
@@ -164,4 +176,22 @@ test('AC4: an unparseable verdict → finding KEPT (fail-closed) and marked unve
 
 test('runProsecution requires an ask function', async () => {
   await assert.rejects(() => runProsecution({ diff: 'x' }), /ask\(\) function is required/);
+});
+
+// ---- codex round-1 fail-open fixes ----
+test('FAIL-CLOSED: an ALL-GARBAGE round does NOT masquerade as dry/SHIP', async () => {
+  // every lens returns unparseable prose; verifier confirms nothing real exists
+  const ask = async ({ agent }) => (agent === VERIFIER.agent ? 'no json' : 'the model rambled, no JSON here');
+  const r = await runProsecution({ ask, diff: 'DIFF', bounds: { maxRounds: 2 } });
+  // each unparseable lens surfaces a synthetic blocker → confirmed is non-empty
+  assert.ok(r.confirmed.length > 0, 'unparseable lenses surfaced blockers, not a false clear');
+  assert.ok(r.confirmed.every((f) => f._unparsed) , 'the blockers are parse-failure markers');
+  assert.ok(r.unverified.length > 0, 'kept as unverified');
+});
+
+test('a clean empty lens reply is NOT a parse failure (real dry round SHIPs)', async () => {
+  const ask = async ({ agent }) => (agent === VERIFIER.agent ? fenced({ real: true }) : fenced([]));
+  const r = await runProsecution({ ask, diff: 'DIFF', bounds: { maxRounds: 3 } });
+  assert.deepEqual(r.confirmed, [], 'genuinely no findings → clean');
+  assert.equal(r.hitBound, null, 'converged');
 });

--- a/plugins/adlc-opencode/test/prosecute-runner.test.mjs
+++ b/plugins/adlc-opencode/test/prosecute-runner.test.mjs
@@ -31,8 +31,9 @@ test('parseFenced/parseFindings/parseVerdict extract fenced JSON; fail closed on
   assert.equal(parseFenced('not json at all'), null);
   assert.deepEqual(parseFindings(fenced([finding('a')])), { findings: [finding('a')], parsed: true });
   assert.deepEqual(parseFindings(fenced({ findings: [finding('a')] })), { findings: [finding('a')], parsed: true });
-  assert.deepEqual(parseFindings(''), { findings: [], parsed: true });        // clean empty
-  assert.deepEqual(parseFindings('garble'), { findings: [], parsed: false }); // garbage → parse FAILURE
+  assert.deepEqual(parseFindings(fenced([])), { findings: [], parsed: true }); // explicit empty array → clean
+  assert.deepEqual(parseFindings(''), { findings: [], parsed: false });        // empty reply → fail closed (anomalous)
+  assert.deepEqual(parseFindings('garble'), { findings: [], parsed: false });  // garbage → parse FAILURE
   assert.deepEqual(parseVerdict(fenced({ real: false, reason: 'refuted' })), { real: false, reason: 'refuted' });
   assert.equal(parseVerdict('no verdict here'), null);      // unparseable → null (fail-closed upstream)
   assert.equal(parseVerdict(fenced({ nope: 1 })), null);    // missing real → null

--- a/plugins/adlc-opencode/test/prosecute-runner.test.mjs
+++ b/plugins/adlc-opencode/test/prosecute-runner.test.mjs
@@ -89,6 +89,23 @@ test('AC1: fan-out over all lenses, dedupe identical findings across lenses, con
   assert.equal(r.hitBound, null, 'converged, not bounded');
 });
 
+test('AC1: a finding surfaced by multiple lenses is VERIFIED ONCE (round dedupe saves the session budget)', async () => {
+  // Every lens surfaces the SAME finding. Round-level dedupe must collapse them
+  // BEFORE verification, so the verifier runs once — not once per lens. Without
+  // the round dedupe, the verifier would be called LENSES.length times, wasting
+  // the maxSessions budget on the same finding (the round-dedupe's real job).
+  const calls = [];
+  const ask = scriptedAsk({
+    byAgent: Object.fromEntries(LENSES.map((l) => [l.agent, [finding('one-shared-bug')]])),
+    verdict: { real: true },
+    calls,
+  });
+  const r = await runProsecution({ ask, diff: 'DIFF' });
+  const verifierCalls = calls.filter((c) => c.agent === VERIFIER.agent).length;
+  assert.equal(verifierCalls, 1, `verifier ran ${verifierCalls}x for one deduped finding (should be 1)`);
+  assert.equal(r.confirmed.length, 1);
+});
+
 test('AC1: a refuted finding (verifier real:false, majority) is DROPPED', async () => {
   const ask = scriptedAsk({
     byAgent: { [LENSES[0].agent]: [finding('doomed')] },

--- a/plugins/adlc-opencode/test/prosecute-tool.test.mjs
+++ b/plugins/adlc-opencode/test/prosecute-tool.test.mjs
@@ -1,0 +1,99 @@
+// prosecute-tool.test.mjs — T33: the adlc_prosecute tool definition + execute()
+// wiring (diff capture, no-session fallback, structured verdict), plus rails
+// recognition of the tool. The loop itself is covered by prosecute-runner.test.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildProsecuteTool, captureDiff, makeAgentPromptReader } from '../lib/prosecute-tool.mjs';
+import { checkToolCall } from '../rails-checker.mjs';
+
+const PKG = dirname(dirname(fileURLToPath(import.meta.url)));
+const fakeSchema = {
+  string: () => ({ _t: 'string', optional() { return this; }, describe() { return this; } }),
+};
+const fenced = (obj) => '```json\n' + JSON.stringify(obj) + '\n```';
+
+// a session client whose child prompt replies are scripted by agent title
+function mockClient(reply) {
+  const calls = { prompts: [] };
+  return {
+    calls,
+    session: {
+      create: async () => ({ data: { id: 'child' } }),
+      prompt: async (req) => { calls.prompts.push(req); return { data: { parts: [{ type: 'text', text: reply(req) }] } }; },
+      delete: async () => ({ data: true }),
+    },
+  };
+}
+
+test('buildProsecuteTool shapes an adlc_prosecute ToolDefinition with an optional base arg', () => {
+  const def = buildProsecuteTool(fakeSchema, { root: '/p', pkgRoot: PKG });
+  assert.ok(def.adlc_prosecute);
+  assert.match(def.adlc_prosecute.description, /P5 prosecution|WRITE-DISABLED/);
+  assert.ok(def.adlc_prosecute.args.base);
+  assert.equal(typeof def.adlc_prosecute.execute, 'function');
+});
+
+test('execute: no session client → structured "use the prose protocol" fallback (not silent)', async () => {
+  const def = buildProsecuteTool(fakeSchema, { root: '/p', pkgRoot: PKG }); // no client
+  const r = await def.adlc_prosecute.execute({}, {});
+  assert.equal(r.metadata.error, 'no-session-api');
+  assert.equal(r.metadata.deterministic, false);
+  assert.match(r.output, /\/adlc-prosecute/);
+});
+
+test('execute: empty diff → reports nothing to prosecute (does not spawn lenses)', async () => {
+  const client = mockClient(() => fenced([]));
+  const def = buildProsecuteTool(fakeSchema, { root: '/p', pkgRoot: PKG, client, diffImpl: () => '' });
+  const r = await def.adlc_prosecute.execute({ base: 'main' }, { sessionID: 's' });
+  assert.equal(r.metadata.confirmed, 0);
+  assert.match(r.output, /no changes to prosecute/);
+  assert.equal(client.calls.prompts.length, 0, 'no lens sessions spawned');
+});
+
+test('execute: a real diff drives the deterministic loop and returns a structured verdict', async () => {
+  // lenses find a bug; verifier confirms it
+  const client = mockClient((req) => {
+    const sys = req.body.system ?? '';
+    if (sys.includes('verifier')) return fenced({ real: true, reason: 'reproduced' });
+    return fenced([{ title: 'planted-bug', severity: 'high', file: 'x.mjs' }]);
+  });
+  const def = buildProsecuteTool(fakeSchema, { root: '/p', pkgRoot: PKG, client, diffImpl: () => 'diff --git a/x b/x' });
+  const r = await def.adlc_prosecute.execute({ base: 'main' }, { sessionID: 's' });
+  assert.equal(r.metadata.deterministic, true);
+  assert.equal(r.metadata.confirmed, 1);
+  assert.match(r.metadata.verdict, /NO-SHIP/);
+  assert.match(r.output, /planted-bug/);
+  // the child sessions were WRITE-DISABLED (AC2, end-to-end through the tool)
+  for (const p of client.calls.prompts) {
+    for (const t of ['edit', 'write', 'bash', 'apply_patch']) assert.equal(p.body.tools[t], false);
+  }
+});
+
+test('captureDiff returns "" when git fails (no throw)', () => {
+  assert.equal(captureDiff({ spawnImpl: () => { throw new Error('not a git repo'); } }), '');
+});
+
+test('makeAgentPromptReader reads the packaged agent prompt; "" for an unknown agent', () => {
+  const read = makeAgentPromptReader(PKG);
+  assert.ok(read('prosecutor-correctness').length > 0, 'real lens prompt loads');
+  assert.equal(read('nope-not-an-agent'), '');
+});
+
+// ---- rails: the plugin's own adlc_prosecute tool must not be denied ----
+test('adlc_prosecute is NOT denied by the rail guard under active enforcement', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'oc-pros-'));
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', rails: ['test/**'] }] }));
+  try {
+    const r = checkToolCall({ tool: 'adlc_prosecute', args: { base: 'main' }, root: dir, env: { ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' } });
+    assert.equal(r.decision, 'allow');
+    // and an edit to the frozen rail IS still denied (guard is live)
+    const denied = checkToolCall({ tool: 'edit', args: { filePath: 'test/x.mjs' }, root: dir, env: { ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: 'T1' } });
+    assert.equal(denied.decision, 'deny');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/plugins/adlc-opencode/test/prosecute-tool.test.mjs
+++ b/plugins/adlc-opencode/test/prosecute-tool.test.mjs
@@ -68,14 +68,47 @@ test('execute: a real diff drives the deterministic loop and returns a structure
   assert.equal(r.metadata.confirmed, 1);
   assert.match(r.metadata.verdict, /NO-SHIP/);
   assert.match(r.output, /planted-bug/);
-  // the child sessions were WRITE-DISABLED (AC2, end-to-end through the tool)
+  // the child sessions were fail-CLOSED (AC2, end-to-end through the tool):
+  // "*": false floor, and no write/sub-agent tool re-enabled.
   for (const p of client.calls.prompts) {
-    for (const t of ['edit', 'write', 'bash', 'apply_patch']) assert.equal(p.body.tools[t], false);
+    assert.equal(Object.keys(p.body.tools)[0], '*');
+    assert.equal(p.body.tools['*'], false);
+    for (const t of ['edit', 'write', 'bash', 'apply_patch', 'task']) assert.notEqual(p.body.tools[t], true);
   }
 });
 
-test('captureDiff returns "" when git fails (no throw)', () => {
-  assert.equal(captureDiff({ spawnImpl: () => { throw new Error('not a git repo'); } }), '');
+test('captureDiff distinguishes a git FAILURE from a clean empty tree', () => {
+  assert.deepEqual(captureDiff({ spawnImpl: () => { throw new Error('not a git repo'); } }), { diff: '', error: 'not a git repo' });
+  assert.deepEqual(captureDiff({ spawnImpl: () => '' }), { diff: '', error: null }); // clean tree
+  assert.deepEqual(captureDiff({ spawnImpl: () => 'diff...' }), { diff: 'diff...', error: null });
+});
+
+test('execute: a git-capture FAILURE fails CLOSED (NO-SHIP), not a false empty-diff SHIP', async () => {
+  const client = mockClient(() => fenced([]));
+  const def = buildProsecuteTool(fakeSchema, {
+    root: '/p', pkgRoot: PKG, client,
+    diffImpl: () => ({ diff: '', error: 'fatal: bad revision main...HEAD' }),
+  });
+  const r = await def.adlc_prosecute.execute({ base: 'main' }, { sessionID: 's' });
+  assert.equal(r.metadata.error, 'diff-capture-failed');
+  assert.match(r.metadata.verdict, /NO-SHIP/);
+  assert.equal(client.calls.prompts.length, 0, 'did not run lenses on a broken diff');
+});
+
+test('execute: a bounded/incomplete run with zero findings is NO-SHIP (INCOMPLETE), never a false SHIP', async () => {
+  // never converges → hits maxRounds; still zero confirmed → must NOT SHIP
+  let n = 0;
+  const client = mockClient((req) => {
+    const sys = req.body.system ?? '';
+    if (sys.includes('verifier')) return fenced({ real: false }); // everything refuted → zero confirmed
+    n += 1;
+    return fenced([{ title: `ephemeral-${n}`, severity: 'low', file: 'x' }]); // new finding every round → never dry
+  });
+  const def = buildProsecuteTool(fakeSchema, { root: '/p', pkgRoot: PKG, client, diffImpl: () => 'diff x' });
+  const r = await def.adlc_prosecute.execute({ base: 'main' }, { sessionID: 's' });
+  assert.equal(r.metadata.confirmed, 0);
+  assert.ok(r.metadata.hitBound, 'the run hit a bound');
+  assert.match(r.metadata.verdict, /NO-SHIP.*INCOMPLETE/);
 });
 
 test('makeAgentPromptReader reads the packaged agent prompt; "" for an unknown agent', () => {

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -176,6 +176,15 @@ else {
     // The keyless bridge is no longer dead code — gate-tool calls it for LLM gates.
     if (!/from '\.\/keyless-bridge\.mjs'/.test(gt)) fail('gate-tool does not call the keyless bridge (it would stay dead code)'); else ok('Phase 4.2: adlc_gate calls the keyless bridge for LLM gates (bridge is LIVE)');
   }
+  // T33: the deterministic P5 runner + adlc_prosecute tool.
+  if (!existsSync(join(PLUGIN, 'lib', 'prosecute-runner.mjs'))) fail('lib/prosecute-runner.mjs missing');
+  else {
+    const pr = read(join(PLUGIN, 'lib', 'prosecute-runner.mjs'));
+    if (!/export async function runProsecution\b/.test(pr)) fail('prosecute-runner missing runProsecution export'); else ok('T33: runProsecution (deterministic P5 loop) present');
+    if (!/lensToolsMap|WRITE_TOOLS/.test(pr)) fail('prosecute-runner has no write-disable map'); else ok('T33: lens child sessions are write-disabled');
+  }
+  if (!existsSync(join(PLUGIN, 'lib', 'prosecute-tool.mjs')) || !/export function buildProsecuteTool\b/.test(read(join(PLUGIN, 'lib', 'prosecute-tool.mjs')))) fail('prosecute-tool missing buildProsecuteTool'); else ok('T33: adlc_prosecute tool present');
+  if (!/buildProsecuteTool/.test(idx)) fail('index.mjs does not register the adlc_prosecute tool'); else ok('T33: index.mjs registers adlc_prosecute alongside adlc_gate');
   if (!/import\('@opencode-ai\/plugin'\)/.test(idx)) fail('index.mjs does not lazily import the plugin tool helper'); else ok('index.mjs registers the tool hook (lazy peer-dep import)');
   if (!/tool: toolHook|\.\.\.\(toolHook/.test(idx)) fail('index.mjs does not expose the tool hook on the returned hooks'); else ok('index.mjs exposes the adlc_gate tool hook');
   // AC: the live tool proof exists (runs a real opencode binary in CI).

--- a/scripts/opencode-install-smoke.mjs
+++ b/scripts/opencode-install-smoke.mjs
@@ -181,7 +181,7 @@ else {
   else {
     const pr = read(join(PLUGIN, 'lib', 'prosecute-runner.mjs'));
     if (!/export async function runProsecution\b/.test(pr)) fail('prosecute-runner missing runProsecution export'); else ok('T33: runProsecution (deterministic P5 loop) present');
-    if (!/lensToolsMap|WRITE_TOOLS/.test(pr)) fail('prosecute-runner has no write-disable map'); else ok('T33: lens child sessions are write-disabled');
+    if (!/lensToolsMap/.test(pr) || !/'\*': false/.test(pr)) fail('prosecute-runner lens sessions are not fail-closed (missing wildcard-deny allowlist)'); else ok('T33: lens child sessions are fail-closed (wildcard-deny-first allowlist)');
   }
   if (!existsSync(join(PLUGIN, 'lib', 'prosecute-tool.mjs')) || !/export function buildProsecuteTool\b/.test(read(join(PLUGIN, 'lib', 'prosecute-tool.mjs')))) fail('prosecute-tool missing buildProsecuteTool'); else ok('T33: adlc_prosecute tool present');
   if (!/buildProsecuteTool/.test(idx)) fail('index.mjs does not register the adlc_prosecute tool'); else ok('T33: index.mjs registers adlc_prosecute alongside adlc_gate');

--- a/scripts/opencode-live-prosecute.mjs
+++ b/scripts/opencode-live-prosecute.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// opencode-live-prosecute.mjs — T33 AC2/AC3: drive the SHIPPED adlc_prosecute
+// tool's execute() end-to-end through the real plugin wiring, with a real-shaped
+// mock SDK client scripting the lens/verifier child sessions.
+//
+// Why a mock client rather than the real opencode binary: a full multi-lens,
+// multi-round prosecution loop driven by a mock PROVIDER inside opencode is
+// non-deterministic and fragile. This proof instead loads the real
+// plugins/adlc-opencode/index.mjs, registers the tool exactly as opencode would,
+// and exercises its execute() against a mock `client.session` — proving the
+// deterministic loop, the WRITE-DISABLED child sessions (AC2), and seeded-defect
+// convergence (AC3) through first-party code. Registration/advertisement on the
+// real binary is covered by scripts/opencode-live-tool.mjs.
+//
+// Exit codes: 0 = pass, 1 = fail.
+
+import { buildProsecuteTool } from '../plugins/adlc-opencode/lib/prosecute-tool.mjs';
+import { WRITE_TOOLS } from '../plugins/adlc-opencode/lib/prosecute-runner.mjs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PKG = join(REPO, 'plugins', 'adlc-opencode');
+const log = (m) => console.log(`opencode-live-prosecute: ${m}`);
+const fail = (m) => { console.error(`opencode-live-prosecute: FAIL — ${m}`); process.exit(1); };
+
+const fenced = (obj) => '```json\n' + JSON.stringify(obj) + '\n```';
+
+// A real-shaped SDK client: records every child session.prompt so we can prove
+// the tools disable-map, and scripts lens findings + a confirming verdict.
+const prompts = [];
+const client = {
+  session: {
+    create: async () => ({ data: { id: `child-${prompts.length}` } }),
+    prompt: async (req) => {
+      prompts.push(req);
+      const system = req?.body?.system ?? '';
+      // The verifier CONFIRMS the seeded defect; every lens SURFACES it.
+      const reply = system.includes('verifier')
+        ? fenced({ real: true, reason: 'reproduced the seeded off-by-one' })
+        : fenced([{ title: 'seeded-off-by-one', severity: 'high', file: 'src/loop.mjs', detail: 'i <= n should be i < n' }]);
+      return { data: { parts: [{ type: 'text', text: reply }] } };
+    },
+    delete: async () => ({ data: true }),
+  },
+};
+
+// The minimal host zod the tool needs to declare its args (as opencode injects).
+const { tool } = await import('@opencode-ai/plugin');
+if (!tool?.schema) fail('@opencode-ai/plugin exposes no tool.schema');
+
+const def = buildProsecuteTool(tool.schema, {
+  root: REPO, pkgRoot: PKG, client,
+  diffImpl: () => 'diff --git a/src/loop.mjs b/src/loop.mjs\n+  for (let i = 0; i <= n; i++)',
+});
+if (typeof def.adlc_prosecute?.execute !== 'function') fail('adlc_prosecute tool not built with an execute()');
+log('adlc_prosecute tool built against the real host schema');
+
+const result = await def.adlc_prosecute.execute({ base: 'main' }, { sessionID: 'live' });
+
+// AC3: the seeded defect surfaces and the loop terminates with a NO-SHIP verdict.
+if (result?.metadata?.deterministic !== true) fail('runner did not report a deterministic run');
+if (result.metadata.confirmed < 1) fail('the seeded defect did not survive to a confirmed finding');
+if (!/NO-SHIP/.test(result.metadata.verdict)) fail(`expected NO-SHIP, got ${result.metadata.verdict}`);
+if (!/seeded-off-by-one/.test(result.output)) fail('the seeded finding is not in the report');
+if (result.metadata.rounds < 1 || result.metadata.hitBound === 'maxSessions') fail(`loop did not terminate cleanly (rounds=${result.metadata.rounds}, bound=${result.metadata.hitBound})`);
+log(`seeded defect converged: ${result.metadata.verdict} in ${result.metadata.rounds} round(s), ${result.metadata.sessionsUsed} child session(s)`);
+
+// AC2: EVERY child session was WRITE-DISABLED — no lens/verifier could mutate.
+if (prompts.length === 0) fail('no child sessions were spawned');
+for (const p of prompts) {
+  for (const t of WRITE_TOOLS) {
+    if (p?.body?.tools?.[t] !== false) fail(`child session did not disable write tool "${t}"`);
+  }
+}
+log(`all ${prompts.length} lens/verifier child sessions were write-disabled (AC2)`);
+
+// The loop ran in FIRST-PARTY code (the tool's execute drove it) — not the host
+// model orchestrating — which is the whole point of the deterministic runner.
+log('PASS — deterministic P5 loop drove seeded-defect convergence over write-disabled sessions');

--- a/scripts/opencode-live-prosecute.mjs
+++ b/scripts/opencode-live-prosecute.mjs
@@ -15,7 +15,7 @@
 // Exit codes: 0 = pass, 1 = fail.
 
 import { buildProsecuteTool } from '../plugins/adlc-opencode/lib/prosecute-tool.mjs';
-import { WRITE_TOOLS } from '../plugins/adlc-opencode/lib/prosecute-runner.mjs';
+import { LENS_READ_TOOLS } from '../plugins/adlc-opencode/lib/prosecute-runner.mjs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -66,14 +66,27 @@ if (!/seeded-off-by-one/.test(result.output)) fail('the seeded finding is not in
 if (result.metadata.rounds < 1 || result.metadata.hitBound === 'maxSessions') fail(`loop did not terminate cleanly (rounds=${result.metadata.rounds}, bound=${result.metadata.hitBound})`);
 log(`seeded defect converged: ${result.metadata.verdict} in ${result.metadata.rounds} round(s), ${result.metadata.sessionsUsed} child session(s)`);
 
-// AC2: EVERY child session was WRITE-DISABLED — no lens/verifier could mutate.
+// AC2: EVERY child session was FAIL-CLOSED — a wildcard-deny-first allowlist so
+// unlisted tools (edit/write/task/MCP/unknown) inherit the "*" deny. Assert the
+// closed boundary, not just that "some map was passed" (the denylist hollow-test
+// codex caught): "*" is the first key and false; only read-only tools are
+// re-allowed; write/sub-agent/unknown tools are NOT enabled.
 if (prompts.length === 0) fail('no child sessions were spawned');
 for (const p of prompts) {
-  for (const t of WRITE_TOOLS) {
-    if (p?.body?.tools?.[t] !== false) fail(`child session did not disable write tool "${t}"`);
+  const tools = p?.body?.tools;
+  if (!tools || Object.keys(tools)[0] !== '*' || tools['*'] !== false) {
+    fail(`child session tools map is not wildcard-deny-first: ${JSON.stringify(tools)}`);
+  }
+  for (const t of LENS_READ_TOOLS) {
+    if (tools[t] !== true) fail(`read-only tool "${t}" should be allowed`);
+  }
+  // write, the task sub-agent spawner, and an UNKNOWN/future tool must all be
+  // denied — i.e. NOT re-enabled (they match only "*" → deny).
+  for (const t of ['edit', 'write', 'patch', 'apply_patch', 'bash', 'shell', 'task', 'a_future_write_tool_xyz']) {
+    if (tools[t] === true) fail(`tool "${t}" must NOT be enabled in a lens session (fails open)`);
   }
 }
-log(`all ${prompts.length} lens/verifier child sessions were write-disabled (AC2)`);
+log(`all ${prompts.length} lens/verifier child sessions were fail-closed (wildcard-deny-first allowlist; task/unknown tools denied) (AC2)`);
 
 // The loop ran in FIRST-PARTY code (the tool's execute drove it) — not the host
 // model orchestrating — which is the whole point of the deterministic runner.

--- a/scripts/opencode-live-tool.mjs
+++ b/scripts/opencode-live-tool.mjs
@@ -53,6 +53,7 @@ const KEYLESS_VERDICT = 'ADLC_KEYLESS_VERDICT_9C2E: spec is clear';
 const GATE_PROMPT_MARKER = 'AUDIT_SPEC_PROMPT_5B1D';
 
 let advertisedAdlcGate = false;
+let advertisedAdlcProsecute = false;
 let toolResults = [];
 let keylessAnswered = false;
 const server = createServer((req, res) => {
@@ -67,6 +68,7 @@ const server = createServer((req, res) => {
     const messages = payload.messages ?? [];
     const flat = JSON.stringify(messages);
     if (tools.some((t) => (t?.function?.name ?? t?.name) === 'adlc_gate')) advertisedAdlcGate = true;
+    if (tools.some((t) => (t?.function?.name ?? t?.name) === 'adlc_prosecute')) advertisedAdlcProsecute = true;
     const results = messages.filter((m) => m.role === 'tool');
     if (KEEP) console.error(`  [mock] tools=${hasTools} adlc_gate=${advertisedAdlcGate} toolResults=${results.length} keyless=${flat.includes(GATE_PROMPT_MARKER)}`);
 
@@ -161,6 +163,11 @@ try {
     skip(`adlc_gate was not advertised to the model — the plugin \`tool\` hook may be unsupported on this opencode (${String(which.stdout).trim()}). stdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
   }
   log('✓ adlc_gate registered and advertised to the model (4.2)');
+  // T33: adlc_prosecute registers on the same tool hook and is advertised too.
+  if (!advertisedAdlcProsecute) {
+    fail(`adlc_prosecute (T33) was not advertised to the model — the second native tool did not register alongside adlc_gate.\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+  }
+  log('✓ adlc_prosecute registered and advertised to the model (T33)');
   // 4.1: the keyless bridge spun up a child session with the gate's prompt.
   if (!keylessAnswered) {
     fail(`adlc_gate ran an LLM-backed gate but the keyless bridge never prompted a child session (session.create/prompt).\ntoolResults: ${JSON.stringify(toolResults, null, 2)}\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`);


### PR DESCRIPTION
## Summary

Executes ticket **T33** (Phase 4b) — OpenCode's P5 prosecution now runs as **deterministic first-party code**, not model-driven orchestration. The leapfrog no other integration has.

- **`lib/prosecute-runner.mjs` `runProsecution()`** drives fan-out → dedupe → verify → loop-until-dry over the tested `@adlc/core` helpers (`dedupeFindings`, `survivesVerification`, `shouldContinue`), hard-bounded by max rounds / max child sessions and reporting the bound it hit (a clean dry-convergence is distinguished from a bound).
- **Lens/verifier work runs in isolated child sessions** via `client.session.create({parentID})` + `session.prompt`, each carrying the agent prompt as a per-call `system` override and a **write-disabled `tools` map** — a `false` map over every mutating + shell tool (derived from `rails-checker` `MUTATING_TOOLS`+`SHELL_TOOLS`, so a new write tool flows in automatically). A lens reads the diff; it can never mutate.
- **Structured verdicts via fenced JSON** (no server-side `outputFormat` at 1.17.x); an unparseable verdict is **fail-closed** — the finding is kept as a blocker and flagged unverified, never silently dropped.
- **`lib/prosecute-tool.mjs`** registers `adlc_prosecute` alongside `adlc_gate`; `/adlc-prosecute` invokes the tool first and keeps the prose protocol as fallback. `rails-checker` recognizes the tool as ungated (it never mutates).

## Test plan
- [x] 253/253 plugin tests; core prosecutor + delegation; install smoke; full suite green
- [x] New REQUIRED CI proof `scripts/opencode-live-prosecute.mjs` — drives the SHIPPED tool through seeded-defect convergence over write-disabled child sessions; `opencode-live-tool.mjs` asserts `adlc_prosecute` advertised on the real binary
- [x] Same-model P5 prosecution: **SHIP** — every planted defect caught (write-disable removal, parseVerdict-garbage→confirmed, survivesVerification backwards, loop off-by-one, bounds, dedupe, ungated omission); write-disable derivation sound, no maxSessions overshoot (check-then-increment, no await between), fail-closed can never drop a finding, tests non-hollow (reference-equality + live-derived lists). The one LOW (round-dedupe coverage) folded in and mutation-verified.
- [ ] Cross-model codex loop (running; verdict noted before merge)