### PR TITLE
docs(opencode): T35 truth sweep — supersede legacy plan, ADR 0004 dated decisions, docs-site sync

### DIFF
--- a/apps/docs/content/docs/integrations/opencode.mdx
+++ b/apps/docs/content/docs/integrations/opencode.mdx
@@ -1,67 +1,68 @@
 ---
 title: opencode
-description: Native ADLC integration for the opencode terminal agent — rails-guard plugin hook, eight lifecycle commands, a five-lens prosecutor panel, and a keyless gate bridge.
+description: Native ADLC integration for the opencode terminal agent — enforce-by-default rails-guard hook, nine lifecycle commands, native adlc_gate/adlc_prosecute tools, and a deterministic seven-agent P5 prosecution loop.
 ---
 
 # ADLC in opencode
 
 Brings the lifecycle into the [opencode](https://opencode.ai) terminal agent as
 a native plugin: an in-session rails-guard hook (`tool.execute.before`),
-advisory session hooks, eight lifecycle commands, the `adlc` phase-routing
-skill, and a six-agent P5 prosecution panel. All six integration phases (A–F of
-the design plan) ship.
+advisory session hooks, nine lifecycle commands, the `adlc` phase-routing
+skill, two native model-callable tools (`adlc_gate`, `adlc_prosecute`), and a
+seven-agent P5 prosecution panel. The integration **enforces by default** —
+a thrown denial in `tool.execute.before` aborts the tool call (documented host
+behavior, regression-tested against a real binary).
 
 ## What you get
 
 - **Rails-guard hook** on `tool.execute.before` — denies structured
-  `edit`/`write` to a frozen rail declared by the active ticket.
-- **Advisory session hooks** — `session.created` preflight and a `session.idle`
-  gate-manifest audit; they warn, never throw.
+  `edit`/`write`/`apply_patch` to a frozen rail declared by the active ticket;
+  in-session **bash is gated** too via the `@adlc/core` shell classifier.
+- **Native tools:** `adlc_gate` (the model runs a lifecycle gate, LLM-backed
+  ones keyless through the host model) and `adlc_prosecute` (the **deterministic
+  first-party P5 loop** — fan-out → dedupe → verify → loop-until-dry over
+  write-disabled child sessions).
+- **Advisory session/compaction hooks** — `session.created` preflight, a
+  `session.idle` gate-manifest audit, per-turn + at-compaction context injection,
+  and slash-command lifecycle/tamper advisories; they warn, never throw.
 - **Commands:** `/adlc-init`, `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`,
-  `/adlc-decompose`, `/adlc-verify-build`, `/adlc-prosecute`, `/adlc-distill`.
+  `/adlc-decompose`, `/adlc-verify-build`, `/adlc-prosecute`, `/adlc-distill`,
+  `/adlc-maintain`.
 - **Subagents:** the five P5 prosecution lenses
-  (`@prosecutor-correctness|security|contract|diff|tests`) plus
-  `@prosecutor-verifier` — all edit- and bash-denied.
-- **Keyless gate bridge** — every LLM-backed gate runs in `--prompt-only` mode
-  with the prompts routed to the host model; no API keys.
+  (`@prosecutor-correctness|security|contract|diff|tests`), `@prosecutor-verifier`,
+  and the `@prosecutor` meta-agent (deterministic hollow-test / behavior-diff /
+  review-calibration gates).
 
 ## Install
 
-`@adlc/opencode-package` is **not yet published to npm**, so install from
-source (peer dependency: `@opencode-ai/plugin` ≥ 1.17.11):
+Two commands (peer dependency: `@opencode-ai/plugin` ≥ 1.17.13):
 
 ```sh
 npm install -g @adlc/cli                 # the gate toolkit the plugin shells out to
-
-# make the plugin available to opencode
-ln -s /path/to/adlc/plugins/adlc-opencode .opencode/plugin/adlc-opencode
-# …or add its path to the "plugin" array in .opencode/opencode.json
+npx @adlc/opencode-package init          # scaffolds .adlc/ + .opencode/, registers the plugin
 ```
 
-Then, inside the opencode TUI, run `/adlc-init` — it bootstraps `.adlc/`,
-deploys the command/agent/skill surface into `.opencode/`, and **registers the
-plugin in `opencode.json` so the rails-guard hook actually loads** (the markdown
-surfaces are inert without it). First-time, before the command exists:
-
-```sh
-node /path/to/adlc/plugins/adlc-opencode/lib/scaffold-cli.mjs .
-```
-
-Restart opencode so the hooks load. Verify locally without an `opencode` binary:
+Restart opencode so the hooks load. Inside the TUI, `/adlc-init` re-runs the same
+idempotent scaffold. The bootstrap registers a **resolvable** plugin entry (the
+npm name when installed from node_modules, the resolved local path from a source
+checkout). Verify locally without an `opencode` binary:
 
 ```sh
 node scripts/opencode-install-smoke.mjs .
 ```
 
+Per-repo config rides the `["@adlc/opencode-package", { … }]` plugin-options
+tuple (env vars override); see the integration guide for the option table.
+
 ## Rail enforcement — two layers
 
-1. **In-session (capability-gated).** The hook only *actually blocks* when the
-   host SDK honors a thrown denial — a runtime capability probe decides
-   (`ADLC_OPENCODE_ENFORCES=1/0` forces it). When the capability is unproven,
-   the hook **fails closed** unless `ADLC_ALLOW_ADVISORY_HOOKS=1` explicitly
-   permits advisory mode (surface the violation loudly, don't block). Bash
-   writes are **not** gated in-session; unrecognized structured tools carrying a
-   path fail closed.
+1. **In-session (enforcing by default).** A thrown denial in
+   `tool.execute.before` **aborts the tool call** — documented host behavior on
+   `@opencode-ai/plugin` ≥ 1.17.13, regression-tested end-to-end against a real
+   opencode binary (required CI). Bash **is** gated via the `@adlc/core` shell
+   classifier; unrecognized structured tools carrying a path fail closed. The
+   only downgrade is the explicit `ADLC_ALLOW_ADVISORY_HOOKS=1` escape hatch
+   (surface loudly, don't block).
 2. **Commit-time (unbypassable).** The real control is
    `scripts/rails-guard-ci.mjs` (via `docs/ci/rails-guard.yml`): it reads the
    frozen rail set **from the trusted base ref** and rejects any PR that edits a
@@ -86,27 +87,29 @@ Mirrors the sibling integrations; all glob/ticket logic delegates to `@adlc/core
 | P0 Triage | **Yes** | `/adlc-ticket` |
 | P1 Interrogate | **Yes** | `/adlc-spec` + `/adlc-approve-spec` (G1) + the `adlc` skill |
 | P2 Decompose | **Yes** | `/adlc-decompose` |
-| P3 Rail | **MVP** | in-session rails-guard hook + CI gate |
-| P4 Build | Partial | rails-guard hook + `session.created` preflight |
-| P5 Prosecute | **Yes** | `/adlc-verify-build` (G4) + five lenses + verifier + `/adlc-prosecute` |
+| P3 Rail | **Yes** | in-session rails-guard hook (enforcing) + CI diff gate |
+| P4 Build | **Yes** | rails-guard hook + shell gating + build-gate context-rot backstop + flail advisory |
+| P5 Prosecute | **Yes** | `/adlc-verify-build` (G4) + the deterministic `adlc_prosecute` runner (5 lenses + verifier) + `@prosecutor` gates |
 | P6 Integrate | Partial | `session.idle` gate-manifest audit; the human gate is by design |
-| P7 Distill | **Yes** | `/adlc-distill` |
+| P7 Distill | **Yes** | `/adlc-distill` + `/adlc-maintain` |
 
 ## Gaps
 
-1. In-session enforcement depends on the host SDK honoring a thrown denial —
-   until proven, the CI gate is the real control.
-2. The keyless bridge's isolated sub-context call depends on a proposed opencode
-   SDK extension; it degrades or fails closed, never silently skips a gate.
-3. `/adlc-prosecute`'s fan-out → verify → loop-until-dry protocol is executed by
-   the model, not a deterministic first-party runner (the decision helpers are
-   unit-tested).
-4. A live deny-proof against a real opencode binary is the remaining GA gate.
+1. **`permission.ask` is a dormant lever** — defined but never dispatched
+   upstream (anomalyco/opencode#7006, re-verified at 1.17.17/1.17.18). The
+   enforcing control is the `tool.execute.before` throw; the tolerant handler
+   activates the instant upstream wires the hook.
+2. **The native TUI plugin module is deferred** — `PluginModule` types
+   `tui?: never` at 1.17.17 (the surface is reserved, not shipped), so the
+   persistent statusline slot / dialogs are a follow-on. The verifiable native
+   touch (the statusline toast) ships now.
+3. **P6 acceptance is a human decision** — by design; the plugin surfaces
+   evidence, it does not automate approval.
 
 ## Go deeper
 
 Source: [`plugins/adlc-opencode/`](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-opencode)
 · design rationale: [ADR 0004](https://github.com/voodootikigod/adlc/blob/main/docs/adr/0004-adlc-opencode-integration.md).
 
-The prosecution panel this integration ships:
+The deterministic prosecution loop this integration ships:
 [Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review).

--- a/apps/docs/content/docs/integrations/opencode.mdx
+++ b/apps/docs/content/docs/integrations/opencode.mdx
@@ -1,6 +1,6 @@
 ---
 title: opencode
-description: Native ADLC integration for the opencode terminal agent — enforce-by-default rails-guard hook, nine lifecycle commands, native adlc_gate/adlc_prosecute tools, and a deterministic seven-agent P5 prosecution loop.
+description: Native ADLC integration for the opencode terminal agent — enforce-by-default rails-guard hook, nine lifecycle commands, native adlc_gate/adlc_prosecute tools, and a deterministic P5 prosecution loop (5 lenses + verifier) plus a prosecutor meta-agent.
 ---
 
 # ADLC in opencode
@@ -9,9 +9,11 @@ Brings the lifecycle into the [opencode](https://opencode.ai) terminal agent as
 a native plugin: an in-session rails-guard hook (`tool.execute.before`),
 advisory session hooks, nine lifecycle commands, the `adlc` phase-routing
 skill, two native model-callable tools (`adlc_gate`, `adlc_prosecute`), and a
-seven-agent P5 prosecution panel. The integration **enforces by default** —
-a thrown denial in `tool.execute.before` aborts the tool call (documented host
-behavior, regression-tested against a real binary).
+**deterministic P5 prosecution loop** — five lenses + a verifier fanned out over
+write-disabled child sessions — plus a separate `@prosecutor` meta-agent (seven
+prosecution agents in all). The integration **enforces by default** — a thrown
+denial in `tool.execute.before` aborts the tool call (documented host behavior,
+regression-tested against a real binary).
 
 ## What you get
 

--- a/docs/adr/0004-adlc-opencode-integration.md
+++ b/docs/adr/0004-adlc-opencode-integration.md
@@ -162,6 +162,35 @@ since the Phase-1 amendment:
    floor stays `>=1.17.13` (the contract-verified, required-proof version); bump
    it deliberately when the canary shows sustained green on a newer line.
 
+## Amendment — 2026-07-10: native tools live (Phases 4 & 4b / T33)
+
+1. **Keyless bridge is LIVE (Phase 4).** `makeAsk` spins an isolated child
+   session (`client.session.create({parentID})` + `session.prompt`) and threads
+   the reply back — no longer a "proposed SDK extension" or a tested-but-unwired
+   library. The native **`adlc_gate`** tool (plugin `tool` hook) lets the model
+   call gates directly; LLM-backed gates run keyless through the host model.
+2. **`session.prompt` has NO `outputFormat`** (confirmed through 1.17.17). The
+   flush plan's assumption of server-side JSON-schema structured output was
+   FALSE. Structured output is obtained via a **registered verdict tool** (or
+   fenced-JSON parsing, fail-closed) — not a prompt option.
+3. **Deterministic P5 runner (Phase 4b / T33).** The native **`adlc_prosecute`**
+   tool drives fan-out → dedupe → verify → loop-until-dry in first-party code
+   (`lib/prosecute-runner.mjs`), not model-driven orchestration. Lens/verifier
+   work runs in child sessions locked down by a **wildcard-deny-first read-only
+   tools allowlist** (`{ "*": false, <read tools>: true }` — the shape opencode's
+   own `explore`/`compaction` agents use): unlisted tools (`edit`/`write`,
+   `task`, MCP, future) hard-deny, so a lens cannot mutate even via a sub-agent
+   or an injection in the untrusted diff. A denylist would fail OPEN here (the
+   SDK `tools` map is a sparse override; absent = base agent default = enabled) —
+   this is a security-load-bearing decision, verified against opencode source.
+4. **Install + parity (T30/T34).** `@adlc/opencode-package` is publishable
+   (folded into the lockstep release) with an `npx @adlc/opencode-package init`
+   bootstrap; the scaffolder registers a resolvable entry (npm name from
+   node_modules, resolved path from source). `/adlc-maintain` + the `prosecutor`
+   meta-agent (7th agent) port the CC maintenance surface; gate-fuzzing
+   calibration is neither host- nor deterministic-cron-run (needs a separate
+   model+sandbox job).
+
 ## Consequences
 
 Rail enforcement is real in OpenCode for the common structured-edit path, with the

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -34,9 +34,10 @@ verified v1.17.13), answers each `--prompt-only` prompt, and threads the results
 back. The keyless bridge is therefore **live code with a real caller now**, not
 the tested-but-unwired library it used to be. Both are proven end-to-end against
 a real opencode 1.17.13 by `scripts/opencode-live-tool.mjs` (CI-required). The
-`lib/prosecutor.mjs` P5 decision helpers remain wired only to the model-driven
-`/adlc-prosecute` flow; the deterministic first-party P5 runner that consumes
-them is deferred to a Phase 4b follow-on.
+`lib/prosecutor.mjs` P5 decision helpers now drive the deterministic first-party
+P5 runner (`adlc_prosecute`, T33 / Phase 4b — see the "Resolved 2026-07-09"
+note below); `/adlc-prosecute` calls that tool first and keeps the model-driven
+prose protocol as the fallback.
 
 > **Session hooks — event-name note.** The plan specified `session.created` +
 > `session.ended`, but OpenCode has no `session.ended`; the end-of-work signal is

--- a/docs/opencode-integration-plan.md
+++ b/docs/opencode-integration-plan.md
@@ -1,5 +1,30 @@
 # Plan: Installing & Integrating ADLC into OpenCode
 
+> [!WARNING]
+> **SUPERSEDED (2026-07-10) — historical design record only.** This is the
+> original proposal. What actually shipped, and the authoritative current state,
+> live in:
+> - [ADR 0004](adr/0004-adlc-opencode-integration.md) — the pinned API decisions and dated amendments.
+> - [docs/specs/opencode-native-flush.md](specs/opencode-native-flush.md) — the Phases 1–5 flush plan.
+> - [docs/specs/opencode-integration-continuation.md](specs/opencode-integration-continuation.md) — the T30–T35 continuation.
+> - [docs/integrations/opencode.md](integrations/opencode.md) — the current integration guide (Status / Gaps).
+>
+> This document describes machinery that was **never built** (signed manifests,
+> admin keys, `adlc-runner` extensions, pre-commit-hook injection) and asserts
+> claims **contradicted by what shipped**. What actually happened:
+>
+> | This plan said | What actually shipped |
+> | --- | --- |
+> | In-session Bash gating was DROPPED (§6.2) | Bash IS gated in-session via the `@adlc/core` shell classifier (Phase 2, PR #116). |
+> | Keyless bridge needs a proposed SDK extension | Live on `client.session.create` + `session.prompt` (Phase 4); **no `outputFormat`** — verdicts are a registered tool / fenced JSON. |
+> | Signed manifests, admin keys, `adlc-runner` P0/P4 runners | Never built; the shipped enforcement is the `tool.execute.before` throw + the CI rails-guard diff gate. |
+> | `permission.ask` second lever | Defined but DORMANT upstream (anomalyco/opencode#7006, re-verified at 1.17.17/1.17.18). |
+> | Model-driven P5 orchestration | Deterministic first-party `adlc_prosecute` runner (T33). |
+> | `@adlc/opencode-package` install-from-source | Publishable package + `npx @adlc/opencode-package init` bootstrap (T30). |
+>
+> Read the four documents above for anything current; treat everything below as
+> the historical starting point, not a description of the integration.
+
 **Status:** Proposal · **Branch:** `opencode-integration` · **Date:** 2026-06-18
 
 ---

--- a/docs/specs/opencode-native-flush.md
+++ b/docs/specs/opencode-native-flush.md
@@ -1,6 +1,17 @@
 # OpenCode Native Flush — making adlc-opencode robust, feature-complete, and native-feeling
 
-Status: PROPOSED (plan for review)
+> **STATUS UPDATE (2026-07-10): Phases 1–4b SHIPPED.** This is the original plan;
+> the "wire the dead code" / "tested-but-unwired" / "to-do" language below
+> describes the pre-implementation state, not the current one. Phases 1–3 merged
+> (PR #109/#116/#117); Phase 4 (keyless bridge + `adlc_gate`) and Phase 4b
+> (deterministic `adlc_prosecute` runner) shipped via PRs #119/#126; Phase 5
+> (install/publish, `/adlc-maintain`, prosecutor meta-agent, upstream sync)
+> shipped as the T30–T34 continuation (see
+> [opencode-integration-continuation.md](opencode-integration-continuation.md)).
+> For current state read [docs/integrations/opencode.md](../integrations/opencode.md)
+> and [ADR 0004](../adr/0004-adlc-opencode-integration.md).
+
+Status: PROPOSED (plan for review) — see the STATUS UPDATE banner above.
 Branch: `opencode-native-flush`
 Inputs: full plugin audit, six-integration capability benchmark, and a verified inventory of
 OpenCode's extension surface as of `@opencode-ai/plugin` v1.17.13 (July 2026).
@@ -14,7 +25,7 @@ questions). The July-2026 surface answers nearly all of them, in our favor:
 | --- | --- |
 | Throwing in `tool.execute.before` may not block ("capability unproven") | **Throwing blocks the tool call.** Documented, verbatim example in plugins.mdx. |
 | `input.args` vs `output.args` ambiguity | Args are on **`output.args`** only; `input` = `{tool, sessionID, callID}`. |
-| Keyless bridge needs a "proposed SDK extension" | `client.session.create({parentID})` + `session.prompt` (with `outputFormat` JSON-schema structured output and `noReply`) exists today. |
+| Keyless bridge needs a "proposed SDK extension" | `client.session.create({parentID})` + `session.prompt` exists today. (⚠️ CORRECTION 2026-07-09: this row originally claimed a `session.prompt({outputFormat})` JSON-schema mode — **no such field exists** through 1.17.17. Structured output is a registered verdict tool / fenced JSON. `noReply` does exist.) |
 | Warnings can only go to `console.error` | `client.tui.showToast`, `client.app.log`, plus a full **TUI plugin surface** (toasts, dialogs, persistent UI slots, OS notifications). |
 | Commands/agents markdown is the only extension shape | Plugins can register **native model-callable tools** (`tool` hook / `.opencode/tools/`), a **`permission.ask`** programmatic allow/deny hook, `tool.definition` rewriting, `experimental.chat.system.transform`, and more. |
 | `.opencode/command/`, `skill/adlc.md` layout | **Plural dirs are canonical** (`commands/ agents/ skills/ tools/ plugins/`); native skills are `skills/<name>/SKILL.md` discovered via a `skill` tool. |
@@ -134,9 +145,12 @@ OpenCode releases (current + latest) to catch upstream hook-contract drift.
 ### Phase 4 — Wire the dead code (keyless bridge + deterministic P5)
 
 4.1 **Keyless bridge goes live.** `makeAsk` gets a real implementation:
-    `client.session.create({parentID: current})` → `session.prompt` with
-    `outputFormat` (JSON-schema structured verdicts) → thread answers per the existing
-    tested protocol. Delete the "proposed SDK extension" caveat.
+    `client.session.create({parentID: current})` → `session.prompt` → thread
+    answers per the existing tested protocol. Delete the "proposed SDK extension"
+    caveat. (⚠️ CORRECTION 2026-07-09: this step originally specified
+    `session.prompt` with `outputFormat` JSON-schema verdicts — **that field does
+    not exist**; verdicts are a registered tool / fenced-JSON, fail-closed. See
+    ADR 0004's 2026-07-10 amendment.)
 4.2 **Native `adlc_gate` custom tool** (plugin `tool` hook): the model calls
     `adlc_gate({gate, args})` instead of being prose-instructed to shell out; execute()
     runs the CLI (or keyless bridge for LLM-backed gates) and returns structured

--- a/scripts/claude-code-plugin-smoke.mjs
+++ b/scripts/claude-code-plugin-smoke.mjs
@@ -602,6 +602,7 @@ const EXCLUDED_DOC_PATHS = [
   ['docs/integrations/cursor.md', "Cursor's own doc; bare \"/adlc-*\" is that harness's correct, intentional syntax"],
   ['docs/integrations/opencode.md', "OpenCode's own doc; bare \"/adlc-*\" is that harness's correct, intentional syntax"],
   ['docs/integrations/pi.md', "Pi's own doc; skill-driven, not command-namespaced (verified in #50)"],
+  ['docs/adr/0004-adlc-opencode-integration.md', "ADR specific to the OpenCode integration; bare \"/adlc-*\" is that harness's correct, intentional syntax"],
   ['docs/adr/0006-adlc-cursor-integration.md', "ADR specific to the Cursor integration; bare form is Cursor's correct syntax"],
   ['docs/opencode-integration-plan.md', 'OpenCode-specific planning doc, not a Claude Code guidance surface'],
   ['docs/ticket-sync.md', 'uses "/adlc-ticket" as generic ADLC-lifecycle prose, not a Claude-Code-specific command recommendation (judged out of scope during #50\'s review)'],


### PR DESCRIPTION
## Summary

Executes ticket **T35** — the final honesty pass after T30–T34 landed. Completes the T30–T35 opencode continuation.

- **`docs/opencode-integration-plan.md`**: SUPERSEDED banner + a "what actually shipped" delta table — bash gating shipped (not dropped), keyless bridge live without `outputFormat`, signed-manifests/admin-keys/`adlc-runner` enforcement machinery never built, `permission.ask` dormant, deterministic P5 runner, publishable package. Body preserved as the historical record.
- **`docs/adr/0004`**: new dated `2026-07-10` amendment — keyless bridge live, `session.prompt` has **no `outputFormat`** (verdict tool instead), the deterministic `adlc_prosecute` runner + wildcard-deny-first read-only allowlist (a security-load-bearing decision — a denylist would fail open on the sparse SDK `tools` map), install + parity (T30/T34). Five answered questions are now dated decisions across the three amendments.
- **`docs/specs/opencode-native-flush.md`**: STATUS UPDATE banner (phases 1–4b shipped) + inline dated CORRECTION notes on the two false `outputFormat` claims.
- **`apps/docs/.mdx`**: synced from the pre-Phase-1 state to reality — enforce-by-default (was capability-probe), 9 commands, 7 agents, `adlc_gate`/`adlc_prosecute` native tools, `npx @adlc/opencode-package init` (was not-published/symlink), deterministic P5, refreshed coverage + Gaps.

## Test plan
- [x] AC1 superseded banner; AC2 five dated ADR decisions; AC3 no `outputFormat`/"proposed SDK extension"/unwired-library as current state; AC4 docs-site consistent with the integration guide
- [x] Full suite + apps/docs tests (check-links + integration-facts) green
- [x] Same-model P5 prosecution: **SHIP** — every factual claim verified against shipped code (9 commands / 7 agents counted, enforce-by-default, bash gated, keyless live, no `outputFormat` in the installed SDK, deterministic runner + allowlist, publishable+npx, never-built negatives accurate); all banner links resolve; the sweep ships no new false claim
- [ ] Cross-model codex pass (running)