### PR TITLE
fix(opencode): correct the last two gate refs in the command suite (closes #105)

### DIFF
--- a/plugins/adlc-opencode/command/adlc-distill.md
+++ b/plugins/adlc-opencode/command/adlc-distill.md
@@ -13,7 +13,9 @@ recur. Target scope: **$ARGUMENTS** (default to recent history).
    `adlc lesson-foundry --prompt-only` (answer the printed prompts yourself).
 2. For each recurring class, propose the cheapest deterministic defense: a lint
    rule, a new prosecution lens, a skill update, or a test.
-3. Check skill decay: `adlc skill-rot --prompt-only`.
+3. Check skill decay: `adlc skill-rot .opencode/skills --json` (deterministic —
+   it has no `--prompt-only`; exit 2 = stale validation metadata, exit 1
+   `nothing to verify` = no metadata, informational).
 4. Optional `--simplify`: once all tests are green, run a local Simplify pass under
    the completed ticket's still-frozen rails (advisory deviation from strict
    post-merge P7 — warn the user; never edit frozen rails).

--- a/plugins/adlc-opencode/command/adlc-verify-build.md
+++ b/plugins/adlc-opencode/command/adlc-verify-build.md
@@ -13,9 +13,13 @@ Target ticket: **$ARGUMENTS** (default to the active ticket).
 1. Run the configured build, lint, and test commands (from `.adlc/config.json` or
    the project's `package.json`). Capture exit codes.
 2. If any fail, STOP — report the failures; the change is not eligible for P5.
-3. On success, record the build evidence:
-   `adlc-runner run p4 --ticket <id>` (or, if the runner is unavailable, append an
-   unsigned `p4-build` entry to `.adlc/manifest.jsonl`, flagged `unsigned_fallback`).
+3. On success, RECORD the build evidence with
+   `adlc gate-manifest record p4-build --files <changed files>` (or, if that is
+   unavailable, append an unsigned `p4-build` entry to `.adlc/manifest.jsonl`,
+   flagged `unsigned_fallback`). Note: `adlc-runner run p4 --ticket <id>` does
+   **not** record — it is a read-only ASSERTION that the P4 evidence is already
+   present (it exits 2 on a green build with no prior record), so run it (if the
+   runner is available) only AFTER recording, as a confirmation.
 
 ## Summarize
 Report each command's result and what was recorded. When green, point the user at


### PR DESCRIPTION
Closes #105.

Two of the four OpenCode command-suite gate-reference defects from #105 still shipped on main (the other two were already fixed — #2 `model-router`/`adlc-rail-write` in the flush-spec work, #3 `approve-spec`'s `accept --gate p1` during the T32 loop). This fixes the remaining two:

- **`adlc-distill.md`**: `adlc skill-rot --prompt-only` → `adlc skill-rot .opencode/skills --json`. skill-rot is deterministic and has no `--prompt-only`, so the strict `@adlc/core` parseArgs would crash it (`ERR_PARSE_ARGS_UNKNOWN_OPTION`).
- **`adlc-verify-build.md`**: `adlc-runner run p4 --ticket <id>` was described as *recording* build evidence, but `run p4` is a read-only **assertion** that exits 2 on a green build with no prior record (`packages/runner/lib/assertions.mjs`). Now records via `adlc gate-manifest record p4-build` and runs `run p4` only after, as a confirmation.

Verified no sibling harness (claude-code / cursor / codex / pi / antigravity) ships the same wording.

## Test plan
- [x] All four #105 defects grep-clean on the OpenCode command files
- [x] `opencode-install-smoke` PASS; `claude-code-plugin-smoke` 13/0 (bare-command scanner unaffected)