### PR TITLE
test(adlc-antigravity): lock single-ticket projection contract (dangling-edge deny-all)

### DIFF
--- a/.adlc/tickets.json
+++ b/.adlc/tickets.json
@@ -959,6 +959,36 @@
       "duration": 2,
       "category": "feature",
       "budget": "direct"
+    },
+    {
+      "id": "A142",
+      "title": "Lock single-ticket projection contract in adlc-antigravity (dangling-edge deny-all)",
+      "body": "GitHub issue: https://github.com/voodootikigod/adlc/issues/142\n\n=== CONTEXT (P0 regression guard, pairs with antigravity-booster#11) ===\nThe antigravity-booster projects a SINGLE-ticket .adlc/tickets.json into each build worktree. When that ticket has an outgoing edge, plugins/adlc-antigravity/core-inline.mjs loadTickets (~lines 51-55) reports 'edge to unknown ticket <id>'; rails-checker.mjs railPreconditions (~lines 222-224) treats any validation error as tamper and fails closed ({state:deny}); checkRail/decide (~line 249, hooks/adlc-rails-guard.mjs ~line 117) then deny EVERY mutating tool call for the whole session — not just rail paths. The plugin's decide.test.mjs always writes a full ticket set, so the single-ticket projection shape was never tested. The booster-side fix (issue #11) strips edges from the projection; this ticket locks the contract from the plugin side.\n\n=== TASK ===\n1. Add tests in plugins/adlc-antigravity/test/ over the projection shapes: (a) single-ticket tickets.json, NO edges, with rails -> hook enforces the rail (denies a rail write) AND allows an in-scope non-rail write; (b) single-ticket tickets.json WITH a dangling edge -> assert the CURRENT fail-closed deny-all behavior explicitly, with a comment linking booster#11 and adlc#142 so the failure mode is visible and intentional in the suite.\n2. Document the contract decision (plugin stays fail-closed on dangling edges; booster must project edge-free single-ticket files) in docs/integrations/antigravity.md.\n\n=== ACCEPTANCE CRITERIA ===\n- AC1: Both projection-shape tests exist and pass under node --test in plugins/adlc-antigravity/. VERIFY: run the plugin test suite, exit 0, and the two new test names appear in output.\n- AC2: The dangling-edge deny-all behavior is asserted (not implicit) with the cross-repo comment. VERIFY: grep the test file for issues/142 and issues/11 references.\n- AC3: The contract decision is documented in docs/integrations/antigravity.md. VERIFY: grep for a 'single-ticket projection' section.\n- AC4: No production code changes in this ticket — tests + docs only. VERIFY: git diff touches only test/ and docs/.",
+      "scope": [
+        "plugins/adlc-antigravity/test/**",
+        "docs/integrations/antigravity.md"
+      ],
+      "rails": [],
+      "edges": [],
+      "duration": 1,
+      "category": "test",
+      "budget": "direct"
+    },
+    {
+      "id": "A143",
+      "title": "Single version + adlcContract field in adlc-antigravity plugin manifest",
+      "body": "GitHub issue: https://github.com/voodootikigod/adlc/issues/143\n\n=== CONTEXT (P0, enables booster handshake; pairs with antigravity-booster#12) ===\nThe plugin carries two conflicting versions: plugins/adlc-antigravity/plugin.json says 0.2.0, plugins/adlc-antigravity/package.json says 1.2.0. Consumers (antigravity-booster) have no way to detect schema/payload drift: today the booster only substring-matches agy plugin list output. Booster issue #12 adds a manifest-based handshake that reads an adlcContract field from the installed plugin.json (installed location: ~/.gemini/config/plugins/adlc-antigravity/plugin.json — agy copies the whole plugin dir).\n\n=== TASK ===\n1. Reconcile to ONE version with plugin.json authoritative; make package.json mirror it. Pick the reconciled number deliberately (recommend 1.2.0 since package.json history is the real release lineage) and state the choice in the commit message.\n2. Add \"adlcContract\": 1 to plugin.json, versioning the interfaces: (a) the tickets.json schema accepted by core-inline.mjs, (b) the hook stdin payload shape, (c) the hook decision output shape. Document bump rules (any breaking change to those three interfaces bumps the integer) in a comment-adjacent doc — plugins/adlc-antigravity/README.md (create it — do NOT touch docs/integrations/antigravity.md, which is in ticket A142's scope).\n3. Add a test asserting plugin.json and package.json versions agree and adlcContract is a positive integer, so CI fails on future divergence.\n\n=== ACCEPTANCE CRITERIA ===\n- AC1: plugin.json and package.json carry the same version; test enforces it. VERIFY: plugin test suite exit 0; intentionally desync locally -> test fails.\n- AC2: adlcContract present in plugin.json with documented bump rules. VERIFY: grep plugin.json for adlcContract; grep docs for the bump rules.\n- AC3: agy plugin validate plugins/adlc-antigravity still passes (manifest remains agy-loadable). VERIFY: run it, exit 0.\n- AC4: Booster issue #12 unblocked: the field is readable from the plugin source dir (no build step required).",
+      "scope": [
+        "plugins/adlc-antigravity/plugin.json",
+        "plugins/adlc-antigravity/package.json",
+        "plugins/adlc-antigravity/test/**",
+        "plugins/adlc-antigravity/README.md"
+      ],
+      "rails": [],
+      "edges": [],
+      "duration": 1,
+      "category": "chore",
+      "budget": "direct"
     }
   ]
 }

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -110,6 +110,43 @@ not re-implemented here):
   ticket resolves.
 - Symlink aliases whose real target is a frozen rail are resolved and denied.
 
+## Single-ticket projection
+
+The [antigravity-booster](https://github.com/voodootikigod/antigravity-booster)
+projects a **single-ticket** `.adlc/tickets.json` into each build worktree: the
+worktree sees exactly one ticket — the one it is building — not the whole ticket
+graph. This section pins the contract between that projection and the plugin's
+fail-closed loader so the two repos cannot drift.
+
+**The contract: the booster must project *edge-free* single-ticket files.** A
+ticket in the full graph normally carries `edges[].to` references to sibling
+tickets. When a single ticket is projected in isolation, any such edge becomes
+**dangling** — it points at a ticket that is no longer present in the file.
+`core-inline.mjs` `loadTickets` reports that as `edge to unknown ticket <id>`,
+`rails-checker.mjs` `railPreconditions` treats **any** validation error as a
+tamper signal and returns `{ state: 'deny' }`, and `checkRail`/`decide` then deny
+**every mutating tool call for the whole session** — not just writes to rail
+paths. A build worktree in that state cannot edit anything.
+
+**The plugin stays fail-closed by design; it does not repair the trust root.**
+Refusing to load a malformed `.adlc/tickets.json` is the correct security posture
+(a partially-parseable trust root is exactly where a silent rail-narrowing attack
+would hide). So the fix lives on the **booster** side: it must strip `edges` from
+the single-ticket projection before writing it into the worktree, producing a
+clean file that validates. The plugin does **not** add a special-case that
+tolerates dangling edges.
+
+This split is asserted from both sides so it can't regress:
+
+- **Plugin (this repo):** `test/projection.test.mjs` pins both shapes — a clean
+  single-ticket projection enforces its rail while allowing in-scope non-rail
+  writes, and a dangling-edge projection produces the fail-closed deny-all
+  (denying even a non-rail, in-scope write). See
+  [antigravity-booster#11](https://github.com/voodootikigod/antigravity-booster/issues/11)
+  and [adlc#142](https://github.com/voodootikigod/adlc/issues/142).
+- **Booster (antigravity-booster#11):** strips edges from the projection so the
+  dangling-edge state never reaches a real build worktree.
+
 ## Platform notes / limitations
 
 - **POSIX only in-session** (`$HOME` command path); Windows in-session is unsupported —

--- a/plugins/adlc-antigravity/test/projection.test.mjs
+++ b/plugins/adlc-antigravity/test/projection.test.mjs
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { decide } from '../hooks/adlc-rails-guard.mjs';
+
+// Projection-shape contract tests (adlc#142, antigravity-booster#11).
+//
+// The antigravity-booster projects a SINGLE-ticket .adlc/tickets.json into each
+// build worktree: exactly one ticket (the active build ticket). decide.test.mjs
+// only ever writes a ticket that happens to be alone but carries no edges, so
+// the two projection shapes that MATTER at the booster boundary — a clean
+// single-ticket file, and one whose outgoing edge dangles because the target
+// ticket was projected away — were never pinned. This file pins both.
+
+const ENF = { ADLC_P4_ENFORCEMENT: '1' };
+
+// Build a booster-style SINGLE-ticket projection. `edges` is opt-in so a test can
+// reproduce the dangling-edge shape the booster produces when it fails to strip a
+// projected-away edge target.
+function projectionRepo({ rails = [], scope = ['src/**'], edges, id = 'T1' } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'agy-proj-'));
+  mkdirSync(join(root, '.adlc'), { recursive: true });
+  const ticket = { id, title: 't', body: 'b', scope, rails };
+  if (edges !== undefined) ticket.edges = edges;
+  writeFileSync(join(root, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [ticket] }));
+  writeFileSync(join(root, '.adlc', 'current-ticket.json'), JSON.stringify({ id }));
+  mkdirSync(join(root, 'src'), { recursive: true });
+  return root;
+}
+const call = (name, args, env = ENF, extra = {}) => decide({ toolCall: { name, args }, ...extra }, { env });
+
+test('single-ticket projection (no edges): enforces the rail (denies a rail write) and allows an in-scope non-rail write', () => {
+  const root = projectionRepo({ rails: ['src/frozen.js'], scope: ['src/**'] });
+
+  // The declared rail is frozen: a structured write to it is denied.
+  const railWrite = call('write_to_file', { TargetFile: join(root, 'src', 'frozen.js') });
+  assert.equal(railWrite.allow_tool, false);
+  assert.match(railWrite.deny_reason, /frozen rail/i);
+
+  // An in-scope, non-rail path is the normal P4 edit surface and stays allowed.
+  const nonRailWrite = call('write_to_file', { TargetFile: join(root, 'src', 'feature.js') });
+  assert.equal(nonRailWrite.allow_tool, true);
+});
+
+test('single-ticket projection WITH a dangling edge: current fail-closed deny-all (pins the antigravity-booster#11 / adlc#142 regression)', () => {
+  // When the booster projects a single ticket but leaves an outgoing edge whose
+  // target was projected away, core-inline.mjs loadTickets reports
+  // "edge to unknown ticket <id>"; rails-checker.mjs railPreconditions reads ANY
+  // validation error as tamper and returns { state: 'deny' }, so checkRail/decide
+  // deny EVERY mutating tool call for the whole session — not just rail paths.
+  //
+  // This is deliberate, documented fail-closed behavior: the plugin does not try
+  // to repair a malformed trust root. The booster-side fix strips edges from the
+  // single-ticket projection so this state never occurs in practice. We assert the
+  // deny-all EXPLICITLY here so the failure mode stays visible and intentional in
+  // the suite rather than being silently "discovered" by a future projection bug.
+  //   https://github.com/voodootikigod/antigravity-booster/issues/11
+  //   https://github.com/voodootikigod/adlc/issues/142
+  const root = projectionRepo({ rails: ['src/frozen.js'], scope: ['src/**'], edges: [{ to: 'T2' }] });
+
+  // The rail write is denied — but so is EVERYTHING, so the rail deny alone does
+  // not distinguish deny-all from healthy enforcement.
+  const railWrite = call('write_to_file', { TargetFile: join(root, 'src', 'frozen.js') });
+  assert.equal(railWrite.allow_tool, false);
+  assert.match(railWrite.deny_reason, /failed to validate/i);
+
+  // The tell-tale of deny-all: an in-scope, NON-RAIL write that the no-edges case
+  // above allowed is ALSO denied here — the dangling edge trips the fail-closed
+  // precondition before any per-path rail matching runs.
+  const nonRailWrite = call('write_to_file', { TargetFile: join(root, 'src', 'feature.js') });
+  assert.equal(
+    nonRailWrite.allow_tool,
+    false,
+    'a dangling edge must fail closed and deny even a non-rail, in-scope write'
+  );
+  assert.match(nonRailWrite.deny_reason, /failed to validate.*failing closed/i);
+
+  // The deny-all is scoped to MUTATING tool calls: read-only tools are classified
+  // before preconditions run, so a read of the same path is still allowed. This
+  // pins that the fail-closed blast radius is "every mutation", not "every tool".
+  const read = decide(
+    { toolCall: { name: 'view_file', args: { AbsolutePath: join(root, 'src', 'feature.js') } } },
+    { env: ENF }
+  );
+  assert.equal(read.allow_tool, true);
+});


### PR DESCRIPTION
## Summary

Ticket **A142** (P4, tests + docs only). Locks the contract between the
antigravity-booster's single-ticket projection and the plugin's fail-closed
loader, so the two repos cannot drift. No production code changes.

The booster projects a **single-ticket** `.adlc/tickets.json` into each build
worktree. `decide.test.mjs` always writes a full ticket set, so the two shapes
that matter at that boundary were never pinned:

1. **Clean single-ticket projection (no edges)** — the hook enforces the declared
   rail (denies a rail write) and allows an in-scope non-rail write.
2. **Single-ticket projection with a dangling edge** — when the booster leaves an
   `edges[].to` pointing at a projected-away ticket, `core-inline.mjs` loadTickets
   reports `edge to unknown ticket <id>`, `railPreconditions` treats any validation
   error as tamper and returns `{ state: 'deny' }`, and `decide` then denies
   **every mutating tool call for the whole session** — not just rail paths. This
   PR asserts that deny-all **explicitly** so the failure mode is visible and
   intentional, and pins that reads still pass (blast radius is every *mutation*,
   not every *tool*).

`docs/integrations/antigravity.md` gains a **Single-ticket projection** section:
the plugin stays fail-closed by design (it does not repair a malformed trust
root); the fix lives on the booster side, which must strip `edges` from the
projection. Cross-linked to antigravity-booster#11 and adlc#142.

## Observed dangling-edge behavior

Confirmed empirically before writing the test — the deny-all is real:

| Projection | rail write | in-scope non-rail write | read |
|---|---|---|---|
| clean (no edges) | **deny** (`frozen rail`) | allow | allow |
| dangling edge | **deny** (`failed to validate … failing closed`) | **deny** (same reason) | allow |

The discriminating assertion is the non-rail in-scope write: allowed in the clean
case, denied under the dangling edge — that is the deny-all.

## Test plan

New file `plugins/adlc-antigravity/test/projection.test.mjs` (2 tests):

- `single-ticket projection (no edges): enforces the rail (denies a rail write) and allows an in-scope non-rail write`
- `single-ticket projection WITH a dangling edge: current fail-closed deny-all (pins the antigravity-booster#11 / adlc#142 regression)`

Run the plugin suite the way `package.json`'s `test` script does:

```
$ node --test plugins/adlc-antigravity/test/*.test.mjs
# tests 54   # pass 54   # fail 0   (was 52 on main)
$ node scripts/antigravity-install-smoke.mjs .   # exit 0
```

`git diff --stat` touches only `plugins/adlc-antigravity/test/` and
`docs/integrations/antigravity.md`.

P5 cross-context prosecution runs in the coordinating session and will be
commented on this PR.

Closes #142