### PR TITLE
test(prosecute/ticket-sync): producer→consumer round-trip coverage + drift gate (T40, #138)

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -87,10 +87,18 @@ How to write one (see `packages/ticket-prune/test/roundtrip.test.mjs` and
 3. Cover BOTH directions: the accepted case (real output merges) AND that anything
    the producer REFUSES corresponds to a case the gate DENIES.
 
-This rule is itself enforced: `scripts/test/roundtrip-coverage.test.mjs` scans
-`packages/*/` for genuine `.adlc/tickets.json` writers and FAILS if any lacks a test
-invoking `scripts/rails-guard-ci.mjs`. A new gated-artifact producer must add its
-round-trip test (and, if it writes a *different* gated artifact, extend that scan).
+The **requirement** is the round-trip pattern itself, and it is enforced by **review**.
+As a backstop, `scripts/test/roundtrip-coverage.test.mjs` is a **best-effort heuristic
+tripwire**, NOT a formal proof: it lexically scans `packages/*/` for genuine
+`.adlc/tickets.json` writers (bare `'.adlc/tickets.json'` and segmented
+`join(x,'.adlc','tickets.json')` spellings, gated on a `{ tickets }` envelope write)
+and FAILS if any lacks a test that BOTH names `rails-guard-ci` AND spawns a subprocess.
+It catches the common in-repo spellings; a fully-indirected writer (path assembled by a
+helper in another file, exotic serialization, a wrapper that hides the primitive) can
+still evade a text scan — so do not treat a green tripwire as proof the pattern was
+followed. A new gated-artifact producer must add its round-trip test (and, if it writes
+a *different* gated artifact, extend that scan); reviewers must still verify the pattern
+is present rather than relying on the tripwire alone.
 
 ## Shared data (read via core, never reinvent)
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -61,6 +61,37 @@ package.json template:
     semantics, which ADLC phase (P0–P7 / D1–D3) it serves, and its
     relationship to sibling tools.
 
+## Producer→consumer round-trip tests (gated artifacts)
+
+**Rule: any tool that WRITES an artifact a gate VALIDATES must own a test that runs
+the tool's REAL output through the REAL gate** — not a re-encoding of the gate's
+rule, the actual gate binary/script on the actual committed diff.
+
+Worked example (#104): `ticket-prune` (the PRODUCER) tombstones a shipped ticket
+by adding `completed: true` to `.adlc/tickets.json`, and `scripts/rails-guard-ci.mjs`
+(the CONSUMER gate) exempts *exactly* an add-only `completed: true` on a rails-less
+base ticket. The two predicates were encoded INDEPENDENTLY, in different packages,
+with no shared test — so `ticket-prune --write` could emit a PR the very gate it
+exists to satisfy would DENY (it rewrote a pre-existing `completed: false` → `true`,
+a mutation the add-only gate rejects). Only cross-model review, reasoning across both
+files, caught it. A deterministic round-trip test would have caught it for free.
+
+How to write one (see `packages/ticket-prune/test/roundtrip.test.mjs` and
+`packages/ticket-sync/test/roundtrip.test.mjs`):
+
+1. In a `mkdtempSync` scratch git repo, commit a base, branch, and run the REAL
+   producer (`ticket-prune --write` / ticket-sync `pull --write`) so it writes its
+   ACTUAL output.
+2. Commit that diff, then run the REAL consumer (`node scripts/rails-guard-ci.mjs
+   main`) as a subprocess and assert its exit code (0 = accepted, 2 = denied).
+3. Cover BOTH directions: the accepted case (real output merges) AND that anything
+   the producer REFUSES corresponds to a case the gate DENIES.
+
+This rule is itself enforced: `scripts/test/roundtrip-coverage.test.mjs` scans
+`packages/*/` for genuine `.adlc/tickets.json` writers and FAILS if any lacks a test
+invoking `scripts/rails-guard-ci.mjs`. A new gated-artifact producer must add its
+round-trip test (and, if it writes a *different* gated artifact, extend that scan).
+
 ## Shared data (read via core, never reinvent)
 
 - Tickets: `.adlc/tickets.json` — `loadTickets()` from core. Schema in

--- a/packages/ticket-prune/test/roundtrip.test.mjs
+++ b/packages/ticket-prune/test/roundtrip.test.mjs
@@ -1,0 +1,197 @@
+// roundtrip.test.mjs — producer→consumer round-trip coverage (T40 / #104).
+//
+// #104: `ticket-prune` (PRODUCER) and `scripts/rails-guard-ci.mjs` (CONSUMER
+// gate) encoded the "add-only completed annotation" predicate INDEPENDENTLY, in
+// different packages, and nothing tested the seam — so ticket-prune could emit a
+// tickets.json diff the very gate it exists to satisfy would DENY.
+//
+// These tests close the seam DETERMINISTICALLY (no model needed): they run the
+// REAL `ticket-prune --write` in a temp git repo, commit its ACTUAL output, then
+// run the REAL `scripts/rails-guard-ci.mjs` on that committed diff and assert the
+// gate's verdict. Nothing here is mocked — both are real subprocesses.
+//
+// Offline, leaves no trace (mkdtempSync temp dirs + scratch git repos inside them).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PRUNE_BIN = join(HERE, '..', 'bin', 'ticket-prune.mjs');
+// The REAL consumer gate, resolved from the repo root (packages/ticket-prune/test → root).
+const RAILS_GUARD_CI = join(HERE, '..', '..', '..', 'scripts', 'rails-guard-ci.mjs');
+
+function git(dir, args) {
+  execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+}
+
+function writeTickets(dir, tickets) {
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets }, null, 2));
+}
+
+/** Run the REAL ticket-prune bin (subprocess) in `dir`. Returns its exit code. */
+function runPruneWrite(dir) {
+  try {
+    execFileSync(process.execPath, [PRUNE_BIN, '--write'], { cwd: dir, stdio: 'pipe' });
+    return 0;
+  } catch (e) {
+    return e.status ?? 1;
+  }
+}
+
+/** Run the REAL rails-guard-ci gate (subprocess) against base=main in `dir`. */
+function runRailsGuardCi(dir) {
+  try {
+    execFileSync(process.execPath, [RAILS_GUARD_CI, 'main'], { cwd: dir, stdio: 'pipe' });
+    return 0;
+  } catch (e) {
+    return e.status ?? 1;
+  }
+}
+
+/**
+ * Build a base repo on `main` with `baseTickets` committed to
+ * .adlc/tickets.json plus each `seedFiles` path (so a ticket's scope can be
+ * "shipped"), then branch `feat`. No .adlc/config.json or manifest is created,
+ * matching the established rails-guard-ci scratch-repo pattern (base has nothing
+ * frozen beyond what the base tickets declare).
+ */
+function setupBaseRepo({ baseTickets, seedFiles = [] }) {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-rt-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'a@b.c']);
+  git(dir, ['config', 'user.name', 'x']);
+  writeTickets(dir, baseTickets);
+  for (const f of seedFiles) {
+    mkdirSync(join(dir, dirname(f)), { recursive: true });
+    writeFileSync(join(dir, f), 'shipped\n');
+  }
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-qm', 'base']);
+  git(dir, ['checkout', '-q', '-b', 'feat']);
+  return dir;
+}
+
+// ── AC1(a): the real tombstone output MERGES through the real gate → exit 0 ───
+
+test('AC1(a): ticket-prune --write tombstones a rails-LESS stale ticket, and the REAL committed diff is ACCEPTED by the REAL rails-guard-ci → exit 0', () => {
+  // Base: T1 rails-less + shipped scope (→ ticket-prune classifies it stale and
+  // tombstones it). T2 is RAILED and in-flight (scope not shipped), so rails are
+  // genuinely ACTIVE at base — the gate is not trivially satisfied. The tombstone
+  // touches only .adlc/tickets.json and no frozen path, so it must still merge.
+  const dir = setupBaseRepo({
+    baseTickets: [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: [] },
+      { id: 'T2', title: 'Still building', scope: ['packages/never-built/**'], rails: ['src/guarded/**'] },
+    ],
+    seedFiles: ['plugins/adlc-widget/index.mjs', 'src/guarded/thing.mjs'],
+  });
+  try {
+    assert.equal(runPruneWrite(dir), 0, 'ticket-prune --write exits 0 (advisory)');
+
+    // Prove ticket-prune ACTUALLY produced the tombstone (real output, not a mock).
+    const after = JSON.parse(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'));
+    assert.equal(after.tickets.find((t) => t.id === 'T1').completed, true, 'T1 tombstoned');
+    assert.equal(after.tickets.find((t) => t.id === 'T2').completed, undefined, 'railed T2 left alone');
+
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'prune tombstone']);
+
+    assert.equal(runRailsGuardCi(dir), 0, 'the tombstone diff must merge through the gate');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── AC1(b): the tool REFUSES a railed stale ticket, and the gate DENIES the
+//            hand-made completion the tool refused → the two predicates agree ──
+
+test('AC1(b) part 1: ticket-prune --write does NOT tombstone a RAILED stale ticket — it reports needsCeremony and leaves tickets.json byte-untouched', () => {
+  const dir = setupBaseRepo({
+    baseTickets: [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: ['test/adlc-widget/**'] },
+    ],
+    seedFiles: ['plugins/adlc-widget/index.mjs'],
+  });
+  try {
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+    // Use --json to read the tool's own report; --write must be a no-op on tickets.json.
+    const out = execFileSync(process.execPath, [PRUNE_BIN, '--write', '--json'], { cwd: dir, encoding: 'utf8' });
+    const report = JSON.parse(out);
+    assert.deepEqual(report.tombstoned, [], 'a railed stale ticket is NOT auto-tombstoned');
+    assert.deepEqual(report.needsCeremony.map((t) => t.id), ['T1']);
+    assert.equal(report.needsCeremony[0].blocker, 'rails-freeze');
+    assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before, 'tickets.json untouched');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('AC1(b) part 2: the completion the tool REFUSED (completed:true on a RAILED base ticket), hand-constructed and run through the REAL rails-guard-ci, is DENIED → exit 2', () => {
+  // This is the other half of the seam: the tool refuses exactly what the gate
+  // rejects. If the two predicates ever drift apart, one of these two asserts breaks.
+  const dir = setupBaseRepo({
+    baseTickets: [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: ['test/adlc-widget/**'] },
+    ],
+    seedFiles: ['plugins/adlc-widget/index.mjs'],
+  });
+  try {
+    // Hand-construct the mutation ticket-prune declined to make.
+    writeTickets(dir, [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: ['test/adlc-widget/**'], completed: true },
+    ]);
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'forge completion on a railed ticket']);
+    assert.equal(runRailsGuardCi(dir), 2, 'completing a still-railed ticket would unfreeze it → the gate DENIES it');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── AC1(c): the #104 regression — a rails-less ticket already carrying
+//            completed:false is NOT rewritten (no gate-denied mutation emitted) ─
+
+test('AC1(c): ticket-prune --write does NOT rewrite a rails-less stale ticket that already carries completed:false — tickets.json is byte-untouched (the #104 mismatch)', () => {
+  const dir = setupBaseRepo({
+    baseTickets: [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: [], completed: false },
+    ],
+    seedFiles: ['plugins/adlc-widget/index.mjs'],
+  });
+  try {
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+    const out = execFileSync(process.execPath, [PRUNE_BIN, '--write', '--json'], { cwd: dir, encoding: 'utf8' });
+    const report = JSON.parse(out);
+    assert.deepEqual(report.tombstoned, [], 'false→true would be a MUTATION the add-only gate denies; the tool must not make it');
+    assert.deepEqual(report.needsCeremony.map((t) => t.id), ['T1']);
+    assert.equal(report.needsCeremony[0].blocker, 'preexisting-completed-field');
+    assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before, 'tickets.json untouched');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('AC1(c) gate half: the false→true mutation the tool refused, hand-constructed and run through the REAL rails-guard-ci, is DENIED → exit 2 (proving why the tool must refuse it)', () => {
+  const dir = setupBaseRepo({
+    baseTickets: [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: [], completed: false },
+    ],
+    seedFiles: ['plugins/adlc-widget/index.mjs'],
+  });
+  try {
+    writeTickets(dir, [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: [], completed: true },
+    ]);
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'rewrite completed:false to true']);
+    assert.equal(runRailsGuardCi(dir), 2, 'the add-only exemption is pristine→completed only; false→true is a denied mutation');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/ticket-sync/test/roundtrip.test.mjs
+++ b/packages/ticket-sync/test/roundtrip.test.mjs
@@ -25,7 +25,9 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pull } from '../lib/pull.mjs';
+import { push } from '../lib/push.mjs';
 import { serializeBlock } from '../lib/block.mjs';
+import { githubProvider } from '../lib/providers/github.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // The REAL consumer gate, resolved from the repo root (packages/ticket-sync/test → root).
@@ -101,6 +103,158 @@ test('AC2: pull --write adds a new ticket to .adlc/tickets.json, and the REAL co
 
     // ── run the REAL consumer gate on the real additive diff.
     assert.equal(runRailsGuardCi(dir), 0, 'the additive tickets.json write must merge through the gate');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── AC2 (push writer): the SECOND tickets.json writer — push.mjs writeTicketsAtomic ──
+//
+// The pull test above exercises pull.mjs's writeTicketsAtomic; push.mjs has its
+// OWN writeTicketsAtomic callsite (push.mjs:292, when a local-only ticket is
+// created and its id reassigned to gh:<repo>#<n>). That write must ALSO merge
+// through rails-guard-ci. This drives the REAL `push --write` with an OFFLINE
+// stateful fake `gh` runner (network boundary only — the real githubProvider and
+// the real write path both run), commits its additive tickets.json output, and
+// asserts the REAL gate accepts it.
+
+// Stateful offline fake `gh` runner (mirrors packages/ticket-sync/test/github.test.mjs
+// — stubs ONLY the network boundary, so push's real create→reassign→write path runs).
+function fakeGitHub({ issues = [], login = 'bot' } = {}) {
+  const state = { issues: issues.map((i) => ({ labels: [], comments: [], state: 'open', ...i })) };
+  let seq = Math.max(0, ...state.issues.map((i) => i.number));
+  const mutating = [];
+  const find = (n) => state.issues.find((i) => String(i.number) === String(n));
+  const ok = (stdout = '') => ({ ok: true, code: 0, stdout, stderr: '', error: null });
+  const runner = async (args) => {
+    const [a0, a1] = args;
+    if (a0 === 'issue' && a1 === 'list') {
+      const want = [];
+      for (let k = 0; k < args.length; k++) if (args[k] === '--label') want.push(args[k + 1]);
+      const selected = state.issues.filter((i) => want.every((l) => i.labels.includes(l)));
+      return ok(JSON.stringify(selected.map((i) => ({
+        id: i.id, number: i.number, title: i.title, body: i.body,
+        labels: i.labels.map((name) => ({ name })), state: i.state.toUpperCase(), url: i.url,
+      }))));
+    }
+    if (a0 === 'api' && a1 === 'user') return ok(JSON.stringify({ login }));
+    if (a0 === 'issue' && a1 === 'view') {
+      const i = find(args[2]);
+      const fields = args[args.indexOf('--json') + 1];
+      if (!i) return { ok: false, code: 1, stdout: '', stderr: 'not found', error: 'not found' };
+      if (fields.includes('comments')) return ok(JSON.stringify({ comments: i.comments }));
+      const out = { id: i.id, number: i.number, url: i.url };
+      if (fields.includes('labels')) out.labels = i.labels.map((name) => ({ name }));
+      if (fields.includes('state')) out.state = i.state.toUpperCase();
+      if (fields.includes('body')) out.body = i.body;
+      return ok(JSON.stringify(out));
+    }
+    if (a0 === 'issue' && a1 === 'create') {
+      mutating.push(args);
+      seq += 1;
+      const number = seq;
+      const labels = [];
+      for (let k = 0; k < args.length; k++) if (args[k] === '--label') labels.push(args[k + 1]);
+      state.issues.push({
+        number, id: `I_${number}`, url: `https://github.com/acme/app/issues/${number}`,
+        title: args[args.indexOf('--title') + 1], body: args[args.indexOf('--body') + 1],
+        labels, state: 'open', comments: [],
+      });
+      return ok(`https://github.com/acme/app/issues/${number}\n`);
+    }
+    if (a0 === 'label' && a1 === 'create') { mutating.push(args); return ok(); }
+    if (a0 === 'issue' && a1 === 'edit') {
+      mutating.push(args);
+      const i = find(args[2]);
+      for (let k = 0; k < args.length; k++) {
+        if (args[k] === '--add-label' && !i.labels.includes(args[k + 1])) i.labels.push(args[k + 1]);
+        if (args[k] === '--remove-label') i.labels = i.labels.filter((l) => l !== args[k + 1]);
+      }
+      return ok();
+    }
+    if (a0 === 'issue' && a1 === 'comment') {
+      mutating.push(args);
+      const i = find(args[2]);
+      const cid = 1000 + i.comments.length + 1;
+      i.comments.push({ author: { login }, body: args[args.indexOf('--body') + 1], url: `${i.url}#issuecomment-${cid}` });
+      return ok();
+    }
+    return { ok: false, code: 1, stdout: '', stderr: `unhandled: ${args.join(' ')}`, error: `unhandled: ${args.join(' ')}` };
+  };
+  return { runner, state, mutating };
+}
+
+const PUSH_CONFIG = {
+  ticketSync: {
+    provider: 'github', repo: 'acme/app',
+    select: { state: 'open', labels: ['adlc'] }, createLabel: 'adlc',
+    statusLabels: { 'p5-pass': 'adlc:passed', 'p5-fail': 'adlc:failed', wip: 'adlc:in-progress' },
+  },
+};
+
+test('AC2 (push): ticket-sync push --write creates a local ticket (writeTicketsAtomic reassign path), and the REAL committed additive diff is ACCEPTED by the REAL rails-guard-ci → exit 0', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-sync-push-rt-'));
+  try {
+    // ── base on main: an existing SYNCED, RAILED, in-flight ticket + its rail file.
+    //    (An already-`gh:` id that is NOT in the push selection is skipped by push's
+    //    update pass, so it is preserved byte-for-byte — the base-contract the gate
+    //    enforces — while rails stay ACTIVE so the exit 0 is non-trivial.)
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']);
+    git(dir, ['config', 'user.name', 'x']);
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    const baseTickets = {
+      tickets: [{ id: 'gh:acme/app#5', title: 'existing synced work', scope: ['src/x/**'], rails: ['src/guarded/**'], duration: 1 }],
+    };
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), `${JSON.stringify(baseTickets, null, 2)}\n`);
+    mkdirSync(join(dir, 'src', 'guarded'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'guarded', 'thing.mjs'), 'frozen\n');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+
+    // ── config.json written for push to read, DELIBERATELY not committed (same
+    //    trust-root reasoning as the pull test).
+    writeFileSync(join(dir, '.adlc', 'config.json'), JSON.stringify(PUSH_CONFIG));
+
+    // ── a NEW local-only ticket lands in the working tree (as /adlc-ticket would
+    //    add it), alongside the preserved synced ticket. NO manifest → migrate is a
+    //    no-op → no untracked manifest.jsonl for the gate to reject.
+    const working = {
+      tickets: [
+        baseTickets.tickets[0],
+        { id: 'T7', title: 'new local work', scope: ['src/newfeature/**'], duration: 1 },
+      ],
+    };
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), `${JSON.stringify(working, null, 2)}\n`);
+
+    // ── run the REAL producer: push creates T7 and reassigns it → gh:acme/app#1,
+    //    writing tickets.json via writeTicketsAtomic (push.mjs:292).
+    const gh = fakeGitHub(); // empty remote → #5 is not in the selection (skipped), T7 creates as #1
+    const r = await push({ dir, provider: githubProvider(), runner: gh.runner, write: true, now: 'T', uuid: () => 'K' });
+    assert.equal(r.exitCode, 0, `push --write must succeed: ${JSON.stringify(r.errors)}`);
+
+    // Prove the ACTUAL additive output of the push write path.
+    const outTickets = JSON.parse(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8')).tickets;
+    const ids = outTickets.map((t) => t.id);
+    assert.ok(ids.includes('gh:acme/app#5'), 'existing synced base ticket preserved by push');
+    assert.ok(ids.includes('gh:acme/app#1'), 'T7 was created and reassigned by the real push writer');
+    assert.ok(!ids.includes('T7'), 'the local T7 id was reassigned, not left behind');
+
+    // Guard the manifest assumption: push must not have emitted an untracked
+    // manifest.jsonl (which rails-guard-ci would reject) for a ticket with no evidence.
+    assert.equal(
+      execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).includes('manifest.jsonl'),
+      false,
+      'no untracked manifest.jsonl should exist',
+    );
+
+    // Commit ONLY the tickets.json change (config/sidecar stay untracked).
+    git(dir, ['add', '.adlc/tickets.json']);
+    git(dir, ['commit', '-qm', 'ticket-sync push: create gh:acme/app#1']);
+
+    // ── run the REAL consumer gate on the real additive diff.
+    assert.equal(runRailsGuardCi(dir), 0, 'the push additive tickets.json write must merge through the gate');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/ticket-sync/test/roundtrip.test.mjs
+++ b/packages/ticket-sync/test/roundtrip.test.mjs
@@ -1,0 +1,107 @@
+// roundtrip.test.mjs — producer→consumer round-trip coverage (T40 / #104).
+//
+// ticket-sync is the OTHER `.adlc/tickets.json` producer. Its additive writes
+// (adopting a new remote issue as a new ticket) must merge through the same
+// CONSUMER gate `ticket-prune` has to satisfy: `scripts/rails-guard-ci.mjs`.
+//
+// This test runs the REAL `pull` (offline, via an injected fake provider — no
+// network) with --write against a temp git repo, commits its ACTUAL additive
+// tickets.json output, then runs the REAL `scripts/rails-guard-ci.mjs` on the
+// committed diff and asserts the gate ACCEPTS it (exit 0). Nothing is mocked but
+// the GitHub provider (whose job is only to hand `pull` the issue list offline).
+//
+// Load-bearing, not trivial: the base ticket is RAILED, so rails are genuinely
+// ACTIVE at base — the gate runs its full rail-glob + base-contract-preservation
+// check, and exit 0 means "the additive write preserved every base ticket and
+// touched no frozen path", exactly what a producer must guarantee.
+//
+// Offline, leaves no trace (mkdtempSync temp dirs + scratch git repos inside them).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pull } from '../lib/pull.mjs';
+import { serializeBlock } from '../lib/block.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// The REAL consumer gate, resolved from the repo root (packages/ticket-sync/test → root).
+const RAILS_GUARD_CI = join(HERE, '..', '..', '..', 'scripts', 'rails-guard-ci.mjs');
+
+function git(dir, args) {
+  execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+}
+
+/** Run the REAL rails-guard-ci gate (subprocess) against base=main in `dir`. */
+function runRailsGuardCi(dir) {
+  try {
+    execFileSync(process.execPath, [RAILS_GUARD_CI, 'main'], { cwd: dir, stdio: 'pipe' });
+    return 0;
+  } catch (e) {
+    return e.status ?? 1;
+  }
+}
+
+// Offline fake provider (same shape validity.test.mjs uses).
+const fakeProvider = (issues) => ({ listIssues: async () => ({ ok: true, issues }) });
+const issue = (number, block, prose = 'desc') => ({
+  number, nodeId: `N${number}`, url: `https://github.com/acme/app/issues/${number}`,
+  title: `issue ${number}`, body: serializeBlock({ prefix: `${prose}\n`, suffix: '' }, block), labels: [], state: 'open',
+});
+
+test('AC2: pull --write adds a new ticket to .adlc/tickets.json, and the REAL committed additive diff is ACCEPTED by the REAL rails-guard-ci → exit 0', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-sync-rt-'));
+  try {
+    // ── base commit on main: an existing RAILED, in-flight ticket + its rail file.
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']);
+    git(dir, ['config', 'user.name', 'x']);
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    const baseTickets = {
+      tickets: [{ id: 'T1', title: 'existing in-flight work', scope: ['src/x/**'], rails: ['src/guarded/**'] }],
+    };
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), `${JSON.stringify(baseTickets, null, 2)}\n`);
+    mkdirSync(join(dir, 'src', 'guarded'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'guarded', 'thing.mjs'), 'frozen\n');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+
+    // ── config.json is written to disk for `pull` to read, but is DELIBERATELY
+    //    NOT committed: rails-guard-ci reads `baseHasConfig` from the base tree,
+    //    and an added-in-PR .adlc/config.json would trip the trust-root guard
+    //    (config.json is an immutable trust root once base rails exist). Keeping
+    //    it untracked keeps the PR diff to exactly the additive tickets.json write.
+    writeFileSync(
+      join(dir, '.adlc', 'config.json'),
+      JSON.stringify({ ticketSync: { provider: 'github', repo: 'acme/app' } }),
+    );
+
+    // ── run the REAL producer: adopt a new remote issue as a new local ticket.
+    const r = await pull({
+      dir,
+      provider: fakeProvider([issue(1, { scope: ['src/newfeature/**'], duration: 1 })]),
+      write: true,
+      now: 'T',
+    });
+    assert.equal(r.exitCode, 0, `pull --write must succeed: ${JSON.stringify(r.errors)}`);
+
+    // Prove the ACTUAL additive output: T1 preserved, a NEW gh ticket added.
+    const after = JSON.parse(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'));
+    const ids = after.tickets.map((t) => t.id);
+    assert.ok(ids.includes('T1'), 'existing base ticket preserved');
+    assert.ok(ids.includes('gh:acme/app#1'), 'new ticket added by the real writer');
+
+    // Commit ONLY the tickets.json change (config/sidecar stay untracked).
+    git(dir, ['add', '.adlc/tickets.json']);
+    git(dir, ['commit', '-qm', 'ticket-sync: adopt gh:acme/app#1']);
+
+    // ── run the REAL consumer gate on the real additive diff.
+    assert.equal(runRailsGuardCi(dir), 0, 'the additive tickets.json write must merge through the gate');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/roundtrip-coverage.test.mjs
+++ b/scripts/test/roundtrip-coverage.test.mjs
@@ -32,7 +32,9 @@ const REAL_PACKAGES = join(REPO_ROOT, 'packages');
 
 // ── the detector (pure; exercised on both the real tree and temp fixtures) ────
 
-/** List every *.mjs under `dir`, skipping test/ and node_modules/ subtrees. */
+const SOURCE_EXTS = ['.mjs', '.js', '.cjs'];
+
+/** List every source file under `dir`, skipping test/ and node_modules/ subtrees. */
 function sourceFiles(dir) {
   const out = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -40,7 +42,7 @@ function sourceFiles(dir) {
     if (entry.isDirectory()) {
       if (entry.name === 'test' || entry.name === 'node_modules') continue;
       out.push(...sourceFiles(p));
-    } else if (entry.name.endsWith('.mjs')) {
+    } else if (SOURCE_EXTS.some((ext) => entry.name.endsWith(ext))) {
       out.push(p);
     }
   }
@@ -54,22 +56,42 @@ function sourceFiles(dir) {
  *   2. it references the tickets.json path as a real file location AND serializes
  *      a `{ tickets: ... }` envelope through a write/rename primitive.
  *
- * Robustness to false positives: the path is matched only in its BARE quoted form
- * (`'.adlc/tickets.json'`), so a gitignore negation (`'!.adlc/tickets.json'`) —
- * the quote is followed by `!`, not `.` — never counts. A package that only names
- * the path in an ignore stanza (e.g. core/scaffold-hygiene.mjs) is NOT a writer.
+ * The path reference is matched two ways, so an idiomatic writer cannot evade:
+ *   - BARE quoted form: `'.adlc/tickets.json'` (a gitignore negation
+ *     `'!.adlc/tickets.json'` is NOT matched — the quote is followed by `!`), and
+ *   - SEGMENTED construction: quoted `'tickets.json'` together with a quoted
+ *     `'.adlc'` segment nearby, i.e. `join(x, '.adlc', 'tickets.json')` — the EXACT
+ *     spelling the round-trip helpers themselves use.
+ *
+ * The write primitive set covers sync, promise, and callback forms:
+ * writeJsonAtomic / writeTicketsAtomic / writeFileSync / renameSync / writeFile
+ * (the bare `writeFile(` alt also catches `fs.promises.writeFile(`).
+ *
+ * Robustness to false positives: still gated on a `{ tickets }`-shaped envelope,
+ * so a READER (`data.tickets.map(...)` — a `.` follows `tickets`) and a package
+ * that only names the path in an ignore stanza (core/scaffold-hygiene.mjs) are
+ * NOT writers.
+ *
+ * NOTE (see CONVENTIONS.md): this is a heuristic lexical tripwire for the common
+ * in-repo spellings, NOT a proof of absence. A fully-indirected writer (path
+ * assembled in a helper in another file, exotic serialization) can still slip
+ * past a text scan; the round-trip PATTERN itself is the requirement, enforced by
+ * review, with this gate catching the idiomatic cases.
  */
 export function isTicketsWriterSource(src) {
   const callsDedicatedWriter = /writeTicketsAtomic\s*\(/.test(src);
   if (callsDedicatedWriter) return true;
-  const referencesBareTicketsPath = /['"`]\.adlc\/tickets\.json/.test(src);
+  const bareTicketsPath = /['"`]\.adlc\/tickets\.json/.test(src);
+  const segmentedTicketsPath =
+    /['"`]tickets\.json['"`]/.test(src) && /['"`]\.adlc['"`]/.test(src);
+  const referencesTicketsPath = bareTicketsPath || segmentedTicketsPath;
   // A `tickets` envelope key: `tickets:` (property) or `{ tickets }` / `{ tickets,`
   // (shorthand). The trailing [:,}] excludes a READER's `data.tickets.map(...)`
   // (a `.` follows `tickets`), so reads never masquerade as writes.
   const writesEnvelope =
     /\btickets\s*[:,}]/.test(src) &&
-    /(?:writeJsonAtomic|writeFileSync|renameSync|writeTicketsAtomic)\s*\(/.test(src);
-  return referencesBareTicketsPath && writesEnvelope;
+    /(?:writeJsonAtomic|writeTicketsAtomic|writeFileSync|renameSync|writeFile)\s*\(/.test(src);
+  return referencesTicketsPath && writesEnvelope;
 }
 
 /** Names of packages under `packagesDir` that write `.adlc/tickets.json`. */
@@ -84,13 +106,21 @@ export function findTicketsWriterPackages(packagesDir) {
   return writers.sort();
 }
 
-/** True iff the package owns a test that invokes scripts/rails-guard-ci.mjs. */
+/**
+ * True iff the package owns a test that REALLY invokes scripts/rails-guard-ci.mjs.
+ * A mere textual mention (e.g. a `// rails-guard-ci` comment) does NOT count — the
+ * file must also spawn a subprocess (`execFileSync` / `spawnSync`), so "coverage"
+ * cannot be faked without actually running the gate.
+ */
 export function packageHasRailsGuardRoundTrip(pkgDir) {
   const testDir = join(pkgDir, 'test');
   if (!existsSync(testDir) || !statSync(testDir).isDirectory()) return false;
   return readdirSync(testDir)
     .filter((f) => f.endsWith('.mjs'))
-    .some((f) => /rails-guard-ci/.test(readFileSync(join(testDir, f), 'utf8')));
+    .some((f) => {
+      const src = readFileSync(join(testDir, f), 'utf8');
+      return /rails-guard-ci/.test(src) && /(?:execFileSync|spawnSync)\s*\(/.test(src);
+    });
 }
 
 /** Writer packages that lack a rails-guard-ci round-trip test (the drift). */
@@ -134,9 +164,36 @@ export function ensureGitignore(path) {
 }
 `;
 
+// A SNEAKY writer that evades a bare-path scan: it assembles the tickets.json
+// path from SEGMENTS via join(dir, '.adlc', 'tickets.json') — the exact idiom the
+// round-trip helpers use — and writes the envelope with writeFileSync. If the
+// detector only matched the bare '.adlc/tickets.json' string this would read GREEN.
+const SNEAKY_SEGMENTED_WRITER_LIB = `
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+export function writeIt(dir, tickets) {
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets }, null, 2) + '\\n');
+}
+`;
+
+// A writer using the promise form (fs.promises.writeFile) + segmented path.
+const PROMISE_WRITER_LIB = `
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+export async function writeIt(dir, tickets) {
+  await writeFile(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets }) + '\\n');
+}
+`;
+
 const ROUND_TRIP_TEST = `import { execFileSync } from 'node:child_process';
 // drives scripts/rails-guard-ci.mjs on real writer output
 execFileSync('node', ['scripts/rails-guard-ci.mjs', 'main']);
+`;
+
+// A HOLLOW "test": it mentions rails-guard-ci in a comment but never spawns it.
+// A string-only "covered" check would be fooled; a real-invocation check is not.
+const COMMENT_ONLY_TEST = `// this file name-drops rails-guard-ci but does NOT run it
+export const notReallyATest = 1;
 `;
 
 function withScratchPackages(fn) {
@@ -166,6 +223,23 @@ test('isTicketsWriterSource: does NOT flag a tickets.json READER (reads, never w
   assert.equal(isTicketsWriterSource(reader), false);
 });
 
+test('FIX 1 (evasion closed): flags a SEGMENTED-path writer — join(dir, ".adlc", "tickets.json") + writeFileSync', () => {
+  // The #104-class hole the prosecutor found: a real writer using the exact
+  // join-idiom the round-trip helpers use read GREEN under the old bare-string scan.
+  assert.equal(isTicketsWriterSource(SNEAKY_SEGMENTED_WRITER_LIB), true);
+});
+
+test('FIX 1 (evasion closed): flags a PROMISE-form writer — fs.promises.writeFile + segmented path', () => {
+  assert.equal(isTicketsWriterSource(PROMISE_WRITER_LIB), true);
+});
+
+test('FIX 1: a segmented "tickets.json" with NO .adlc segment is NOT a writer (avoids matching unrelated tickets.json files)', () => {
+  const unrelated = `import { writeFileSync } from 'node:fs';
+    // writes a DIFFERENT tickets.json (not under .adlc)
+    writeFileSync('build/tickets.json', JSON.stringify({ tickets: [] }));`;
+  assert.equal(isTicketsWriterSource(unrelated), false);
+});
+
 // ── direction 1: the check CATCHES a planted uncovered writer ─────────────────
 
 test('findUncoveredWriters FLAGS a planted writer package that has no rails-guard round-trip test', () => {
@@ -173,6 +247,25 @@ test('findUncoveredWriters FLAGS a planted writer package that has no rails-guar
     mkPackage(packagesDir, 'rogue-writer', { libSrc: WRITER_LIB }); // writer, NO test
     const uncovered = findUncoveredWriters(packagesDir);
     assert.deepEqual(uncovered, ['rogue-writer'], 'a new tickets.json writer without a round-trip test must be flagged');
+  });
+});
+
+test('FIX 1 end-to-end: findUncoveredWriters FLAGS a planted SEGMENTED-path writer with no round-trip test', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'sneaky-writer', { libSrc: SNEAKY_SEGMENTED_WRITER_LIB }); // writer, NO test
+    assert.deepEqual(findTicketsWriterPackages(packagesDir), ['sneaky-writer'], 'segmented-path writer must be detected');
+    assert.deepEqual(findUncoveredWriters(packagesDir), ['sneaky-writer']);
+  });
+});
+
+test('FIX 2 (hollow coverage closed): a writer whose only test MENTIONS rails-guard-ci in a comment (never spawns it) is still UNCOVERED', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'fake-covered', { libSrc: WRITER_LIB, testSrc: COMMENT_ONLY_TEST });
+    assert.deepEqual(
+      findUncoveredWriters(packagesDir),
+      ['fake-covered'],
+      'a comment-only mention of rails-guard-ci must NOT count as coverage',
+    );
   });
 });
 

--- a/scripts/test/roundtrip-coverage.test.mjs
+++ b/scripts/test/roundtrip-coverage.test.mjs
@@ -1,0 +1,221 @@
+// roundtrip-coverage.test.mjs — the drift gate for the producer→consumer
+// round-trip pattern (T40 / #104).
+//
+// #104 was a producer/consumer contract mismatch: `ticket-prune` (producer)
+// wrote a `.adlc/tickets.json` diff that `scripts/rails-guard-ci.mjs` (consumer
+// gate) then DENIED, and no test exercised the seam. The fix is the round-trip
+// tests; THIS test keeps the pattern from silently rotting: any package that
+// WRITES `.adlc/tickets.json` must own a test that runs its real output through
+// the real `rails-guard-ci.mjs`.
+//
+// It is a static, deterministic, offline scan (no subprocesses, no network):
+//   - findTicketsWriterPackages(packagesDir) → packages whose lib/bin genuinely
+//     write the tickets.json envelope (robust to false positives — a package that
+//     only NAMES the path, e.g. in a .gitignore stanza, is NOT a writer).
+//   - packageHasRailsGuardRoundTrip(pkgDir) → the package has a test that invokes
+//     scripts/rails-guard-ci.mjs.
+//   - findUncoveredWriters(packagesDir) → writers missing that test (the drift).
+//
+// Proven BOTH ways: it FLAGS a planted writer-with-no-round-trip fixture, does
+// NOT flag a planted false-positive (path-naming-only) package, and PASSES for
+// the real packages/ tree (ticket-prune + ticket-sync now have round-trips).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const REAL_PACKAGES = join(REPO_ROOT, 'packages');
+
+// ── the detector (pure; exercised on both the real tree and temp fixtures) ────
+
+/** List every *.mjs under `dir`, skipping test/ and node_modules/ subtrees. */
+function sourceFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'test' || entry.name === 'node_modules') continue;
+      out.push(...sourceFiles(p));
+    } else if (entry.name.endsWith('.mjs')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/**
+ * True iff `src` GENUINELY writes the `.adlc/tickets.json` envelope — not merely
+ * references the path string. Two independent positive signals:
+ *   1. It calls a tickets-dedicated atomic writer (`writeTicketsAtomic(...)`), or
+ *   2. it references the tickets.json path as a real file location AND serializes
+ *      a `{ tickets: ... }` envelope through a write/rename primitive.
+ *
+ * Robustness to false positives: the path is matched only in its BARE quoted form
+ * (`'.adlc/tickets.json'`), so a gitignore negation (`'!.adlc/tickets.json'`) —
+ * the quote is followed by `!`, not `.` — never counts. A package that only names
+ * the path in an ignore stanza (e.g. core/scaffold-hygiene.mjs) is NOT a writer.
+ */
+export function isTicketsWriterSource(src) {
+  const callsDedicatedWriter = /writeTicketsAtomic\s*\(/.test(src);
+  if (callsDedicatedWriter) return true;
+  const referencesBareTicketsPath = /['"`]\.adlc\/tickets\.json/.test(src);
+  // A `tickets` envelope key: `tickets:` (property) or `{ tickets }` / `{ tickets,`
+  // (shorthand). The trailing [:,}] excludes a READER's `data.tickets.map(...)`
+  // (a `.` follows `tickets`), so reads never masquerade as writes.
+  const writesEnvelope =
+    /\btickets\s*[:,}]/.test(src) &&
+    /(?:writeJsonAtomic|writeFileSync|renameSync|writeTicketsAtomic)\s*\(/.test(src);
+  return referencesBareTicketsPath && writesEnvelope;
+}
+
+/** Names of packages under `packagesDir` that write `.adlc/tickets.json`. */
+export function findTicketsWriterPackages(packagesDir) {
+  const writers = [];
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const pkgDir = join(packagesDir, entry.name);
+    const isWriter = sourceFiles(pkgDir).some((f) => isTicketsWriterSource(readFileSync(f, 'utf8')));
+    if (isWriter) writers.push(entry.name);
+  }
+  return writers.sort();
+}
+
+/** True iff the package owns a test that invokes scripts/rails-guard-ci.mjs. */
+export function packageHasRailsGuardRoundTrip(pkgDir) {
+  const testDir = join(pkgDir, 'test');
+  if (!existsSync(testDir) || !statSync(testDir).isDirectory()) return false;
+  return readdirSync(testDir)
+    .filter((f) => f.endsWith('.mjs'))
+    .some((f) => /rails-guard-ci/.test(readFileSync(join(testDir, f), 'utf8')));
+}
+
+/** Writer packages that lack a rails-guard-ci round-trip test (the drift). */
+export function findUncoveredWriters(packagesDir) {
+  return findTicketsWriterPackages(packagesDir).filter(
+    (name) => !packageHasRailsGuardRoundTrip(join(packagesDir, name)),
+  );
+}
+
+// ── fixtures: a scratch packages/ tree we can plant writers into ──────────────
+
+function mkPackage(packagesDir, name, { libSrc, testSrc } = {}) {
+  const pkgDir = join(packagesDir, name);
+  mkdirSync(join(pkgDir, 'lib'), { recursive: true });
+  if (libSrc !== undefined) writeFileSync(join(pkgDir, 'lib', 'run.mjs'), libSrc);
+  if (testSrc !== undefined) {
+    mkdirSync(join(pkgDir, 'test'), { recursive: true });
+    writeFileSync(join(pkgDir, 'test', 'roundtrip.test.mjs'), testSrc);
+  }
+  return pkgDir;
+}
+
+// A genuine tickets.json writer body (mirrors ticket-prune/ticket-sync shape).
+const WRITER_LIB = `
+import { writeFileSync, renameSync } from 'node:fs';
+const TICKETS = '.adlc/tickets.json';
+export function writeIt(dir, tickets) {
+  const tmp = TICKETS + '.tmp';
+  writeFileSync(tmp, JSON.stringify({ tickets }, null, 2) + '\\n');
+  renameSync(tmp, TICKETS);
+}
+`;
+
+// A false-positive body: names the tickets.json path ONLY as a gitignore
+// negation stanza (exactly core/scaffold-hygiene.mjs's shape) and writes .gitignore.
+const NON_WRITER_LIB = `
+import { writeFileSync } from 'node:fs';
+const GITIGNORE_STANZA = ['.adlc/*', '!.adlc/tickets.json', '!.adlc/specs/'];
+export function ensureGitignore(path) {
+  writeFileSync(path, GITIGNORE_STANZA.join('\\n') + '\\n');
+}
+`;
+
+const ROUND_TRIP_TEST = `import { execFileSync } from 'node:child_process';
+// drives scripts/rails-guard-ci.mjs on real writer output
+execFileSync('node', ['scripts/rails-guard-ci.mjs', 'main']);
+`;
+
+function withScratchPackages(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'rt-coverage-'));
+  try {
+    mkdirSync(join(dir, 'packages'));
+    return fn(join(dir, 'packages'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── the pure-detector unit contract (documents the both-ways behavior) ────────
+
+test('isTicketsWriterSource: flags a genuine { tickets } envelope writer', () => {
+  assert.equal(isTicketsWriterSource(WRITER_LIB), true);
+});
+
+test('isTicketsWriterSource: does NOT flag a package that only names the path in a gitignore stanza (no false positive)', () => {
+  assert.equal(isTicketsWriterSource(NON_WRITER_LIB), false);
+});
+
+test('isTicketsWriterSource: does NOT flag a tickets.json READER (reads, never writes an envelope)', () => {
+  const reader = `import { readFileSync } from 'node:fs';
+    const d = JSON.parse(readFileSync('.adlc/tickets.json', 'utf8'));
+    export const ids = d.tickets.map((t) => t.id);`;
+  assert.equal(isTicketsWriterSource(reader), false);
+});
+
+// ── direction 1: the check CATCHES a planted uncovered writer ─────────────────
+
+test('findUncoveredWriters FLAGS a planted writer package that has no rails-guard round-trip test', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'rogue-writer', { libSrc: WRITER_LIB }); // writer, NO test
+    const uncovered = findUncoveredWriters(packagesDir);
+    assert.deepEqual(uncovered, ['rogue-writer'], 'a new tickets.json writer without a round-trip test must be flagged');
+  });
+});
+
+// ── direction 2: the check PASSES once the writer gains a round-trip test ──────
+
+test('findUncoveredWriters does NOT flag a writer once it owns a rails-guard-ci round-trip test', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'good-writer', { libSrc: WRITER_LIB, testSrc: ROUND_TRIP_TEST });
+    assert.deepEqual(findUncoveredWriters(packagesDir), []);
+  });
+});
+
+// ── robustness: a false-positive package is neither a writer nor flagged ───────
+
+test('findUncoveredWriters ignores a false-positive (path-naming-only) package even with no round-trip test', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'not-a-writer', { libSrc: NON_WRITER_LIB }); // names path, never writes envelope
+    assert.deepEqual(findTicketsWriterPackages(packagesDir), [], 'must not be treated as a writer');
+    assert.deepEqual(findUncoveredWriters(packagesDir), [], 'and therefore must not be flagged');
+  });
+});
+
+test('a writer AND a false-positive together: only the real writer is flagged when uncovered', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'rogue-writer', { libSrc: WRITER_LIB });
+    mkPackage(packagesDir, 'not-a-writer', { libSrc: NON_WRITER_LIB });
+    assert.deepEqual(findUncoveredWriters(packagesDir), ['rogue-writer']);
+  });
+});
+
+// ── the real tree: the two known writers exist AND are covered ────────────────
+
+test('the REAL packages/ tree has exactly the expected tickets.json writers', () => {
+  const writers = findTicketsWriterPackages(REAL_PACKAGES);
+  assert.ok(writers.includes('ticket-prune'), `ticket-prune must be detected as a writer; got ${writers.join(', ')}`);
+  assert.ok(writers.includes('ticket-sync'), `ticket-sync must be detected as a writer; got ${writers.join(', ')}`);
+});
+
+test('the REAL packages/ tree has NO uncovered tickets.json writer (every writer owns a rails-guard round-trip test)', () => {
+  const uncovered = findUncoveredWriters(REAL_PACKAGES);
+  assert.deepEqual(
+    uncovered,
+    [],
+    `these packages write .adlc/tickets.json but have no test invoking scripts/rails-guard-ci.mjs: ${uncovered.join(', ')}`,
+  );
+});

--- a/scripts/test/roundtrip-coverage.test.mjs
+++ b/scripts/test/roundtrip-coverage.test.mjs
@@ -82,8 +82,13 @@ export function isTicketsWriterSource(src) {
   const callsDedicatedWriter = /writeTicketsAtomic\s*\(/.test(src);
   if (callsDedicatedWriter) return true;
   const bareTicketsPath = /['"`]\.adlc\/tickets\.json/.test(src);
-  const segmentedTicketsPath =
-    /['"`]tickets\.json['"`]/.test(src) && /['"`]\.adlc['"`]/.test(src);
+  // Segmented construction must be ADJACENT (`'.adlc', 'tickets.json'` as
+  // consecutive join args), NOT mere file-wide co-occurrence — otherwise a
+  // package writing an UNRELATED `build/tickets.json` that merely mentions
+  // `'.adlc'` elsewhere in the file would be falsely flagged (a drift-gate that
+  // cries wolf gets disabled). Proximity is what makes it a `.adlc/tickets.json`
+  // path, not two coincidental strings.
+  const segmentedTicketsPath = /['"`]\.adlc['"`]\s*,\s*['"`]tickets\.json['"`]/.test(src);
   const referencesTicketsPath = bareTicketsPath || segmentedTicketsPath;
   // A `tickets` envelope key: `tickets:` (property) or `{ tickets }` / `{ tickets,`
   // (shorthand). The trailing [:,}] excludes a READER's `data.tickets.map(...)`
@@ -106,11 +111,21 @@ export function findTicketsWriterPackages(packagesDir) {
   return writers.sort();
 }
 
+// Strip `//` line comments and `/* */` block comments so a COMMENTED mention of
+// rails-guard-ci (e.g. `// rails-guard-ci`) can't be counted as real coverage.
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
 /**
  * True iff the package owns a test that REALLY invokes scripts/rails-guard-ci.mjs.
- * A mere textual mention (e.g. a `// rails-guard-ci` comment) does NOT count — the
- * file must also spawn a subprocess (`execFileSync` / `spawnSync`), so "coverage"
- * cannot be faked without actually running the gate.
+ * The reference must be in CODE (comments are stripped first, so a bare
+ * `// rails-guard-ci` no longer counts) AND the file must spawn a subprocess
+ * (`execFileSync` / `spawnSync`) — the real round-trip tests bind a
+ * `RAILS_GUARD_CI` path constant (which carries the `rails-guard-ci` string) and
+ * spawn it. NOTE (heuristic tripwire, see CONVENTIONS.md): a contrived file with
+ * a non-comment rails-guard-ci string AND an unrelated spawn is the residual
+ * lexical limit; the round-trip PATTERN, enforced by review, is the requirement.
  */
 export function packageHasRailsGuardRoundTrip(pkgDir) {
   const testDir = join(pkgDir, 'test');
@@ -118,7 +133,7 @@ export function packageHasRailsGuardRoundTrip(pkgDir) {
   return readdirSync(testDir)
     .filter((f) => f.endsWith('.mjs'))
     .some((f) => {
-      const src = readFileSync(join(testDir, f), 'utf8');
+      const src = stripComments(readFileSync(join(testDir, f), 'utf8'));
       return /rails-guard-ci/.test(src) && /(?:execFileSync|spawnSync)\s*\(/.test(src);
     });
 }
@@ -196,6 +211,29 @@ const COMMENT_ONLY_TEST = `// this file name-drops rails-guard-ci but does NOT r
 export const notReallyATest = 1;
 `;
 
+// A FALSE-POSITIVE probe for the segmented broadening: writes an UNRELATED
+// build/tickets.json envelope AND has a QUOTED '.adlc' elsewhere (non-adjacent).
+// A file-wide co-occurrence check (quoted 'tickets.json' + quoted '.adlc' anywhere)
+// would WRONGLY flag it; the adjacency requirement must not.
+const UNRELATED_BUILD_WRITER_LIB = `
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+const IGNORED_DIRS = ['.adlc', 'node_modules'];
+export function writeBuildManifest(tickets) {
+  writeFileSync(join('build', 'tickets.json'), JSON.stringify({ tickets }));
+}
+`;
+
+// A HOLLOW "covered" probe that's sneakier than COMMENT_ONLY: rails-guard-ci is
+// mentioned ONLY in a comment, but the file ALSO has an UNRELATED subprocess spawn.
+// A naive "rails-guard-ci AND spawn co-occur" check counts it as covered; stripping
+// comments first must not (the rails-guard-ci mention vanishes with the comment).
+const COMMENT_PLUS_UNRELATED_SPAWN_TEST = `import { execFileSync } from 'node:child_process';
+// this comment name-drops rails-guard-ci but the spawn below is unrelated
+execFileSync('git', ['status']);
+export const notReallyATest = 1;
+`;
+
 function withScratchPackages(fn) {
   const dir = mkdtempSync(join(tmpdir(), 'rt-coverage-'));
   try {
@@ -240,6 +278,13 @@ test('FIX 1: a segmented "tickets.json" with NO .adlc segment is NOT a writer (a
   assert.equal(isTicketsWriterSource(unrelated), false);
 });
 
+test('FIX 1 (no over-flag): a build/tickets.json writer that also has a QUOTED ".adlc" elsewhere (non-adjacent) is NOT a writer — proximity, not co-occurrence', () => {
+  // Under the old file-wide co-occurrence check this read as a writer (quoted
+  // 'tickets.json' + quoted '.adlc' both present); adjacency must reject it so the
+  // drift-gate doesn't cry wolf on an unrelated build artifact.
+  assert.equal(isTicketsWriterSource(UNRELATED_BUILD_WRITER_LIB), false);
+});
+
 // ── direction 1: the check CATCHES a planted uncovered writer ─────────────────
 
 test('findUncoveredWriters FLAGS a planted writer package that has no rails-guard round-trip test', () => {
@@ -265,6 +310,17 @@ test('FIX 2 (hollow coverage closed): a writer whose only test MENTIONS rails-gu
       findUncoveredWriters(packagesDir),
       ['fake-covered'],
       'a comment-only mention of rails-guard-ci must NOT count as coverage',
+    );
+  });
+});
+
+test('FIX 2 (residual closed): rails-guard-ci in a COMMENT plus an UNRELATED spawn is still UNCOVERED — comments are stripped before the check', () => {
+  withScratchPackages((packagesDir) => {
+    mkPackage(packagesDir, 'sneaky-covered', { libSrc: WRITER_LIB, testSrc: COMMENT_PLUS_UNRELATED_SPAWN_TEST });
+    assert.deepEqual(
+      findUncoveredWriters(packagesDir),
+      ['sneaky-covered'],
+      'a commented rails-guard-ci mention next to an unrelated spawn must NOT count as coverage',
     );
   });
 });


### PR DESCRIPTION
## What & why

Adds the DETERMINISTIC defense that would have caught #104's producer/consumer contract mismatch without needing a model: tests that run a tool's REAL output through the REAL gate that validates it, plus a drift-gate that flags any future `.adlc/tickets.json` writer lacking such a test. Implements ticket **T40** (issue #138). Test + docs only — no producer/gate/core behavior changed.

## Deliverables
- **Round-trip seam tests** (`packages/ticket-prune/test/roundtrip.test.mjs`, `packages/ticket-sync/test/roundtrip.test.mjs`): build a scratch git repo, run the **real** `ticket-prune --write` / `ticket-sync pull|push --write` (offline provider — only the network boundary is stubbed), commit the actual output, run the **real** `scripts/rails-guard-ci.mjs` and assert its exit code (0 = tombstone/additive write merges; 2 = a railed-completion / #104 `false→true` mutation is denied). Covers BOTH ticket-sync writers (pull + push).
- **Coverage drift-gate** (`scripts/test/roundtrip-coverage.test.mjs`): scans `packages/*` for a `.adlc/tickets.json` writer (`{tickets}` envelope + real path — bare or segmented `join(dir,'.adlc','tickets.json')` — via any write primitive, scanning `.mjs/.js/.cjs`) and flags any lacking a test that *really* spawns rails-guard-ci (comments stripped, so a `// rails-guard-ci` mention doesn't count). Proven both directions + against false positives.
- **CONVENTIONS.md**: the producer→consumer round-trip pattern, with #104 as the worked example; the drift-gate is honestly framed as a heuristic tripwire (the pattern, enforced by review, is the requirement).

## P5 provenance (T40 is trust-root tier — it touches producer packages)
Prosecuted to convergence — the round-trip tests are confirmed load-bearing (a reintroduced #104-class producer mutation makes them fail), and the drift-gate was hardened until non-hollow:
- Same-model mutation prosecution: 3 producer/gate mutations all flip the seam tests.
- Cross-model (codex), 3 rounds → **VERIFIED-CLEAN**: (R1) the drift-gate was hollow — a `join(dir,'.adlc','tickets.json')` writer read GREEN; (R2) segmented-path + write-primitive + `.js/.cjs` coverage, real subprocess required for "covered", added the ticket-sync push gap; (R3) adjacency (no false-positive) + comment-stripping, confirmed no real writer under-detected.

## Test plan
- [x] `node --test` the three round-trip/coverage files → 23 pass / 0 fail (incl. fixtures proving every named evasion is closed and no over-flagging)
- [x] full `npm test` green except the pre-existing `publish-over-1.3.0` packaging flake (no release/version files touched)
- [x] `rails-guard-ci` passes on the ticket diff

Closes #138