### PR TITLE
fix(prosecute): exempt test-only producer/enforcement changes from trust-root tier (T41, #154)

### DIFF
--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -39,6 +39,19 @@ function toPosix(file) {
   return String(file).replaceAll('\\', '/');
 }
 
+// A TEST file: under a `test/` directory segment, or a `*.test.{mjs,js,cjs}`
+// basename (the repo's test conventions). Test-only changes to a producer/
+// enforcement package cannot alter the produced artifact or the gate LOGIC, so
+// they do not create the producer↔consumer CONTRACT mismatch the cross-model
+// tier exists to gate (a hollow test is caught by P5 prosecution/mutation
+// instead). This exemption applies ONLY to the package-PREFIX surfaces below —
+// NOT to the exact trust-root files (a test-path file like
+// scripts/test/rails-guard-workflow-hashes.json still tiers) nor to the rails
+// deny-path surface (a test path that IS a declared rail still tiers). #154/T41.
+function isTestFile(path) {
+  return /(^|\/)test\//.test(path) || /\.test\.(mjs|js|cjs)$/.test(path);
+}
+
 /**
  * Classify a change as trust-root tier.
  *
@@ -58,11 +71,15 @@ export function classifyTrustRootTier({ changedFiles = [], tickets = [] } = {}) 
     if (TRUST_ROOT_FILES.includes(path)) {
       push(`touches trust-root file ${path}`);
     }
+    // Package-prefix surfaces gate on LOGIC/CONTRACT risk; a test-only change
+    // touches neither, so it is exempt here (#154/T41). The exact-file check
+    // above and the rails-deny-path check below stay unconditional.
+    const contractRelevant = !isTestFile(path);
     for (const prefix of ENFORCEMENT_PREFIXES) {
-      if (path.startsWith(prefix)) push(`touches enforcement package ${prefix}`);
+      if (contractRelevant && path.startsWith(prefix)) push(`touches enforcement package ${prefix}`);
     }
     for (const prefix of PRODUCER_PREFIXES) {
-      if (path.startsWith(prefix)) push(`touches gated-artifact producer package ${prefix}`);
+      if (contractRelevant && path.startsWith(prefix)) push(`touches gated-artifact producer package ${prefix}`);
     }
     for (const ticket of Array.isArray(tickets) ? tickets : []) {
       const rails = Array.isArray(ticket?.rails) ? ticket.rails : [];

--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -48,7 +48,22 @@ function toPosix(file) {
 // NOT to the exact trust-root files (a test-path file like
 // scripts/test/rails-guard-workflow-hashes.json still tiers) nor to the rails
 // deny-path surface (a test path that IS a declared rail still tiers). #154/T41.
+//
+// STATED ASSUMPTION (safety of this exemption rests on it): a `test/` path or a
+// `*.test.*` basename holds TEST code that is NEVER imported by production
+// `lib/`/`bin/`. A test-named module can only affect the produced artifact if a
+// NON-test file imports it — and that importer edit is itself non-test, so it
+// tiers. The invariant "no production code imports a test-classified module in a
+// producer/enforcement package" is ENFORCED by a guard test (see
+// tier.test.mjs), so a future convention violation can't silently open a bypass.
+//
+// FAIL-SAFE on non-canonical paths: a path containing a `..` segment is not a
+// clean test path (e.g. `test/../lib/run.mjs` resolves into production); refuse
+// to exempt it (tier it) rather than risk exempting production. The live caller
+// feeds two-dot `git diff --name-only` output (already canonical), so this is
+// defense-in-depth for out-of-contract input.
 function isTestFile(path) {
+  if (/(^|\/)\.\.(\/|$)/.test(path)) return false;
   return /(^|\/)test\//.test(path) || /\.test\.(mjs|js|cjs)$/.test(path);
 }
 

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -9,6 +9,9 @@
 // Positive AND negative fixtures for every surface class; an ordinary diff is FALSE.
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
 
 const TICKETS = [
@@ -147,5 +150,62 @@ describe('classifyTrustRootTier — test-only exemption (#154/T41)', () => {
   it('precision: a non-test path that merely CONTAINS "test" (test-utils/) is NOT exempted', () => {
     const r = classifyTrustRootTier({ changedFiles: ['packages/prosecute/test-utils/helper.mjs'], tickets: TICKETS });
     assert.equal(r.isTrustRootTier, true, 'test-utils is not a test dir; a real helper edit must still tier');
+  });
+
+  it('precision (boundary): a segment that merely ENDS with "test" (latest/, contest/) is NOT a test dir — the ^|/ left-anchor must hold', () => {
+    // "latest/" and "contest/" both CONTAIN the substring "test/"; a boundary-less
+    // /test\// would wrongly exempt them. The ^|/ anchor requires `test` at a
+    // segment start, so these shipped-code paths must still tier.
+    for (const f of ['packages/prosecute/latest/run.mjs', 'packages/build-gate/contest/x.mjs']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, true, `${f}: ends-with-"test" is not a test dir; must tier`);
+    }
+  });
+
+  it('fail-safe: a non-canonical path with a ".." segment (e.g. test/../lib/...) is NOT exempted — it must tier', () => {
+    // A `/test/` segment that resolves back into production must not exempt the
+    // change. Out-of-contract input (the live caller feeds canonical git-diff
+    // paths), but the exemption fails safe by tiering it.
+    const r = classifyTrustRootTier({ changedFiles: ['packages/prosecute/test/../lib/run.mjs'], tickets: TICKETS });
+    assert.equal(r.isTrustRootTier, true, 'a ..-containing test path must not be exempted');
+  });
+});
+
+// The test-file exemption (#154/T41) is only SAFE if a test-classified path never
+// holds production code imported by a gate. Enforce that invariant so a future
+// convention violation can't silently open a tier bypass.
+describe('trust-root tier — test-exemption assumption is enforced (#154/T41)', () => {
+  const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+  const GATED_PACKAGES = ['rails-guard', 'prosecute', 'gate-manifest', 'build-gate', 'ticket-prune', 'ticket-sync'];
+
+  function walkMjs(dir) {
+    if (!existsSync(dir)) return [];
+    const out = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...walkMjs(p));
+      else if (entry.name.endsWith('.mjs')) out.push(p);
+    }
+    return out;
+  }
+
+  it('no production lib/bin module in a producer/enforcement package imports a test-classified file', () => {
+    const importsTestPath =
+      /(?:import\s[^;\n]*from|require\s*\()\s*['"`][^'"`]*(?:\.test\.(?:mjs|js|cjs)|\/test\/)[^'"`]*['"`]/;
+    const offenders = [];
+    for (const pkg of GATED_PACKAGES) {
+      for (const sub of ['lib', 'bin']) {
+        for (const file of walkMjs(join(REPO_ROOT, 'packages', pkg, sub))) {
+          if (importsTestPath.test(readFileSync(file, 'utf8'))) {
+            offenders.push(file.slice(REPO_ROOT.length));
+          }
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      'a production module importing a test-classified file would silently open the T41 test-exemption bypass — route shared code through a non-test path',
+    );
   });
 });

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -106,3 +106,46 @@ describe('classifyTrustRootTier — hygiene', () => {
     assert.equal(r.reasons.length, 3);
   });
 });
+
+describe('classifyTrustRootTier — test-only exemption (#154/T41)', () => {
+  it('AC1: a diff touching ONLY test files in a producer/enforcement package is NOT trust-root tier', () => {
+    for (const f of [
+      'packages/ticket-prune/test/roundtrip.test.mjs',      // producer, under test/
+      'packages/ticket-sync/test/pull.test.mjs',            // producer, under test/
+      'packages/prosecute/test/run.test.mjs',               // enforcement, under test/
+      'packages/rails-guard/test/guard.test.mjs',           // enforcement, under test/
+      'packages/build-gate/lib/foo.test.mjs',               // enforcement, *.test.mjs basename (not under test/)
+    ]) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, false, `${f} (test-only) must NOT tier`);
+      assert.deepEqual(r.reasons, []);
+    }
+  });
+
+  it('AC2: the same test-only diff PLUS one non-test file in the package DOES tier', () => {
+    const r = classifyTrustRootTier({
+      changedFiles: ['packages/ticket-prune/test/roundtrip.test.mjs', 'packages/ticket-prune/lib/run.mjs'],
+      tickets: TICKETS,
+    });
+    assert.equal(r.isTrustRootTier, true);
+    assert.ok(r.reasons.some((x) => x.includes('packages/ticket-prune/')));
+  });
+
+  it('AC3: a trust-root EXACT file that is itself a TEST path still tiers (rails-guard-workflow-hashes.json)', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['scripts/test/rails-guard-workflow-hashes.json'], tickets: TICKETS });
+    assert.equal(r.isTrustRootTier, true);
+    assert.ok(r.reasons.some((x) => x.includes('rails-guard-workflow-hashes.json')));
+  });
+
+  it('AC4: a TEST path matching a ticket rails deny-path still tiers (rails surface is not exempted)', () => {
+    // T7 rails = test/auth/**; a test file under it is a frozen rail.
+    const r = classifyTrustRootTier({ changedFiles: ['test/auth/login.test.mjs'], tickets: TICKETS });
+    assert.equal(r.isTrustRootTier, true);
+    assert.ok(r.reasons.some((x) => x.includes('rails deny-path of ticket T7')));
+  });
+
+  it('precision: a non-test path that merely CONTAINS "test" (test-utils/) is NOT exempted', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['packages/prosecute/test-utils/helper.mjs'], tickets: TICKETS });
+    assert.equal(r.isTrustRootTier, true, 'test-utils is not a test dir; a real helper edit must still tier');
+  });
+});


### PR DESCRIPTION
## What & why
`classifyTrustRootTier` fired the cross-model trust-root tier for a change touching a producer/enforcement package via its path-prefix **even when every changed file was a test** — e.g. T40's test-only diff was forced through a full cross-model loop, though a test-only change can't alter the produced artifact or gate LOGIC and so can't cause the producer/consumer CONTRACT mismatch the tier gates. Implements T41 (issue #154).

## Change
- The **package-prefix** surfaces (enforcement + producer) now exempt test files (`isTestFile`: a `/test/` segment or a `*.test.{mjs,js,cjs}` basename).
- The **exact trust-root files** (incl. the test-path `scripts/test/rails-guard-workflow-hashes.json`) and the **rails deny-path** surface stay **unconditional** — a test path that is a trust-root file or a declared rail still tiers.
- Fail-safe: a non-canonical path with a `..` segment is not exempted (tiers).
- The exemption's safety assumption (test paths never hold production code imported by a gate) is **enforced** by a guard test, and documented.

## P5 provenance (T41 is itself trust-root tier — it edits packages/prosecute)
Prosecuted to convergence:
- Same-model mutation: **SHIP** — every AC mutation-killed (exemption load-bearing; exact-file + rails proven unconditional; precision holds). One unpinned `^|/` boundary mutant → pinned with a `latest/`/`contest/` fixture.
- Cross-model (codex), 2 rounds → **VERIFIED-CLEAN**: (R1) MEDIUM — the path-name exemption trusts the test-file convention (a production module named `*.test.*` / under `test/` imported by production would evade; verified absent today) → resolved via the `..` fail-safe + an **enforced** guard test (no production module in a gated package imports a test-classified file) + docs; (R2) confirmed the fix is strictly more restrictive, the guard catches realistic imports, no regression.

## Test plan
- [x] `node --test packages/prosecute/test/tier.test.mjs` — 21 pass (AC1–AC4, boundary, fail-safe, convention guard)
- [x] `node --test packages/prosecute/test/*.test.mjs` — 91 pass / 0 fail
- [x] full `npm test` green except the known `publish-over-1.3.0` packaging flake (no release/version files touched)
- [x] `rails-guard-ci` passes

Closes #154