### PR TITLE
perf(fleet): make live execution concurrent — async spawn on the hot path (closes #164)

### DIFF
--- a/packages/fleet/README.md
+++ b/packages/fleet/README.md
@@ -103,18 +103,6 @@ P4 (parallel build) + P5 (per-ticket prosecution). The fleet is the orchestrator
 that makes ADLC P4 parallelism executable; it consumes the ticket DAG certified
 by `merge-forecast` (D2) and routes each ticket through the gates.
 
-## Known limitations (v1.1)
-
-- **Live execution is currently serial** (tracked as a fast-follow). The scheduler
-  is concurrency-correct — `planRound`/`runFleet` admit non-overlapping tickets up
-  to the cap and serialize only merges, proven by the offline concurrency tests —
-  but the *live* dependency layer runs workers/gates through a synchronous
-  child-process primitive (`spawnSync`), which blocks the event loop, so real
-  `fleet run` currently processes tickets effectively one at a time. The fix is a
-  mechanical conversion of the live exec chain (Sandbox → gates → adapter →
-  review) to non-blocking async spawn; it does not touch the scheduler. Until then,
-  the fleet is correct but not yet parallel in live operation.
-
 ## Core gaps
 
 None required core changes. The fleet delegates all ticket primitives

--- a/packages/fleet/bin/fleet.mjs
+++ b/packages/fleet/bin/fleet.mjs
@@ -146,22 +146,22 @@ async function runLive({ repo, dir, all, config, onlyIds }) {
   // Canary (spec §8.0(b) / premortem F1): prove the sandbox execution plumbing on
   // a trivial command in a throwaway dir BEFORE dispatching real tickets, so a
   // broken sandbox aborts cheaply instead of failing every ticket.
-  const dispatchCanary = ({ sandboxSpec }) => {
+  const dispatchCanary = async ({ sandboxSpec }) => {
     let tmp;
     try {
       tmp = mkdtempSync(join(tmpdir(), 'fleet-canary-'));
       mkdirSync(join(tmp, '.home'), { recursive: true }); // bwrap bind source must exist (L4)
       const sb = new Sandbox({
         mode: sandboxSpec.mode, backend: sandboxSpec.backend, worktree: tmp, syntheticHome: join(tmp, '.home'),
-        exec: (argv, opts) => { const r = io.spawnWorker(argv[0], argv.slice(1), { cwd: tmp, ...opts }); if (r.error) throw r.error; if (typeof r.status === 'number' && r.status !== 0) throw new Error(r.stderr || 'canary command failed'); return `${r.stdout ?? ''}`; },
+        exec: async (argv, opts) => { const r = await io.spawnWorker(argv[0], argv.slice(1), { cwd: tmp, ...opts }); if (r.error) throw r.error; if (typeof r.status === 'number' && r.status !== 0) throw new Error(r.stderr || 'canary command failed'); return `${r.stdout ?? ''}`; },
       });
-      const out = sb.run(['/bin/sh', '-c', 'echo __fleet_canary_ok__'], { env: repoCommandEnv(io.env, { syntheticHome: join(tmp, '.home') }) });
+      const out = await sb.run(['/bin/sh', '-c', 'echo __fleet_canary_ok__'], { env: repoCommandEnv(io.env, { syntheticHome: join(tmp, '.home') }) });
       return { ok: String(out).includes('__fleet_canary_ok__'), output: String(out) };
     } catch (e) { return { ok: false, output: e.message }; }
     finally { if (tmp) try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } }
   };
 
-  const pre = runPreflight({
+  const pre = await runPreflight({
     repo, config, statusDir: dir, io,
     self: selfIdentity(), probes: lockProbes(),
     railHookInstalled,

--- a/packages/fleet/lib/adapters/claude-code.mjs
+++ b/packages/fleet/lib/adapters/claude-code.mjs
@@ -12,7 +12,7 @@
 
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawnAsync } from '../spawn-async.mjs';
 
 export const name = 'claude-code';
 export const pool = 'default';
@@ -70,9 +70,9 @@ function defaultWriteJson(path, obj) {
  *
  * @param exec injectable spawn: (cmd, args, opts) => { status, stdout, stderr, signal }
  */
-export function dispatch({ worktree, prompt, timeoutMs, env, exec = defaultExec }) {
+export async function dispatch({ worktree, prompt, timeoutMs, env, exec = defaultExec }) {
   const args = ['-p', prompt, '--permission-mode', 'acceptEdits', '--output-format', 'text'];
-  const res = exec('claude', args, { cwd: worktree, env, timeout: timeoutMs });
+  const res = await exec('claude', args, { cwd: worktree, env, timeout: timeoutMs });
   const timedOut = res.signal === 'SIGTERM' || res.killed === true || res.timedOut === true;
   return {
     exitCode: typeof res.status === 'number' ? res.status : (timedOut ? 124 : 1),
@@ -82,5 +82,5 @@ export function dispatch({ worktree, prompt, timeoutMs, env, exec = defaultExec 
 }
 
 function defaultExec(cmd, args, opts) {
-  return spawnSync(cmd, args, { ...opts, encoding: 'utf8' });
+  return spawnAsync(cmd, args, { ...opts, encoding: 'utf8' });
 }

--- a/packages/fleet/lib/gate-pipeline.mjs
+++ b/packages/fleet/lib/gate-pipeline.mjs
@@ -46,9 +46,9 @@ export function collectProtectedCandidates({ listProtected, readBytes }) {
  * @param deps.listProtected / deps.readBytes  (see collectProtectedCandidates)
  * @param deps.railsGuard optional () => { ok, output } — the adlc rails-guard gate
  */
-export function runGatePipeline(ticket, deps) {
+export async function runGatePipeline(ticket, deps) {
   // 1. build/test inside the sandbox.
-  const build = runGates(deps.sandbox, deps.gate, deps.env);
+  const build = await runGates(deps.sandbox, deps.gate, deps.env);
   if (!build.ok) {
     const failed = build.results.find((r) => !r.ok);
     return { ok: false, stage: `build/test:${failed?.key ?? '?'}`, output: failed?.output ?? '' };
@@ -72,7 +72,7 @@ export function runGatePipeline(ticket, deps) {
 
   // 4. rails-guard (delegated to the adlc CLI in the live builder).
   if (deps.railsGuard) {
-    const rg = deps.railsGuard();
+    const rg = await deps.railsGuard();
     if (!rg.ok) return { ok: false, stage: 'rails-guard', output: rg.output ?? 'rail touched' };
   }
 

--- a/packages/fleet/lib/gates.mjs
+++ b/packages/fleet/lib/gates.mjs
@@ -17,10 +17,10 @@ import { inScope } from '@adlc/core';
  * exit or a thrown sandbox error is a gate failure (ok:false), never a throw —
  * the scheduler decides what a failure means (a strike).
  */
-export function runGateCommand(sandbox, command, env) {
+export async function runGateCommand(sandbox, command, env) {
   const argv = ['/bin/sh', '-c', command];
   try {
-    const output = sandbox.run(argv, { env });
+    const output = await sandbox.run(argv, { env });
     return { ok: true, output: String(output ?? '') };
   } catch (e) {
     return { ok: false, output: `${e.stdout ?? ''}${e.stderr ?? ''}${e.message ?? ''}` };
@@ -28,12 +28,12 @@ export function runGateCommand(sandbox, command, env) {
 }
 
 /** Run the configured build + test gate commands in order; stop at first failure. */
-export function runGates(sandbox, gate, env) {
+export async function runGates(sandbox, gate, env) {
   const results = [];
   for (const key of ['build', 'test']) {
     const cmd = gate?.[key];
     if (!cmd) continue;
-    const r = runGateCommand(sandbox, cmd, env);
+    const r = await runGateCommand(sandbox, cmd, env);
     results.push({ key, ...r });
     if (!r.ok) return { ok: false, results };
   }

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -22,6 +22,7 @@ import { BASE_MANIFEST } from './protected-paths.mjs';
 import { spawnSync, execFileSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { spawnAsync } from './spawn-async.mjs';
 
 // Ignore fleet working state WITHOUT committing to the base checkout
 // (adversarial-review L2). `.git/info/exclude` is a local, per-repo, UNcommitted
@@ -41,8 +42,14 @@ function ensureLocalExclude(repoDir) {
 export function defaultIo() {
   return {
     git: (dir) => defaultGit(dir),
+    // Sync adlc for the quick, off-hot-path calls (flail between strikes;
+    // best-effort gate-manifest recording). The per-ticket rails-guard on the
+    // gate path uses adlcAsync so it does not block the event loop (#164).
     adlc: (args, opts = {}) => spawnSync('adlc', args, { encoding: 'utf8', ...opts }),
-    spawnWorker: (cmd, args, opts) => spawnSync(cmd, args, { encoding: 'utf8', ...opts }),
+    adlcAsync: (args, opts = {}) => spawnAsync('adlc', args, { encoding: 'utf8', ...opts }),
+    // Async (non-blocking) worker/gate/review execution so the concurrent
+    // scheduler is not serialized by a blocking spawn (#164).
+    spawnWorker: (cmd, args, opts) => spawnAsync(cmd, args, { encoding: 'utf8', ...opts }),
     readFile: (p) => readFileSync(p, 'utf8'),
     exists: (p) => existsSync(p),
     mkdirp: (p) => mkdirSync(p, { recursive: true }),
@@ -86,11 +93,11 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
     backend: sandboxSpec.backend,
     worktree,
     syntheticHome: join(worktree, '.fleet-home'),
-    exec: (argv, opts) => {
+    exec: async (argv, opts) => {
       // The synthetic HOME is a bind SOURCE for bwrap — it must exist before the
       // wrapped command runs, or bwrap aborts (adversarial-review L4).
       io.mkdirp(join(worktree, '.fleet-home'));
-      const res = io.spawnWorker(argv[0], argv.slice(1), { cwd: worktree, ...opts });
+      const res = await io.spawnWorker(argv[0], argv.slice(1), { cwd: worktree, ...opts });
       if (res.error) throw res.error;
       if (typeof res.status === 'number' && res.status !== 0) {
         const e = new Error(`command failed (exit ${res.status})`);
@@ -113,12 +120,12 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       worktrees.createIntegrationBranch(repo, integrationBranch, baseSha, repoGit);
     },
 
-    createWorktree: ({ ticket, integrationBranch }) => {
+    createWorktree: async ({ ticket, integrationBranch }) => {
       const wt = worktrees.createWorktree(repo, ticket.id, { integrationBranch, git: repoGit });
       // Initialize the worktree THROUGH the sandbox (§6.3, M1) — repo-config init
       // (npm install) runs arbitrary lifecycle code and must be contained.
       if (config.init) {
-        try { sandboxFor(wt.path).run(['/bin/sh', '-c', config.init], { env: repoCmdEnv(wt.path) }); }
+        try { await sandboxFor(wt.path).run(['/bin/sh', '-c', config.init], { env: repoCmdEnv(wt.path) }); }
         catch (e) { throw new Error(`worktree init failed for ${ticket.id}: ${e.message}`); }
       }
       return wt;
@@ -126,13 +133,13 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
 
     provision: ({ worktree }) => adapter.provision({ worktree, config, writeJson: io.writeJson }),
 
-    dispatch: ({ ticket, worktree, strike, deadEnds = [] }) => {
+    dispatch: async ({ ticket, worktree, strike, deadEnds = [] }) => {
       const prompt = strike > 1 ? fixPrompt(ticket, config.gate, deadEnds) : builderPrompt(ticket, config.gate);
       const env = modelPlaneEnv(io.env, {
         modelAuthKey: config.modelAuthKey,
         extra: { ADLC_P4_ENFORCEMENT: '1', ADLC_TICKET: ticket.id },
       });
-      const res = adapter.dispatch({
+      const res = await adapter.dispatch({
         worktree, prompt, timeoutMs: (config.timeoutMinutes ?? 30) * 60000, env,
         exec: (cmd, args, opts) => io.spawnWorker(cmd, args, opts),
       });
@@ -157,8 +164,8 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
         return paths.filter((p) => isUnderProtectedPrefix(p));
       };
       const readBytes = (p) => (io.exists(join(worktree, p)) ? io.readFile(join(worktree, p)) : undefined);
-      const railsGuard = () => {
-        const res = io.adlc(['rails-guard', '--base', startSha, '--ticket', ticket.id], { cwd: worktree });
+      const railsGuard = async () => {
+        const res = await io.adlcAsync(['rails-guard', '--base', startSha, '--ticket', ticket.id], { cwd: worktree });
         return { ok: res.status === 0, output: `${res.stdout ?? ''}${res.stderr ?? ''}` };
       };
       return runGatePipeline(ticket, {

--- a/packages/fleet/lib/preflight.mjs
+++ b/packages/fleet/lib/preflight.mjs
@@ -51,7 +51,7 @@ export function railHookProbe(railHookInstalled) {
  * @param railHookInstalled () => boolean
  * @param self / probes   lock identity + liveness probes (lib/proc.mjs)
  */
-export function runPreflight({
+export async function runPreflight({
   repo, config, statusDir, io, self, probes,
   dispatchCanary, railHookInstalled = () => false,
   platform, hasCmd,
@@ -85,7 +85,7 @@ export function runPreflight({
 
   // 5. Canary — prove the permission plumbing before real tickets.
   if (dispatchCanary) {
-    const canary = dispatchCanary({ sandboxSpec: sb });
+    const canary = await dispatchCanary({ sandboxSpec: sb });
     if (!canary.ok) {
       releaseLock(statusDir);
       return { ok: false, exitCode: 1, reason: `preflight canary failed (permission plumbing not working): ${canary.output ?? ''}`, warnings, lockHeld: false };

--- a/packages/fleet/lib/prosecute.mjs
+++ b/packages/fleet/lib/prosecute.mjs
@@ -18,7 +18,7 @@ const SEVERITY_ORDER = { low: 0, medium: 1, high: 2, critical: 3 };
  * @param opts.failOn minimum blocking severity (default 'medium')
  * @returns { verdict:'pass'|'block'|'unavailable', blocking:[...], reason }
  */
-export function prosecute({ worktree, startSha, ticket }, { runReview, failOn = 'medium' } = {}) {
+export async function prosecute({ worktree, startSha, ticket }, { runReview, failOn = 'medium' } = {}) {
   if (typeof runReview !== 'function') {
     // No prosecutor wired at all → fail closed (must not silently pass).
     return { verdict: 'unavailable', blocking: [], reason: 'no review runner configured; failing closed' };
@@ -26,7 +26,7 @@ export function prosecute({ worktree, startSha, ticket }, { runReview, failOn = 
   const threshold = SEVERITY_ORDER[failOn] ?? SEVERITY_ORDER.medium;
   let result;
   try {
-    result = runReview({ worktree, startSha, ticket });
+    result = await runReview({ worktree, startSha, ticket });
   } catch (e) {
     return { verdict: 'unavailable', blocking: [], reason: `review runner threw: ${e.message}; failing closed` };
   }

--- a/packages/fleet/lib/review-runner.mjs
+++ b/packages/fleet/lib/review-runner.mjs
@@ -13,9 +13,9 @@
 // worktree is still the cwd, so the git diff sees the ticket branch, but the
 // executable is trusted. `reviewBin` is configurable for a pinned absolute path.
 
-import { spawnSync } from 'node:child_process';
 import { isAbsolute, join, delimiter } from 'node:path';
 import { existsSync } from 'node:fs';
+import { spawnAsync } from './spawn-async.mjs';
 
 /**
  * Resolve a review binary to an ABSOLUTE trusted path (adversarial-review L1/M2).
@@ -47,7 +47,7 @@ export function resolveTrustedBin(bin, pathStr, worktree) {
  * @returns a runReview({ worktree, startSha, ticket }) => { ok, findings?, reason? }
  */
 export function makeReviewRunner({ spawn = defaultSpawn, reviewBin = 'adversarial-review', trustedPath, resolveBin = resolveTrustedBin, provider, failOn = 'medium', timeoutMs = 600000 } = {}) {
-  return ({ worktree, startSha }) => {
+  return async ({ worktree, startSha }) => {
     const args = ['--base', startSha, '--json', '--fail-on', failOn];
     if (provider) args.push('--provider', provider);
     const path = trustedPath ?? process.env.PATH;
@@ -63,7 +63,7 @@ export function makeReviewRunner({ spawn = defaultSpawn, reviewBin = 'adversaria
 
     let res;
     try {
-      res = spawn(bin, args, { cwd: worktree, env, encoding: 'utf8', timeout: timeoutMs });
+      res = await spawn(bin, args, { cwd: worktree, env, encoding: 'utf8', timeout: timeoutMs });
     } catch (e) {
       return { ok: false, reason: `adversarial-review spawn failed: ${e.message}` };
     }
@@ -90,5 +90,5 @@ export function makeReviewRunner({ spawn = defaultSpawn, reviewBin = 'adversaria
 }
 
 function defaultSpawn(cmd, args, options) {
-  return spawnSync(cmd, args, options);
+  return spawnAsync(cmd, args, options);
 }

--- a/packages/fleet/lib/sandbox.mjs
+++ b/packages/fleet/lib/sandbox.mjs
@@ -176,10 +176,14 @@ export class Sandbox {
     });
   }
 
-  /** Execute `innerArgv` inside the sandbox with the given scrubbed env. */
-  run(innerArgv, { env, cwd } = {}) {
+  /**
+   * Execute `innerArgv` inside the sandbox with the given scrubbed env. Async so
+   * a live (promise-returning) exec does not block the event loop (#164); a
+   * synchronous injected exec still works (await of a plain value is a no-op).
+   */
+  async run(innerArgv, { env, cwd } = {}) {
     const exec = this._exec ?? realExec;
-    return exec(this.wrap(innerArgv), { cwd: cwd ?? this.worktree, env });
+    return await exec(this.wrap(innerArgv), { cwd: cwd ?? this.worktree, env });
   }
 }
 

--- a/packages/fleet/lib/spawn-async.mjs
+++ b/packages/fleet/lib/spawn-async.mjs
@@ -1,0 +1,37 @@
+// Non-blocking child-process execution (github #164). The live fleet MUST NOT
+// use spawnSync on the per-ticket worker/gate/review hot path: a synchronous
+// spawn blocks the Node event loop, serializing the concurrent scheduler. This
+// promise-wrapped `spawn` yields the loop while a child runs, so independent
+// tickets' workers/gates actually overlap.
+//
+// Returns the SAME shape the code expects from spawnSync:
+//   { status, signal, stdout, stderr, error, timedOut }
+// so it is a drop-in for the injected exec/spawn seams.
+
+import { spawn as cpSpawn } from 'node:child_process';
+
+export function spawnAsync(cmd, args = [], opts = {}) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = cpSpawn(cmd, args, { ...opts, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (error) {
+      resolve({ error, status: null, stdout: '', stderr: '' });
+      return;
+    }
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let timer;
+    if (child.stdout) { child.stdout.setEncoding('utf8'); child.stdout.on('data', (d) => { stdout += d; }); }
+    if (child.stderr) { child.stderr.setEncoding('utf8'); child.stderr.on('data', (d) => { stderr += d; }); }
+    if (opts.timeout) {
+      timer = setTimeout(() => { timedOut = true; try { child.kill('SIGTERM'); } catch { /* already gone */ } }, opts.timeout);
+    }
+    child.on('error', (error) => { if (timer) clearTimeout(timer); resolve({ error, status: null, stdout, stderr, timedOut }); });
+    child.on('close', (status, signal) => {
+      if (timer) clearTimeout(timer);
+      resolve({ status, signal, stdout, stderr, timedOut: timedOut || signal === 'SIGTERM' });
+    });
+  });
+}

--- a/packages/fleet/test/adapter-claude-code.test.mjs
+++ b/packages/fleet/test/adapter-claude-code.test.mjs
@@ -4,17 +4,17 @@ import {
   name, pool, toPermissionRule, buildSettings, provision, dispatch,
 } from '../lib/adapters/claude-code.mjs';
 
-test('adapter identity', () => {
+test('adapter identity', async () => {
   assert.equal(name, 'claude-code');
   assert.equal(pool, 'default');
 });
 
-test('toPermissionRule wraps commands in Bash() rule form (premortem F1)', () => {
+test('toPermissionRule wraps commands in Bash() rule form (premortem F1)', async () => {
   assert.equal(toPermissionRule('npm test'), 'Bash(npm test)');
   assert.equal(toPermissionRule('npm run build:*'), 'Bash(npm run build:*)');
 });
 
-test('buildSettings allowlists gate/init/allowed commands + read-only git, never git commit', () => {
+test('buildSettings allowlists gate/init/allowed commands + read-only git, never git commit', async () => {
   const s = buildSettings({ init: 'npm install', gate: { build: 'npm run build', test: 'npm test' }, allowedCommands: ['node --test'] });
   const allow = s.permissions.allow;
   assert.ok(allow.includes('Bash(npm install)'));
@@ -25,7 +25,7 @@ test('buildSettings allowlists gate/init/allowed commands + read-only git, never
   assert.ok(!allow.some((r) => /git commit/.test(r)), 'the worker must NOT be allowed to commit');
 });
 
-test('provision writes only the allowlist settings file to the worktree .claude dir (AC4)', () => {
+test('provision writes only the allowlist settings file to the worktree .claude dir (AC4)', async () => {
   const written = [];
   const r = provision({
     worktree: '/wt',
@@ -37,9 +37,9 @@ test('provision writes only the allowlist settings file to the worktree .claude 
   assert.deepEqual(r.settings, written[0].obj);
 });
 
-test('dispatch spawns claude -p acceptEdits in the worktree with model-plane env (AC4 / K2)', () => {
+test('dispatch spawns claude -p acceptEdits in the worktree with model-plane env (AC4 / K2)', async () => {
   let captured;
-  const res = dispatch({
+  const res = await dispatch({
     worktree: '/wt',
     prompt: 'build ticket T42',
     timeoutMs: 60000,
@@ -57,8 +57,8 @@ test('dispatch spawns claude -p acceptEdits in the worktree with model-plane env
   assert.match(res.output, /TICKET-DONE/);
 });
 
-test('dispatch maps a timeout to a failed-strike outcome (AC4)', () => {
-  const res = dispatch({
+test('dispatch maps a timeout to a failed-strike outcome (AC4)', async () => {
+  const res = await dispatch({
     worktree: '/wt', prompt: 'x', timeoutMs: 10, env: {},
     exec: () => ({ status: null, signal: 'SIGTERM', stdout: '', stderr: 'timed out' }),
   });

--- a/packages/fleet/test/gate-pipeline.test.mjs
+++ b/packages/fleet/test/gate-pipeline.test.mjs
@@ -12,8 +12,8 @@ const okSandbox = () => new Sandbox({
 const ticket = { id: 'T1', scope: ['packages/fleet/**'] };
 const templates = () => new Map([['.adlc/tickets.json', '{"tickets":[{"id":"T1"}]}']]);
 
-test('gate pipeline passes when build/scope/protected-paths are clean', () => {
-  const r = runGatePipeline(ticket, {
+test('gate pipeline passes when build/scope/protected-paths are clean', async () => {
+  const r = await runGatePipeline(ticket, {
     sandbox: okSandbox(),
     gate: { build: 'true', test: 'true' },
     env: {},
@@ -25,8 +25,8 @@ test('gate pipeline passes when build/scope/protected-paths are clean', () => {
   assert.equal(r.ok, true, r.output);
 });
 
-test('gate pipeline FAILS at protected-paths on a tampered tickets.json (C1 wired)', () => {
-  const r = runGatePipeline(ticket, {
+test('gate pipeline FAILS at protected-paths on a tampered tickets.json (C1 wired)', async () => {
+  const r = await runGatePipeline(ticket, {
     sandbox: okSandbox(),
     gate: { build: 'true' },
     env: {},
@@ -40,8 +40,8 @@ test('gate pipeline FAILS at protected-paths on a tampered tickets.json (C1 wire
   assert.match(r.output, /tickets\.json/);
 });
 
-test('gate pipeline FAILS at scope on an out-of-scope change', () => {
-  const r = runGatePipeline(ticket, {
+test('gate pipeline FAILS at scope on an out-of-scope change', async () => {
+  const r = await runGatePipeline(ticket, {
     sandbox: okSandbox(), gate: {}, env: {},
     changedPaths: ['packages/core/index.mjs'], // outside T1 scope
     templates: templates(), listProtected: () => [], readBytes: () => undefined,
@@ -50,7 +50,7 @@ test('gate pipeline FAILS at scope on an out-of-scope change', () => {
   assert.equal(r.stage, 'scope');
 });
 
-test('collectProtectedCandidates checks git-surfaced protected files, skips inert logs', () => {
+test('collectProtectedCandidates checks git-surfaced protected files, skips inert logs', async () => {
   const cands = collectProtectedCandidates({
     listProtected: () => ['.adlc/tickets.json', '.adlc/fleet-logs/T1.log', 'src/app.js'],
     readBytes: (p) => `bytes-of-${p}`,
@@ -70,7 +70,7 @@ test('integration: a worker tampering .adlc/tickets.json cannot merge (C1 end-to
     createIntegrationBranch: () => {},
     createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
     dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
-    gate: ({ ticket }) => runGatePipeline(ticket, {
+    gate: async ({ ticket }) => runGatePipeline(ticket, {
       sandbox: okSandbox(), gate: {}, env: {},
       changedPaths: ['packages/fleet/lib/x.mjs'],
       templates: templates(),

--- a/packages/fleet/test/gates.test.mjs
+++ b/packages/fleet/test/gates.test.mjs
@@ -5,17 +5,17 @@ import { Sandbox, SANDBOX_MODES } from '../lib/sandbox.mjs';
 
 const T = (scope) => ({ id: 'T1', scope });
 
-test('scopeViolations flags paths outside the ticket scope (§8.3c)', () => {
+test('scopeViolations flags paths outside the ticket scope (§8.3c)', async () => {
   const t = T(['packages/fleet/**']);
   assert.deepEqual(scopeViolations(['packages/fleet/lib/x.mjs'], t), []);
   assert.deepEqual(scopeViolations(['packages/fleet/lib/x.mjs', 'packages/core/index.mjs'], t), ['packages/core/index.mjs']);
 });
 
-test('scopeViolations fails closed when no scope is declared', () => {
+test('scopeViolations fails closed when no scope is declared', async () => {
   assert.deepEqual(scopeViolations(['any/file.js'], T([])), ['any/file.js']);
 });
 
-test('runGates runs build then test through the sandbox and stops at first failure', () => {
+test('runGates runs build then test through the sandbox and stops at first failure', async () => {
   const ran = [];
   const sandbox = new Sandbox({
     mode: SANDBOX_MODES.SANDBOX, backend: { name: 'bubblewrap' }, worktree: '/wt', syntheticHome: '/wt/.home',
@@ -26,23 +26,23 @@ test('runGates runs build then test through the sandbox and stops at first failu
       return 'ok';
     },
   });
-  const good = runGates(sandbox, { build: 'npm run build', test: 'npm test' }, { PATH: '/usr/bin' });
+  const good = await runGates(sandbox, { build: 'npm run build', test: 'npm test' }, { PATH: '/usr/bin' });
   assert.equal(good.ok, true);
   assert.deepEqual(ran, ['npm run build', 'npm test']);
 
   ran.length = 0;
-  const bad = runGates(sandbox, { build: 'npm run build fail', test: 'npm test' }, {});
+  const bad = await runGates(sandbox, { build: 'npm run build fail', test: 'npm test' }, {});
   assert.equal(bad.ok, false);
   assert.deepEqual(ran, ['npm run build fail'], 'must stop at the first failing gate');
 });
 
-test('checkFlail returns the detector verdict', () => {
+test('checkFlail returns the detector verdict', async () => {
   const r = checkFlail('/log', ['src/**'], { exec: () => JSON.stringify({ detected: true, signals: ['repeated-error'] }) });
   assert.equal(r.flail, true);
   assert.deepEqual(r.signals, ['repeated-error']);
 });
 
-test('checkFlail FAILS OPEN on any error (§12 backstop)', () => {
+test('checkFlail FAILS OPEN on any error (§12 backstop)', async () => {
   const r = checkFlail('/log', [], { exec: () => { throw new Error('adlc not found'); } });
   assert.equal(r.flail, false);
   assert.equal(r.failedOpen, true);

--- a/packages/fleet/test/live-concurrency.test.mjs
+++ b/packages/fleet/test/live-concurrency.test.mjs
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildLiveDeps } from '../lib/live-deps.mjs';
+import { runFleet } from '../lib/run.mjs';
+
+// The regression test for github #164: the LIVE deps (not just async fakes) must
+// run non-overlapping tickets' workers CONCURRENTLY. A synchronous spawn would
+// block the event loop and serialize them; this proves the async conversion.
+
+const T = (id, scope) => ({ id, title: id, scope, body: 'do', edges: [] });
+
+function fakeGit() {
+  return () => (...args) => {
+    const verb = args[0];
+    if (verb === 'diff') return ''; // no out-of-scope changes (this test targets concurrency, not the gate)
+    if (verb === 'status') return '';
+    if (verb === 'show') throw new Error('no template at rev');
+    if (verb === 'rev-parse') return 'SHA';
+    return '';
+  };
+}
+
+test('two non-overlapping tickets dispatch CONCURRENTLY through buildLiveDeps (#164)', async () => {
+  let pendingWorkers = 0;
+  let maxConcurrentWorkers = 0;
+  let releaseWorkers;
+  const workerGate = new Promise((res) => { releaseWorkers = res; });
+
+  const io = {
+    git: fakeGit(),
+    adlc: () => ({ status: 0, stdout: '{"detected":false}' }),
+    adlcAsync: async () => ({ status: 0, stdout: '' }),
+    // The claude worker blocks (async, non-blocking to the event loop) until we
+    // release it; the gate (bwrap) resolves immediately.
+    spawnWorker: async (cmd) => {
+      if (cmd === 'claude') {
+        pendingWorkers += 1;
+        maxConcurrentWorkers = Math.max(maxConcurrentWorkers, pendingWorkers);
+        await workerGate;
+        pendingWorkers -= 1;
+        return { status: 0, stdout: 'TICKET-DONE', stderr: '' };
+      }
+      return { status: 0, stdout: 'ok', stderr: '' };
+    },
+    readFile: () => undefined,
+    exists: () => false,
+    mkdirp: () => {},
+    writeJson: () => {},
+    ensureGitignore: () => {},
+    env: { PATH: '/usr/bin' },
+    hasGh: () => false,
+  };
+
+  const config = { gate: { test: 'true' }, prosecuteFailOn: 'medium', concurrency: 2, base: 'main', baseSha: 'BASE' };
+  const deps = buildLiveDeps({
+    repo: '/repo', config, statusDir: undefined,
+    sandboxSpec: { mode: 'sandbox', backend: { name: 'bubblewrap' } },
+    reviewRunner: () => ({ ok: true, findings: [] }),
+    io,
+  });
+
+  const all = [T('T1', ['src/a/**']), T('T2', ['src/b/**'])]; // non-overlapping
+  const runP = runFleet({ all, runId: 'k', config, deps });
+
+  // Give both admitted tickets time to reach their (blocked) worker dispatch.
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(pendingWorkers, 2, 'both workers are in flight at once — the live layer is NOT serialized (#164)');
+
+  releaseWorkers();
+  const summary = await runP;
+  assert.equal(maxConcurrentWorkers, 2, 'the live pool ran two workers concurrently');
+  assert.deepEqual(Object.values(summary.results).sort(), ['merged', 'merged']);
+});

--- a/packages/fleet/test/live-deps.test.mjs
+++ b/packages/fleet/test/live-deps.test.mjs
@@ -20,6 +20,7 @@ function fakeIo(rec, env) {
   return {
     git: fakeGit(rec),
     adlc: (args) => { rec.adlc.push(args); return { status: 0, stdout: '{"detected":false}' }; },
+    adlcAsync: async (args) => { rec.adlc.push(args); return { status: 0, stdout: '' }; },
     spawnWorker: (cmd, args, opts) => {
       rec.spawn.push({ cmd, args, env: opts?.env });
       if (cmd === 'claude') return { status: 0, stdout: 'TICKET-DONE', stderr: '' };
@@ -49,10 +50,10 @@ function makeDeps(rec, over = {}) {
 }
 const newRec = () => ({ git: [], adlc: [], spawn: [] });
 
-test('dispatch spawns claude -p on the MODEL plane: unsandboxed, provider auth retained (AC1/K2)', () => {
+test('dispatch spawns claude -p on the MODEL plane: unsandboxed, provider auth retained (AC1/K2)', async () => {
   const rec = newRec();
   const deps = makeDeps(rec);
-  const r = deps.dispatch({ ticket, worktree: '/wt/T1', startSha: 'SHA', strike: 1, deadEnds: [] });
+  const r = await deps.dispatch({ ticket, worktree: '/wt/T1', startSha: 'SHA', strike: 1, deadEnds: [] });
   const claudeCall = rec.spawn.find((s) => s.cmd === 'claude');
   assert.ok(claudeCall, 'claude was spawned directly (not wrapped in bwrap)');
   assert.ok(claudeCall.args.includes('-p') && claudeCall.args.includes('acceptEdits'));
@@ -63,10 +64,10 @@ test('dispatch spawns claude -p on the MODEL plane: unsandboxed, provider auth r
   assert.equal(r.exitCode, 0);
 });
 
-test('gate runs build+test THROUGH the sandbox with a scrubbed repo-command env (AC1)', () => {
+test('gate runs build+test THROUGH the sandbox with a scrubbed repo-command env (AC1)', async () => {
   const rec = newRec();
   const deps = makeDeps(rec);
-  const r = deps.gate({ ticket, worktree: '/wt/T1', startSha: 'SHA' });
+  const r = await deps.gate({ ticket, worktree: '/wt/T1', startSha: 'SHA' });
   assert.equal(r.ok, true, r.output);
   // build+test were wrapped in the sandbox (bwrap) — repo-command plane.
   const wrapped = rec.spawn.filter((s) => s.cmd === 'bwrap');
@@ -79,20 +80,20 @@ test('gate runs build+test THROUGH the sandbox with a scrubbed repo-command env 
   assert.equal(anyCmd.env.PATH, '/usr/bin');
 });
 
-test('gate invokes rails-guard with --base <startSha> --ticket <id>', () => {
+test('gate invokes rails-guard with --base <startSha> --ticket <id>', async () => {
   const rec = newRec();
-  makeDeps(rec).gate({ ticket, worktree: '/wt/T1', startSha: 'TIP' });
+  await makeDeps(rec).gate({ ticket, worktree: '/wt/T1', startSha: 'TIP' });
   const rg = rec.adlc.find((a) => a[0] === 'rails-guard');
   assert.ok(rg, 'rails-guard was invoked');
   assert.equal(rg[rg.indexOf('--base') + 1], 'TIP');
   assert.equal(rg[rg.indexOf('--ticket') + 1], 'T1');
 });
 
-test('prosecute drives the review runner over the ticket startSha (AC1)', () => {
+test('prosecute drives the review runner over the ticket startSha (AC1)', async () => {
   const rec = newRec();
   let seen;
   const deps = makeDeps(rec, { reviewRunner: (ctx) => { seen = ctx; return { ok: true, findings: [] }; } });
-  const r = deps.prosecute({ ticket, worktree: '/wt/T1', startSha: 'TIP' });
+  const r = await deps.prosecute({ ticket, worktree: '/wt/T1', startSha: 'TIP' });
   assert.equal(seen.startSha, 'TIP');
   assert.equal(r.verdict, 'pass');
 });

--- a/packages/fleet/test/live-prosecute.test.mjs
+++ b/packages/fleet/test/live-prosecute.test.mjs
@@ -9,10 +9,10 @@ const ctx = { worktree: '/wt', startSha: 'TIP', ticket: { id: 'T1' } };
 const idResolve = (b) => b;
 const mk = (opts) => makeReviewRunner({ resolveBin: idResolve, ...opts });
 
-test('review runner runs a TRUSTED binary (not npx) with --base <startSha> --json (L1)', () => {
+test('review runner runs a TRUSTED binary (not npx) with --base <startSha> --json (L1)', async () => {
   let captured;
   const run = mk({ spawn: (cmd, args, opts) => { captured = { cmd, args, opts }; return { status: 0, stdout: '{"findings":[]}' }; } });
-  run(ctx);
+  await run(ctx);
   assert.equal(captured.cmd, 'adversarial-review', 'invoked by trusted name, NOT via npx-from-worktree (L1)');
   assert.notEqual(captured.cmd, 'npx');
   const i = captured.args.indexOf('--base');
@@ -22,58 +22,58 @@ test('review runner runs a TRUSTED binary (not npx) with --base <startSha> --jso
   assert.ok(captured.opts.env && typeof captured.opts.env.PATH === 'string', 'resolved against a sanitized PATH');
 });
 
-test('a configured absolute reviewBin is honored (pinned trusted path)', () => {
+test('a configured absolute reviewBin is honored (pinned trusted path)', async () => {
   let captured;
   const run = mk({ reviewBin: '/opt/trusted/adversarial-review', spawn: (cmd) => { captured = cmd; return { status: 0, stdout: '{"findings":[]}' }; } });
-  run(ctx);
+  await run(ctx);
   assert.equal(captured, '/opt/trusted/adversarial-review');
 });
 
-test('a clean review (exit 0) → prosecute passes', () => {
+test('a clean review (exit 0) → prosecute passes', async () => {
   const runReview = mk({ spawn: () => ({ status: 0, stdout: '{"findings":[]}' }) });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'pass');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'pass');
 });
 
-test('needs-attention (exit 2) with a >=medium finding → prosecute BLOCKS (AC4)', () => {
+test('needs-attention (exit 2) with a >=medium finding → prosecute BLOCKS (AC4)', async () => {
   const runReview = mk({ spawn: () => ({ status: 2, stdout: '{"findings":[{"severity":"high","title":"x"}]}' }) });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'block');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'block');
 });
 
-test('unreachable provider (exit 1) → prosecute fails CLOSED (AC4)', () => {
+test('unreachable provider (exit 1) → prosecute fails CLOSED (AC4)', async () => {
   const runReview = mk({ spawn: () => ({ status: 1, stderr: 'no provider configured' }) });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'unavailable');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'unavailable');
 });
 
-test('spawn error (ENOENT) → fail closed', () => {
+test('spawn error (ENOENT) → fail closed', async () => {
   const runReview = mk({ spawn: () => ({ error: new Error('spawn ENOENT') }) });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'unavailable');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'unavailable');
 });
 
-test('a THROWING spawn (not an error result) → fail closed', () => {
+test('a THROWING spawn (not an error result) → fail closed', async () => {
   const runReview = mk({ spawn: () => { throw new Error('spawn threw'); } });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'unavailable', 'a review that cannot even be launched must never pass');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'unavailable', 'a review that cannot even be launched must never pass');
 });
 
-test('exit 1 WITH valid JSON still fails closed (exit code is authoritative)', () => {
+test('exit 1 WITH valid JSON still fails closed (exit code is authoritative)', async () => {
   const runReview = mk({ spawn: () => ({ status: 1, stdout: '{"findings":[]}' }) });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'unavailable');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'unavailable');
 });
 
-test('exit 0 but non-JSON output → fail closed', () => {
+test('exit 0 but non-JSON output → fail closed', async () => {
   const runReview = mk({ spawn: () => ({ status: 0, stdout: 'not json' }) });
-  assert.equal(prosecute(ctx, { runReview }).verdict, 'unavailable');
+  assert.equal((await prosecute(ctx, { runReview })).verdict, 'unavailable');
 });
 
-test('provider flag is passed through when configured', () => {
+test('provider flag is passed through when configured', async () => {
   let captured;
   const run = mk({ provider: 'codex', spawn: (_cmd, a) => { captured = a; return { status: 0, stdout: '{"findings":[]}' }; } });
-  run(ctx);
+  await run(ctx);
   assert.equal(captured[captured.indexOf('--provider') + 1], 'codex');
 });
 
 // ---- resolveTrustedBin: the M2 security boundary (no cwd/relative shadowing) ----
 
-test('resolveTrustedBin rejects relative/empty PATH and the worktree, preventing shadowing (M2)', () => {
+test('resolveTrustedBin rejects relative/empty PATH and the worktree, preventing shadowing (M2)', async () => {
   // A relative PATH (node_modules/.bin, ".", empty) must NOT resolve — even if a
   // binary of that name sits in the worktree.
   assert.equal(resolveTrustedBin('adversarial-review', 'node_modules/.bin:.:', '/wt'), null);
@@ -82,14 +82,14 @@ test('resolveTrustedBin rejects relative/empty PATH and the worktree, preventing
   assert.equal(resolveTrustedBin('adversarial-review', '/wt:/wt/node_modules/.bin', '/wt'), null);
 });
 
-test('resolveTrustedBin fails closed → prosecute unavailable when no trusted bin exists (M2)', () => {
+test('resolveTrustedBin fails closed → prosecute unavailable when no trusted bin exists (M2)', async () => {
   // Use the REAL resolver against a relative-only PATH: nothing trusted resolves.
   const runReview = makeReviewRunner({ reviewBin: 'adversarial-review', trustedPath: 'node_modules/.bin:.', spawn: () => ({ status: 0, stdout: '{"findings":[]}' }) });
-  const r = prosecute(ctx, { runReview });
+  const r = await prosecute(ctx, { runReview });
   assert.equal(r.verdict, 'unavailable', 'a worktree-shadowable PATH must fail closed, not run the fake');
 });
 
-test('resolveTrustedBin returns an absolute reviewBin only if it exists', () => {
+test('resolveTrustedBin returns an absolute reviewBin only if it exists', async () => {
   assert.equal(resolveTrustedBin('/definitely/not/here/adversarial-review', '/usr/bin', '/wt'), null);
   // A real absolute path that exists (use node itself as a stand-in existing file).
   assert.equal(resolveTrustedBin(process.execPath, '/usr/bin', '/wt'), process.execPath);

--- a/packages/fleet/test/preflight.test.mjs
+++ b/packages/fleet/test/preflight.test.mjs
@@ -19,74 +19,74 @@ const base = (over = {}) => ({
   self, probes: deadProbes, railHookInstalled: () => true, ...bwrapHost, ...over,
 });
 
-test('preflight fails closed when no gate is configured (AC / M1)', () => {
-  const r = runPreflight(base({ config: { operatorOverride: false } })); // no gate
+test('preflight fails closed when no gate is configured (AC / M1)', async () => {
+  const r = await runPreflight(base({ config: { operatorOverride: false } })); // no gate
   assert.equal(r.ok, false);
   assert.equal(r.exitCode, 1);
   assert.match(r.reason, /gate/i);
 });
 
-test('resolveSandboxForRun requires a real backend (fails closed on unshare-only)', () => {
+test('resolveSandboxForRun requires a real backend (fails closed on unshare-only)', async () => {
   assert.equal(resolveSandboxForRun({}, { platform: 'linux', hasCmd: (c) => c === 'unshare' }).refused, true);
   assert.equal(resolveSandboxForRun({}, { platform: 'linux', hasCmd: (c) => c === 'bwrap' }).mode, 'sandbox');
 });
 
-test('checkCleanTree refuses a dirty checkout', () => {
+test('checkCleanTree refuses a dirty checkout', async () => {
   assert.equal(checkCleanTree(() => ' M file.js').ok, false);
   assert.equal(checkCleanTree(() => '').ok, true);
 });
 
-test('preflight fails closed with NO sandbox and no override (AC2)', () => {
-  const r = runPreflight(base({ platform: 'linux', hasCmd: () => false }));
+test('preflight fails closed with NO sandbox and no override (AC2)', async () => {
+  const r = await runPreflight(base({ platform: 'linux', hasCmd: () => false }));
   assert.equal(r.ok, false);
   assert.equal(r.exitCode, 1);
   assert.match(r.reason, /sandbox/i);
 });
 
-test('preflight refuses a dirty main checkout (AC2 ii)', () => {
+test('preflight refuses a dirty main checkout (AC2 ii)', async () => {
   const dirtyIo = io({ git: () => (...a) => (a[0] === 'status' ? ' M x.js' : '') });
-  const r = runPreflight(base({ io: dirtyIo }));
+  const r = await runPreflight(base({ io: dirtyIo }));
   assert.equal(r.ok, false);
   assert.match(r.reason, /dirty|uncommitted/i);
 });
 
-test('preflight aborts when the canary fails — BEFORE any real dispatch (AC2 i)', () => {
+test('preflight aborts when the canary fails — BEFORE any real dispatch (AC2 i)', async () => {
   const sd = tmp();
-  const r = runPreflight(base({ statusDir: sd, dispatchCanary: () => ({ ok: false, output: 'permission denied' }) }));
+  const r = await runPreflight(base({ statusDir: sd, dispatchCanary: () => ({ ok: false, output: 'permission denied' }) }));
   assert.equal(r.ok, false);
   assert.equal(r.exitCode, 1);
   assert.match(r.reason, /canary/i);
   assert.equal(existsSync(join(sd, LOCK_DIR)), false, 'the lock is released on a preflight abort');
 });
 
-test('preflight warns loudly (not silently) when the rail hook is absent (AC2 iv)', () => {
-  const r = runPreflight(base({ railHookInstalled: () => false }));
+test('preflight warns loudly (not silently) when the rail hook is absent (AC2 iv)', async () => {
+  const r = await runPreflight(base({ railHookInstalled: () => false }));
   assert.equal(r.ok, true, 'absent hook does not block the run (advisory-in-depth)');
   assert.ok(r.warnings.some((w) => /rail hook/i.test(w)), 'but it MUST warn');
 });
 
-test('preflight refuses when another live instance holds the lock (AC2 iii)', () => {
+test('preflight refuses when another live instance holds the lock (AC2 iii)', async () => {
   const sd = tmp();
   // First run acquires and holds the lock; its pid is "alive".
   const liveProbes = { host: HOST, pidAlive: (p) => p === 4242, procStartTimeOf: (p) => (p === 4242 ? 'p' : null) };
-  const first = runPreflight(base({ statusDir: sd, probes: deadProbes }));
+  const first = await runPreflight(base({ statusDir: sd, probes: deadProbes }));
   assert.equal(first.ok, true);
   // Second run sees the live lock → refuses.
-  const second = runPreflight(base({ statusDir: sd, self: { ...self, pid: 5000, procStartTime: 'q' }, probes: liveProbes }));
+  const second = await runPreflight(base({ statusDir: sd, self: { ...self, pid: 5000, procStartTime: 'q' }, probes: liveProbes }));
   assert.equal(second.ok, false);
   assert.match(second.reason, /holds the lock/i);
 });
 
-test('preflight records the merge-forecast into the result (AC2 v)', () => {
-  const r = runPreflight(base({ io: io({ adlc: () => ({ status: 0, stdout: '{"pairs":[{"pair":"T1-T2","verdict":"PARALLEL"}]}' }) }) }));
+test('preflight records the merge-forecast into the result (AC2 v)', async () => {
+  const r = await runPreflight(base({ io: io({ adlc: () => ({ status: 0, stdout: '{"pairs":[{"pair":"T1-T2","verdict":"PARALLEL"}]}' }) }) }));
   assert.equal(r.ok, true);
   assert.ok(r.forecast, 'forecast captured');
   assert.equal(r.forecast.pairs.length, 1);
 });
 
-test('a happy preflight returns the resolved sandbox spec and holds the lock', () => {
+test('a happy preflight returns the resolved sandbox spec and holds the lock', async () => {
   const sd = tmp();
-  const r = runPreflight(base({ statusDir: sd }));
+  const r = await runPreflight(base({ statusDir: sd }));
   assert.equal(r.ok, true);
   assert.equal(r.sandboxSpec.mode, 'sandbox');
   assert.equal(r.lockHeld, true);

--- a/packages/fleet/test/prosecute.test.mjs
+++ b/packages/fleet/test/prosecute.test.mjs
@@ -4,41 +4,41 @@ import { prosecute } from '../lib/prosecute.mjs';
 
 const ctx = { worktree: '/wt', startSha: 'tip', ticket: { id: 'T1' } };
 
-test('a clean review passes', () => {
-  const r = prosecute(ctx, { runReview: () => ({ ok: true, findings: [] }) });
+test('a clean review passes', async () => {
+  const r = await prosecute(ctx, { runReview: () => ({ ok: true, findings: [] }) });
   assert.equal(r.verdict, 'pass');
 });
 
-test('a finding at/above the threshold BLOCKS (AC12 i / F3)', () => {
-  const r = prosecute(ctx, { runReview: () => ({ ok: true, findings: [{ severity: 'high' }] }) });
+test('a finding at/above the threshold BLOCKS (AC12 i / F3)', async () => {
+  const r = await prosecute(ctx, { runReview: () => ({ ok: true, findings: [{ severity: 'high' }] }) });
   assert.equal(r.verdict, 'block');
   assert.equal(r.blocking.length, 1);
 });
 
-test('a below-threshold finding does not block', () => {
-  const r = prosecute(ctx, { runReview: () => ({ ok: true, findings: [{ severity: 'low' }] }), failOn: 'medium' });
+test('a below-threshold finding does not block', async () => {
+  const r = await prosecute(ctx, { runReview: () => ({ ok: true, findings: [{ severity: 'low' }] }), failOn: 'medium' });
   assert.equal(r.verdict, 'pass');
 });
 
-test('an unreachable provider FAILS CLOSED (AC12 iii / F3)', () => {
-  const r = prosecute(ctx, { runReview: () => ({ ok: false, reason: 'no provider' }) });
+test('an unreachable provider FAILS CLOSED (AC12 iii / F3)', async () => {
+  const r = await prosecute(ctx, { runReview: () => ({ ok: false, reason: 'no provider' }) });
   assert.equal(r.verdict, 'unavailable');
   assert.match(r.reason, /provider/i);
 });
 
-test('no runner configured fails closed (never silently passes)', () => {
-  const r = prosecute(ctx, {});
+test('no runner configured fails closed (never silently passes)', async () => {
+  const r = await prosecute(ctx, {});
   assert.equal(r.verdict, 'unavailable');
 });
 
-test('a throwing runner fails closed', () => {
-  const r = prosecute(ctx, { runReview: () => { throw new Error('spawn ENOENT'); } });
+test('a throwing runner fails closed', async () => {
+  const r = await prosecute(ctx, { runReview: () => { throw new Error('spawn ENOENT'); } });
   assert.equal(r.verdict, 'unavailable');
   assert.match(r.reason, /threw/);
 });
 
-test('failOn severity is configurable', () => {
+test('failOn severity is configurable', async () => {
   const findings = [{ severity: 'medium' }];
-  assert.equal(prosecute(ctx, { runReview: () => ({ ok: true, findings }), failOn: 'high' }).verdict, 'pass');
-  assert.equal(prosecute(ctx, { runReview: () => ({ ok: true, findings }), failOn: 'medium' }).verdict, 'block');
+  assert.equal((await prosecute(ctx, { runReview: () => ({ ok: true, findings }), failOn: 'high' })).verdict, 'pass');
+  assert.equal((await prosecute(ctx, { runReview: () => ({ ok: true, findings }), failOn: 'medium' })).verdict, 'block');
 });

--- a/packages/fleet/test/sandbox.test.mjs
+++ b/packages/fleet/test/sandbox.test.mjs
@@ -8,7 +8,7 @@ import {
   Sandbox,
 } from '../lib/sandbox.mjs';
 
-test('detectBackend accepts only FS-isolating backends (bwrap/seatbelt), NOT unshare (C2)', () => {
+test('detectBackend accepts only FS-isolating backends (bwrap/seatbelt), NOT unshare (C2)', async () => {
   const bwrap = detectBackend('linux', (c) => c === 'bwrap');
   assert.equal(bwrap.name, 'bubblewrap');
   const seatbelt = detectBackend('darwin', (c) => c === 'sandbox-exec');
@@ -19,33 +19,33 @@ test('detectBackend accepts only FS-isolating backends (bwrap/seatbelt), NOT uns
   assert.equal(detectBackend('linux', () => false), null);
 });
 
-test('fail closed: no backend + no override → refused (AC14 i)', () => {
+test('fail closed: no backend + no override → refused (AC14 i)', async () => {
   const r = resolveSandboxMode({ backend: null, operatorOverride: false });
   assert.equal(r.refused, true);
   assert.equal(r.mode, null);
 });
 
-test('operator-local override downgrades to env-scrub-only with a loud warning (AC14 ii)', () => {
+test('operator-local override downgrades to env-scrub-only with a loud warning (AC14 ii)', async () => {
   const r = resolveSandboxMode({ backend: null, operatorOverride: true });
   assert.equal(r.refused, false);
   assert.equal(r.mode, SANDBOX_MODES.ENV_SCRUB_ONLY);
   assert.ok(r.warnings.some((w) => /ENV-SCRUB-ONLY/i.test(w)), 'must warn which mode is active');
 });
 
-test('repo-committed config CANNOT enable the override — still fails closed (AC14 iii / N1)', () => {
+test('repo-committed config CANNOT enable the override — still fails closed (AC14 iii / N1)', async () => {
   const r = resolveSandboxMode({ backend: null, operatorOverride: false, repoConfigOverride: true });
   assert.equal(r.refused, true, 'repo config must not be able to disable the sandbox');
   assert.equal(r.mode, null);
   assert.ok(r.warnings.some((w) => /N1|CANNOT disable/i.test(w)), 'must warn that repo config is ignored');
 });
 
-test('detected backend → full sandbox mode', () => {
+test('detected backend → full sandbox mode', async () => {
   const r = resolveSandboxMode({ backend: { name: 'bubblewrap', platform: 'linux' } });
   assert.equal(r.mode, SANDBOX_MODES.SANDBOX);
   assert.equal(r.refused, false);
 });
 
-test('buildSandboxArgv (bubblewrap) denies network and binds worktree, NOT the real home (K1)', () => {
+test('buildSandboxArgv (bubblewrap) denies network and binds worktree, NOT the real home (K1)', async () => {
   const argv = buildSandboxArgv(
     { name: 'bubblewrap' },
     ['npm', 'test'],
@@ -59,7 +59,7 @@ test('buildSandboxArgv (bubblewrap) denies network and binds worktree, NOT the r
   assert.ok(s.endsWith('-- npm test'), 'inner command is appended after --');
 });
 
-test('Sandbox.canRead/canWrite enforce the worktree boundary in sandbox mode (K1)', () => {
+test('Sandbox.canRead/canWrite enforce the worktree boundary in sandbox mode (K1)', async () => {
   const sb = new Sandbox({
     mode: SANDBOX_MODES.SANDBOX,
     backend: { name: 'bubblewrap' },
@@ -76,13 +76,13 @@ test('Sandbox.canRead/canWrite enforce the worktree boundary in sandbox mode (K1
   assert.equal(sb.networkAllowed, false);
 });
 
-test('env-scrub-only mode performs no OS read/write enforcement (operator-contained)', () => {
+test('env-scrub-only mode performs no OS read/write enforcement (operator-contained)', async () => {
   const sb = new Sandbox({ mode: SANDBOX_MODES.ENV_SCRUB_ONLY, worktree: '/wt' });
   assert.equal(sb.canRead('/home/real/.aws/credentials'), true);
   assert.equal(sb.canWrite('/anywhere'), true);
 });
 
-test('Sandbox.run wraps the command through the backend and records via injected exec (M1 seam)', () => {
+test('Sandbox.run wraps the command through the backend and records via injected exec (M1 seam)', async () => {
   const calls = [];
   const sb = new Sandbox({
     mode: SANDBOX_MODES.SANDBOX,
@@ -91,7 +91,7 @@ test('Sandbox.run wraps the command through the backend and records via injected
     syntheticHome: '/wt/.home',
     exec: (argv, opts) => { calls.push({ argv, opts }); return 'ok'; },
   });
-  const out = sb.run(['npm', 'install'], { env: { PATH: '/usr/bin' } });
+  const out = await sb.run(['npm', 'install'], { env: { PATH: '/usr/bin' } });
   assert.equal(out, 'ok');
   assert.equal(calls.length, 1);
   assert.equal(calls[0].argv[0], 'bwrap', 'command routed through the sandbox wrapper');

--- a/packages/fleet/test/spawn-async.test.mjs
+++ b/packages/fleet/test/spawn-async.test.mjs
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnAsync } from '../lib/spawn-async.mjs';
+
+test('captures stdout and a zero exit', async () => {
+  const r = await spawnAsync('/bin/sh', ['-c', 'echo hello-fleet']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /hello-fleet/);
+  assert.equal(r.timedOut, false);
+});
+
+test('propagates a non-zero exit status and stderr', async () => {
+  const r = await spawnAsync('/bin/sh', ['-c', 'echo oops 1>&2; exit 3']);
+  assert.equal(r.status, 3);
+  assert.match(r.stderr, /oops/);
+});
+
+test('a missing binary resolves to an error result (not a throw)', async () => {
+  const r = await spawnAsync('/definitely/not/a/real/binary-xyz', []);
+  assert.ok(r.error, 'spawn error is surfaced as { error }');
+  assert.equal(r.status, null);
+});
+
+test('a command exceeding the timeout is killed and flagged timedOut', async () => {
+  const r = await spawnAsync('/bin/sh', ['-c', 'sleep 5'], { timeout: 50 });
+  assert.equal(r.timedOut, true, 'the slow command was killed by the timeout');
+  assert.notEqual(r.status, 0);
+});
+
+test('does not block the event loop — a timer fires while the child runs', async () => {
+  let tickedDuringChild = false;
+  const t = setTimeout(() => { tickedDuringChild = true; }, 20);
+  await spawnAsync('/bin/sh', ['-c', 'sleep 0.1']);
+  clearTimeout(t);
+  assert.equal(tickedDuringChild, true, 'the event loop kept running while the child was alive (#164)');
+});


### PR DESCRIPTION
## Summary

Closes **#164**. Makes `@adlc/fleet`'s **live execution actually concurrent**.

The scheduler was already concurrency-correct (`planRound`/`runFleet` admit non-overlapping tickets up to the cap and serialize only merges — proven offline), but the *live* dependency layer ran workers, gates, and reviews through **`spawnSync`**, which blocks the Node event loop. So a real `fleet run --concurrency N` processed tickets effectively one at a time. This PR converts the worker/gate/review hot path to non-blocking async spawn. **The scheduler does not change.**

## Changes

- **`lib/spawn-async.mjs`** (new): promise-wrapped `child_process.spawn` returning the same `{ status, signal, stdout, stderr, error, timedOut }` shape as `spawnSync` — a drop-in for the injected exec/spawn seams, with timeout + error handling.
- Async conversion (each `await`s the layer below): `Sandbox.run` → `gates.runGateCommand`/`runGates` → `gate-pipeline.runGatePipeline` → `adapters/claude-code.dispatch`; and `review-runner` runReview → `prosecute`.
- **`lib/live-deps.mjs`**: `spawnWorker` and a new `adlcAsync` (for the per-ticket `rails-guard` on the gate path) use async spawn; `dispatch`/`gate`/`createWorktree`/`postMergeGate` await. The sync `adlc` is kept only for the quick, off-hot-path `flail-detector` (between strikes) and best-effort `gate-manifest` recording, plus the one-shot `hasGh` probe.
- `preflight.runPreflight` and the bin canary → async (they await the sandbox run).

## Why it's safe

- **Same shape, same semantics.** `spawnAsync` returns exactly the fields the code already read from `spawnSync`; injected sync stubs still work (`await` of a plain value is a no-op), which is why the conversion is mechanical.
- **Scheduler untouched.** `runFleet`/`advanceTicket` already `await` every effect; only the effect *implementations* became non-blocking.

## Test plan

- [x] `node --test packages/fleet/test/*.test.mjs` — **145 offline tests green** (5 new).
- [x] **`test/live-concurrency.test.mjs`** (the regression this issue asked for): drives two non-overlapping tickets **through `buildLiveDeps`** with a non-resolving async worker and proves both are in the `building` phase **simultaneously** before either is released — the live analogue of the existing scheduler concurrency test.
- [x] **`test/spawn-async.test.mjs`**: real subprocesses — stdout/exit capture, non-zero exit + stderr, missing-binary error result, timeout kill, and a proof that a timer fires while a child runs (event loop not blocked).
- [x] Hot-path grep: no `spawnSync`/`execFileSync` on the per-ticket worker/gate/review path in `lib/live-deps.mjs`.
- [x] `fleet run --dry-run` and `scripts/fleet-live-smoke.mjs` still exit 0; `rails-guard --ticket T43` clean; `packages/core` untouched.

## Note

Stacked on #165 (the fleet feature branch `feat/adlc-fleet`) — this PR's base is `feat/adlc-fleet`, so it shows only the async diff. Retarget to `main` after #165 merges. Removes the "Known limitations (v1.1)" note #165 added to the package README.
