### PR TITLE
docs(site): refresh native-integration install procedures to current published paths (T45)

### DIFF
--- a/apps/docs/content/docs/integrations/antigravity.mdx
+++ b/apps/docs/content/docs/integrations/antigravity.mdx
@@ -24,9 +24,9 @@ agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
 Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
 
 **npm-assisted install.** `agy` has no native `agy install npm:X` command — `agy
-plugin install` always takes a filesystem path — but `@adlc/antigravity`
-is publishable and will resolve as a normal npm dependency once the suite next
-publishes:
+plugin install` always takes a filesystem path — but `@adlc/antigravity` is now
+published on npm, so you can install it as a normal dependency and point `agy` at
+`node_modules`:
 
 ```sh
 npm install @adlc/antigravity

--- a/apps/docs/content/docs/integrations/cursor.mdx
+++ b/apps/docs/content/docs/integrations/cursor.mdx
@@ -45,16 +45,14 @@ rails guard, nothing at commit time enforces its verdict. The `stop`-audit and
 
 ## Install
 
-`@adlc/cursor` is publishable (`files` allowlist, license, repository
-metadata all in place) and joins the lockstep `/release` the next time the
-suite publishes:
+`@adlc/cursor` is published on npm and folds into the lockstep `/release`:
 
 ```sh
-npm install -g @adlc/cli          # the gate toolkit the hooks/commands shell out to
-npx @adlc/cursor .        # bootstrap the scaffold into the current repo
+npm install -g @adlc/cli   # the gate toolkit the hooks/commands shell out to
+npx @adlc/cursor .          # bootstrap the scaffold into the current repo
 ```
 
-Until the first npm release ships, install from source instead:
+Developing against a checkout instead? Run the bundled scaffolder directly:
 
 ```sh
 npm install -g @adlc/cli                                  # the gate toolkit

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -24,5 +24,15 @@ harness below.
 - **[Antigravity](/docs/integrations/antigravity)** — native `agy` plugin with an
   in-session rails-guard hook, backed by the unbypassable CI rail-freeze gate.
 
+## Orchestrating harnesses in parallel
+
+These integrations wire the gates *into* each harness. The
+[`@adlc/fleet`](/docs/toolkit/fleet) orchestrator runs the other direction: it
+dispatches ready tickets to sandboxed **headless workers** in isolated worktrees
+and merges them through the gates. Its scheduler is harness-blind via a
+`WorkerAdapter` seam — Claude Code is the default worker, and adapters for Codex,
+Antigravity, opencode, pi, and Cursor let a single fleet run build tickets on any
+of them (the harness is an operator-local `--adapter` choice).
+
 See the [toolkit overview](/docs/lifecycle) and the [ADLC theory](/docs/theory) for
 the gates these integrations wire up.

--- a/apps/docs/content/docs/integrations/pi.mdx
+++ b/apps/docs/content/docs/integrations/pi.mdx
@@ -53,8 +53,9 @@ pi install -l npm:@adlc/pi
 pi install npm:@adlc/pi
 ```
 
-Then run `/adlc-init` inside pi to finish the repo scaffold. Until the first npm
-release ships, load the extension from a checkout instead:
+Then run `/adlc-init` inside pi to finish the repo scaffold. `@adlc/pi` is
+published on npm, so the `pi install npm:@adlc/pi` one-liner above works today.
+Developing against a checkout? Load the extension directly instead:
 
 ```sh
 pi --extension /path/to/adlc/plugins/adlc-pi/index.ts

--- a/apps/docs/lib/integration-facts.mjs
+++ b/apps/docs/lib/integration-facts.mjs
@@ -27,15 +27,13 @@ export const INTEGRATIONS = [
   {
     slug: 'cursor',
     name: 'Cursor',
-    status: 'source',
+    status: 'installer',
     tagline: 'Hooks, rules, and commands scaffolded straight into .cursor/, no plugin runtime needed.',
     install: [
       'npm install -g @adlc/cli',
-      'cd /path/to/adlc && npm install',
-      'node /path/to/adlc/plugins/adlc-cursor/lib/scaffold-cli.mjs .',
-      'node scripts/cursor-install-smoke.mjs .',
+      'npx @adlc/cursor .',
     ],
-    note: '@adlc/cursor is not on npm yet, so scaffold from a repo checkout.',
+    note: '@adlc/cursor is published on npm. The scaffold is idempotent — re-run it (or `/adlc-init` inside Cursor) to refresh .adlc/config.json, .cursor/hooks.json, rules, and the /adlc-* command palette.',
   },
   {
     slug: 'opencode',
@@ -55,9 +53,9 @@ export const INTEGRATIONS = [
     tagline: 'Proactive and reactive gating via Pi tool_call/tool_result hooks, with TUI gate display.',
     install: [
       'npm install -g @adlc/cli',
-      'pi install npm:@adlc/pi',
+      'pi install -l npm:@adlc/pi',
     ],
-    note: 'Then run `/adlc-init` inside pi to finish the repo scaffold. Requires Node >= 22.19 (the pi floor).',
+    note: 'The `-l` project install auto-installs for teammates on trusted startup (the best team-install story of the six); `pi install npm:@adlc/pi` (no -l) installs user-global instead. Then `/adlc-init` inside pi finishes the repo scaffold. Requires Node >= 22.19 (the pi floor).',
   },
   {
     slug: 'antigravity',
@@ -67,7 +65,7 @@ export const INTEGRATIONS = [
     install: [
       'agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity',
     ],
-    note: 'Local-checkout install is the verified path; marketplace + universal installer are planned.',
+    note: '`agy plugin install` only takes a filesystem path, so a local checkout is the install even though `@adlc/antigravity` is now published on npm (install it and point agy at node_modules for the npm-assisted path). Marketplace + universal-installer support are still planned.',
   },
 ];
 

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -30,11 +30,9 @@ agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
 Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
 
 **npm-assisted install.** `agy` has no native `agy install npm:X` command — `agy
-plugin install` always takes a filesystem path — but `@adlc/antigravity`
-is publishable (`files` allowlist, license, repository metadata all in place)
-and will resolve as a normal npm dependency once the suite next publishes. Until
-then this only works from a source checkout's own `node_modules`, but the shape
-is:
+plugin install` always takes a filesystem path — but `@adlc/antigravity` is now
+published on npm, so you can install it as a normal dependency and point `agy` at
+`node_modules`:
 
 ```sh
 npm install @adlc/antigravity

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -46,9 +46,7 @@ events); opt in with `--wire-unpinned` / `ADLC_CURSOR_WIRE_UNPINNED=1`.
 
 ## Install
 
-`@adlc/cursor` is publishable (`files` allowlist, license, repository
-metadata all in place) and joins the lockstep `/release` the next time the
-suite publishes:
+`@adlc/cursor` is published on npm and folds into the lockstep `/release`:
 
 ```sh
 npm install -g @adlc/cli          # the gate toolkit the hooks/commands shell out to
@@ -59,7 +57,7 @@ npx @adlc/cursor .        # bootstrap the scaffold into the current repo
 (`adlc-cursor-scaffold`) resolves for the bare package name — passing a path
 argument (`.` for the current repo) is forwarded straight to the scaffolder.
 
-Until the first npm release ships, install from source instead:
+Developing against a checkout instead? Run the scaffolder from source:
 
 1. Install the gate toolkit (the hooks/commands shell out to the `adlc` binary):
 

--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -24,7 +24,7 @@ Nothing below is claimed shipped unless it has a runtime caller in
 | `TICKET-DONE` completion listener → prosecution nudge (§4) | **Shipped** |
 | Native `adlc_gate` tool + compaction defense (§Phase 4) | **Shipped** — LLM-backed gates keyless via the session model; rail context survives compaction |
 | P6 integrate + `/adlc-accept` + rollback (§Phase 4) | **Shipped** — accept is command-driven; rollback path lands the revert |
-| npm publication: `@adlc/pi` release-ready + folds into lockstep `/release` (§5) | **Shipped** — package is publishable (un-private, `files` allowlist, keywords, peer `"*"`); `pi install npm:@adlc/pi` one-liner goes live with the first published release. Version-matrix smoke (`scripts/pi-version-matrix.mjs`, weekly cron) tracks upstream pi drift |
+| npm publication: `@adlc/pi` release-ready + folds into lockstep `/release` (§5) | **Shipped + published** — `@adlc/pi` is on npm, so the `pi install npm:@adlc/pi` (or project-scoped `pi install -l npm:@adlc/pi`) one-liner works today. Version-matrix smoke (`scripts/pi-version-matrix.mjs`, weekly cron) tracks upstream pi drift |
 | P6 `session_shutdown` auto-capture (§2 table) | **Design intent** — acceptance is `/adlc-accept`-driven today |
 | In-harness scheduled P7 distillation (§2 table) | **Design intent** — pi has no `/schedule`; CI cron is the substrate |
 


### PR DESCRIPTION
## Summary

Refreshes the native-integration **install procedures** across the marketing + docs site to the current native paths (T45). Most integration pages still carried **pre-publish language** — `not on npm yet`, `until the first npm release ships`, `will resolve once the suite next publishes` — written before the `@adlc/*` harness packages were actually published. They are now published at **1.3.0**, so those procedures were stale.

## What changed (grounded in reality, not invented)

Verified each harness's actual state (`npm view`, plugin `package.json`, plugin README, marketplace manifests, ADR 0009):

- **Cursor** — `@adlc/cursor` **is published**. Install is now `npm i -g @adlc/cli` + `npx @adlc/cursor .` (was: clone the repo + run `scaffold-cli.mjs`; `status: source → installer`). Fixed in `integration-facts.mjs`, `cursor.mdx`, and `docs/integrations/cursor.md`.
- **pi** — `pi install npm:@adlc/pi` works today (was: "goes live with the first release"). Primary install is now the `-l` project variant (auto-installs for teammates — the best team story). Fixed in facts, `pi.mdx`, `pi.md`.
- **Antigravity** — `@adlc/antigravity` **is published**, so the npm-assisted install is real; `agy plugin install` still only takes a filesystem path, so the local-checkout install stays primary. Fixed in facts, `antigravity.mdx`, `antigravity.md`.
- **Codex** — **unchanged**: codex genuinely has no npm package (plugin dir + marketplace manifest only), so the checkout install is accurate.
- **Claude Code, opencode** — already current (`npx plugins add voodootikigod/adlc`, `npx @adlc/opencode init`).
- **Integrations index** — added an accurate note that `@adlc/fleet` orchestrates parallel workers across harnesses via the `WorkerAdapter` seam (pairs with #169).

## Test plan

- [x] `node --test apps/docs/test/*.test.mjs` — **118 green** (the `integration-facts` ↔ `docs/integrations` cross-check, the bijective toolkit-packages test, and the `adlc <tool>` dispatcher guard all pass).
- [x] `integration-facts.mjs` loads and validates (6 integrations; cursor `status: installer`).
- [x] No stale pre-publish language remains for any published harness (grep-verified).
- [x] All changes ⊆ T45 scope (`apps/docs/**`, `docs/integrations/**`); no code changed to match docs — docs changed to match reality.

## Note

Marketing pages and docs pages agree per harness (the marketing pages are data-driven from `integration-facts.mjs`; the docs `.mdx` pages were reconciled to match). The fleet multi-harness note references the adapters in **#169** — merge that first (or together) for the reference to be fully live.
