### PR TITLE
fix(core): canonicalize symlinked paths in revision ignore-set

### DIFF
--- a/packages/core/lib/revision.mjs
+++ b/packages/core/lib/revision.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, statSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 
 const GIT_MAX_BUFFER = 64 * 1024 * 1024;
 
@@ -101,8 +101,30 @@ const DEFAULT_IGNORED_PATHS = [
   '.adlc/current-ticket.json',
 ];
 
+// Canonicalize a path through symlinks so that different aliases of the same
+// location collapse to one form (macOS /var -> /private/var, /tmp -> /private/tmp).
+// A not-yet-existent leaf (e.g. manifest.jsonl before it is written) is handled by
+// resolving the longest existing ancestor and re-appending the remainder.
+function canonicalize(absPath) {
+  try {
+    return realpathSync.native(absPath);
+  } catch {
+    const parent = dirname(absPath);
+    if (parent === absPath) return absPath; // reached the filesystem root
+    return join(canonicalize(parent), basename(absPath));
+  }
+}
+
+// Return `path` relative to `cwd`, or null if it falls outside the worktree. Both
+// sides are symlink-canonicalized first: without this, an ignore path recorded via
+// a symlink alias of cwd (e.g. an evidence file stored as /var/... while
+// process.cwd() reports /private/var/...) yields a spurious '../'-escaping relative
+// path, silently drops out of the ignore set, and makes the worktree revision
+// self-referential (it would hash evidence that itself embeds the revision).
 function normalizeRelativePath(cwd, path) {
-  const normalized = relative(cwd, resolve(cwd, path)).replaceAll('\\', '/');
+  const base = canonicalize(resolve(cwd));
+  const target = canonicalize(resolve(cwd, path));
+  const normalized = relative(base, target).replaceAll('\\', '/');
   if (!normalized || normalized.startsWith('../') || normalized === '..') return null;
   return normalized;
 }


### PR DESCRIPTION
## Summary

Fixes a non-deterministic `git-worktree:` revision hash in `@adlc/core`'s `resolveRevision()`.

`normalizeRelativePath` dropped an ignore path when it was expressed via a **symlink alias of `cwd`**. On macOS `process.cwd()` reports the realpath (`/private/var/…`), while evidence paths recorded in a P5 `passes.json` are stored in the `/var/…` symlink form. `relative(cwd, path)` then produced a `../`-escaping path that got rejected, so the evidence file (transcript / prompt / inputs) **silently fell out of the ignore set**. The worktree revision then hashed evidence that itself embeds the revision → the hash became non-deterministic across processes.

Symptom: `packages/prosecute` cross-model CLI tests failed on macOS (`exit 1` op-error: *reviewed revision mismatch*) while passing on Linux CI (no `/var` symlink). Any repo checked out under a symlinked prefix (`/tmp` → `/private/tmp`) hit the same instability.

## Fix

Canonicalize **both** `cwd` and each candidate path through `realpathSync` before computing the relative path, resolving the longest existing ancestor for not-yet-created paths (e.g. `manifest.jsonl` before it is written).

## Test plan

- [x] `node --test packages/prosecute/test/*.test.mjs` → 91/91 pass (was 87/91 on macOS)
- [x] `node --test packages/core/test/*.test.mjs` → all pass
- [x] All `packages/*/test` suites green
- [x] Verified the same worktree yields an identical revision under both `/var` and `/private/var` cwd forms

## ⚠️ Rails-guard will be red (expected)

`packages/core/**` is frozen by **active** tickets T42/T43/T44 (the `@adlc/fleet` work). The unbypassable CI rails-guard reads rails from the base ref, so it will fail on this diff. This PR is intended for an **admin merge over the red check**, per decision. Alternative clean path: mark T42/T43/T44 `completed: true` on main first (their work merged in #165/#169), which expires the freeze.