### PR TITLE
test(cursor,antigravity): make publish --dry-run access check version-state-independent

### DIFF
--- a/plugins/adlc-antigravity/test/packaging.test.mjs
+++ b/plugins/adlc-antigravity/test/packaging.test.mjs
@@ -11,7 +11,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -52,8 +52,22 @@ test('AC1: publishConfig grants public access + provenance (release.mjs relies o
 });
 
 test('AC1 (real subprocess): npm publish --dry-run reports PUBLIC access, never "default access"', () => {
-  const res = spawnSync('npm', ['publish', '--dry-run'], { cwd: pkgDir, encoding: 'utf8', timeout: 60_000 });
-  const out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+  // Dry-run against a throwaway, never-published version. npm aborts a dry-run for
+  // an ALREADY-published version before printing the access line ("cannot publish
+  // over the previously published versions: X"), which would flip this assertion red
+  // the moment the current version ships. Bumping to an unpublishable-high version
+  // keeps the public-access check deterministic regardless of what is live on the
+  // registry. The real package.json is restored in finally.
+  const pkgJsonPath = join(pkgDir, 'package.json');
+  const originalPkgJson = readFileSync(pkgJsonPath, 'utf8');
+  let out;
+  try {
+    writeFileSync(pkgJsonPath, JSON.stringify({ ...JSON.parse(originalPkgJson), version: '999.999.999' }, null, 2) + '\n');
+    const res = spawnSync('npm', ['publish', '--dry-run'], { cwd: pkgDir, encoding: 'utf8', timeout: 60_000 });
+    out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+  } finally {
+    writeFileSync(pkgJsonPath, originalPkgJson);
+  }
   assert.match(out, /with tag latest and public access/, `expected real npm to report public access:\n${out}`);
   assert.ok(!/default access/.test(out), `npm reported "default access" (restricted) — publishConfig is missing or wrong:\n${out}`);
 });

--- a/plugins/adlc-cursor/test/packaging.test.mjs
+++ b/plugins/adlc-cursor/test/packaging.test.mjs
@@ -13,7 +13,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -56,8 +56,22 @@ test('AC1: publishConfig grants public access + provenance (release.mjs relies o
 });
 
 test('AC1 (real subprocess): npm publish --dry-run reports PUBLIC access, never "default access"', () => {
-  const res = spawnSync('npm', ['publish', '--dry-run'], { cwd: pkgDir, encoding: 'utf8', timeout: 60_000 });
-  const out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+  // Dry-run against a throwaway, never-published version. npm aborts a dry-run for
+  // an ALREADY-published version before printing the access line ("cannot publish
+  // over the previously published versions: X"), which would flip this assertion red
+  // the moment the current version ships. Bumping to an unpublishable-high version
+  // keeps the public-access check deterministic regardless of what is live on the
+  // registry. The real package.json is restored in finally.
+  const pkgJsonPath = join(pkgDir, 'package.json');
+  const originalPkgJson = readFileSync(pkgJsonPath, 'utf8');
+  let out;
+  try {
+    writeFileSync(pkgJsonPath, JSON.stringify({ ...JSON.parse(originalPkgJson), version: '999.999.999' }, null, 2) + '\n');
+    const res = spawnSync('npm', ['publish', '--dry-run'], { cwd: pkgDir, encoding: 'utf8', timeout: 60_000 });
+    out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+  } finally {
+    writeFileSync(pkgJsonPath, originalPkgJson);
+  }
   assert.match(out, /with tag latest and public access/, `expected real npm to report public access:\n${out}`);
   assert.ok(!/default access/.test(out), `npm reported "default access" (restricted) — publishConfig is missing or wrong:\n${out}`);
 });


### PR DESCRIPTION
## Problem

The `AC1 (real subprocess)` packaging tests in `@adlc/cursor` and `@adlc/antigravity` run a real `npm publish --dry-run` and assert the output contains *"with tag latest and public access"*. But npm aborts the dry-run for an **already-published version** before printing that line:

```
npm error You cannot publish over the previously published versions: 1.3.0.
```

So these tests are green only while the package version is **unpublished**. On `main` — which sits at the live `1.3.0` — they fail locally, and they'd flip red again immediately after every release. This makes the `/release` ceremony's *"npm test passes at the current version"* precondition oscillate.

## Fix

Run the dry-run against a throwaway, never-published version (`999.999.999`) so the public-access assertion is deterministic regardless of what's live on the registry. The real `package.json` is restored in a `finally` block (verified no residue).

## Verification

- [x] Both packaging suites pass at the currently-published `1.3.0` (**were red before this change**)
- [x] Deterministic across repeated runs (3×, 0 failures)
- [x] `package.json` byte-identical after the run (finally-restore)
- [x] Assertion intent preserved — still a real `npm publish --dry-run` subprocess check

Unblocks the release precondition (see the release-readiness discussion; next bump is minor → `1.4.0`).