### PR TITLE
docs: add CHANGELOG.md + maintain it from the release ceremony

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -16,24 +16,28 @@ Release a new lockstep version of the `@adlc` suite (all 21 packages publish tog
 
 3. **Bump versions:** run `node scripts/release.mjs <NEW_VERSION>` (no `--publish`). This sets the new version across `@adlc/core` + all 19 phase CLIs + the `@adlc/cli` umbrella, **every versioned `plugins/*` package** (e.g. `@adlc/pi`), and the root; repins **every** `"@adlc/*"` dependency to match (preserving each one's existing `^`/`~`/exact range style); and **regenerates `package-lock.json`** so the lockfile tracks the new versions. Do NOT hand-edit package.json or package-lock.json.
    - The script then runs a **drift gate**: if any versioned `package.json`, the root, or `package-lock.json` is not at `<NEW_VERSION>`, it prints the offenders and exits non-zero. A non-zero exit means the release is incomplete — fix it before continuing, do not commit a partial bump. (This gate exists because v1.1.0 once shipped with `package-lock.json` stranded at 1.0.2 and `plugins/adlc-pi` missed entirely.)
+   - It also runs a **publish-metadata gate**: every non-private publish target must carry a `repository.url` that references the source repo, or the script exits non-zero. (This gate exists because v1.4.0 stranded a partial publish — `@adlc/tickets` had no `repository` field, so npm's provenance check 422'd mid-publish after 27 of 34 packages had already shipped.)
 
-4. **Commit the version bump** — stage everything the script touched, including `package-lock.json` and every `package.json` (packages *and* plugins):
+4. **Update the changelog:** run `node scripts/changelog.mjs <NEW_VERSION>`. This derives a new `## [X.Y.Z] - <date>` section in `CHANGELOG.md` from the conventional-commit subjects since the previous tag (grouping `feat`/`fix`/`perf`/`refactor`, omitting `chore`/`test`/`ci`/`docs` noise) and prepends it under the header. The generated section is a **starting point** — open `CHANGELOG.md` and hand-edit it into a curated, user-facing summary (merge related bullets, lead with the headline features, drop internal churn) before continuing.
+
+5. **Commit the version bump** — stage everything the bump touched (`package-lock.json` and every `package.json`, packages *and* plugins) **plus `CHANGELOG.md`**:
    ```
    chore: bump version to X.Y.Z
    ```
-   Sanity check before committing: `git status --porcelain` should show `package-lock.json` among the changes, and `npm ci` (or `node scripts/release.mjs X.Y.Z` re-run, which is idempotent) must report no drift.
+   Sanity check before committing: `git status --porcelain` should show `package-lock.json` and `CHANGELOG.md` among the changes, and `npm ci` (or `node scripts/release.mjs X.Y.Z` re-run, which is idempotent) must report no drift.
 
-5. **Create the version tag:** `vX.Y.Z`
+6. **Create the version tag:** `vX.Y.Z`
 
-6. **Push commit and tag:**
+7. **Push commit and tag:**
    ```
    git push origin main
    git push origin vX.Y.Z
    ```
 
-7. **Confirm completion.** Print a summary of:
+8. **Confirm completion.** Print a summary of:
    - Previous version → new version
    - Tag created
+   - The `CHANGELOG.md` entry that will ship with the release
    - Remind the user that the GitHub Actions publish workflow (`.github/workflows/publish.yml`, triggered on `v*` tags) publishes all 21 packages to npm automatically — `@adlc/core` first, then the phase CLIs, and the `@adlc/cli` umbrella last (it depends on every other CLI), each with `--provenance --access public`.
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,142 @@
+# Changelog
+
+All notable changes to the `@adlc` suite are documented here.
+
+The suite is released in **lockstep** — every package (`@adlc/core`, the phase
+CLIs, the `@adlc/cli` umbrella, and the versioned harness plugins) shares one
+version and is published together.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.1] - 2026-07-14
+
+### Fixed
+- `@adlc/tickets` shipped without a `repository` field, which caused npm's
+  sigstore provenance check to reject it mid-publish and stranded the 1.4.0
+  lockstep release after 27 of 34 packages (leaving `@adlc/core@1.4.0`
+  uninstallable, since it exact-pins the never-published `@adlc/tickets@1.4.0`).
+  Added the missing `repository`/`homepage` metadata.
+- **Release safety:** `scripts/release.mjs` now fails closed at bump time if any
+  publishable package is missing a `repository.url` that references the source
+  repo (`findPublishMetadataProblems`), so a partial provenance publish cannot
+  recur — the whole suite ships or none of it does.
+
+> If you installed any `@adlc/*` package at `1.4.0`, upgrade to `1.4.1`.
+
+## [1.4.0] - 2026-07-14
+
+> Partial release — several packages did not publish. Use `1.4.1` or later.
+
+### Added
+- **`@adlc/fleet`** — parallel ticket orchestration on the ADLC, with a
+  worker-adapter registry spanning the codex, agy, opencode, pi, and cursor
+  harnesses, and concurrent live execution.
+- **Sharded ticket store** for large backlogs.
+- **Native Codex integration.**
+- **Cross-model adversarial review gate** for the trust-root tier (P5): a clean
+  same-model prosecution of a trust-root change now additionally requires a
+  cross-model `approve` from a distinct provider.
+
+### Fixed
+- `@adlc/core`: canonicalize symlinked paths in the revision ignore-set, so the
+  worktree revision hash is stable when the repo sits under a symlinked path
+  (e.g. macOS `/var` → `/private/var`).
+- `@adlc/prosecute`: exempt test-only producer/enforcement changes from the
+  trust-root tier.
+- `@adlc/ticket-prune`: tombstone stale, already-shipped tickets across the
+  backlog tools.
+
+## [1.3.0] - 2026-07-11
+
+### Changed
+- Renamed the harness plugin packages to short names:
+  `@adlc/{pi,opencode,cursor,antigravity}` (from the `-package` suffixes).
+- Made `@adlc/cursor` and `@adlc/antigravity` npm-publishable (release-ready).
+
+### Fixed
+- `@adlc/opencode`: corrected the last crashing / misdescribed gate references in
+  the command suite.
+
+## [1.2.1] - 2026-07-10
+
+### Fixed
+- Corrected the `@adlc/opencode` package `repository` field for npm provenance.
+- Updated the contact address to `help@agenticlifecycle.ai`.
+
+## [1.2.0] - 2026-07-10
+
+### Added
+- **OpenCode integration** (Phases 1–5): enforce-by-default rails guard, a native
+  `adlc_gate` tool over a keyless two-phase LLM bridge, a deterministic P5
+  prosecutor (`adlc_prosecute`), the `/adlc-maintain` command, shell gating, and
+  a build-gate backstop.
+- **Pi harness native integration** (Phases 1–5): build-gate on context usage,
+  flail steering, the `/adlc` command surface with live widgets, a deterministic
+  P5 prosecutor, and P6 integrate + rollback.
+- **Cursor native-parity integration**: command suite, `/adlc-prosecute`, and
+  hook parity.
+- **`agenticlifecycle.ai` marketing site.**
+- **T36 rails completion lifecycle** — a completed ticket's build-time rails
+  auto-expire.
+- `@adlc/build-gate`: a machine-checkable fitness-to-build gate.
+- Per-invocation `--provider` / `--providers` model selection across the tools.
+- A risk-gated adversarial-review CI template.
+
+### Changed
+- Consolidated the replicated per-phase model routers into a single generated
+  source (T13/T14).
+
+### Fixed
+- Hardened text-scanning gates and closed the P5 → P7 loop.
+- `@adlc/spec-lint`, `@adlc/review-calibration`, `@adlc/hollow-test`, and the
+  prompt-only gate verdicts (`coldstart`/`premortem`/`parallax`) received
+  correctness fixes.
+
+## [1.1.0] - 2026-06-23
+
+### Added
+- **ADLC Claude Code plugin** with rail-guard enforcement (Phases A–F).
+- **Codex-native ADLC integration** with hardened rail-hook enforcement.
+- **OpenCode integration** — rails-guard plugin, keyless two-phase LLM-gate
+  bridge, advisory session hooks, and prosecutor lenses (Phases A–F).
+- **Pi harness** deep native integration.
+- **Antigravity (agy)** native rails-guard integration.
+- **Cursor** native rails-guard integration (MVP).
+- **`@adlc/ticket-sync`** — external ticketing sync.
+- **ADLC documentation site** (Fumadocs).
+
+### Fixed
+- Guarded unhandled `JSON.parse` in the gate and `gh` helpers.
+- Resolved `/plugin install` "Marketplace not found" regression and unified the
+  plugin install on the `plugins` npm package.
+
+## [1.0.2] - 2026-06-14
+
+### Changed
+- Maintenance release — packaging and lockfile alignment.
+
+## [1.0.1] - 2026-06-14
+
+### Changed
+- Hardened the npm publish supply chain.
+- Added open-source contribution setup and documentation.
+
+## [1.0.0] - 2026-06-13
+
+### Added
+- Initial public release of the ADLC toolkit: 18 gate-shaped, zero-dependency
+  phase tools built via a parallel build → prosecute → fix workflow.
+- The ADLC specification and the frozen `@adlc/core` contract (`llm`, `git`,
+  `cli`, `ledger`, `tickets`, `mutate`).
+- Lockstep `/release` tooling for the suite.
+
+[1.4.1]: https://github.com/voodootikigod/adlc/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/voodootikigod/adlc/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/voodootikigod/adlc/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/voodootikigod/adlc/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/voodootikigod/adlc/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/voodootikigod/adlc/compare/v1.0.2...v1.1.0
+[1.0.2]: https://github.com/voodootikigod/adlc/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/voodootikigod/adlc/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/voodootikigod/adlc/releases/tag/v1.0.0

--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Maintain CHANGELOG.md for the lockstep @adlc release.
+//
+//   node scripts/changelog.mjs <version> [--date YYYY-MM-DD] [--from <ref>]
+//
+// Derives a new "## [version] - date" section from the conventional-commit
+// subjects since the previous release tag and prepends it under the CHANGELOG
+// header. Run this DURING the release ceremony (after the version bump, before
+// the bump commit) so the changelog entry lands in the same commit as the bump.
+//
+// The output is a STARTING POINT: it groups feat/fix/perf/refactor commits and
+// drops chore/test/ci/docs noise. Review and hand-edit the generated section
+// before committing — a good changelog is curated, not just a commit dump.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CHANGELOG = join(ROOT, 'CHANGELOG.md');
+
+const HEADER = `# Changelog
+
+All notable changes to the \`@adlc\` suite are documented here.
+
+The suite is released in **lockstep** — every package shares one version and is
+published together.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+`;
+
+// Conventional-commit type → changelog section. Types not listed (chore, test,
+// ci, build, docs) are treated as internal and omitted from the user-facing log.
+const SECTIONS = [
+  ['Added', new Set(['feat'])],
+  ['Fixed', new Set(['fix'])],
+  ['Performance', new Set(['perf'])],
+  ['Changed', new Set(['refactor'])],
+];
+
+function git(args, { cwd = ROOT } = {}) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+/** Highest v<semver> tag strictly below `version`, or null if none. */
+export function previousTag(version, tags) {
+  const parse = (t) => t.replace(/^v/, '').split('.').map((n) => parseInt(n, 10));
+  const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+  const target = parse(`v${version}`);
+  return tags
+    .filter((t) => /^v\d+\.\d+\.\d+$/.test(t))
+    .filter((t) => cmp(parse(t), target) < 0)
+    .sort((a, b) => cmp(parse(a), parse(b)))
+    .pop() ?? null;
+}
+
+/** Parse a commit subject into { type, scope, description } (or null if not conventional). */
+export function parseSubject(subject) {
+  const m = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+  if (!m) return null;
+  return { type: m[1], scope: m[2] ?? null, description: m[4] };
+}
+
+/** Build the markdown body (sections) for a set of commit subjects. */
+export function buildSections(subjects) {
+  const buckets = new Map(SECTIONS.map(([name]) => [name, []]));
+  for (const subject of subjects) {
+    const parsed = parseSubject(subject);
+    if (!parsed) continue;
+    // Skip the bump commit and pure ticket-bookkeeping chores.
+    if (/^bump version to /.test(parsed.description)) continue;
+    const section = SECTIONS.find(([, types]) => types.has(parsed.type))?.[0];
+    if (!section) continue;
+    const prefix = parsed.scope ? `**${parsed.scope}:** ` : '';
+    buckets.get(section).push(`- ${prefix}${parsed.description}`);
+  }
+  const parts = [];
+  for (const [name] of SECTIONS) {
+    const items = buckets.get(name);
+    if (items.length) parts.push(`### ${name}\n${items.join('\n')}`);
+  }
+  return parts.join('\n\n');
+}
+
+export function buildEntry({ version, date, subjects }) {
+  const body = buildSections(subjects);
+  const heading = `## [${version}] - ${date}`;
+  return body ? `${heading}\n\n${body}\n` : `${heading}\n\n_No user-facing changes._\n`;
+}
+
+/** Insert `entry` directly under the header, above any existing version sections. */
+export function insertEntry(existing, entry, version) {
+  const base = existing && existing.includes('# Changelog') ? existing : `${HEADER}\n`;
+  if (new RegExp(`^## \\[${version.replace(/\./g, '\\.')}\\]`, 'm').test(base)) {
+    return base; // already present — never duplicate
+  }
+  const idx = base.search(/^## \[/m);
+  if (idx === -1) {
+    return `${base.replace(/\s*$/, '')}\n\n${entry}`;
+  }
+  return `${base.slice(0, idx)}${entry}\n${base.slice(idx)}`;
+}
+
+function main(argv) {
+  const version = argv[0];
+  if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+    console.error('usage: changelog.mjs <version> [--date YYYY-MM-DD] [--from <ref>]');
+    return 1;
+  }
+  const dateArg = argv[argv.indexOf('--date') + 1];
+  const date = argv.includes('--date') && dateArg ? dateArg : new Date().toISOString().slice(0, 10);
+  const fromArg = argv.includes('--from') ? argv[argv.indexOf('--from') + 1] : null;
+
+  const tags = git(['tag', '--list']).split('\n').filter(Boolean);
+  const from = fromArg ?? previousTag(version, tags);
+  const range = from ? `${from}..HEAD` : 'HEAD';
+  const subjects = git(['log', '--no-merges', '--pretty=format:%s', range])
+    .split('\n')
+    .filter(Boolean);
+
+  const entry = buildEntry({ version, date, subjects });
+  const existing = existsSync(CHANGELOG) ? readFileSync(CHANGELOG, 'utf8') : '';
+  const next = insertEntry(existing, entry, version);
+  writeFileSync(CHANGELOG, next.replace(/\s*$/, '') + '\n');
+  console.log(`CHANGELOG.md: added [${version}] (${subjects.length} commits since ${from ?? 'repo start'}).`);
+  console.log('Review and hand-edit the new section before committing.');
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/test/changelog.test.mjs
+++ b/scripts/test/changelog.test.mjs
@@ -1,0 +1,59 @@
+// Unit coverage for scripts/changelog.mjs — the release changelog generator.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { previousTag, parseSubject, buildSections, buildEntry, insertEntry } from '../changelog.mjs';
+
+test('previousTag returns the highest v-tag strictly below the target', () => {
+  const tags = ['v1.2.1', 'v1.3.0', 'v1.4.0', 'v1.4.1', 'not-a-tag', 'v1.10.0'];
+  assert.equal(previousTag('1.4.1', tags), 'v1.4.0');
+  assert.equal(previousTag('1.5.0', tags), 'v1.4.1'); // v1.10.0 (=1.10.0) is ABOVE 1.5.0 → excluded
+  assert.equal(previousTag('1.11.0', tags), 'v1.10.0'); // numeric sort: 1.10.0 > 1.4.1, not lexical
+  assert.equal(previousTag('1.0.0', ['v1.0.0']), null); // no earlier tag
+});
+
+test('parseSubject splits conventional commits and rejects free-form', () => {
+  assert.deepEqual(parseSubject('feat(fleet): parallel orchestration (#165)'),
+    { type: 'feat', scope: 'fleet', description: 'parallel orchestration (#165)' });
+  assert.deepEqual(parseSubject('fix: bare fix'), { type: 'fix', scope: null, description: 'bare fix' });
+  assert.equal(parseSubject('merge branch main'), null);
+});
+
+test('buildSections categorizes and drops non-user-facing noise', () => {
+  const body = buildSections([
+    'feat(fleet): parallel orchestration (#165)',
+    'fix(core): symlink revision (#182)',
+    'perf(fleet): concurrent execution (#166)',
+    'refactor(router): consolidate routers',
+    'chore: bump version to 1.4.0',
+    'test(prosecute): guard (#183)',
+    'docs(site): refresh install',
+  ]);
+  assert.match(body, /### Added\n- \*\*fleet:\*\* parallel orchestration \(#165\)/);
+  assert.match(body, /### Fixed\n- \*\*core:\*\* symlink revision \(#182\)/);
+  assert.match(body, /### Performance/);
+  assert.match(body, /### Changed/);
+  assert.doesNotMatch(body, /bump version/, 'the bump commit is excluded');
+  assert.doesNotMatch(body, /guard \(#183\)/, 'test commits are excluded');
+  assert.doesNotMatch(body, /refresh install/, 'docs commits are excluded');
+});
+
+test('buildEntry falls back to a placeholder when nothing is user-facing', () => {
+  const entry = buildEntry({ version: '1.4.2', date: '2026-08-01', subjects: ['chore: housekeeping', 'test: more'] });
+  assert.match(entry, /^## \[1\.4\.2\] - 2026-08-01/);
+  assert.match(entry, /_No user-facing changes\._/);
+});
+
+test('insertEntry prepends above existing versions and never duplicates', () => {
+  const entry = buildEntry({ version: '1.5.0', date: '2026-08-01', subjects: ['feat: new thing'] });
+  const base = '# Changelog\n\nintro\n\n## [1.4.1] - 2026-07-14\n\n### Fixed\n- x\n';
+  const once = insertEntry(base, entry, '1.5.0');
+  assert.ok(once.indexOf('## [1.5.0]') < once.indexOf('## [1.4.1]'), 'new entry sits above the old');
+  assert.equal(insertEntry(once, entry, '1.5.0'), once, 'a second run is a no-op (idempotent)');
+});
+
+test('insertEntry seeds a header when the changelog does not exist yet', () => {
+  const entry = buildEntry({ version: '1.0.0', date: '2026-06-13', subjects: ['feat: initial release'] });
+  const out = insertEntry('', entry, '1.0.0');
+  assert.match(out, /^# Changelog/);
+  assert.match(out, /## \[1\.0\.0\] - 2026-06-13/);
+});


### PR DESCRIPTION
## Summary

Adds a traceable, user-facing changelog and wires its upkeep into `/release` so every future version ships an entry.

### What's here
- **`CHANGELOG.md`** — a curated retrospective covering every release **v1.0.0 → v1.4.1** in [Keep a Changelog](https://keepachangelog.com/) format, grouped by Added/Changed/Fixed with `compare` links per version. Notes the 1.4.0 partial publish and points users to 1.4.1.
- **`scripts/changelog.mjs`** — derives a new `## [X.Y.Z] - <date>` section from the conventional-commit subjects since the previous tag (groups `feat`/`fix`/`perf`/`refactor`, drops `chore`/`test`/`ci`/`docs` noise), prepends it under the header, is **idempotent**, and seeds a header when the file is absent.
- **`scripts/test/changelog.test.mjs`** — unit coverage for tag selection, commit parsing, section grouping, insertion/dedup, and the empty-file path.
- **`/release` command** (`.claude/commands/release.md`) — new step 4 runs the generator and hand-curates the entry; the bump commit now includes `CHANGELOG.md`.

### Test plan
- [x] `node --test scripts/test/changelog.test.mjs` — 6/6
- [x] `node --test scripts/test/release.test.mjs` — 12/12 (unaffected)
- [x] Generator is idempotent against the curated `CHANGELOG.md` (re-running for an existing version is a no-op)

### Note on scope
The generated section is a **starting point** — the ceremony step calls for hand-curating it before committing (a good changelog is curated, not a commit dump). The retrospective entries in this PR are hand-curated.