### PR TITLE
docs(cursor): fix marketing install to marketplace-first

### DIFF
--- a/apps/docs/components/marketing/integration-card.tsx
+++ b/apps/docs/components/marketing/integration-card.tsx
@@ -5,6 +5,7 @@ export const STATUS_LABEL: Record<string, string> = {
   installer: 'One-line install',
   source: 'Install from source',
   local: 'Local plugin install',
+  marketplace: 'Marketplace plugin',
 };
 
 interface IntegrationCardProps {

--- a/apps/docs/content/docs/integrations/cursor.mdx
+++ b/apps/docs/content/docs/integrations/cursor.mdx
@@ -29,9 +29,10 @@ one GA honesty gate.
 - **`beforeShellExecution` advisory** — string-matches obvious shell writes to the
   active ticket's rails. It **never denies** and is trivially bypassable — an
   honesty nudge, not a control.
-- **Command palette** — the scaffolder deploys the bare `/adlc-*` phase suite into
-  `.cursor/commands/` (`init`, `ticket`, `spec`, `approve-spec`, `decompose`,
-  `verify-build`, `prosecute`, `distill`, `maintain`).
+- **Command palette** — the plugin ships the bare `/adlc-*` phase suite
+  (`init`, `ticket`, `spec`, `approve-spec`, `decompose`, `verify-build`,
+  `prosecute`, `distill`, `maintain`). The legacy scaffolder can still copy them
+  into a project `.cursor/commands/` for local-dev installs.
 - **`.cursor/rules/adlc.mdc`** — the ADLC phase-router rule.
 
 The **buildgate is advisory, disabled by default** (opt in with
@@ -44,9 +45,10 @@ rails guard, nothing at commit time enforces its verdict. The `stop`-audit and
 
 ### Preferred — marketplace plugin
 
-1. Add this repo as a Cursor plugin marketplace (root
-   `.cursor-plugin/marketplace.json` lists `adlc-cursor`).
-2. Install the `adlc-cursor` plugin.
+1. In Cursor: **Settings → Plugins → Add marketplace** and paste
+   `https://github.com/voodootikigod/adlc` (root `.cursor-plugin/marketplace.json`
+   lists `adlc-cursor`).
+2. Install the **`adlc-cursor`** plugin.
 3. Initialize the `.adlc/` runtime:
 
 ```sh

--- a/apps/docs/lib/integration-facts.mjs
+++ b/apps/docs/lib/integration-facts.mjs
@@ -31,15 +31,16 @@ export const INTEGRATIONS = [
   {
     slug: 'cursor',
     name: 'Cursor',
-    status: 'source',
+    status: 'marketplace',
     tagline: 'Native Cursor plugin: marketplace hooks, skills, rules, and /adlc-* commands with CI rail backstop.',
     install: [
-      'git clone https://github.com/voodootikigod/adlc.git && cd adlc',
+      '# Cursor → Settings → Plugins → Add marketplace:',
+      '#   https://github.com/voodootikigod/adlc',
+      '# Install plugin: adlc-cursor',
       'npm install -g @adlc/cli',
       'adlc init --harness cursor',
-      '# In Cursor: add this repo as a plugin marketplace, then install adlc-cursor',
     ],
-    note: 'Preferred path: add the repo .cursor-plugin marketplace, install the adlc-cursor plugin, then run adlc init --harness cursor for the .adlc/ runtime only. Legacy fallback: npx @adlc/cursor . Wire docs/ci/rails-guard.yml as the unbypassable control. Do not commit a generated .adlc/config.json into a repo that already freezes that path as a trust root.',
+    note: 'Marketplace install is preferred — the plugin brings hooks, skills, and /adlc-* commands. adlc init only bootstraps the .adlc/ runtime (do not commit a generated .adlc/config.json into a repo that already freezes that path). Legacy fallback: npx @adlc/cursor . Wire docs/ci/rails-guard.yml as the unbypassable control.',
   },
   {
     slug: 'opencode',

--- a/apps/docs/test/integration-facts.test.mjs
+++ b/apps/docs/test/integration-facts.test.mjs
@@ -36,7 +36,7 @@ test('every integration has a name, tagline, valid status, and at least one inst
   for (const i of INTEGRATIONS) {
     assert.ok(i.name.length > 0, `${i.slug}: name`);
     assert.ok(i.tagline.length > 0, `${i.slug}: tagline`);
-    assert.ok(['installer', 'source', 'local'].includes(i.status), `${i.slug}: status "${i.status}"`);
+    assert.ok(['installer', 'source', 'local', 'marketplace'].includes(i.status), `${i.slug}: status "${i.status}"`);
     assert.ok(Array.isArray(i.install) && i.install.length > 0, `${i.slug}: install commands`);
     for (const cmd of i.install) assert.ok(cmd.trim().length > 0, `${i.slug}: empty install command`);
   }
@@ -49,8 +49,10 @@ test('integrationFor resolves known slugs and returns undefined for unknown', ()
 
 test('Cursor marketing facts describe the marketplace plugin install', () => {
   const cursor = integrationFor('cursor');
-  assert.equal(cursor?.status, 'source');
+  assert.equal(cursor?.status, 'marketplace');
   assert.ok(cursor?.install.some((c) => c.includes('adlc init --harness cursor')));
+  assert.ok(cursor?.install.some((c) => /adlc-cursor|marketplace/i.test(c)));
+  assert.ok(!cursor?.install.some((c) => c.includes('git clone')), 'marketing install must not lead with a clone-from-source path');
   assert.match(cursor?.tagline ?? '', /marketplace|plugin/i);
   assert.match(cursor?.note ?? '', /marketplace|\.cursor-plugin/i);
 });

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -31,9 +31,10 @@ against a real Cursor binary remains the one GA honesty gate (see
 - **`beforeShellExecution` advisory** — string-matches obvious shell writes to the
   active ticket's rails and reminds the agent that the CI gate catches rail edits.
   It **never denies** and is **trivially bypassable** — an honesty nudge, not a control.
-- **Command palette** — the scaffolder deploys the bare `/adlc-*` phase suite into
-  `.cursor/commands/` (init, ticket, spec, approve-spec, decompose, verify-build,
-  prosecute, distill, maintain).
+- **Command palette** — the plugin ships the bare `/adlc-*` phase suite
+  (init, ticket, spec, approve-spec, decompose, verify-build, prosecute,
+  distill, maintain). The legacy scaffolder can still copy them into a project
+  `.cursor/commands/` for local-dev installs.
 - **`.cursor/rules/adlc.mdc`** — the ADLC phase-router rule, available to the agent
   in-session.
 
@@ -49,10 +50,11 @@ documented events); opt out of the legacy scaffolder path with `--no-unpinned` /
 
 ### Preferred — Cursor marketplace plugin
 
-1. Clone this repo (or add it as a Cursor plugin marketplace source). The root
+1. In Cursor: **Settings → Plugins → Add marketplace** and paste
+   `https://github.com/voodootikigod/adlc`. The root
    [`.cursor-plugin/marketplace.json`](../../.cursor-plugin/marketplace.json)
    lists `adlc-cursor` → `./plugins/adlc-cursor`.
-2. Install the `adlc-cursor` plugin in Cursor (see
+2. Install the `adlc-cursor` plugin (see
    [Cursor plugins](https://cursor.com/docs/reference/plugins)).
 3. Install the gate toolkit and initialize only the `.adlc/` runtime:
 


### PR DESCRIPTION
## Summary
- `/integrations/cursor` was showing **Install from source** + `git clone` as the primary terminal steps even after T47.
- Reorder marketing install to Cursor Plugins marketplace → `@adlc/cli` → `adlc init --harness cursor`.
- Add a `marketplace` status badge; sync fumadocs + `docs/integrations/cursor.md`.

## Test plan
- [ ] `node --test apps/docs/test/integration-facts.test.mjs`
- [ ] After deploy, https://www.agenticlifecycle.ai/integrations/cursor shows marketplace-first steps (no clone-first)
- [ ] Docs page preferred install matches


Made with [Cursor](https://cursor.com)