### PR TITLE
docs: rewrite site copy to remove AI writing tells

### DIFF
--- a/apps/docs/app/(home)/enterprise/contact-form.tsx
+++ b/apps/docs/app/(home)/enterprise/contact-form.tsx
@@ -69,7 +69,7 @@ export function ContactForm() {
         style={{ borderColor: '#3f4044', background: '#26272c' }}
       >
         <p className="font-semibold" style={{ color: '#4fb4d8' }}>
-          Thanks — your message is in.
+          Thanks, your message is in.
         </p>
         <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
           We read every enterprise inquiry ourselves and reply within a couple of business days.

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -92,7 +92,7 @@ export default function HomePage() {
             </Link>
           </div>
           <div
-            className="mt-4 max-w-2xl rounded-lg border p-6"
+            className="mt-4 rounded-lg border p-6"
             style={{ borderColor: '#3f4044', background: 'rgba(38,39,44,0.85)' }}
           >
             <GateSequence />

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -166,16 +166,18 @@ export default function HomePage() {
               className="border-l-2 pl-5 text-xl font-medium leading-snug"
               style={{ borderColor: '#ef7c2a', color: '#cbcdd2' }}
             >
-              The unit of account is cost per merged, verified change — never
+              The unit of account is cost per merged, verified change. Not
               tokens per developer per month.
             </blockquote>
             <p className="leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-              Inverted from the SDLC, because misbuilding is expensive and
-              building is cheap. What that buys the executive: throughput
-              without a review bottleneck, review depth no human team sustains,
-              a lifecycle that gets cheaper every run as lessons distill into
-              lints and skills, senior time redeployed to the two human gates,
-              and auditability — an evidence manifest attached to every merge.
+              This is the SDLC inverted, because misbuilding is expensive and
+              building is cheap. Review stops being the bottleneck, and it goes
+              deeper than a human team could sustain anyway. Every merge carries
+              an evidence manifest, so auditors get an answer without an
+              engineer translating. Senior time goes to the two human gates
+              instead of rubber-stamping diffs. And each run costs a little less
+              than the last, as findings distill into lints and skills nobody
+              has to learn twice.
             </p>
             <p className="text-sm">
               <a href={theoryLink('distill')} style={{ color: '#4fb4d8' }}>

--- a/apps/docs/app/privacy/page.tsx
+++ b/apps/docs/app/privacy/page.tsx
@@ -65,11 +65,11 @@ export default function PrivacyPage() {
           </p>
           <ul className="mt-2 list-disc space-y-1 pl-6">
             <li>
-              <strong style={{ color: '#cbcdd2' }}>Attio</strong> — a CRM that stores your inquiry so
+              <strong style={{ color: '#cbcdd2' }}>Attio</strong>, a CRM that stores your inquiry so
               we can follow up. See Attio&apos;s own privacy terms for how they handle data.
             </li>
             <li>
-              <strong style={{ color: '#cbcdd2' }}>Resend</strong> — an email delivery service that
+              <strong style={{ color: '#cbcdd2' }}>Resend</strong>, an email delivery service that
               sends your message to our inbox.
             </li>
           </ul>

--- a/apps/docs/components/failure-mode.tsx
+++ b/apps/docs/components/failure-mode.tsx
@@ -10,7 +10,7 @@ export function FailureMode({ id }: { id: keyof typeof FAILURE_MODES }) {
       style={{ borderColor: 'var(--adlc-highlight)', background: '#2f3137' }}
     >
       <strong>
-        {id} — {fm.name}
+        {id}: {fm.name}
       </strong>{' '}
       <a href={theoryLink(id)} className="text-sm">
         (theory ↗)

--- a/apps/docs/components/marketing/barbell.tsx
+++ b/apps/docs/components/marketing/barbell.tsx
@@ -37,7 +37,7 @@ export function Barbell() {
         ))}
       </div>
       <figcaption className="mt-4 text-sm" style={{ color: 'var(--mk-muted)' }}>
-        Relative spend by phase — heavy at the ends, light in the middle.
+        Relative spend by phase: heavy at the ends, light in the middle.
         Schematic, not to scale.
       </figcaption>
     </figure>

--- a/apps/docs/components/marketing/gate-sequence.tsx
+++ b/apps/docs/components/marketing/gate-sequence.tsx
@@ -11,23 +11,32 @@ const SEQUENCE: ReadonlyArray<{ cmd: string; state: GateState; detail: string }>
 
 // Staggered entrance is pure CSS (.mk-gate-line + animation-delay), so the
 // prefers-reduced-motion guard in global.css shows all lines statically.
+// The verdict detail rides above its command as a shell comment (dimmed like
+// the install snippets in IntegrationCard), which keeps command lines short
+// enough to sit on one line at the section width.
 export function GateSequence() {
   return (
     <div
-      className="flex flex-col gap-2"
+      className="flex flex-col gap-4"
       role="img"
       aria-label="Terminal showing executable ADLC gate commands and their example verdicts"
     >
       {SEQUENCE.map((line, i) => (
         <div
           key={line.cmd}
-          className="mk-gate-line flex flex-wrap items-center gap-3 font-mono text-sm"
+          className="mk-gate-line flex flex-col gap-1 font-mono text-sm"
           style={{ animationDelay: `${0.5 + i * 0.7}s` }}
         >
-          <span style={{ color: 'var(--mk-muted)' }}>$</span>
-          <span style={{ color: '#cbcdd2' }}>{line.cmd}</span>
-          <GateBadge state={line.state} />
-          <span style={{ color: 'var(--mk-muted)' }}>{line.detail}</span>
+          <span style={{ color: 'var(--mk-muted)' }}># {line.detail}</span>
+          <div className="flex flex-wrap items-center gap-3">
+            {/* The prompt is inline with the command so a wrapped command
+                never strands a lone "$" on the line above. */}
+            <span style={{ color: '#cbcdd2' }}>
+              <span style={{ color: 'var(--mk-muted)' }}>$ </span>
+              {line.cmd}
+            </span>
+            <GateBadge state={line.state} />
+          </div>
         </div>
       ))}
       <div

--- a/apps/docs/components/marketing/gate-sequence.tsx
+++ b/apps/docs/components/marketing/gate-sequence.tsx
@@ -11,9 +11,10 @@ const SEQUENCE: ReadonlyArray<{ cmd: string; state: GateState; detail: string }>
 
 // Staggered entrance is pure CSS (.mk-gate-line + animation-delay), so the
 // prefers-reduced-motion guard in global.css shows all lines statically.
-// The verdict detail rides above its command as a shell comment (dimmed like
-// the install snippets in IntegrationCard), which keeps command lines short
-// enough to sit on one line at the section width.
+// The verdict detail sits below its command as a shell comment (dimmed like
+// the install snippets in IntegrationCard): it explains a result, so it reads
+// as output rather than intent. Keeping it off the command line also lets
+// every command sit on one line at the section width.
 export function GateSequence() {
   return (
     <div
@@ -27,7 +28,6 @@ export function GateSequence() {
           className="mk-gate-line flex flex-col gap-1 font-mono text-sm"
           style={{ animationDelay: `${0.5 + i * 0.7}s` }}
         >
-          <span style={{ color: 'var(--mk-muted)' }}># {line.detail}</span>
           <div className="flex flex-wrap items-center gap-3">
             {/* The prompt is inline with the command so a wrapped command
                 never strands a lone "$" on the line above. */}
@@ -37,6 +37,7 @@ export function GateSequence() {
             </span>
             <GateBadge state={line.state} />
           </div>
+          <span style={{ color: 'var(--mk-muted)' }}># {line.detail}</span>
         </div>
       ))}
       <div

--- a/apps/docs/components/phase-diagram.tsx
+++ b/apps/docs/components/phase-diagram.tsx
@@ -7,7 +7,7 @@ export function PhaseDiagram({ phase }: { phase: string }) {
     <figure className="my-4">
       <Mermaid chart={buildPhaseMermaid(phase)} />
       <figcaption className="text-sm" style={{ color: 'var(--color-fd-muted-foreground)' }}>
-        The ADLC lifecycle — highlighted: {phase}.{' '}
+        The ADLC lifecycle, with {phase} highlighted.{' '}
         <a href={theoryLink(phase)}>Read the theory for {phase}</a>
       </figcaption>
     </figure>

--- a/apps/docs/content/docs/getting-started.mdx
+++ b/apps/docs/content/docs/getting-started.mdx
@@ -29,18 +29,18 @@ it will be verified.
 adlc spec-lint spec.md
 ```
 
-Exit code `0` means the gate passes, `2` means it fails (wishes found — line
+Exit code `0` means the gate passes, `2` means it fails (wishes found, with line
 numbers printed), `1` means an operational error. Every gate in the toolkit
 follows this [exit-code convention](/docs/reference/exit-codes), so they compose
 in scripts and CI without special-casing.
 
-No API keys are required for the core checks. Gates with an LLM-assisted pass
-accept `--prompt-only`, which prints the exact prompt and exits `0` — paste it
-into whatever harness you already have.
+The core checks need no API keys. Gates with an LLM-assisted pass accept
+`--prompt-only`, which prints the exact prompt and exits `0`, so you can paste
+it into whatever harness you already have.
 
 ## 3. Bootstrap a repo
 
-Check the workspace is ready before any fan-out — the P0 gate:
+Check the workspace is ready before any fan-out. This is the P0 gate:
 
 ```sh
 adlc preflight        # environment & permissions table, pass/fail verdict
@@ -69,7 +69,7 @@ for six harnesses. Each guide uses that harness's own extension mechanism;
 there is no universal install syntax:
 
 ```sh
-npx plugins add voodootikigod/adlc   # vendor-neutral installer — Claude Code today
+npx plugins add voodootikigod/adlc   # vendor-neutral installer, Claude Code today
 codex plugin marketplace add voodootikigod/adlc --ref main
 codex plugin add adlc-codex@adlc
 ```
@@ -85,6 +85,6 @@ Then initialize once per repo. See the per-harness guides:
 
 ## Where to go next
 
-- [The Lifecycle](/docs/lifecycle) — which gate guards each phase, end to end.
-- [Toolkit](/docs/toolkit) — every tool's flags, exit codes, and examples.
-- [Theory](/docs/theory) — the eight failure modes the gates defend against.
+- [The Lifecycle](/docs/lifecycle): which gate guards each phase, end to end.
+- [Toolkit](/docs/toolkit): every tool's flags, exit codes, and examples.
+- [Theory](/docs/theory): the eight failure modes the gates defend against.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,17 +1,17 @@
 ---
 title: ADLC Documentation
-description: The Agentic Development Lifecycle — a toolkit and harness for shipping reliable software with AI models.
+description: "The Agentic Development Lifecycle: a toolkit and harness for shipping reliable software with AI models."
 ---
 
 # ADLC Documentation
 
-The Agentic Development Lifecycle (ADLC) redesigns the development lifecycle around the eight ways models fail,
-replacing ad-hoc prompting with deterministic gates that enforce correctness at every phase.
-This site documents the toolkit, the theory behind it, and its integrations with Claude Code and other agent harnesses.
+The Agentic Development Lifecycle (ADLC) rebuilds the development lifecycle around the eight ways models fail.
+Instead of ad-hoc prompting, every phase ends at a gate that has to pass before the work moves on.
+This site covers the toolkit, the theory it came from, and how to install it in Claude Code and other agent harnesses.
 
 <Cards>
   <Card title="Theory & Introduction" href="/docs/theory" description="Why models fail and what ADLC does about it." />
-  <Card title="The Lifecycle" href="/docs/lifecycle" description="Eight phases, two human gates — end-to-end." />
+  <Card title="The Lifecycle" href="/docs/lifecycle" description="Eight phases, two human gates, end to end." />
   <Card title="Getting Started" href="/docs/getting-started" description="Install the CLI and run your first gate." />
   <Card title="Toolkit" href="/docs/toolkit" description="Every gate command, flags, exit codes, and examples." />
   <Card title="Integrations" href="/docs/integrations" description="Claude Code, Codex, Cursor, opencode, pi, Antigravity, and CI/CD wiring." />

--- a/apps/docs/content/docs/integrations/antigravity.mdx
+++ b/apps/docs/content/docs/integrations/antigravity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antigravity
-description: Native ADLC integration for Google Antigravity (agy) — an in-session rails-guard hook plus the unbypassable CI diff gate that is the real enforcement layer.
+description: "Native ADLC integration for Google Antigravity (agy): an in-session rails-guard hook plus the unbypassable CI diff gate that is the real enforcement layer."
 ---
 
 # ADLC × Google Antigravity (`agy`)
@@ -23,8 +23,8 @@ agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
 
 Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
 
-**npm-assisted install.** `agy` has no native `agy install npm:X` command — `agy
-plugin install` always takes a filesystem path — but `@adlc/antigravity` is now
+**npm-assisted install.** `agy` has no native `agy install npm:X` command, and `agy
+plugin install` always takes a filesystem path. But `@adlc/antigravity` is now
 published on npm, so you can install it as a normal dependency and point `agy` at
 `node_modules`:
 
@@ -33,7 +33,7 @@ npm install @adlc/antigravity
 agy plugin install ./node_modules/@adlc/antigravity
 ```
 
-**Universal installer (planned — not yet supported).** Support for Google Antigravity inside the vendor-neutral `plugins` installer is currently in development and **not yet present**. Once implemented, you will be able to install it via:
+**Universal installer (planned, not yet supported).** Support for Google Antigravity inside the vendor-neutral `plugins` installer is currently in development and **not yet present**. Once implemented, you will be able to install it via:
 
 ```sh
 npx plugins add voodootikigod/adlc
@@ -53,10 +53,10 @@ Then `/adlc-init` (or manual bootstrap). Enforcement: `export ADLC_P4_ENFORCEMEN
 | P3 Rail | **PreToolUse rails-guard hook** (advisory) + CI gate (guarantee) |
 | P4 Build | doctrine skill; `adlc flail-detector/consensus-fix` |
 | P5 Prosecute | `adlc-prosecutor` skill + `prosecutor` agent; `adlc hollow-test/behavior-diff` |
-| P6 Integrate | human gate — `adlc gate-manifest` |
+| P6 Integrate | human gate via `adlc gate-manifest` |
 | P7 Distill | `adlc lesson-foundry/rejection-mining` |
 
-## Rail enforcement — two layers
+## Rail enforcement: two layers
 
 Antigravity's hooks are a **best-effort, in-session** layer, not the control:
 
@@ -74,7 +74,7 @@ Antigravity's hooks are a **best-effort, in-session** layer, not the control:
 
    **Scope limit:** because the rail set is read from the base ref, the gate protects
    rails **already frozen on the base branch**. A PR that *introduces* a new rail
-   **and** edits that path in the same PR is **not** caught — first-time rails are
+   **and** edits that path in the same PR is **not** caught. First-time rails are
    enforced only once they land on the base branch. Freeze rails in a separate,
    merged commit before the build PR if you need same-PR protection.
 
@@ -94,8 +94,8 @@ not re-implemented here):
 
 ## Platform notes / limitations
 
-- **POSIX only in-session** (`$HOME` command path); Windows in-session is unsupported —
-  the CI gate protects Windows users regardless.
+- **POSIX only in-session** (`$HOME` command path); Windows in-session is unsupported,
+  but the CI gate protects Windows users regardless.
 - Shell (`run_command`) writes are not gated in-session (CI gate catches them).
 
 ## Appendix: verified `agy` hook contract (agy 1.0.13)
@@ -107,11 +107,11 @@ any document describing the integration's enforcement surface.
 | # | Fact |
 | --- | --- |
 | V1 | agy has a **native plugin system**: `agy plugin install <path>` installs into `~/.gemini/config/plugins/<name>/`. Manifest is Claude-Code-shaped: root `plugin.json` (name, version) + `skills/`, `agents/`, `commands/` (auto-converted to skills), root `hooks.json`. `agy plugin import claude` even ingests Claude Code plugins. |
-| V2 | `agy plugin validate` checks component **presence only**, not deep hook schema — it passed a `hooks.json` the runtime later refused to parse. **Validation is not sufficient; runtime load must be tested.** |
-| V3 | **hooks.json schema (agy-native)** — verified working: `{ "<hook-name>": { "PreToolUse": [ { "matcher": ".*", "hooks": [ { "type":"command", "command":"<cmd>", "timeout":15 } ] } ] } }`. Top level is keyed by **hook name**, then event, then an **array** of `{matcher, hooks:[handler]}`. |
-| V4 | `matcher` is a **regex on the tool name**. `.*` matches all. `write` did **not** match tool `write_to_file` — so use `.*` or exact names. |
+| V2 | `agy plugin validate` checks component **presence only**, not deep hook schema: it passed a `hooks.json` the runtime later refused to parse. **Validation is not sufficient; runtime load must be tested.** |
+| V3 | **hooks.json schema (agy-native)**, verified working: `{ "<hook-name>": { "PreToolUse": [ { "matcher": ".*", "hooks": [ { "type":"command", "command":"<cmd>", "timeout":15 } ] } ] } }`. Top level is keyed by **hook name**, then event, then an **array** of `{matcher, hooks:[handler]}`. |
+| V4 | `matcher` is a **regex on the tool name**. `.*` matches all. `write` did **not** match tool `write_to_file`, so use `.*` or exact names. |
 | V5 | **Deny contract (inverted from Claude Code/Codex):** a hook denies by writing stdout `{"allow_tool": false, "deny_reason": "..."}` and **exiting 0**. `{"allow_tool": true}` allows. **Non-zero exit = hook FAILURE = FAIL-OPEN (tool proceeds).** |
-| V6 | Hooks **fire in `agy --print` (headless) mode** — a write to a rail was actually blocked. So rails-guard protects both interactive sessions and the headless fleet path. |
+| V6 | Hooks **fire in `agy --print` (headless) mode**: a write to a rail was actually blocked. So rails-guard protects both interactive sessions and the headless fleet path. |
 | V7 | **stdin payload** (verbatim): `{"toolCall":{"name":"write_to_file","args":{"TargetFile":"/abs","CodeContent":"…","Overwrite":true}},"workspacePaths":[],"conversationId":…,"transcriptPath":…,"stepIdx":3}`. The path field varies per tool: `write_to_file`→`TargetFile`, `view_file`→`AbsolutePath`, `run_command`→`CommandLine`. Observed target paths were **absolute**. |
 | V8 | Hook **cwd is the plugin dir** (`~/.gemini/config/plugins/<name>/`), **not the repo**. In `--print` mode `workspacePaths` was observed **empty (`[]`)**. There is **no workspace-root env var** (env exposes `ANTIGRAVITY_CONVERSATION_ID`, not a workspace path). |
 | V9 | agy **expands `$HOME`** (and shell env vars) in the `command` string; there is **no** `${CLAUDE_PLUGIN_ROOT}`/`${AGY_PLUGIN_ROOT}`. Because plugins always install to `$HOME/.gemini/config/plugins/<name>/`, `node $HOME/.gemini/config/plugins/adlc-antigravity/hooks/adlc-rails-guard.mjs` is portable across users with no install-time rewrite. |

--- a/apps/docs/content/docs/integrations/claude-code.mdx
+++ b/apps/docs/content/docs/integrations/claude-code.mdx
@@ -1,6 +1,6 @@
 ---
 title: Claude Code
-description: Adopt the ADLC inside Claude Code — phase-routing skill, gate commands, prosecutor subagent, and hooks that fire the gates automatically.
+description: Adopt the ADLC inside Claude Code with a phase-routing skill, gate commands, a prosecutor subagent, and hooks that fire the gates automatically.
 ---
 
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
@@ -9,7 +9,8 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 Claude Code runs the whole lifecycle from inside the editor: a phase-routing
 skill, ticket/distill/maintain commands, a prosecutor subagent, and hooks that
-fire the gates automatically. No API keys — Claude is the model via `--prompt-only`.
+fire the gates automatically. No API keys are required; Claude is the model via
+`--prompt-only`.
 
 ## Install
 
@@ -50,7 +51,7 @@ npm install -g @adlc/cli
 
 - **Skill:** the `adlc` phase-routing skill that picks the right gate.
 - **Commands:** `/adlc-init`, `/adlc-ticket`, `/adlc-prosecute`, `/adlc-distill`, `/adlc-maintain`.
-- **Subagents:** `adlc:prosecutor` — the P5 pre-merge gate — backed by a specialist
+- **Subagents:** `adlc:prosecutor`, the P5 pre-merge gate, backed by a specialist
   panel (contract, correctness, diff, security, tests, verifier).
 - **Hooks:** structured-edit rails-guard + CI backstop.
 

--- a/apps/docs/content/docs/integrations/codex.mdx
+++ b/apps/docs/content/docs/integrations/codex.mdx
@@ -79,7 +79,7 @@ ticket explicitly. `ADLC_P4_ENFORCEMENT=1` forces enforcement and
 `ADLC_P4_ENFORCEMENT=0` deliberately opts out locally.
 
 Once active, conflicting or stale ticket state and writes to frozen rails fail
-closed. The hook gives immediate feedback, but Codex hooks are guardrails—not a
+closed. The hook gives immediate feedback, but Codex hooks are guardrails, not a
 complete security boundary. Keep the repository `rails-guard` CI job required;
 it is the authoritative proof over the committed diff.
 

--- a/apps/docs/content/docs/integrations/cursor.mdx
+++ b/apps/docs/content/docs/integrations/cursor.mdx
@@ -1,12 +1,12 @@
 ---
 title: Cursor
-description: Native ADLC integration for Cursor — a preToolUse rails dispatcher, the afterFileEdit audit, an advisory shell notice, the full /adlc-* command suite, and the sequential five-lens /adlc-prosecute loop, backstopped by the unbypassable CI rail-freeze gate.
+description: "Native ADLC integration for Cursor: a preToolUse rails dispatcher, the afterFileEdit audit, an advisory shell notice, the full /adlc-* command suite, and the sequential five-lens /adlc-prosecute loop, backstopped by the unbypassable CI rail-freeze gate."
 ---
 
 # ADLC in Cursor
 
 Wire the Agentic Development Lifecycle into [Cursor](https://cursor.com) using its
-**native** plugin surfaces — hooks, rules, skills, and commands. The integration
+**native** plugin surfaces: hooks, rules, skills, and commands. The integration
 ships as `plugins/adlc-cursor` with a Cursor marketplace manifest
 (`.cursor-plugin/`) plus an npm scaffolder kept as a legacy/dev fallback.
 
@@ -19,31 +19,31 @@ one GA honesty gate.
 
 ## What you get
 
-- **`preToolUse` dispatcher hook** — runs the rails decision **first** (a
+- **`preToolUse` dispatcher hook.** Runs the rails decision **first** (a
   frozen-rail edit is denied) and, only when rails allow **and**
   `ADLC_BUILD_GATE_ENFORCEMENT=1`, consults the advisory buildgate. One entry, so
   a second hook can never mask a rails deny.
-- **`afterFileEdit` audit hook** — surfaces a notice when a frozen rail was edited,
+- **`afterFileEdit` audit hook.** Surfaces a notice when a frozen rail was edited,
   plus a flail (edit-churn) reminder. It fires *after* the write and **cannot
   block**, so it is observational only.
-- **`beforeShellExecution` advisory** — string-matches obvious shell writes to the
-  active ticket's rails. It **never denies** and is trivially bypassable — an
+- **`beforeShellExecution` advisory.** String-matches obvious shell writes to the
+  active ticket's rails. It **never denies** and is trivially bypassable: an
   honesty nudge, not a control.
-- **Command palette** — the plugin ships the bare `/adlc-*` phase suite
+- **Command palette.** The plugin ships the bare `/adlc-*` phase suite
   (`init`, `ticket`, `spec`, `approve-spec`, `decompose`, `verify-build`,
   `prosecute`, `distill`, `maintain`). The legacy scaffolder can still copy them
   into a project `.cursor/commands/` for local-dev installs.
-- **`.cursor/rules/adlc.mdc`** — the ADLC phase-router rule.
+- **`.cursor/rules/adlc.mdc`** is the ADLC phase-router rule.
 
 The **buildgate is advisory, disabled by default** (opt in with
-`ADLC_BUILD_GATE_ENFORCEMENT=1`), and has **NO unbypassable backstop** — unlike the
+`ADLC_BUILD_GATE_ENFORCEMENT=1`), and has **NO unbypassable backstop**: unlike the
 rails guard, nothing at commit time enforces its verdict. The `stop`-audit and
 `preflight` hooks are **on by default**; opt out of the scaffold path with
 `--no-unpinned` / `ADLC_CURSOR_WIRE_UNPINNED=0`.
 
 ## Install
 
-### Preferred — marketplace plugin
+### Preferred: marketplace plugin
 
 1. In Cursor: **Settings → Plugins → Add marketplace** and paste
    `https://github.com/voodootikigod/adlc` (root `.cursor-plugin/marketplace.json`
@@ -57,7 +57,7 @@ adlc init --harness cursor
 ```
 
 `adlc init` may write a **local** `.adlc/config.json`. Do **not** commit that
-file into a repository that already has frozen rails on the base branch — CI
+file into a repository that already has frozen rails on the base branch. CI
 treats `.adlc/config.json` as a trust root once any base ticket declares rails.
 Bootstrap a real config only through the protected-base ceremony (with
 `securityMode` and `acknowledgedNewRailBypass`), not as part of installing the
@@ -65,7 +65,7 @@ Cursor plugin.
 
 4. Wire `docs/ci/rails-guard.yml` as a required check.
 
-### Legacy fallback — npm scaffolder
+### Legacy fallback: npm scaffolder
 
 ```sh
 npm install -g @adlc/cli
@@ -80,12 +80,12 @@ node plugins/adlc-cursor/lib/scaffold-cli.mjs .
 node scripts/cursor-install-smoke.mjs .
 ```
 
-## Rail enforcement — two layers
+## Rail enforcement: two layers
 
 Cursor's hooks are a **best-effort, in-session** layer, not the control:
 
 1. **In-session (advisory).** The `preToolUse` dispatcher returns
-   `{ "permission": "deny" }` on a frozen-rail edit. Cursor *should* block it — but
+   `{ "permission": "deny" }` on a frozen-rail edit. Cursor *should* block it, but
    `permission: "deny"` has [open reliability reports](https://forum.cursor.com/t/hooks-returning-deny-do-not-seem-to-block-tool-execution-possible-security-concern/154377),
    and `afterFileEdit` cannot block at all. The hook is configured
    `failClosed: false` so a hook bug can never brick your editor. Bash/shell writes
@@ -105,20 +105,20 @@ Cursor's hooks are a **best-effort, in-session** layer, not the control:
 
 | Phase | Surface in Cursor |
 | --- | --- |
-| P0 Triage | `/adlc-ticket` — authors a ticket into `.adlc/tickets.json` |
-| P1 Interrogate | `/adlc-spec` · `/adlc-approve-spec` — spec-lint / premortem + the human approval gate |
-| P2 Decompose | `/adlc-decompose` — coldstart + merge forecast |
-| **P3 Rail** | **`preToolUse` dispatcher** — rails-guard (this package + CI gate) + the advisory, default-off buildgate |
-| P4 Build | `/adlc-verify-build` — targeted tests + flail check |
-| P5 Prosecute | `/adlc-prosecute` — the sequential five-lens loop (**weaker independence** than the siblings' fresh-context fan-out) + `hollow-test` / `behavior-diff` + cross-model `adversarial-review --providers` |
-| P6 Integrate | `adlc gate-manifest` — human gate |
-| P7 Distill | `/adlc-distill` — lesson-foundry + rejection-mining |
+| P0 Triage | `/adlc-ticket` authors a ticket into `.adlc/tickets.json` |
+| P1 Interrogate | `/adlc-spec` · `/adlc-approve-spec`: spec-lint / premortem + the human approval gate |
+| P2 Decompose | `/adlc-decompose`: coldstart + merge forecast |
+| **P3 Rail** | **`preToolUse` dispatcher**: rails-guard (this package + CI gate) + the advisory, default-off buildgate |
+| P4 Build | `/adlc-verify-build`: targeted tests + flail check |
+| P5 Prosecute | `/adlc-prosecute`: the sequential five-lens loop (**weaker independence** than the siblings' fresh-context fan-out) + `hollow-test` / `behavior-diff` + cross-model `adversarial-review --providers` |
+| P6 Integrate | `adlc gate-manifest`, the human gate |
+| P7 Distill | `/adlc-distill`: lesson-foundry + rejection-mining |
 
 ## Gaps
 
 - **Live deny-proof** against a real Cursor binary, and pinning the exact
-  `preToolUse` payload field names — the one GA gate; the adapter extracts the path
-  defensively until then.
+  `preToolUse` payload field names. This is the one GA gate; the adapter extracts
+  the path defensively until then.
 - **Prosecutor independence caveat.** `/adlc-prosecute` runs its five lenses
   sequentially in one context (Cursor has no subagent fan-out), so it has **weaker
   independence** than the sibling reviews. Run

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -1,26 +1,26 @@
 ---
 title: Integrations
-description: Native ADLC integrations for six agentic coding harnesses — Claude Code, Codex, Cursor, opencode, pi, and Antigravity.
+description: "Native ADLC integrations for six agentic coding harnesses: Claude Code, Codex, Cursor, opencode, pi, and Antigravity."
 ---
 
 # Integrations
 
 ADLC gates are implemented once in [`@adlc/core`](/docs/lifecycle) and wired into each
-harness through its own native mechanism — skills, hooks, plugins, or agents. Pick your
+harness through its own native mechanism: skills, hooks, plugins, or agents. Pick your
 harness below.
 
-- **[Claude Code](/docs/integrations/claude-code)** — phase-routing skill, gate
+- **[Claude Code](/docs/integrations/claude-code)** ships a phase-routing skill, gate
   commands, a `prosecutor` subagent, and hooks that fire the gates automatically.
-- **[Codex](/docs/integrations/codex)** — native Git-marketplace plugin with six
+- **[Codex](/docs/integrations/codex)** is a native Git-marketplace plugin with six
   skills, eight lifecycle hooks, allowlisted MCP gates, and project agents.
-- **[Cursor](/docs/integrations/cursor)** — marketplace `.cursor-plugin` with a
+- **[Cursor](/docs/integrations/cursor)** is a marketplace `.cursor-plugin` with a
   `preToolUse` rails dispatcher, skills, `/adlc-*` commands, and the sequential
   five-lens `/adlc-prosecute` loop, backed by the CI rail-freeze gate.
-- **[opencode](/docs/integrations/opencode)** — rails-guard plugin hook, eight
+- **[opencode](/docs/integrations/opencode)** ships a rails-guard plugin hook, eight
   lifecycle commands, a five-lens prosecutor panel, and a keyless gate bridge.
-- **[pi](/docs/integrations/pi)** — native extension with proactive rail blocking,
-  git-diff revert, and a suppression gate; five phase skills wrap the CLIs.
-- **[Antigravity](/docs/integrations/antigravity)** — native `agy` plugin with an
+- **[pi](/docs/integrations/pi)** is a native extension with proactive rail blocking,
+  git-diff revert, and a suppression gate. Five phase skills wrap the CLIs.
+- **[Antigravity](/docs/integrations/antigravity)** is a native `agy` plugin with an
   in-session rails-guard hook, backed by the unbypassable CI rail-freeze gate.
 
 ## Orchestrating harnesses in parallel
@@ -29,7 +29,7 @@ These integrations wire the gates *into* each harness. The
 [`@adlc/fleet`](/docs/toolkit/fleet) orchestrator runs the other direction: it
 dispatches ready tickets to sandboxed **headless workers** in isolated worktrees
 and merges them through the gates. Its scheduler is harness-blind via a
-`WorkerAdapter` seam — Claude Code is the default worker, and adapters for Codex,
+`WorkerAdapter` seam. Claude Code is the default worker, and adapters for Codex,
 Antigravity, opencode, pi, and Cursor let a single fleet run build tickets on any
 of them (the harness is an operator-local `--adapter` choice).
 

--- a/apps/docs/content/docs/integrations/opencode.mdx
+++ b/apps/docs/content/docs/integrations/opencode.mdx
@@ -1,6 +1,6 @@
 ---
 title: opencode
-description: Native ADLC integration for the opencode terminal agent — enforce-by-default rails-guard hook, nine lifecycle commands, native adlc_gate/adlc_prosecute tools, and a deterministic P5 prosecution loop (5 lenses + verifier) plus a prosecutor meta-agent.
+description: "Native ADLC integration for the opencode terminal agent: an enforce-by-default rails-guard hook, nine lifecycle commands, native adlc_gate/adlc_prosecute tools, and a deterministic P5 prosecution loop (5 lenses + verifier) plus a prosecutor meta-agent."
 ---
 
 # ADLC in opencode
@@ -8,25 +8,25 @@ description: Native ADLC integration for the opencode terminal agent — enforce
 Brings the lifecycle into the [opencode](https://opencode.ai) terminal agent as
 a native plugin: an in-session rails-guard hook (`tool.execute.before`),
 advisory session hooks, nine lifecycle commands, the `adlc` phase-routing
-skill, two native model-callable tools (`adlc_gate`, `adlc_prosecute`), and a
-**deterministic P5 prosecution loop** — five lenses + a verifier fanned out over
-write-disabled child sessions — plus a separate `@prosecutor` meta-agent (seven
-prosecution agents in all). The integration **enforces by default** — a thrown
+skill, two native model-callable tools (`adlc_gate`, `adlc_prosecute`), a
+**deterministic P5 prosecution loop** (five lenses + a verifier fanned out over
+write-disabled child sessions), and a separate `@prosecutor` meta-agent (seven
+prosecution agents in all). The integration **enforces by default**: a thrown
 denial in `tool.execute.before` aborts the tool call (documented host behavior,
 regression-tested against a real binary).
 
 ## What you get
 
-- **Rails-guard hook** on `tool.execute.before` — denies structured
+- **Rails-guard hook** on `tool.execute.before`. Denies structured
   `edit`/`write`/`apply_patch` to a frozen rail declared by the active ticket;
   in-session **bash is gated** too via the `@adlc/core` shell classifier.
 - **Native tools:** `adlc_gate` (the model runs a lifecycle gate, LLM-backed
   ones keyless through the host model) and `adlc_prosecute` (the **deterministic
-  first-party P5 loop** — fan-out → dedupe → verify → loop-until-dry over
+  first-party P5 loop**: fan-out → dedupe → verify → loop-until-dry over
   write-disabled child sessions).
-- **Advisory session/compaction hooks** — `session.created` preflight, a
+- **Advisory session/compaction hooks:** `session.created` preflight, a
   `session.idle` gate-manifest audit, per-turn + at-compaction context injection,
-  and slash-command lifecycle/tamper advisories; they warn, never throw.
+  and slash-command lifecycle/tamper advisories. They warn, never throw.
 - **Commands:** `/adlc-init`, `/adlc-ticket`, `/adlc-spec`, `/adlc-approve-spec`,
   `/adlc-decompose`, `/adlc-verify-build`, `/adlc-prosecute`, `/adlc-distill`,
   `/adlc-maintain`.
@@ -56,10 +56,10 @@ node scripts/opencode-install-smoke.mjs .
 Per-repo config rides the `["@adlc/opencode", { … }]` plugin-options
 tuple (env vars override); see the integration guide for the option table.
 
-## Rail enforcement — two layers
+## Rail enforcement: two layers
 
 1. **In-session (enforcing by default).** A thrown denial in
-   `tool.execute.before` **aborts the tool call** — documented host behavior on
+   `tool.execute.before` **aborts the tool call**: documented host behavior on
    `@opencode-ai/plugin` ≥ 1.17.13, regression-tested end-to-end against a real
    opencode binary (required CI). Bash **is** gated via the `@adlc/core` shell
    classifier; unrecognized structured tools carrying a path fail closed. The
@@ -68,7 +68,7 @@ tuple (env vars override); see the integration guide for the option table.
 2. **Commit-time (unbypassable).** The real control is
    `scripts/rails-guard-ci.mjs` (via `docs/ci/rails-guard.yml`): it reads the
    frozen rail set **from the trusted base ref** and rejects any PR that edits a
-   rail — including the shell-driven writes the in-session hook cannot see.
+   rail, including the shell-driven writes the in-session hook cannot see.
    **Make it a required check.**
 
 ## Rail contract
@@ -97,15 +97,15 @@ Mirrors the sibling integrations; all glob/ticket logic delegates to `@adlc/core
 
 ## Gaps
 
-1. **`permission.ask` is a dormant lever** — defined but never dispatched
+1. **`permission.ask` is a dormant lever.** It is defined but never dispatched
    upstream (anomalyco/opencode#7006, re-verified at 1.17.17/1.17.18). The
    enforcing control is the `tool.execute.before` throw; the tolerant handler
    activates the instant upstream wires the hook.
-2. **The native TUI plugin module is deferred** — `PluginModule` types
+2. **The native TUI plugin module is deferred.** `PluginModule` types
    `tui?: never` at 1.17.17 (the surface is reserved, not shipped), so the
    persistent statusline slot / dialogs are a follow-on. The verifiable native
    touch (the statusline toast) ships now.
-3. **P6 acceptance is a human decision** — by design; the plugin surfaces
+3. **P6 acceptance is a human decision** by design. The plugin surfaces
    evidence, it does not automate approval.
 
 ## Go deeper

--- a/apps/docs/content/docs/integrations/pi.mdx
+++ b/apps/docs/content/docs/integrations/pi.mdx
@@ -1,6 +1,6 @@
 ---
 title: pi
-description: Native ADLC extension for the pi coding agent — in-session rail, scope, and suppression enforcement with git-diff revert, plus five phase skills.
+description: "Native ADLC extension for the pi coding agent: in-session rail, scope, and suppression enforcement with git-diff revert, plus five phase skills."
 ---
 
 # ADLC in pi
@@ -12,33 +12,33 @@ each phase to the deterministic `adlc` gates.
 
 ## What you get
 
-- **Proactive rail gate** (`tool_call`) — blocks `write`/`edit`/`bash` before it
+- **Proactive rail gate** (`tool_call`). Blocks `write`/`edit`/`bash` before it
   touches disk when the target is a frozen rail, out of the ticket's scope, or
-  the ADLC trust roots. **Bash writes are gated here** — redirects, `tee`,
+  the ADLC trust roots. **Bash writes are gated here:** redirects, `tee`,
   `rm`/`mv`/`cp`, in-place `sed`/`perl`, mutating `git` subcommands, and
   interpreter file-write APIs are recognized and rail-checked.
-- **Reactive revert gate** (`tool_result`) — after any write/edit/bash, computes
+- **Reactive revert gate** (`tool_result`). After any write/edit/bash, computes
   added lines against a **pre-tool snapshot** (never `HEAD`, so your own
   uncommitted edits are never destroyed); a rail violation restores the snapshot
-  and replaces the tool result with a `GATE FAILED` error. Added lines are
+  and replaces the tool result with a `GATE FAILED` error. Added lines are also
   scanned for undeclared suppression markers (`@ts-ignore`, `eslint-disable`,
-  `.skip(`, `# noqa`, …) — operative-vs-inert classification is delegated to
-  `@adlc/rails-guard` — and reverted unless the ticket allows them.
-- **Build-gate + flail backstops** — a degraded (context-rot) session on a
+  `.skip(`, `# noqa`, …) and reverted unless the ticket allows them.
+  Operative-vs-inert classification is delegated to `@adlc/rails-guard`.
+- **Build-gate + flail backstops.** A degraded (context-rot) session on a
   high-risk ticket is denied its build until an audited override is recorded;
   repeated errors, scope churn, and oversized session logs surface as advisories.
-- **Ticket doctrine injection** (`before_agent_start`) — the active ticket's
+- **Ticket doctrine injection** (`before_agent_start`). The active ticket's
   scope, rails, and spec are appended to the system prompt every turn
-  (sanitized; the ticket body is fenced as untrusted), defending premature
-  satisfaction and context rot.
-- **Native agent tools** — `adlc_prosecute` runs the deterministic P5 review
+  (sanitized; the ticket body is fenced as untrusted), which defends against
+  premature satisfaction and context rot.
+- **Native agent tools.** `adlc_prosecute` runs the deterministic P5 review
   loop in-session (fan-out → verify → loop-until-dry over write-disabled child
   sessions); `adlc_gate` runs the LLM-backed gates keyless through your session
   model. A `TICKET-DONE` listener nudges prosecution at ticket completion.
-- **Commands + footer status pill** — `/ticket`, `/adlc-init`, `/adlc-accept`,
-  and a live pill for constant visibility into the active enforcement context.
+- **Commands + footer status pill:** `/ticket`, `/adlc-init`, `/adlc-accept`,
+  and a live pill showing the active enforcement context.
 - **Skills:** `adlc` (phase router), `adlc-spec` (P0–P2), `adlc-rail-build`
-  (P3–P4), `adlc-prosecute` (P5–P6), `adlc-distill` (P7) — each wraps the
+  (P3–P4), `adlc-prosecute` (P5–P6), `adlc-distill` (P7). Each wraps the
   deterministic `adlc` CLIs; hooks are assistive, `adlc rails-guard` is the
   proof.
 
@@ -67,16 +67,16 @@ with a weekly version-matrix smoke tracking the latest published build).
 
 ## Enforcement model
 
-Enforcement is **opt-in by activating a ticket** — set `ADLC_TICKET` or write
+Enforcement is **opt-in by activating a ticket**: set `ADLC_TICKET` or write
 `.adlc/current-ticket.json` (tickets file overridable via `ADLC_TICKETS`). With
 no active ticket the extension is inert. Once a ticket id resolves, the
 extension **fails closed**: an unreadable or unparseable tickets file, or an
 unknown ticket id, blocks *all* tool calls until fixed (with a red status pill
 telling you why). Unlike the sibling integrations, this plugin does not use
-`ADLC_P4_ENFORCEMENT` — the active ticket is the switch.
+`ADLC_P4_ENFORCEMENT`; the active ticket is the switch.
 
 `.adlc/tickets.json` and `.adlc/current-ticket.json` are unconditionally
-blocked from edits regardless of rails — the agent can't rewrite its own
+blocked from edits regardless of rails, so the agent can't rewrite its own
 constraints. An empty ticket `scope` means unrestricted; `.adlc/` and `.omo/`
 stay writable for evidence.
 
@@ -90,8 +90,8 @@ made. **Make it a required check.**
 | Phase | pi surface |
 | --- | --- |
 | P0–P2 Triage → Decompose | `adlc-spec` skill (`parallax`, `spec-lint`, `premortem`, `coldstart`, `merge-forecast`, `model-router`); ticket resolution on `session_start`; prompt templates (`/adlc-spec`, `/adlc-decompose`) |
-| **P3–P4 Rail & Build** | **the extension** — proactive `tool_call` block + reactive `tool_result` snapshot-scoped revert + operative-only suppression gate + build-gate + flail advisory + evidence rail + custom-tool coverage |
-| **P5 Prosecute** | **native `adlc_prosecute` tool** — in-session fan-out → verify → loop-until-dry over write-disabled child sessions; `TICKET-DONE` completion nudge; plus the `adlc-prosecute` skill (`prosecute`, `behavior-diff`, `adlc run p5`) |
+| **P3–P4 Rail & Build** | **the extension**: proactive `tool_call` block + reactive `tool_result` snapshot-scoped revert + operative-only suppression gate + build-gate + flail advisory + evidence rail + custom-tool coverage |
+| **P5 Prosecute** | **native `adlc_prosecute` tool**: in-session fan-out → verify → loop-until-dry over write-disabled child sessions; `TICKET-DONE` completion nudge; plus the `adlc-prosecute` skill (`prosecute`, `behavior-diff`, `adlc run p5`) |
 | **P6 Integrate** | **native `adlc_gate` tool** + `/adlc-accept` command + rollback path; `adlc behavior-diff` / `adlc run p6` |
 | P7 Distill | `adlc-distill` skill (`lesson-foundry`, `rejection-mining`, `skill-rot`, `model-ratchet`); scheduled runs via CI cron |
 
@@ -102,7 +102,7 @@ verdict.
 **Remaining gaps** (design intent, not yet shipped): a `session_shutdown`
 auto-capture for P6 (accept is command-driven today), and an in-harness P7
 scheduler (pi has no `/schedule`; CI cron is the substrate). npm publication is
-release-ready and folds into the lockstep `/release` flow — the one-command
+release-ready and folds into the lockstep `/release` flow. The one-command
 `pi install` story above goes live with the first published release; load from a
 checkout until then.
 

--- a/apps/docs/content/docs/lifecycle.mdx
+++ b/apps/docs/content/docs/lifecycle.mdx
@@ -11,7 +11,7 @@ Each phase has a machine-checkable gate. The toolkit makes those gates concrete.
 
 | Phase | Question the gate answers | Primary tools |
 | --- | --- | --- |
-| **P0 Triage** | Where does this work route on risk × blast radius — trivial, bounded, substantial, or architectural? | [preflight](/docs/toolkit/preflight) |
+| **P0 Triage** | Where does this work route on risk × blast radius: trivial, bounded, substantial, or architectural? | [preflight](/docs/toolkit/preflight) |
 | **P1 Interrogate** | Is the spec testable and stress-tested? | [spec-lint](/docs/toolkit/spec-lint), [premortem](/docs/toolkit/premortem), [parallax](/docs/toolkit/parallax) |
 | **P2 Decompose** | Can an agent execute this ticket without guessing? | [coldstart](/docs/toolkit/coldstart), [model-router](/docs/toolkit/model-router), [merge-forecast](/docs/toolkit/merge-forecast) |
 | **P3–P4 Rail & Build** | Are frozen rails protected; is an agent flailing? | [rails-guard](/docs/toolkit/rails-guard), [flail-detector](/docs/toolkit/flail-detector), [consensus-fix](/docs/toolkit/consensus-fix) |
@@ -21,5 +21,5 @@ Each phase has a machine-checkable gate. The toolkit makes those gates concrete.
 | **Calibration** (maintenance, cross-phase) | What must be re-prosecuted after drift? | [model-ratchet](/docs/toolkit/model-ratchet), [review-calibration](/docs/toolkit/review-calibration), [skill-rot](/docs/toolkit/skill-rot), [gate-fuzzing](/docs/toolkit/gate-fuzzing) |
 
 The two human gates sit at **P1** (spec approval) and **P6** (behavioral acceptance). Everything
-between is deterministic — read
+between is deterministic. Read
 [the full argument](https://voodootikigod.com/adlc-2-two-human-gates).

--- a/apps/docs/content/docs/reference/adlc-runtime.mdx
+++ b/apps/docs/content/docs/reference/adlc-runtime.mdx
@@ -1,12 +1,12 @@
 ---
 title: The .adlc/ Runtime
-description: The on-disk state ADLC gates read and write — tickets, the active-ticket pointer, config, ledgers, evidence — and the environment variables that steer them.
+description: "The on-disk state ADLC gates read and write: tickets, the active-ticket pointer, config, ledgers, evidence, and the environment variables that steer them."
 ---
 
 # The `.adlc/` Runtime
 
 `.adlc/` is the project-local directory where ADLC keeps its runtime state. Tools read and
-write it through [`@adlc/core`](/docs/toolkit/core) — none of them re-parse it by hand. The
+write it through [`@adlc/core`](/docs/toolkit/core); none of them re-parse it by hand. The
 directory is created by `/adlc-init` (or the per-editor scaffolders) and grows as gates run.
 
 ## Directory layout
@@ -24,7 +24,7 @@ directory is created by `/adlc-init` (or the per-editor scaffolders) and grows a
 └── ticket-sync.state.json  # gitignored sync sidecar (rebuildable cache)
 ```
 
-### `tickets/` — the canonical ticket store
+### `tickets/`: the canonical ticket store
 
 The executable contract between P2 decomposition, P3 rails, P4 build, and P5/P6 evidence.
 Each ticket carries `{ id, title, body, scope[], rails[], edges[], duration, category, budget }`.
@@ -37,51 +37,51 @@ schema and rules live in
 [`docs/ticket-authoring.md`](https://github.com/voodootikigod/adlc/blob/main/docs/ticket-authoring.md),
 and `.adlc/tickets.example.json` is a complete fixture.
 
-### `current-ticket.json` — the active-ticket pointer
+### `current-ticket.json`: the active-ticket pointer
 
 Names which ticket is "in flight" so rails-guard and prosecution know what to enforce. It
 holds either a bare id string or `{ "id": "T7" }`. The active ticket is resolved from
 `ADLC_TICKET` **or** this file. If both are set and **disagree**, that is treated as a
-tamper signal, not an ambiguity — resolution fails closed (`conflict: true`) rather than
-guessing. An unparseable pointer file is likewise a tamper signal and fails closed. This
-resolution is shared verbatim across every harness integration (Codex, Cursor, Antigravity,
-OpenCode) and `@adlc/build-gate`.
+tamper signal rather than an ambiguity, and resolution fails closed (`conflict: true`)
+instead of guessing. An unparseable pointer file is likewise a tamper signal and fails
+closed. This resolution is shared verbatim across every harness integration (Codex,
+Cursor, Antigravity, OpenCode) and `@adlc/build-gate`.
 
-### `config.json` — runtime config
+### `config.json`: runtime config
 
 Created with safe defaults by the scaffolders and never clobbered on re-init. It carries the
 [`ticket-sync`](/docs/toolkit/ticket-sync) provider configuration and the security posture
 for signed bundles (`securityMode`, `signers`, `revokedKeys`, `securitySensitivePatterns`,
 `maxBundleAgeDays`).
 
-### Ledgers — `manifest.jsonl` and `findings.jsonl`
+### Ledgers: `manifest.jsonl` and `findings.jsonl`
 
 Append-only JSON-lines ledgers, one object per line, written with `appendEntry` and read
 with `readEntries` (which reports malformed lines rather than swallowing them).
 
-- **`manifest`** — the hash-chained provenance ledger written by
+- **`manifest`** is the hash-chained provenance ledger written by
   [`gate-manifest`](/docs/toolkit/gate-manifest) when a gate is recorded. `manifest.lock`
   guards concurrent appends, and `verify` walks the chain to detect a break. Entries can be
   HMAC-signed when `ADLC_MANIFEST_KEY` is set.
-- **`findings`** — prosecution findings, each `{ ts, tool, file, line, category, severity, desc, verdict }`,
+- **`findings`** holds prosecution findings, each `{ ts, tool, file, line, category, severity, desc, verdict }`,
   written by tools like [`lesson-foundry`](/docs/toolkit/lesson-foundry),
   [`model-ratchet`](/docs/toolkit/model-ratchet), and
   [`gate-fuzzing`](/docs/toolkit/gate-fuzzing).
 
 ### Evidence snapshots
 
-Behavior evidence is captured as JSON snapshots — [`behavior-diff`](/docs/toolkit/behavior-diff)
+Behavior evidence is captured as JSON snapshots. [`behavior-diff`](/docs/toolkit/behavior-diff)
 writes a before/after route snapshot with `writeSnapshot()` and compares the two to prove a
 change is visible. Snapshots are plain files you point the tool at, not a fixed filename in
 `.adlc/`.
 
-### `ticket-sync.state.json` — the sync sidecar
+### `ticket-sync.state.json`: the sync sidecar
 
 Sync bookkeeping (tracker node ids, the 3-way base hash, create keys). It is a **gitignored,
-rebuildable cache** — never authored by hand and read by no gate. It is deliberately outside
-the rails trust root, so a routine sync leaves `tickets.json` byte-identical and never trips
-rails-guard. A missing or tampered sidecar fails safe (at worst it forces a conflict prompt
-on the next pull) and can be deleted and rebuilt at any time.
+rebuildable cache**: no gate reads it, and it is never authored by hand. It is deliberately
+outside the rails trust root, so a routine sync leaves `tickets.json` byte-identical and
+never trips rails-guard. A missing or tampered sidecar fails safe (at worst it forces a
+conflict prompt on the next pull) and can be deleted and rebuilt at any time.
 
 ## Rails trust root
 
@@ -105,6 +105,6 @@ rail edit.
 
 ## Related
 
-- [Ticket authoring](https://github.com/voodootikigod/adlc/blob/main/docs/ticket-authoring.md) — the ticket schema and rules in full.
-- [The Lifecycle](/docs/lifecycle) — which gate reads which state, phase by phase.
-- [Tool Conventions](/docs/reference/conventions) and [Exit Codes](/docs/reference/exit-codes) — the contracts tools honor while reading this runtime.
+- [Ticket authoring](https://github.com/voodootikigod/adlc/blob/main/docs/ticket-authoring.md): the ticket schema and rules in full.
+- [The Lifecycle](/docs/lifecycle): which gate reads which state, phase by phase.
+- [Tool Conventions](/docs/reference/conventions) and [Exit Codes](/docs/reference/exit-codes): the contracts tools honor while reading this runtime.

--- a/apps/docs/content/docs/reference/adrs.mdx
+++ b/apps/docs/content/docs/reference/adrs.mdx
@@ -5,20 +5,20 @@ description: The accepted ADRs behind ADLC's editor integrations and adversarial
 
 # Architecture Decision Records
 
-ADRs capture the decisions that shaped ADLC — chiefly how it integrates with each agentic
+ADRs capture the decisions that shaped ADLC, chiefly how it integrates with each agentic
 editor and where adversarial review sits in the lifecycle. Each links to the full record in
 the repo. All nine are **Accepted**.
 
 | # | Title | Summary |
 | --- | --- | --- |
 | [0001](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0001-codex-native-adlc-integration.md) | Codex-Native ADLC Integration | How the deterministic `@adlc/*` gates and doctrine are brought natively into Codex, following the Claude Code integration. |
-| [0002](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0002-adlc-command-reconciliation.md) | Reconciling the `adlc` command | Two parallel efforts each shipped an `adlc` bin; resolved with **Option D** — separate concern-focused binaries rather than one conflicting package. |
+| [0002](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0002-adlc-command-reconciliation.md) | Reconciling the `adlc` command | Two parallel efforts each shipped an `adlc` bin; resolved with **Option D**: separate concern-focused binaries rather than one conflicting package. |
 | [0003](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0003-adlc-claude-code-plugin.md) | ADLC as a Claude Code plugin | Packages the ~20 gate CLIs as a Claude Code plugin. Shipped GA (phases A–F merged). |
-| [0004](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0004-adlc-opencode-integration.md) | OpenCode integration — rails-guard MVP | The in-session P3 rails-guard hook for OpenCode as an MVP, with the remaining phases as follow-on. |
+| [0004](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0004-adlc-opencode-integration.md) | OpenCode integration: rails-guard MVP | The in-session P3 rails-guard hook for OpenCode as an MVP, with the remaining phases as follow-on. |
 | [0005](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0005-adversarial-design-review-gate.md) | Risk-gated adversarial design review | Adds a risk-gated adversarial design-review gate at the P1→P2 boundary, where clarity gates alone are insufficient. Recommended practice; deterministic tooling deferred. |
-| [0006](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0006-adlc-cursor-integration.md) | Cursor native integration — marketplace plugin | Ships `adlc-cursor` as a `.cursor-plugin` marketplace plugin (hooks, skills, commands) with CI rail backstop; npm scaffolder kept as legacy fallback. |
+| [0006](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0006-adlc-cursor-integration.md) | Cursor native integration: marketplace plugin | Ships `adlc-cursor` as a `.cursor-plugin` marketplace plugin (hooks, skills, commands) with CI rail backstop; npm scaffolder kept as legacy fallback. |
 | [0007](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0007-multimodel-adversarial-review.md) | Risk-tiered multi-model adversarial review | Prefers a reviewer model from a different provider than the builder, tiered by risk. Recommended practice; mechanical enforcement deferred. |
-| [0008](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0008-adversarial-review-coverage-map.md) | Adversarial-review coverage map | Maps the mature adversarial-review engine across the whole ADLC, closing the gap where it was wired into only P1→P2 and P5. |
+| [0008](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0008-adversarial-review-coverage-map.md) | Adversarial-review coverage map | Maps the mature adversarial-review engine across the whole ADLC. It had been wired into only P1→P2 and P5. |
 | [0009](https://github.com/voodootikigod/adlc/tree/main/docs/adr/0009-universal-install-via-plugins.md) | Universal install via the `plugins` installer | `npx plugins add` stays the recommended install path; the third-party-installer supply-chain exposure is an explicitly accepted residual risk, and docs may only claim harness coverage the installer actually has. |
 
 Browse the source directory:

--- a/apps/docs/content/docs/reference/conventions.mdx
+++ b/apps/docs/content/docs/reference/conventions.mdx
@@ -36,10 +36,10 @@ The `package.json` is uniform: `@adlc/<name>`, `"type": "module"`, a single `bin
 3. **Scope discipline.** Write ONLY inside your own `packages/<name>/`. Never touch other
    packages, `ADLC.md`, root files, or `.adlc/`.
 4. **Exit codes are the contract.** `0` = gate passes, `1` = operational error, `2` = gate
-   fails — using `pass` / `opError` / `gateFail` from core. CI gating depends on this. See
-   [Exit Codes](/docs/reference/exit-codes).
+   fails, produced with `pass` / `opError` / `gateFail` from core. CI gating depends on
+   this. See [Exit Codes](/docs/reference/exit-codes).
 5. **`--prompt-only` on every LLM-backed tool.** Print the exact prompt(s) and exit `0`, so
-   the tool is usable with zero API keys — paste the prompt into any harness. Uses
+   the tool is usable with zero API keys. Paste the prompt into any harness. Uses
    `promptOnly()` from core.
 6. **`--json` on every tool.** Machine-readable output for orchestrators, alongside the
    default human-readable output.
@@ -56,13 +56,13 @@ The `package.json` is uniform: `@adlc/<name>`, `"type": "module"`, a single `bin
     semantics, which ADLC phase (P0–P7 / D1–D3) the tool serves, and its relationship to
     sibling tools.
 
-## Shared data — read via core, never reinvent
+## Shared data: read via core, never reinvent
 
 Tools never re-parse shared state; they go through `@adlc/core`:
 
 | Data | Location | Access |
 | --- | --- | --- |
-| Tickets | `.adlc/tickets.json` | `loadTickets()` — schema in `packages/core/lib/tickets.mjs` |
+| Tickets | `.adlc/tickets.json` | `loadTickets()` (schema in `packages/core/lib/tickets.mjs`) |
 | Ledgers | `.adlc/<name>.jsonl` | `appendEntry` / `readEntries` |
 | Foundation rails | `rails` paths on a ticket | read-only to builders; enforced by tools that read them |
 

--- a/apps/docs/content/docs/reference/exit-codes.mdx
+++ b/apps/docs/content/docs/reference/exit-codes.mdx
@@ -8,21 +8,21 @@ description: The canonical 0/1/2 exit-code convention that makes ADLC gates dete
 Every ADLC gate speaks the same three-value language on exit. This is what lets CI wire a
 dozen tools together and branch on a single number: a gate either passed, hit an
 operational problem, or failed. Tools produce these codes through `pass()`, `opError()`,
-and `gateFail()` in [`@adlc/core`](/docs/toolkit/core) — they never call `process.exit`
+and `gateFail()` in [`@adlc/core`](/docs/toolkit/core). They never call `process.exit`
 with a bare number.
 
 ## The canonical convention
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes. The check succeeded (or there was nothing to check; the tool warns loudly rather than fails).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error. The tool could not run the check: bad input, unreadable file, missing binary, network failure, or a failed LLM call.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails. The check ran and the change did not meet the bar. This is the blocking signal CI acts on.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. The check succeeded (or there was nothing to check; the tool warns loudly rather than fails).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. The tool could not run the check: bad input, unreadable file, missing binary, network failure, or a failed LLM call.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. The check ran and the change did not meet the bar. This is the blocking signal CI acts on.</span>
 </div>
 
 The distinction between `1` and `2` matters: **`1` is "I couldn't tell," `2` is "I looked
 and the answer is no."** CI treats `2` as a hard block on the change, while `1` signals a
 setup or environment problem to fix before the gate can render a verdict. Collapsing the
-two — for example, exiting `1` when a check actually fails — would let a genuine gate
+two (for example, exiting `1` when a check actually fails) would let a genuine gate
 failure read as a fixable hiccup.
 
 ## In CI
@@ -50,4 +50,4 @@ The convention holds across the toolkit. A few patterns worth knowing:
   successful "here is the prompt" response, so every LLM-backed tool exits `0` in this
   mode regardless of the underlying change.
 - **Help and usage.** Requesting `--help` exits `0`; invoking a tool with missing required
-  arguments prints usage and exits `1` (an operational error — the tool could not run).
+  arguments prints usage and exits `1` (an operational error: the tool could not run).

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reference
-description: The contracts every ADLC tool honors — conventions, exit codes, the .adlc/ runtime, and the architecture decision records.
+description: "The contracts every ADLC tool honors: conventions, exit codes, the .adlc/ runtime, and the architecture decision records."
 ---
 
 # Reference
@@ -10,10 +10,10 @@ they all honor the same contracts. This section documents those contracts.
 
 | Page | What it covers |
 | --- | --- |
-| [Tool Conventions](/docs/reference/conventions) | The rules every `packages/<name>/` tool follows — layout, zero dependencies, frozen core, `--json`/`--prompt-only`, and mutation safety. |
+| [Tool Conventions](/docs/reference/conventions) | The rules every `packages/<name>/` tool follows: layout, zero dependencies, frozen core, `--json`/`--prompt-only`, and mutation safety. |
 | [Exit Codes](/docs/reference/exit-codes) | The canonical `0` / `1` / `2` convention that makes CI gating deterministic. |
-| [The `.adlc/` Runtime](/docs/reference/adlc-runtime) | The on-disk state gates read and write — tickets, the active-ticket pointer, config, ledgers, and evidence — plus the environment variables that steer them. |
-| [Recommended Models by Phase](/docs/reference/models-by-phase) | The binding from `model-router`'s abstract tiers (`cheap` / `mid` / `frontier`) to concrete models per provider — paid, open-weight, and local. |
+| [The `.adlc/` Runtime](/docs/reference/adlc-runtime) | The on-disk state gates read and write (tickets, the active-ticket pointer, config, ledgers, and evidence), plus the environment variables that steer them. |
+| [Recommended Models by Phase](/docs/reference/models-by-phase) | The binding from `model-router`'s abstract tiers (`cheap` / `mid` / `frontier`) to concrete models per provider, covering paid, open-weight, and local. |
 | [Architecture Decision Records](/docs/reference/adrs) | The accepted ADRs behind the integrations and review gates. |
 
 New to the model itself? Start with [The Lifecycle](/docs/lifecycle) for the phase and

--- a/apps/docs/content/docs/reference/models-by-phase.mdx
+++ b/apps/docs/content/docs/reference/models-by-phase.mdx
@@ -6,7 +6,7 @@ description: A dated binding from the router's abstract tiers to concrete provid
 # Recommended Models by Phase
 
 > **Snapshot date: 2026-07-14.** Model lineups, prices, and benchmark standings decay
-> fast — this page is a cache, and caches need invalidation (ADLC Principle 10).
+> fast. This page is a cache, and caches need invalidation (ADLC Principle 10).
 > Re-verify against provider pricing pages before committing budget, run
 > [`model-ratchet`](/docs/toolkit/model-ratchet) after any model swap, and let your own
 > [`gate-manifest`](/docs/toolkit/gate-manifest) first-pass ledger override every static
@@ -16,7 +16,7 @@ description: A dated binding from the router's abstract tiers to concrete provid
 
 The [ADLC series](https://voodootikigod.com/series/adlc) argues that using the most
 expensive model everywhere is the wrong default: **model tier is a function of the cost
-of detecting an error, not of task prestige**. The toolkit makes that mechanical —
+of detecting an error, not of task prestige**. The toolkit makes that mechanical.
 [`model-router`](/docs/toolkit/model-router) reads rail density and DAG float and emits
 an abstract tier (`cheap` / `mid` / `frontier`) per ticket. What neither the theory nor
 the router resolves is the binding from abstract tier to concrete model. This page is
@@ -28,11 +28,11 @@ that binding.
 | --- | --- | --- |
 | `cheap` | Errors are caught instantly and deterministically by dense rails; regeneration costs pennies | Codemods, mechanical refactors under test, formatting, triage classification, ladder starts |
 | `mid` | Errors are caught by rails + prosecution; paying for single-pass perfection is waste | The build phase proper, rail authoring, prosecution passes, distillation mining |
-| `frontier` | Errors are *expensive to detect* — a subtly wrong artifact sails through every gate | Specs, decomposition, interface contracts, final verdicts |
+| `frontier` | Errors are *expensive to detect*: a subtly wrong artifact sails through every gate | Specs, decomposition, interface contracts, final verdicts |
 
 Two doctrine points shape everything below:
 
-1. **"Frontier" means the best model you are allowed to run — not the most expensive
+1. **"Frontier" means the best model you are allowed to run, not the most expensive
    model that exists.** The Frontier-Free Doctrine sets an Opus-class ceiling as the
    *design center*: the lifecycle must hit its accuracy targets with
    stable, generally available models without depending on any provider's preview or
@@ -40,19 +40,19 @@ Two doctrine points shape everything below:
    You never need a model smarter than the gate it must pass.
 2. **Measure the stack, not the model.** A 3-pass mid-tier prosecution stack with 0.85
    planted-bug recall *is* the more capable reviewer than a 1-pass frontier model at
-   0.6 — [`review-calibration`](/docs/toolkit/review-calibration) makes that exchange
+   0.6. [`review-calibration`](/docs/toolkit/review-calibration) makes that exchange
    rate a number. Tier labels are cold-start estimates only.
 
 ## Phase → tier map
 
 | Phase | Tier | Why |
 | --- | --- | --- |
-| **P0 Triage** | cheap | Classification with low escaped-error cost — a mis-triaged ticket is caught by the lifecycle it's routed into. |
+| **P0 Triage** | cheap | Classification with low escaped-error cost: a mis-triaged ticket is caught by the lifecycle it's routed into. |
 | **P1 Interrogate** | **frontier** | The spec is the least-verified artifact in the system; a subtly wrong requirement poisons everything downstream. *Do not economize in this phase.* [`parallax`](/docs/toolkit/parallax) divergence readings can run on mid. |
 | **P2 Decompose** | **frontier** for contracts; **cheap** as the gate probe | Interface contracts are frontier work for the same reason as specs. The [`coldstart`](/docs/toolkit/coldstart) gate *deliberately* probes with a cheap model: if a cheap model can enumerate what's missing, the ticket is underspecified for the mid model that will build it. |
 | **P3 Rail** | mid | Tests and contracts authored from spec alone in fresh context; [`hollow-test`](/docs/toolkit/hollow-test) catches weak rails deterministically. |
 | **P4 Build** | router-decided: **ladder cheap→mid** with float, **direct best-tier** on the critical path | [`model-router`](/docs/toolkit/model-router)'s home turf. Float > 0 and rail density ≥ 0.5 → start cheap and ladder up on gate failure (escalation is regeneration, never rescue). Float = 0 → the tier with the best first-pass rate from your manifest. |
-| **P5 Prosecute** | **mid, stacked** — plus a **second provider family** on high blast radius | N fresh-context mid passes with loop-until-dry beat one frontier pass. For trust-boundary, auth, secrets, data-loss, schema, or CI/CD changes, run ≥2 distinct-family providers — different models have different blind spots. |
+| **P5 Prosecute** | **mid, stacked**, plus a **second provider family** on high blast radius | N fresh-context mid passes with loop-until-dry beat one frontier pass. For trust-boundary, auth, secrets, data-loss, schema, or CI/CD changes, run ≥2 distinct-family providers, because different models have different blind spots. |
 | **P6 Integrate** | none (human gate) | [`behavior-diff`](/docs/toolkit/behavior-diff) is deterministic. The human is the frontier tier here. |
 | **P7 Distill** | mid for mining; **rent one frontier pass to mint structure** | Lesson mining runs fine on mid. Occasionally rent the frontier model to crystallize judgment into a skill or template, then spend mid inside that structure indefinitely. |
 
@@ -62,7 +62,7 @@ where rails make building cheap.
 ## Tier → model, by provider
 
 Prices are USD per million tokens, input/output, standard API rates. Benchmark numbers
-are directional only — **SWE-bench Verified and SWE-bench Pro are different benchmarks
+are directional only. **SWE-bench Verified and SWE-bench Pro are different benchmarks
 with non-comparable scores.**
 
 ### Anthropic
@@ -116,20 +116,20 @@ never silently retargets the repository policy.
 ### Open-weight, hosted APIs
 
 These are the cheapest capable tiers available, and they are *distinct model
-families* — exactly what the P5 multi-provider quorum needs.
+families*, exactly what the P5 multi-provider quorum needs.
 
 | Tier | Model | Price (in/out) | Context | Notes |
 | --- | --- | --- | --- | --- |
 | cheap | DeepSeek V4 Flash | $0.14 / $0.28 | 1M | Extreme cache discount; arguably the best cheap-tier value |
 | cheap/mid | MiniMax M3 | ~$0.30 / $1.20 (promo) | 1M | ~59% SWE-bench Pro (vendor) |
-| mid | Kimi K2.6 | $0.55 / $2.65 | ~256K | The strongest open agentic/tool-use pick — good P4 builder and P5 reviewer |
+| mid | Kimi K2.6 | $0.55 / $2.65 | ~256K | The strongest open agentic/tool-use pick: good P4 builder and P5 reviewer |
 | mid | GLM-5.2 | $1.40 / $4.40 | 1M | Vendor-reported 62.1% SWE-bench Pro; MIT license; verify before routing |
-| frontier-adjacent | DeepSeek V4 Pro | $1.74 / $3.48 (promo $0.44 / $0.87) | 1M | ~80% SWE-bench Verified (semi-verified) — highest open-weight coding score of the snapshot |
+| frontier-adjacent | DeepSeek V4 Pro | $1.74 / $3.48 (promo $0.44 / $0.87) | 1M | ~80% SWE-bench Verified (semi-verified), the highest open-weight coding score of the snapshot |
 
 ### Local / self-hosted
 
-Local models are a legitimate **cheap tier** — and on strong hardware a legitimate
-**mid tier** — for rail-dense work where the gates do the verification. The practical
+Local models are a legitimate **cheap tier** for rail-dense work where the gates do the
+verification, and on strong hardware a legitimate **mid tier**. The practical
 single-machine ceiling at this snapshot is ~71–72% SWE-bench Verified. Do **not**
 assign local models frontier duties (P1/P2 specs and contracts): those phases exist
 precisely because their errors escape gates.
@@ -138,12 +138,12 @@ precisely because their errors escape gates.
 | --- | --- | --- |
 | 16GB RAM / GPU | gpt-oss-20b; Qwen2.5-Coder 7B/14B | cheap: formatting, codemods, triage, coldstart probe |
 | 24–32GB GPU | Qwen3-Coder-30B-A3B; Devstral Small 2 | cheap, and ladder starts on rail-dense P4 tickets |
-| 64–128GB unified / 96GB GPU | **Qwen3-Coder-Next (80B/A3B)** — the sweet spot; Devstral 2 / gpt-oss-120b at Q4 | mid: P4 builds, P3 rails, P5 fan-out passes |
+| 64–128GB unified / 96GB GPU | **Qwen3-Coder-Next (80B/A3B)**, the sweet spot; Devstral 2 / gpt-oss-120b at Q4 | mid: P4 builds, P3 rails, P5 fan-out passes |
 | Multi-GPU cluster | GLM-5.2, Kimi K2.x, DeepSeek V4 | usually better rented via API unless data residency forces self-hosting |
 
 Notes:
 
-- The [`coldstart`](/docs/toolkit/coldstart) probe is a perfect local job — free,
+- The [`coldstart`](/docs/toolkit/coldstart) probe is a perfect local job: free,
   private, and the *weaker* the probe the more honest the gate.
 - Skip Llama 4 for coding work (~24% Verified at snapshot).
 - A local cheap tier changes the ladder math: when the ladder start costs ~$0, the

--- a/apps/docs/content/docs/theory/index.mdx
+++ b/apps/docs/content/docs/theory/index.mdx
@@ -7,7 +7,7 @@ description: How the ADLC phases and model failure modes map to the toolkit, wit
 
 ADLC starts from one claim: agentic development should defend against **model**
 failure modes, not human ones. The full argument lives in the
-[ADLC series](https://voodootikigod.com/series/adlc) — this page is the map.
+[ADLC series](https://voodootikigod.com/series/adlc). This page is the map.
 
 ## The eight phases, two human gates
 
@@ -27,11 +27,11 @@ everything. Read [Two Human Gates and Everything Between Is Machine-Checked](htt
 <FailureMode id="F7" />
 <FailureMode id="F8" />
 
-Every phase, gate, and loop traces to one of these — see
+Every phase, gate, and loop traces to one of these. See
 [Stop Running the SDLC on Models That Aren't Human](https://voodootikigod.com/adlc-1-models-arent-human).
 
 ## Where to go next
 
-- [The Lifecycle](/docs/lifecycle) — the phase/gate map and which tool runs where.
-- [Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review) — the P5 gate in depth.
-- [The ADLC Toolkit](https://voodootikigod.com/adlc-7-built-with-the-lifecycle) — the tools, by phase.
+- [The Lifecycle](/docs/lifecycle): the phase/gate map and which tool runs where.
+- [Prosecution, Not Code Review](https://voodootikigod.com/adlc-4-prosecution-not-code-review): the P5 gate in depth.
+- [The ADLC Toolkit](https://voodootikigod.com/adlc-7-built-with-the-lifecycle): the tools, by phase.

--- a/apps/docs/content/docs/toolkit/behavior-diff.mdx
+++ b/apps/docs/content/docs/toolkit/behavior-diff.mdx
@@ -14,7 +14,7 @@ description: Captures each route's observable HTTP behavior before and after a c
 A large code diff hides its own consequences: the reviewer cannot tell, from 5,000
 changed lines, which of them actually altered what a client observes. `behavior-diff`
 captures the HTTP surface (status, content-type, body structure) of every route
-before and after a change, then reports the delta in behavior-space — "2 routes
+before and after a change, then reports the delta in behavior-space: "2 routes
 identical, 2 changed, 0 errored." The human spends the gate on the one judgment a
 machine cannot make: does the observed behavior change match the intended one?
 
@@ -33,16 +33,17 @@ adlc behavior-diff compare before.json after.json [--json]
 | `compare` | Diff two snapshots and print a human-readable behavior report. |
 | `--json` | Machine-readable output for orchestrators (both verbs). |
 
-Per-route errors are recorded, not fatal — the snapshot always has an entry for
-every route. `capture` fails operationally if no route returns a real response
-(target down), since an all-errored snapshot cannot be meaningfully diffed.
+Per-route errors are recorded rather than fatal, so the snapshot always has an
+entry for every route. `capture` fails operationally if no route returns a real
+response (target down), since an all-errored snapshot cannot be meaningfully
+diffed.
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — `capture` wrote a snapshot with at least one reachable route; `compare` found every route identical.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: unreadable config or snapshot, invalid JSON, cannot write output, or every route was unreachable.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — `compare` gate fails: one or more routes changed, were added, removed, or are dead in both snapshots.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: `capture` wrote a snapshot with at least one reachable route; `compare` found every route identical.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. Unreadable config or snapshot, invalid JSON, cannot write output, or every route was unreachable.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: `compare` gate fails. One or more routes changed, were added, removed, or are dead in both snapshots.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/build-gate.mdx
+++ b/apps/docs/content/docs/toolkit/build-gate.mdx
@@ -12,7 +12,7 @@ description: Denies starting a high-risk ticket's build in a degraded (context-r
 ## What it defends against
 
 Nothing else in ADLC deterministically prevents *starting* a high-blast-radius
-build while the executing session is context-rotted — deep, drifted, and past
+build while the executing session is context-rotted: deep, drifted, and past
 the point where it reliably holds the plot. `build-gate` sits at the P3→P4 entry:
 it derives the ticket's risk tier from its own fields (`risk`, `external`,
 `mutatesIdentity`, trust-root scope, `contract`/`architecture` category), checks
@@ -40,16 +40,16 @@ adlc build-gate <ticket-id> [--depth <n>] [--session-bytes <n>] [--transcript <p
 | `--reason <text>` | — | Free-text reason recorded with an override. |
 | `--json` | off | Machine-readable JSON result. |
 
-Supplying no signal defaults to "not degraded" — a gate given no signal cannot
-deny. Set `ADLC_BUILD_GATE_BYPASS=1` to override a deny; the override is honored
+Supplying no signal defaults to "not degraded", since a gate given no signal
+cannot deny. Set `ADLC_BUILD_GATE_BYPASS=1` to override a deny; the override is honored
 only if it can be durably recorded to `.adlc/manifest.jsonl`.
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — allow: gate passes (low risk, not degraded, or an audited override recorded).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad ticket id, missing tickets file, bad thresholds).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — deny: a high-risk ticket in a degraded session with no recorded override.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: allow. Gate passes (low risk, not degraded, or an audited override recorded).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad ticket id, missing tickets file, bad thresholds).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: deny. A high-risk ticket in a degraded session with no recorded override.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/cli.mdx
+++ b/apps/docs/content/docs/toolkit/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: cli
-description: The umbrella dispatcher — one stable command surface that routes every adlc verb to the right gate in the suite.
+description: "The umbrella dispatcher: one stable command surface that routes every adlc verb to the right gate in the suite."
 ---
 
 # cli
@@ -10,7 +10,7 @@ description: The umbrella dispatcher — one stable command surface that routes 
 ## What it is
 
 Every ADLC gate ships as its own `@adlc/*` package, but an agent harness needs a
-single stable prefix — a skill or hook that shells out to twenty different
+single stable prefix. A skill or hook that shells out to twenty different
 binaries is brittle and easy to route around. `@adlc/cli` installs the suite and
 makes every gate reachable through one verb: `adlc <tool>`.
 
@@ -42,8 +42,8 @@ Every tool listed on the [Toolkit landing page](/docs/toolkit) is reachable as
 | Verb | What it does |
 | --- | --- |
 | `adlc <tool>` | Resolves the local `@adlc/<tool>` bin and runs it with the remaining args. |
-| `adlc run` / `adlc accept` | Runner verbs — route to `@adlc/runner` to assert phase evidence (`run`) or record P6 acceptance (`accept`). |
-| `adlc review` | External passthrough — shells out to `npx adversarial-review`, the model-judged reviewer that `prosecute` records evidence for but never runs itself. |
+| `adlc run` / `adlc accept` | Runner verbs that route to `@adlc/runner` to assert phase evidence (`run`) or record P6 acceptance (`accept`). |
+| `adlc review` | External passthrough that shells out to `npx adversarial-review`, the model-judged reviewer that `prosecute` records evidence for but never runs itself. |
 | `adlc ticket` | Unified local-store commands (`list`, `create`, `update`, archive, migration) plus external sync verbs (`pull`, `push`, `sync`, `doctor`). |
 
 ### Unknown tools
@@ -60,13 +60,13 @@ exit 1
 
 ## Exit-code convention
 
-The dispatcher mirrors the routed tool's exit code exactly — it adds none of its
+The dispatcher mirrors the routed tool's exit code exactly and adds none of its
 own semantics:
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes or command succeeds.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (including dispatcher-level failures: unknown tool, missing package).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes or command succeeds.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (including dispatcher-level failures: unknown tool, missing package).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails.</span>
 </div>
 
 ## Go deeper

--- a/apps/docs/content/docs/toolkit/coldstart.mdx
+++ b/apps/docs/content/docs/toolkit/coldstart.mdx
@@ -5,7 +5,7 @@ description: A cheap-tier LLM plays a fresh agent and lists every human-only que
 
 # coldstart
 
-**ADLC phase: P2 Decompose** · **Gate:** every ticket is self-contained — no human-only questions remain before it enters the build queue.
+**ADLC phase: P2 Decompose** · **Gate:** every ticket is self-contained: no human-only questions remain before it enters the build queue.
 
 <PhaseDiagram phase="P2" />
 
@@ -13,7 +13,7 @@ description: A cheap-tier LLM plays a fresh agent and lists every human-only que
 
 <FailureMode id="F3" />
 
-A build agent that starts on an under-specified ticket loses the plot fast: it guesses at missing shapes, invents contracts, and drifts. `coldstart` runs the check up front — a cheap-tier model plays a fresh agent with no prior context and lists every question it would have to ask a *human* before it could start. Information derivable from the repo does not count; only genuine gaps (undefined schemas, absent contracts, unverifiable criteria, vague scope) block the gate.
+A build agent that starts on an under-specified ticket loses the plot fast: it guesses at missing shapes, invents contracts, and drifts. `coldstart` runs the check up front. A cheap-tier model plays a fresh agent with no prior context and lists every question it would have to ask a *human* before it could start. Information derivable from the repo does not count; only genuine gaps (undefined schemas, absent contracts, unverifiable criteria, vague scope) block the gate.
 
 ## Usage
 
@@ -28,15 +28,15 @@ adlc coldstart --all [options]
 | `--all` | Run the gate on every ticket in the file. |
 | `--tier cheap\|mid\|frontier` | Model tier (default `cheap`). |
 | `--json` | Machine-readable JSON output for orchestrators. |
-| `--prompt-only` | Print the exact prompt(s) and exit 0 — no LLM call made. |
+| `--prompt-only` | Print the exact prompt(s) and exit 0 without making an LLM call. |
 | `--record-verdict <file\|->` | With `--prompt-only`: record the operator's answer into `.adlc/manifest.jsonl` via gate-manifest. Requires `--prompt-only`. |
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: ticket(s) are fully executable.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad input, unknown ticket id, missing file, no provider).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more tickets have gaps (printed per ticket).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. Ticket(s) are fully executable.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad input, unknown ticket id, missing file, no provider).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more tickets have gaps (printed per ticket).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/consensus-fix.mdx
+++ b/apps/docs/content/docs/toolkit/consensus-fix.mdx
@@ -18,7 +18,7 @@ test, applies each candidate in isolation, and keeps only those that pass BOTH t
 repro command and the full rail regression suite. Survivors are grouped by
 agreement and the smallest diff from the largest consensus group wins. When every
 survivor is a singleton (with `--n >= 3`), that divergence is treated as evidence
-the spec is ambiguous — the tool escalates rather than guessing.
+the spec is ambiguous, and the tool escalates rather than guessing.
 
 ## Usage
 
@@ -38,14 +38,14 @@ adlc consensus-fix --test-cmd "..." --files a.mjs,b.mjs [--rails "..."] [--n 3] 
 | `--apply` | Write the winning fix. Default is dry-run. Never applies when all-divergent. |
 | `--allow-dirty` | Skip the dirty-tree guard (useful in CI with staged-only changes). |
 | `--json` | Machine-readable output. |
-| `--prompt-only` | Print the prompts that would be sent and exit 0 — works with zero API keys. |
+| `--prompt-only` | Print the prompts that would be sent and exit 0. Works with zero API keys. |
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: at least one candidate survived both gates with a usable consensus.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad arguments, unreadable files, dirty tree, no provider).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: no survivors, or all survivors are singletons with `--n >= 3` (spec ambiguity — escalate).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. At least one candidate survived both gates with a usable consensus.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad arguments, unreadable files, dirty tree, no provider).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. No survivors, or all survivors are singletons with `--n >= 3` (spec ambiguity; escalate).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/core.mdx
+++ b/apps/docs/content/docs/toolkit/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: core
-description: The frozen shared foundation every ADLC tool imports — exit-code helpers, provider selection, and the ledger, ticket, rail, and mutation primitives.
+description: "The frozen shared foundation every ADLC tool imports: exit-code helpers, provider selection, and the ledger, ticket, rail, and mutation primitives."
 ---
 
 # core
@@ -10,7 +10,7 @@ description: The frozen shared foundation every ADLC tool imports — exit-code 
 ## What it is
 
 `@adlc/core` is the foundation the whole toolkit stands on. Every gate imports
-from it; no gate modifies it. It is a **frozen contract during tool builds** — a
+from it; no gate modifies it. It is a **frozen contract during tool builds**: a
 rail. If a tool needs something core doesn't offer, it works around the gap in
 its own package and notes it in its README rather than editing core. That
 discipline is what keeps twenty-plus independently published tools behaving
@@ -24,13 +24,13 @@ mutation operators used by prosecution.
 
 This is the contract. Every gate that builds on core reports its result the same
 way, so an orchestrator, hook, or CI job can branch on the exit code without
-parsing output. Core exposes it as three helpers — `pass()`, `opError()`, and
-`gateFail()`:
+parsing output. Core exposes it as three helpers: `pass()`, `opError()`, and
+`gateFail()`.
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — `pass()`: the gate passes or the command succeeds.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — `opError()`: operational error (bad input, unreadable file, failed LLM call).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — `gateFail()`: the gate fails (the finding is real).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: `pass()`. The gate passes or the command succeeds.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: `opError()`. Operational error (bad input, unreadable file, failed LLM call).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: `gateFail()`. The gate fails (the finding is real).</span>
 </div>
 
 The split between 1 and 2 matters: an operational error means the gate couldn't
@@ -39,7 +39,7 @@ let a broken environment read as a clean pass.
 
 ## Provider selection
 
-Tools that run an LLM pass do not embed provider logic — they call core's
+Tools that run an LLM pass do not embed provider logic. They call core's
 `detectProvider` / `complete` / `fan` helpers, which auto-detect a provider from
 the environment. Detection runs in a fixed priority order (cheapest and lowest
 latency first, per ADR-0007), matching the first provider whose key is present:
@@ -61,7 +61,7 @@ overridden with `ADLC_MODEL_CHEAP`, `ADLC_MODEL_MID`, and `ADLC_MODEL_FRONTIER`.
 No ADLC gate requires an API key to be useful. Every LLM-backed tool exposes
 `--prompt-only`, backed by core's `promptOnly()` helper: it prints the exact
 prompt the tool would send and exits `0`. You can paste that prompt into any
-harness — a chat window, a different provider, an air-gapped review — and feed
+harness (a chat window, a different provider, an air-gapped review) and feed
 the answer back. Keys make the gate automatic; they are never a gate to entry.
 
 ## Rail-engine primitives

--- a/apps/docs/content/docs/toolkit/flail-detector.mdx
+++ b/apps/docs/content/docs/toolkit/flail-detector.mdx
@@ -14,7 +14,7 @@ description: Analyzes a build-session log for flail signatures and fails the gat
 A build agent that has lost the thread will loop: hitting the same error over and
 over, wandering outside its declared scope, or churning the same file. Left alone
 it burns context and produces noise. `flail-detector` encodes the mechanical
-two-strike rule — it reads a session log and fails closed when it finds any of
+two-strike rule. It reads a session log and fails closed when it finds any of
 four signatures: a normalized error signature repeating past `--max-repeat`, a
 written path outside every `--scope` glob, one file edited three or more times, or
 a log exceeding `--max-bytes`. It is fully deterministic and makes no LLM calls.
@@ -37,9 +37,9 @@ adlc flail-detector <log-file> [--scope <glob>...] [--max-repeat <n>] [--max-byt
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — clean: no flail signals detected, the session may continue.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (log file not found, bad argument).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — flail: one or more signals triggered; kill the session and append the dead-ends to the ticket.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: clean. No flail signals detected, the session may continue.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (log file not found, bad argument).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: flail. One or more signals triggered; kill the session and append the dead-ends to the ticket.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/fleet.mdx
+++ b/apps/docs/content/docs/toolkit/fleet.mdx
@@ -1,18 +1,18 @@
 ---
 title: fleet
-description: Parallel ticket orchestration — dispatches ready tickets to sandboxed Claude Code workers in isolated worktrees, gates and prosecutes each, and merges to a per-run integration branch with deterministic control flow.
+description: Parallel ticket orchestration. Dispatches ready tickets to sandboxed Claude Code workers in isolated worktrees, gates and prosecutes each, and merges to a per-run integration branch with deterministic control flow.
 ---
 
 # fleet
 
-**ADLC phase: P4 Build + P5 Prosecute** · **Gate:** a ticket merges only after its build/test, rails, scope, protected-path, and blocking cross-model prosecution gates all pass — and nothing is decided by a model.
+**ADLC phase: P4 Build + P5 Prosecute** · **Gate:** a ticket merges only after its build/test, rails, scope, protected-path, and blocking cross-model prosecution gates all pass, and nothing is decided by a model.
 
 ## What it defends against
 
 ADLC P4 parallelism was doctrine without an executor: the ticket DAG says which
 work can fan out, but running it meant one interactive session per ticket. `fleet`
 makes the fan-out real. It reads the ready tickets from `.adlc/tickets.json` (the
-existing contract — completed tickets filtered, scope-overlapping tickets
+existing contract: completed tickets filtered, scope-overlapping tickets
 serialized, single writer per partition), dispatches each to a **sandboxed
 headless Claude Code worker** in an isolated git worktree, and walks it through the
 deterministic gates before a **blocking cross-model `adversarial-review`** pass
@@ -23,7 +23,7 @@ Containment is two-plane: the repo-command surface (init/build/test) runs inside
 OS sandbox (network-denied, reads/writes bounded to the worktree, synthetic HOME),
 while the `claude -p` worker runs on a separate model plane so it can still reach
 its provider. Finished tickets merge sequentially into a per-run
-`fleet/run-<runId>` integration branch — never `base`, and the fleet never pushes.
+`fleet/run-<runId>` integration branch, never into `base`. The fleet never pushes.
 
 ## Usage
 
@@ -51,9 +51,9 @@ trusted `adversarial-review` binary; it fails closed otherwise.
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — every dispatched ticket merged (or a clean dry-run).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad config, dirty tree, lock held, missing gate, no sandbox).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — at least one ticket failed or was blocked.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: every dispatched ticket merged (or a clean dry-run).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad config, dirty tree, lock held, missing gate, no sandbox).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: at least one ticket failed or was blocked.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/gate-fuzzing.mdx
+++ b/apps/docs/content/docs/toolkit/gate-fuzzing.mdx
@@ -12,8 +12,8 @@ description: Fans model instances to generate wrong-but-passing diffs and report
 A gate that never sees a hostile input is a gate nobody has tested.
 `gate-fuzzing` fans N cheap/mid model instances to produce candidate diffs
 engineered to pass every configured gate while being genuinely wrong. Each diff
-that slips through — valid, passing all gates, touching a gate's declared
-surface, and proven wrong by an independent held-out witness — is a defeat, and
+that slips through (valid, passing all gates, touching a gate's declared
+surface, and proven wrong by an independent held-out witness) is a defeat, and
 each defeat becomes a RED test you commit into that gate. It turns "we found
 some bypasses once" into a standing CI check.
 
@@ -35,7 +35,7 @@ adlc gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid] [--provider <n
 | `--providers <a,b,c>` | Fan across distinct named providers, one candidate each. |
 | `--max-rounds <int>` / `--dry-rounds <int>` | Round ceiling (default `10`) and consecutive-dry stop count (default `3`). |
 | `--witness-trials <int>` | Unanimous witness runs per side (default `3`). |
-| `--unsafe-no-sandbox` | Skip the OS sandbox — only inside a disposable VM. |
+| `--unsafe-no-sandbox` | Skip the OS sandbox. Use only inside a disposable VM. |
 | `--strict-budget` | Any inconclusive stop becomes exit 1 (recommended for CI). |
 | `--fail-on-behavioral` | Behavioral defeats exit 2 (default: report only). |
 | `--record` | Write repro artifacts to `.adlc/gate-defeats/` and cluster findings. |
@@ -45,9 +45,9 @@ adlc gate-fuzzing [--suite <path>] [--n <int>] [--tier cheap|mid] [--provider <n
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — earned clean: potency canary beaten, no defeats found, dry streak reached.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: dirty tree, no sandbox binary, failed control self-test, or an inconclusive stop under `--strict-budget`.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — a gate was defeated: wrong-but-passing, surface-bound, independently witnessed.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: earned clean. Potency canary beaten, no defeats found, dry streak reached.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. Dirty tree, no sandbox binary, failed control self-test, or an inconclusive stop under `--strict-budget`.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate defeated. Wrong-but-passing, surface-bound, independently witnessed.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/gate-manifest.mdx
+++ b/apps/docs/content/docs/toolkit/gate-manifest.mdx
@@ -10,14 +10,14 @@ description: A hash-chained evidence ledger recording what each ADLC gate verifi
 ## What it defends against
 
 Agentic code arrives at the merge gate with no memory of what was checked along the way.
-`gate-manifest` is the append-only ledger the other gates write to — spec-lint, hollow-test,
-rails-guard, review-calibration — each recording what it verified into `.adlc/manifest.jsonl`.
+`gate-manifest` is the append-only ledger the other gates write to: spec-lint, hollow-test,
+rails-guard, and review-calibration each record what they verified into `.adlc/manifest.jsonl`.
 Every entry's `prev` is the SHA-256 of the previous raw line, so tampering with any line
 breaks the chain. Set `ADLC_MANIFEST_KEY` and each entry is additionally HMAC-SHA256 signed:
 without it the chain proves only internal consistency (anyone who can write the file can
 forge a clean one); with it, the chain attests authorship and defeats the forge-from-scratch
-attack. It spans phases rather than owning one, giving auditors and the P6 gate the provenance
-that agentic code was checked before it shipped.
+attack. It spans phases rather than owning one, and it gives auditors and the P6 gate the
+provenance that agentic code was checked before it shipped.
 
 ## Usage
 
@@ -46,9 +46,9 @@ adlc gate-manifest repair-chain --reason "..." [--write] [--attest-unsigned] [--
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — `record`, `show`, and `attest` always; `verify` when the chain (and signatures, if keyed) is valid.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: bad input, unreadable file, or malformed `--data` JSON.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — `verify` gate fails: the chain is broken (reports the seq and line of the first break).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: `record`, `show`, and `attest` always; `verify` when the chain (and signatures, if keyed) is valid.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. Bad input, unreadable file, or malformed `--data` JSON.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: `verify` gate fails. The chain is broken (reports the seq and line of the first break).</span>
 </div>
 
 Prosecution, runner acceptance, rails evidence, and manual records share one

--- a/apps/docs/content/docs/toolkit/hollow-test.mdx
+++ b/apps/docs/content/docs/toolkit/hollow-test.mdx
@@ -1,11 +1,11 @@
 ---
 title: hollow-test
-description: Diff-scoped mutation gate — mutates only the lines your change touched and fails if any mutant survives your test suite, proving coverage is load-bearing.
+description: Diff-scoped mutation gate. Mutates only the lines your change touched and fails if any mutant survives your test suite, which proves the coverage is load-bearing.
 ---
 
 # hollow-test
 
-**ADLC phase: P3 Rail (C4)** · **Gate:** every changed line is constrained by an assertion — no mutant survives.
+**ADLC phase: P3 Rail (C4)** · **Gate:** every changed line is constrained by an assertion, so no mutant survives.
 
 <PhaseDiagram phase="P3" />
 
@@ -14,8 +14,8 @@ description: Diff-scoped mutation gate — mutates only the lines your change to
 <FailureMode id="F5" />
 
 Executed lines are not tested lines. A suite can run every changed statement and still
-assert nothing about its behavior — hollow coverage that a reward-seeking model will
-happily produce. `hollow-test` mutates only the lines in your diff (invert a comparison,
+assert nothing about its behavior. That is hollow coverage, and a reward-seeking model
+will happily produce it. `hollow-test` mutates only the lines in your diff (invert a comparison,
 flip a boolean, null a return), reruns the suite against each mutant, and fails if any
 survives. A survivor is proof the line's behavior is unconstrained. Diff-scoping keeps
 the run in seconds-to-minutes instead of the hours whole-codebase mutation testing costs.
@@ -43,9 +43,9 @@ so a failing suite cannot masquerade as killing every mutant.
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: every generated mutant was killed by the suite.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: dirty tree, not a git repo, bad arguments, non-green baseline, or nothing eligible to mutate with no `--target`/`--rails`.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more mutants survived (hollow coverage).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. Every generated mutant was killed by the suite.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. Dirty tree, not a git repo, bad arguments, non-green baseline, or nothing eligible to mutate with no `--target`/`--rails`.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more mutants survived (hollow coverage).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/index.mdx
+++ b/apps/docs/content/docs/toolkit/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Toolkit
-description: The ADLC toolkit — one deterministic gate per lifecycle phase, installed once through @adlc/cli.
+description: "The ADLC toolkit: one deterministic gate per lifecycle phase, installed once through @adlc/cli."
 ---
 
 # Toolkit
 
 The toolkit makes the ADLC gates concrete. Each lifecycle phase asks one
-machine-checkable question, and one tool answers it with an exit code — `0`
+machine-checkable question, and one tool answers it with an exit code: `0`
 passes, `2` fails. The tools publish independently but install together and share
 one command surface: `adlc <tool>`. If you want the phase map first, read
 [The Lifecycle](/docs/lifecycle); this page is the index of every gate.
@@ -55,7 +55,7 @@ compounding defenses, and syncing outward.
 | [review-calibration](/docs/toolkit/review-calibration) | Measure reviewer recall by scoring whether review catches mutants. |
 | [model-ratchet](/docs/toolkit/model-ratchet) | Identify hot files for re-prosecution after model or repo drift. |
 | [gate-fuzzing](/docs/toolkit/gate-fuzzing) | Run hostile candidates against gate suites to find defeats. |
-| `review` | External passthrough — runs the model-judged `npx adversarial-review` that `prosecute` records evidence for. |
+| `review` | External passthrough. Runs the model-judged `npx adversarial-review` that `prosecute` records evidence for. |
 
 ## Compounding defenses
 
@@ -73,10 +73,10 @@ compounding defenses, and syncing outward.
 
 ## Shared foundation
 
-Not gates themselves — the layer every gate is built on.
+These are not gates. They are the layer every gate is built on.
 
 | Package | What it does |
 | --- | --- |
-| [cli](/docs/toolkit/cli) | The `adlc <tool>` dispatcher — one stable command surface for the whole suite. |
+| [cli](/docs/toolkit/cli) | The `adlc <tool>` dispatcher: one stable command surface for the whole suite. |
 | [core](/docs/toolkit/core) | Frozen shared library: exit-code helpers, provider selection, ledger, ticket, rail, and mutation primitives. |
-| [runner](/docs/toolkit/runner) | Backs `adlc run` and `adlc accept` — asserts phase evidence and records P6 acceptance. |
+| [runner](/docs/toolkit/runner) | Backs `adlc run` and `adlc accept`. Asserts phase evidence and records P6 acceptance. |

--- a/apps/docs/content/docs/toolkit/lesson-foundry.mdx
+++ b/apps/docs/content/docs/toolkit/lesson-foundry.mdx
@@ -5,7 +5,7 @@ description: Clusters recurring prosecution findings and routes each to its chea
 
 # lesson-foundry
 
-**ADLC phase: P7 Compound** · **Gate:** with `--gate`, every recurring finding cluster has a banked defense file — no lesson is re-bought.
+**ADLC phase: P7 Compound** · **Gate:** with `--gate`, every recurring finding cluster has a banked defense file, so no lesson is re-bought.
 
 <PhaseDiagram phase="P7" />
 
@@ -16,8 +16,8 @@ description: Clusters recurring prosecution findings and routes each to its chea
 Without a compounding step the lifecycle never gets cheaper: the same finding is
 re-discovered by probabilistic review every run. `lesson-foundry` reads the
 prosecution findings ledger, clusters findings by semantic similarity, and
-routes each recurring cluster to its cheapest permanent defense — a grep-gate
-LINT, a `SKILL.md` stub, or a SPEC-GAP question for P1 — demoting a
+routes each recurring cluster to its cheapest permanent defense: a grep-gate
+LINT, a `SKILL.md` stub, or a SPEC-GAP question for P1. That demotes a
 dollars-per-catch LLM finding into a free-forever deterministic one.
 
 ## Usage
@@ -31,7 +31,7 @@ adlc lesson-foundry [--ledger <name>] [--min <n>] [--out-dir <path>] [--write] [
 | `--ledger <name>` | Ledger name under `.adlc/` to read findings from (default `findings`). |
 | `--min <n>` | Minimum cluster size to surface (default `2`). |
 | `--out-dir <path>` | Output directory for defense files (default `.adlc/lessons`). |
-| `--write` | Emit files (default is dry-run — prints what would be written). |
+| `--write` | Emit files (default is dry-run, which prints what would be written). |
 | `--gate` | Exit 2 if any cluster ≥ `--min` has no defense file in `--out-dir`. |
 | `--llm` | Refine cluster wording via one mid-tier LLM call per cluster. |
 | `--tier cheap\|mid\|frontier` | Model tier for the `--llm` pass (default `mid`). |
@@ -41,9 +41,9 @@ adlc lesson-foundry [--ledger <name>] [--min <n>] [--out-dir <path>] [--write] [
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: no recurring unbanked lessons (or `--gate` not set).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: bad input, unreadable ledger, or a write failure.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more clusters have no defense file in `--out-dir`.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. No recurring unbanked lessons (or `--gate` not set).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. Bad input, unreadable ledger, or a write failure.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more clusters have no defense file in `--out-dir`.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/merge-forecast.mdx
+++ b/apps/docs/content/docs/toolkit/merge-forecast.mdx
@@ -12,7 +12,7 @@ description: Predicts merge conflicts before any agent runs, certifies the safe 
 ## What it defends against
 
 Fanning agents out wide only to have their branches collide at merge time burns
-the parallel speedup twice — once building, once untangling. `merge-forecast`
+the parallel speedup twice: once building, once untangling. `merge-forecast`
 scores every parallel-eligible ticket pair for scope overlap, namespace
 collision, import radius, and historical co-change, then certifies the largest
 independent set as the safe width and orders the merge foundation-first. A hard
@@ -39,9 +39,9 @@ adlc merge-forecast [--tickets <path>] [--width <N>] [--build-min <X>] [--merge-
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: the schedule is safe at the recommended width.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad tickets file, unresolvable input).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: `--width` exceeds the certified width, or a vetoed / high-risk pair is scheduled concurrently.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. The schedule is safe at the recommended width.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad tickets file, unresolvable input).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. `--width` exceeds the certified width, or a vetoed / high-risk pair is scheduled concurrently.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/model-ratchet.mdx
+++ b/apps/docs/content/docs/toolkit/model-ratchet.mdx
@@ -5,15 +5,15 @@ description: Ranks hot files (churn × import criticality) for re-prosecution af
 
 # model-ratchet
 
-**ADLC phase: calibration (cross-phase)** · **Gate:** none — it prints a prosecution plan or drives a review over the highest-value files and records findings.
+**ADLC phase: calibration (cross-phase)** · **Gate:** none. It prints a prosecution plan, or drives a review over the highest-value files and records findings.
 
 ## What it defends against
 
 Every frontier model release is a free re-audit: newer models find what older
-ones missed. `model-ratchet` picks the files worth re-prosecuting first —
-`SCORE = churn × (1 + inDegree)`, high change rate times how many source files
-import it — then either prints a prosecution plan or runs your review command
-over each, appending verified findings to the shared `.adlc/findings` ledger.
+ones missed. `model-ratchet` picks the files worth re-prosecuting first. It ranks
+them by `SCORE = churn × (1 + inDegree)`, high change rate times how many source
+files import it, then either prints a prosecution plan or runs your review command
+over each file and appends verified findings to the shared `.adlc/findings` ledger.
 Run it on every model release (or monthly) to ratchet quality monotonically up.
 
 ## Usage
@@ -33,9 +33,9 @@ adlc model-ratchet [--top <n>] [--review-cmd <cmd>] [--churn-limit <n>] [--dry-r
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — success: plan printed, or the review ran and findings were appended to the ledger.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: not a git repo, a `--review-cmd` exit outside {0,2}, or bad arguments.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — not used by model-ratchet itself; review findings route to the ledger rather than failing a gate.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: success. Plan printed, or the review ran and findings were appended to the ledger.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error. Not a git repo, a `--review-cmd` exit outside {0,2}, or bad arguments.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: not used by model-ratchet itself. Review findings route to the ledger rather than failing a gate.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/model-router.mdx
+++ b/apps/docs/content/docs/toolkit/model-router.mdx
@@ -1,6 +1,6 @@
 ---
 title: model-router
-description: Deterministically assigns every ticket a model tier and ladder mode from the ticket DAG and ledger history — no LLM calls.
+description: Deterministically assigns every ticket a model tier and ladder mode from the ticket DAG and ledger history, with no LLM calls.
 ---
 
 # model-router
@@ -17,7 +17,7 @@ Picking a model per ticket by vibe leaves the seams showing: a cheap model on an
 unrailed, hard-to-verify ticket, or a frontier model burned on slack work.
 `model-router` reads the ticket DAG's rail density and critical-path float, plus
 per-model first-pass rates mined from the manifest ledger, and emits a
-deterministic `tier` + `mode` for every ticket — the same inputs always produce
+deterministic `tier` + `mode` for every ticket. The same inputs always produce
 the same routing.
 
 ## Usage
@@ -40,9 +40,9 @@ ladder up on gate failure.
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: all tickets assigned.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad tickets file, JSON parse error, cycle in the DAG).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more non-frontier-category tickets fall below the rail-density floor.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. All tickets assigned.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad tickets file, JSON parse error, cycle in the DAG).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more non-frontier-category tickets fall below the rail-density floor.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/parallax.mdx
+++ b/apps/docs/content/docs/toolkit/parallax.mdx
@@ -11,7 +11,7 @@ description: Fans N independent readers over a request and surfaces only the div
 
 ## What it defends against
 
-A single model reading an ambiguous request commits to one interpretation and states it with total confidence — the ambiguity never surfaces, it just silently becomes a decision. `parallax` replaces that introspection with measurement: it fans N independent cheap-tier readings, diffs them, and reports only where they disagree. The ambiguity score (`divergences / (divergences + agreements)`) turns "is this spec clear?" into a number you can gate on.
+A single model reading an ambiguous request commits to one interpretation and states it with total confidence. The ambiguity never surfaces; it just silently becomes a decision. `parallax` replaces that introspection with measurement: it fans N independent cheap-tier readings, diffs them, and reports only where they disagree. The ambiguity score (`divergences / (divergences + agreements)`) turns "is this spec clear?" into a number you can gate on.
 
 ## Usage
 
@@ -19,7 +19,7 @@ A single model reading an ambiguous request commits to one interpretation and st
 adlc parallax --request "text" | --file req.md | --edge T1 T2 | --route "question" [flags]
 ```
 
-Three modes: **spec** (default — fan readers over a raw request), **edge** (`--edge T1 T2` — author the contract implied between two tickets), and **route** (`--route` — answer a mid-build question and check the answers agree).
+Three modes: **spec** (default, fans readers over a raw request), **edge** (`--edge T1 T2`, authors the contract implied between two tickets), and **route** (`--route`, answers a mid-build question and checks that the answers agree).
 
 | Flag | Description |
 | --- | --- |
@@ -28,19 +28,19 @@ Three modes: **spec** (default — fan readers over a raw request), **edge** (`-
 | `--route <text>` | Route mode: the question to route. |
 | `--context <file>` | Route mode: context file, repeatable. |
 | `--tickets <path>` | Tickets file for edge mode (default `.adlc/tickets.json`). |
-| `--n <int>` | Fan width — number of independent readings (default 3). |
+| `--n <int>` | Fan width: number of independent readings (default 3). |
 | `--threshold <0-1>` | Ambiguity gate threshold (default 0.25). |
 | `--tier cheap\|mid\|frontier` | Override the LLM tier. |
 | `--json` | Machine-readable output (score + divergences). |
-| `--prompt-only` | Print the exact prompts and exit 0 — no API key needed. |
+| `--prompt-only` | Print the exact prompts and exit 0. No API key needed. |
 | `--record-verdict <file\|->` | With `--prompt-only`: record the operator's answer into `.adlc/manifest.jsonl` via gate-manifest. Requires `--prompt-only`. |
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: ambiguity score at or below threshold (spec/edge), or answers equivalent (route).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad input, missing file, network failure, too few readings).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: ambiguity score exceeds threshold, or route answers diverge.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. Ambiguity score at or below threshold (spec/edge), or answers equivalent (route).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad input, missing file, network failure, too few readings).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. Ambiguity score exceeds threshold, or route answers diverge.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/preflight.mdx
+++ b/apps/docs/content/docs/toolkit/preflight.mdx
@@ -16,7 +16,7 @@ serialization point: one blocked agent stalls its N siblings, races half-started
 state, and wrecks the parallel wall-clock math. `preflight` front-loads bash,
 git, filesystem-write, and branch checks (plus optional worktree, test-command,
 `gh`, and LLM-provider checks) into one batch so the environment is proven
-deterministic before fan-out — not discovered non-deterministic during it.
+deterministic before fan-out, rather than discovered non-deterministic during it.
 
 ## Usage
 
@@ -39,9 +39,9 @@ that creates a side effect cleans up in a `finally` block.
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: every required and explicitly requested check passed.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational / internal error.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more required or requested checks failed.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. Every required and explicitly requested check passed.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational / internal error.</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more required or requested checks failed.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/premortem.mdx
+++ b/apps/docs/content/docs/toolkit/premortem.mdx
@@ -1,11 +1,11 @@
 ---
 title: premortem
-description: Tells a frontier model the project already failed and asks for the postmortem, surfacing concrete risks anchored to the spec.
+description: Tells a frontier model the project already failed and asks for the postmortem, which surfaces concrete risks anchored to the spec.
 ---
 
 # premortem
 
-**ADLC phase: P1 Interrogate** · **Gate:** advisory — every surfaced failure cause becomes an interrogation question folded into spec review before the spec is locked.
+**ADLC phase: P1 Interrogate** · **Gate:** advisory. Every surfaced failure cause becomes an interrogation question folded into spec review before the spec is locked.
 
 <PhaseDiagram phase="P1" />
 
@@ -27,16 +27,16 @@ adlc premortem <spec.md> [--tier cheap|mid|frontier] [--out report.md] [--json] 
 | `--tier cheap\|mid\|frontier` | Model tier (default `frontier`). |
 | `--out <path>` | Write the markdown report to this file instead of stdout. |
 | `--json` | Emit machine-readable JSON `{ causes: [...] }`. |
-| `--prompt-only` | Print the exact system + user prompt and exit 0 — no API key needed. |
+| `--prompt-only` | Print the exact system + user prompt and exit 0. No API key needed. |
 | `--record-verdict <file\|->` | With `--prompt-only`: record the operator's answer into `.adlc/manifest.jsonl` via gate-manifest. Requires `--prompt-only`. |
 | `--help` | Print usage and exit 0. |
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — report produced successfully (or `--prompt-only` / `--help`).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (missing spec file, no LLM provider configured, malformed model response).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — reserved for future gate-fail use; not currently emitted (premortem is advisory).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: report produced successfully (or `--prompt-only` / `--help`).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (missing spec file, no LLM provider configured, malformed model response).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: reserved for future gate-fail use; not currently emitted (premortem is advisory).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/prosecute.mdx
+++ b/apps/docs/content/docs/toolkit/prosecute.mdx
@@ -1,6 +1,6 @@
 ---
 title: prosecute
-description: A P5 review-evidence recorder — validates, hashes, and records ticket- and revision-bound reviewer findings, passing only after two dry passes across three lenses.
+description: A P5 review-evidence recorder. It validates, hashes, and records ticket- and revision-bound reviewer findings, and passes only after two dry passes across three lenses.
 ---
 
 # prosecute
@@ -13,13 +13,13 @@ description: A P5 review-evidence recorder — validates, hashes, and records ti
 
 <FailureMode id="F2" />
 
-`prosecute` is a **recorder, not a reviewer** — it makes zero model calls and finds no bugs
+`prosecute` is a **recorder, not a reviewer**. It makes zero model calls and finds no bugs
 of its own. The model-judged skeptical review is a separate tool (`npx adversarial-review`,
 which `adlc review` wraps); `adlc prosecute` consumes **that** review's output as evidence.
 It validates the findings, hashes and binds them to the ticket and reviewed revision, and
 appends normalized pass records to `.adlc/manifest.jsonl`. It passes only after two
-consecutive dry passes covering three distinct lenses — so a single sycophantic "looks good"
-cannot stand in for a real prosecution, and the recorded evidence is what P6 later checks.
+consecutive dry passes covering three distinct lenses, so a single sycophantic "looks good"
+cannot stand in for a real prosecution. The recorded evidence is what P6 later checks.
 
 Note the binary is `adlc-prosecute` (registry `binName`) but it dispatches as `adlc prosecute`.
 
@@ -41,14 +41,14 @@ adlc-prosecute --input <passes.json> --ticket id [--target label] [--revision re
 
 Evidence files (transcript, prompt, inputs) that resolve inside the worktree must live under
 `.adlc/` or `.omo/evidence/`, and the transcript must reference both the ticket and the
-resolved revision — a trust-boundary control against faked review evidence.
+resolved revision. These are trust-boundary controls against faked review evidence.
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — two consecutive dry passes were recorded.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (unreadable input, missing `--ticket`, bad evidence path).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — verified or needs-human findings remain, or the convergence budget ended before two dry passes.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: two consecutive dry passes were recorded.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (unreadable input, missing `--ticket`, bad evidence path).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: verified or needs-human findings remain, or the convergence budget ended before two dry passes.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/rails-guard.mdx
+++ b/apps/docs/content/docs/toolkit/rails-guard.mdx
@@ -12,7 +12,7 @@ description: Blocks builder edits to frozen rail paths and greps added diff line
 ## What it defends against
 
 During P4 a builder can quietly edit the very tests, contract types, or CI config
-that are supposed to hold it accountable — or slip a `.skip(`, `.only(`,
+that are supposed to hold it accountable, or slip a `.skip(`, `.only(`,
 `@ts-ignore`, or `# noqa` into the diff to turn a red gate green. `rails-guard`
 enforces two invariants on the diff: declared rail globs must not be touched, and
 any newly added suppression marker is blocked unless the active ticket body
@@ -28,7 +28,7 @@ adlc rails-guard [--base <ref>] [--ticket <id>] [--tickets <path>] [--rails <glo
 
 | Flag | Description |
 | --- | --- |
-| `--base <ref>` | Freeze baseline to diff against. When omitted, resolves to the merge-base of HEAD with trunk (`main`/`master`/`origin/main`/`origin/master`) and **fails closed if no trunk ref is found** — it never defaults to HEAD, which would hide already-committed rail edits. |
+| `--base <ref>` | Freeze baseline to diff against. When omitted, resolves to the merge-base of HEAD with trunk (`main`/`master`/`origin/main`/`origin/master`) and **fails closed if no trunk ref is found**. It never defaults to HEAD, which would hide already-committed rail edits. |
 | `--ticket <id>` | Load rail globs and `allow-suppression` declarations from this ticket. |
 | `--tickets <path>` | Path to the tickets file (default `.adlc/tickets.json`). |
 | `--rails <glob>` | Frozen-path glob, repeatable. Overrides `ticket.rails` when supplied. |
@@ -41,9 +41,9 @@ Rails resolve from `--rails` when given, otherwise from `--ticket`; with neither
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: no rail edits and no undeclared suppression markers.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (not a git repo, bad input, no rails resolvable, no trunk baseline).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more violations found (list printed to stderr / JSON).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. No rail edits and no undeclared suppression markers.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (not a git repo, bad input, no rails resolvable, no trunk baseline).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more violations found (list printed to stderr / JSON).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/rejection-mining.mdx
+++ b/apps/docs/content/docs/toolkit/rejection-mining.mdx
@@ -5,13 +5,13 @@ description: Mines human PR review objections into reusable prosecution lenses s
 
 # rejection-mining
 
-**ADLC phase: P7 Compound** · **Gate:** none — it authors prosecution lens files from clustered PR objections for `adversarial-review` to reuse.
+**ADLC phase: P7 Compound** · **Gate:** none. It authors prosecution lens files from clustered PR objections for `adversarial-review` to reuse.
 
 <PhaseDiagram phase="P7" />
 
 ## What it defends against
 
-Institutional reviewers reject the same classes of change over and over — the
+Institutional reviewers reject the same classes of change over and over: the
 "nights of no" that cost days in queue. `rejection-mining` fetches PR review
 threads via the GitHub CLI, filters for negative-signal language, clusters
 similar objections, and authors each cluster into a lens file with a
@@ -40,9 +40,9 @@ Requires the `gh` CLI installed and authenticated (`gh auth login`).
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — success: mining complete (lenses printed, or written with `--write`).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: `gh` missing, auth failure, no PRs found, or bad arguments.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — reserved for a gate-fail; not currently emitted by this tool.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: success. Mining complete (lenses printed, or written with `--write`).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (`gh` missing, auth failure, no PRs found, or bad arguments).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: reserved for a gate-fail; not currently emitted by this tool.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/review-calibration.mdx
+++ b/apps/docs/content/docs/toolkit/review-calibration.mdx
@@ -13,9 +13,9 @@ description: Measures reviewer recall by planting bugs and scoring whether the r
 
 "We do adversarial review" is a vibe until it is a number. `review-calibration`
 plants real bugs into files changed by a commit, runs your review command, and
-scores recall — with a built-in echo control that scores ~0 and an oracle
-control that scores 1.0, so the recall figure is trustworthy rather than gamed
-by a reviewer that merely echoes changed lines.
+scores recall. A built-in echo control scores ~0 and an oracle control scores
+1.0, so the recall figure is trustworthy rather than gamed by a reviewer that
+merely echoes changed lines.
 
 ## Usage
 
@@ -42,9 +42,9 @@ adlc review-calibration --review-cmd "cmd with {base} placeholder" [options]
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: recall (and precision, if set) meet the thresholds.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: dirty tree, no plants generatable, review command crashed (exit not in {0,2}), no judge provider, or a control self-test failed.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: recall/precision below the thresholds, or a `--strict` provider match.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. Recall (and precision, if set) meet the thresholds.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (dirty tree, no plants generatable, review command crashed with an exit not in {0,2}, no judge provider, or a control self-test failed).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. Recall/precision below the thresholds, or a `--strict` provider match.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/runner.mdx
+++ b/apps/docs/content/docs/toolkit/runner.mdx
@@ -1,6 +1,6 @@
 ---
 title: runner
-description: Asserts that each ADLC phase's required manifest evidence is present, failing closed when reviewed content changes.
+description: Asserts that each ADLC phase's required manifest evidence is present, and fails closed when reviewed content changes.
 ---
 
 # runner
@@ -10,7 +10,7 @@ description: Asserts that each ADLC phase's required manifest evidence is presen
 ## What it defends against
 
 "A command ran" is not a gate. An orchestrator can call a tool, ignore its result,
-and march on — or edit the code after it was reviewed. The runner refuses that: it
+and march on, or edit the code after it was reviewed. The runner refuses that: it
 reads `.adlc/manifest.jsonl` and asserts the specific evidence each phase requires,
 scoped to a ticket for P3–P6. P5 and P6 bind to the current content fingerprint and
 fail closed if reviewed content changes after the fact, so committing the exact
@@ -42,9 +42,9 @@ Phases run p1 through p7; p3–p6 require `--ticket`.
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — required phase evidence is present (and still matches the reviewed content).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (unknown phase, missing `--ticket`, bad input).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — required phase evidence is missing.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: required phase evidence is present (and still matches the reviewed content).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (unknown phase, missing `--ticket`, bad input).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: required phase evidence is missing.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/skill-rot.mdx
+++ b/apps/docs/content/docs/toolkit/skill-rot.mdx
@@ -10,7 +10,7 @@ description: Verifies the checkable claims inside SKILL.md files still hold agai
 ## What it defends against
 
 Skills are caches, and a stale cache delivers misinformation with the authority
-of an expert — worse than no skill at all. `skill-rot` walks each `SKILL.md`,
+of an expert. That is worse than no skill at all. `skill-rot` walks each `SKILL.md`,
 extracts the claims it can actually check (command names, file paths, and
 `npm`/`npx`/`pnpm`/`yarn` script references), and verifies them against the
 repo. Verifiable-but-failing claims are `stale` and fail the gate; claims it
@@ -34,9 +34,9 @@ Positional paths override the default search roots (`.claude/skills`,
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: all skills clean.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error: no `SKILL.md` files found, or bad input.</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: at least one skill has stale claims.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. All skills clean.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (no `SKILL.md` files found, or bad input).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. At least one skill has stale claims.</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/spec-lint.mdx
+++ b/apps/docs/content/docs/toolkit/spec-lint.mdx
@@ -27,14 +27,14 @@ adlc spec-lint <spec.md> [--llm] [--tier cheap|mid|frontier] [--json] [--prompt-
 | `--llm` | LLM pass on VERIFIED criteria to catch vacuous methods ("works correctly", "run tests"). Demoted criteria become WISH. Requires a provider env var (see core). |
 | `--tier` | Model tier for the `--llm` pass: `cheap` (default), `mid`, or `frontier`. |
 | `--json` | Machine-readable output for orchestrators. All other output is suppressed. |
-| `--prompt-only` | Print the exact LLM prompt and exit 0 — works with zero API keys; paste into any harness. |
+| `--prompt-only` | Print the exact LLM prompt and exit 0. Works with zero API keys; paste into any harness. |
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — gate passes: every criterion names a verification method (or no criteria found; warns loudly).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad input, unreadable file, or LLM call failed).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — gate fails: one or more criteria are wishes (line numbers printed).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: gate passes. Every criterion names a verification method (or no criteria found; warns loudly).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad input, unreadable file, or LLM call failed).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: gate fails. One or more criteria are wishes (line numbers printed).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/ticket-prune.mdx
+++ b/apps/docs/content/docs/toolkit/ticket-prune.mdx
@@ -5,13 +5,13 @@ description: Reports and archives stale, already-shipped tickets out of .adlc/ti
 
 # ticket-prune
 
-**ADLC phase: maintenance / cross-phase (C12)** · **Gate:** none — advisory report; `--write` archives stale tickets, never deletes.
+**ADLC phase: maintenance / cross-phase (C12)** · **Gate:** none. Advisory report; `--write` archives stale tickets, never deletes.
 
 ## What it defends against
 
-`.adlc/tickets.json` is a mutable scratchpad, and nothing else prunes it after a ticket ships. Completed tickets accumulate and masquerade as an open backlog — you can't tell live work from leftovers without cross-checking deliverables and merged PRs by hand. `ticket-prune` reports (and, with `--write`, archives) the tickets it can determine are stale, so the backlog reflects what is actually open.
+`.adlc/tickets.json` is a mutable scratchpad, and nothing else prunes it after a ticket ships. Completed tickets accumulate and masquerade as an open backlog. You can't tell live work from leftovers without cross-checking deliverables and merged PRs by hand. `ticket-prune` reports (and, with `--write`, archives) the tickets it can determine are stale, so the backlog reflects what is actually open.
 
-A ticket is stale when it carries an explicit terminal `status` (`done` / `closed` / `complete` / `completed` / `archived` / `shipped`, case-insensitive), or — absent a status — when it declares at least one `scope` glob and every glob resolves to a file tracked at `--base-ref`. A ticket with no scope and no status is never inferred stale.
+A ticket is stale when it carries an explicit terminal `status` (`done` / `closed` / `complete` / `completed` / `archived` / `shipped`, case-insensitive), or, absent a status, when it declares at least one `scope` glob and every glob resolves to a file tracked at `--base-ref`. A ticket with no scope and no status is never inferred stale.
 
 ## Usage
 
@@ -24,14 +24,14 @@ adlc ticket-prune [--tickets path] [--archive path] [--base-ref ref] [--write] [
 | `--tickets <path>` | Ticket file to read (default `.adlc/tickets.json`). |
 | `--archive <path>` | Archive file written under `--write` (default `.adlc/tickets.archive.json`, gitignored). |
 | `--base-ref <ref>` | Git ref to check `scope` globs against (default `HEAD`). Point at `origin/main` to audit a branch's tickets against trunk. |
-| `--write` | Archive stale tickets — move them out of `--tickets` into `--archive` (append/upsert by id; never clobbered, never deleted). |
+| `--write` | Archive stale tickets: move them out of `--tickets` into `--archive` (append/upsert by id; never clobbered, never deleted). |
 | `--json` | Machine-readable `{ baseRef, write, stale[], active[], archived[] }`. |
 
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — report or archive succeeded, regardless of how many stale tickets were found. Advisory, not a merge blocker.</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, or the write lock could not be acquired).</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: report or archive succeeded, regardless of how many stale tickets were found. Advisory, not a merge blocker.</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, or the write lock could not be acquired).</span>
 </div>
 
 ## Example

--- a/apps/docs/content/docs/toolkit/ticket-sync.mdx
+++ b/apps/docs/content/docs/toolkit/ticket-sync.mdx
@@ -24,7 +24,7 @@ The standalone binary is `adlc-ticket-sync`; the same command dispatches through
 | Command / Flag | Description |
 | --- | --- |
 | `pull` | Import issues into the active ticket store (3-way reconcile; unions; fails closed on conflict). |
-| `push` | Write tickets back — update synced issues, idempotent create for local-only tickets, display-only status. |
+| `push` | Write tickets back: update synced issues, idempotent create for local-only tickets, display-only status. |
 | `sync` | `pull` then `push`; a non-clean pull aborts before push. |
 | `doctor` | Read-only, offline health checks (config / tickets / schema drift / sidecar / stale lock). |
 | `--write` | Apply changes (dry-run without it). |
@@ -35,9 +35,9 @@ The standalone binary is `adlc-ticket-sync`; the same command dispatches through
 ## Exit codes
 
 <div style={{ display: 'grid', gap: '0.25rem' }}>
-  <span style={{ color: 'var(--adlc-pass)' }}>**0** — ok: command completed (or produced a clean dry-run plan).</span>
-  <span style={{ color: 'var(--adlc-wish)' }}>**1** — operational error (bad config, `gh` failure, unknown flag or subcommand).</span>
-  <span style={{ color: 'var(--adlc-fail)' }}>**2** — blocked: a conflict the sync refuses to resolve automatically.</span>
+  <span style={{ color: 'var(--adlc-pass)' }}>**0**: ok. Command completed (or produced a clean dry-run plan).</span>
+  <span style={{ color: 'var(--adlc-wish)' }}>**1**: operational error (bad config, `gh` failure, unknown flag or subcommand).</span>
+  <span style={{ color: 'var(--adlc-fail)' }}>**2**: blocked. A conflict the sync refuses to resolve automatically.</span>
 </div>
 
 ## Example

--- a/apps/docs/lib/integration-facts.mjs
+++ b/apps/docs/lib/integration-facts.mjs
@@ -40,7 +40,7 @@ export const INTEGRATIONS = [
       'npm install -g @adlc/cli',
       'adlc init --harness cursor',
     ],
-    note: 'Marketplace install is preferred — the plugin brings hooks, skills, and /adlc-* commands. adlc init only bootstraps the .adlc/ runtime (do not commit a generated .adlc/config.json into a repo that already freezes that path). Legacy fallback: npx @adlc/cursor . Wire docs/ci/rails-guard.yml as the unbypassable control.',
+    note: 'Marketplace install is preferred, because the plugin brings hooks, skills, and /adlc-* commands. adlc init only bootstraps the .adlc/ runtime (do not commit a generated .adlc/config.json into a repo that already freezes that path). Legacy fallback: npx @adlc/cursor . Wire docs/ci/rails-guard.yml as the unbypassable control.',
   },
   {
     slug: 'opencode',


### PR DESCRIPTION
Ran a humanizer pass over the marketing pages and the full docs tree, targeting the patterns that read as machine-generated.

**Prose only.** No command, flag, path, or exit-code semantic changed. The near-equal insert/delete ratio (+348/−344) is the point: this rewrites prose rather than deleting content.

## Marketing

The biggest rewrite is the homepage barbell paragraph, which piled five benefits into one comma-separated list behind "What that buys the executive". It makes the same five points now, as varied sentences. Em dashes are also gone from the pull quote, enterprise band, privacy page, and contact form.

## Docs (47 files)

- Every em dash removed from prose. The 26 that remain are deliberate: literal CLI output inside code fences (`✗ gate fails — recall 62.5%`) and the `| — |` no-default table placeholders. Changing those would falsify the docs.
- The patterns underneath are fixed too: "-ing" tack-ons, copula avoidance (`serves as` → `is`), negative parallelisms, and filler.
- Exit-code blocks normalized to a single `**N**: detail` separator. Four files (`cli`, `fleet`, `gate-manifest`, `behavior-diff`) had been mixing two styles inside a single list.
- Frontmatter descriptions containing a colon are now quoted, since YAML would otherwise read the colon as a key separator.

## What was deliberately left alone

The existing copy was already better than typical AI output, so this doesn't touch what worked. The failure-mode taglines, the hero, and the vs-SDLC argument are specific and opinionated. Reference docs keep their plain, neutral voice; that is the correct register for them, so no personality was injected.

## Test plan

- [x] `next build` passes; all 47 doc pages and every marketing route prerender
- [x] 128 tests green, including the link check
- [x] `types:check` clean (confirms all 47 MDX files still parse)
- [x] `npx adversarial-review --base main` → **exit 0, zero findings**, 52/52 files examined, none skipped
- [x] Diffed every inline code span before/after: no command, flag, or path altered
- [x] Exit-code values symmetric across the diff (56/56/54), so only separators changed
- [x] Verified in built HTML that bold still renders inside the JSX spans: `<strong>0</strong>: gate passes.`

## Note for reviewers

Heading changes alter anchor slugs (e.g. `#rail-enforcement--two-layers` → `#rail-enforcement-two-layers`). There are no in-repo anchor links, so nothing internal breaks, but any external deep link to those headings would need updating.