### PR TITLE
fix(plugins): ship the generated ticket readers in the npm tarballs (#193)

### DIFF
--- a/plugins/adlc-antigravity/package.json
+++ b/plugins/adlc-antigravity/package.json
@@ -35,6 +35,8 @@
     "commands/",
     "constants.mjs",
     "core-inline.mjs",
+    "generated-active-ticket.mjs",
+    "generated-ticket-reader.mjs",
     "hooks/",
     "hooks.json",
     "rails-checker.mjs",

--- a/plugins/adlc-antigravity/test/packaging.test.mjs
+++ b/plugins/adlc-antigravity/test/packaging.test.mjs
@@ -10,10 +10,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgDir = resolve(here, '..');
@@ -111,4 +112,59 @@ test('AC2: plugin.json version is untouched by this ticket (still agy-native, no
   // Not asserting an exact version — only that it exists and is independent of
   // package.json's lockstep version (proves the two are not accidentally synced).
   assert.ok(pluginManifest.version, 'plugin.json keeps its own version field');
+});
+
+// --- AC4: the packed tarball actually loads --------------------------------
+
+// The AC1/AC2 checks above compare against a HARDCODED file list, so they pass
+// whenever the list matches itself — they cannot see a module the tarball
+// imports but never ships. That blind spot published 1.4.1 with
+// core-inline.mjs importing ./generated-ticket-reader.mjs while the files
+// allowlist omitted it: every npm install hit the shim fail-safe, which
+// allow-alls when ADLC_P4_ENFORCEMENT is unset, so rails were silently
+// unenforced on the primary distribution path.
+//
+// Resolving the real entry point out of a real tarball is what makes that class
+// of defect impossible to ship: the import graph is the assertion, so a newly
+// added relative import is covered without anyone remembering to list it.
+// agy copies plugins WITHOUT node_modules (see AC3), so extracting with no
+// node_modules present is the faithful install, not a stricter one.
+test('AC4: packed tarball extracted outside the repo imports rails-checker with no node_modules', () => {
+  const work = mkdtempSync(join(tmpdir(), 'adlc-agy-pack-'));
+  try {
+    const tarballName = execFileSync('npm', ['pack', '--pack-destination', work], {
+      cwd: pkgDir,
+      encoding: 'utf8',
+      timeout: 120_000,
+    })
+      .trim()
+      .split('\n')
+      .pop();
+    const extractedRoot = join(work, 'extracted');
+    mkdirSync(extractedRoot, { recursive: true });
+    execFileSync('tar', ['-xzf', join(work, tarballName), '-C', extractedRoot]);
+    const pkgRoot = join(extractedRoot, 'package'); // npm tarballs always nest under package/
+
+    // Every module the plugin's own manifest points agy at must both ship and
+    // resolve — including each module they import transitively.
+    const entryPoints = ['rails-checker.mjs', 'core-inline.mjs', pkg.agy.hooks.replace(/^\.\//, '')];
+    for (const entry of entryPoints) {
+      assert.ok(existsSync(join(pkgRoot, entry)), `tarball must ship ${entry}`);
+    }
+
+    // Importing is the real gate: a relative import of an unshipped module
+    // throws ERR_MODULE_NOT_FOUND here, which is exactly the 1.4.1 break.
+    const res = spawnSync(
+      'node',
+      ['--input-type=module', '-e', `await import(${JSON.stringify(pathToFileURL(join(pkgRoot, 'rails-checker.mjs')).href)})`],
+      { encoding: 'utf8', timeout: 30_000, cwd: pkgRoot }
+    );
+    assert.equal(
+      res.status,
+      0,
+      `packed rails-checker.mjs must import standalone with no node_modules — a relative import is missing from the files allowlist:\n${res.stderr}`
+    );
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
 });

--- a/plugins/adlc-cursor/package.json
+++ b/plugins/adlc-cursor/package.json
@@ -37,6 +37,7 @@
   "files": [
     "command/",
     "constants.mjs",
+    "generated-active-ticket.mjs",
     "hooks/",
     "hooks.json",
     "lib/",

--- a/plugins/adlc-opencode/package.json
+++ b/plugins/adlc-opencode/package.json
@@ -21,6 +21,7 @@
     "agent/",
     "skill/",
     "gate-bins.mjs",
+    "generated-active-ticket.mjs",
     "rails-checker.mjs",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
Fixes #193.

## Problem

`@adlc/antigravity@1.4.1` is broken on npm. It ships `core-inline.mjs`, which imports `./generated-ticket-reader.mjs` — but that file is not in the package `files` allowlist, so it was never published. The plugin cannot be imported at all:

```
npm pack @adlc/antigravity && tar xzf adlc-antigravity-1.4.1.tgz
node -e "import(\"./package/rails-checker.mjs\")"
# ERR_MODULE_NOT_FOUND: Cannot find module ".../package/generated-ticket-reader.mjs"
```

Every npm-installed rails-guard hook then hits the shim fail-safe (`hooks/adlc-rails-guard.cjs:23`): deny-all under `ADLC_P4_ENFORCEMENT=1`, but **silently allow-all otherwise**. Rails have been unenforced on the primary distribution path since 1.4.1 published (2026-07-15), after `core-inline.mjs` began importing the generated reader in #180 (2026-07-14).

## Fix

- Add `generated-ticket-reader.mjs` + `generated-active-ticket.mjs` to antigravity `files`.
- Add `generated-active-ticket.mjs` to cursor and opencode `files`: their `rails-checker.mjs` imports it as of 7ee3c0e (`fix/active-ticket-pointer-contract`), so publishing that branch would break both the same way. npm skips allowlist entries that do not exist yet, so listing them here is inert until that branch lands.

## Why the gates missed it

The existing AC1/AC2 checks compare against a **hardcoded** file list, so they cannot see a module the tarball imports but never ships — all 8 of them pass with the 1.4.1 defect planted (verified). The new **AC4** resolves the real entry point out of a real extracted tarball with **no `node_modules`** (the faithful `agy plugin install`, per AC3), making the import graph itself the assertion: it fails on the planted defect and covers any future relative import without anyone remembering to list it.

`adlc-cursor` already had this test (`packaging.test.mjs:121-160`); antigravity did not. This ports the pattern.

## Test plan

- [x] `npm pack @adlc/antigravity` (from this branch) extracts and imports `rails-checker.mjs` standalone with no `node_modules`.
- [x] AC4 fails when the generated readers are removed from `files` (planted the exact 1.4.1 defect — 8 pre-existing tests still passed, AC4 caught it).
- [x] Plugin suites green: antigravity 66, cursor 133, opencode 258.
- [x] Full repo suite green from a committed state (prosecute 92/0; all suites 0 fail).
- [ ] `npx adversarial-review --base main` before merge (repo workflow gate).
- [ ] Republish `@adlc/antigravity` after merge to ship the fix to npm consumers.

## Note

This PR fixes the *packaging* so the tarball is loadable. Republishing `@adlc/antigravity` is a separate release step (tracked in #193) — the broken 1.4.1 stays live on npm until that publish happens.