### PR TITLE
fix(claude-code): completion expires a ticket's in-session rails (#162)

### DIFF
--- a/plugins/adlc-claude-code/hooks/adlc-hook.mjs
+++ b/plugins/adlc-claude-code/hooks/adlc-hook.mjs
@@ -1025,15 +1025,27 @@ function rails(input) {
     // its own frozen foundation while it runs. Once the ticket is completed
     // there is no in-flight build left to protect, so continuing to freeze its
     // rails only blocks legitimate new work (a completed ticket that declared
-    // `packages/**` otherwise freezes that subtree forever). This matches
-    // scripts/rails-guard-ci.mjs — the unbypassable commit-time gate, which
-    // already skips completed tickets — so in-session and commit-time agree.
+    // `packages/**` otherwise freezes that subtree forever).
+    //
+    // This adopts the same completion rule as scripts/rails-guard-ci.mjs, the
+    // unbypassable commit-time gate. The two are NOT unconditionally identical:
+    // CI reads `completed` from the BASE ref (a deliberate trust anchor — see
+    // its note at rails-guard-ci.mjs:317), whereas this hook reads the working
+    // tree, because in-session there is no committed state to anchor to. They
+    // agree whenever `.adlc/tickets.json` matches base. Where they diverge, a
+    // working-tree edit that marks a live ticket completed expires its rails
+    // in-session but is still DENIED by CI at commit time, so the gate holds.
     //
     // STRICT `=== true` only: a missing, truthy-ish, or tampered `completed`
     // value is NOT a completion and the rail keeps freezing (fail closed).
-    // Note this check does NOT short-circuit the validation above or the
-    // per-rail string check below — a completed ticket carrying malformed rail
-    // data still fails closed rather than being skipped unvalidated.
+    //
+    // Placement note: the expiry skip sits AFTER the shape checks above and
+    // before the per-rail string check below, so a completed ticket carrying
+    // malformed rail data is never skipped unvalidated. In practice those two
+    // in-loop checks are unreachable — `loadTicketStoreReadOnly` validates the
+    // store and throws first (see the failClosed above) — so they are
+    // defense-in-depth against a regression in the reader's contract, not the
+    // live rejection path. Tests assert the reader's message accordingly.
     const expired = t.completed === true;
     for (const r of t.rails ?? []) {
       if (typeof r !== 'string') {

--- a/plugins/adlc-claude-code/hooks/adlc-hook.mjs
+++ b/plugins/adlc-claude-code/hooks/adlc-hook.mjs
@@ -1000,6 +1000,13 @@ function rails(input) {
   // rail could be hiding (non-object entry, non-array rails, non-string rail
   // element) fails closed — never silently read as "no rails".
   const railDecls = [];
+  // Tracks whether ANY ticket declared a rail — including tickets whose rails
+  // have since expired via completion. This is deliberately NOT the same as
+  // `railDecls.length`: the trust-root freeze below keys off "this repo uses
+  // rails at all", not "a rail is in force right now". Conflating the two would
+  // unfreeze `.adlc/tickets.json` the moment the last railed ticket completed,
+  // letting a single edit rewrite the rail config itself. See issue #162.
+  let anyRailsDeclared = false;
   for (const t of parsed.tickets) {
     if (!t || typeof t !== 'object' || Array.isArray(t)) {
       return failClosed(
@@ -1013,6 +1020,21 @@ function rails(input) {
         'invalid-rails-field-bypass'
       );
     }
+    // T36 / issue #162 — completion expires a ticket's build-time rails. A
+    // ticket's rails are a PER-BUILD freeze: they stop that build from editing
+    // its own frozen foundation while it runs. Once the ticket is completed
+    // there is no in-flight build left to protect, so continuing to freeze its
+    // rails only blocks legitimate new work (a completed ticket that declared
+    // `packages/**` otherwise freezes that subtree forever). This matches
+    // scripts/rails-guard-ci.mjs — the unbypassable commit-time gate, which
+    // already skips completed tickets — so in-session and commit-time agree.
+    //
+    // STRICT `=== true` only: a missing, truthy-ish, or tampered `completed`
+    // value is NOT a completion and the rail keeps freezing (fail closed).
+    // Note this check does NOT short-circuit the validation above or the
+    // per-rail string check below — a completed ticket carrying malformed rail
+    // data still fails closed rather than being skipped unvalidated.
+    const expired = t.completed === true;
     for (const r of t.rails ?? []) {
       if (typeof r !== 'string') {
         return failClosed(
@@ -1020,6 +1042,8 @@ function rails(input) {
           'invalid-rail-entry-bypass'
         );
       }
+      anyRailsDeclared = true; // set BEFORE the expiry skip — see the note above
+      if (expired) continue; // rails retired with the ticket; trust roots stay frozen
       const tid = typeof t.id === 'string' ? t.id : '?';
       const normGlob = r.split('\\').join('/'); // normalize Windows-style backslashes
       railDecls.push({ glob: normGlob, ticket: tid });
@@ -1027,7 +1051,7 @@ function rails(input) {
       if (canon !== normGlob) railDecls.push({ glob: canon, ticket: tid });
     }
   }
-  if (railDecls.length === 0) return; // schema-valid, no rails declared → no-op
+  if (!anyRailsDeclared) return; // schema-valid, no rails declared → no-op
 
   // The rail config is its own trust root: once rails exist, editing
   // .adlc/tickets.json to remove them would silently disable enforcement, so

--- a/plugins/adlc-claude-code/hooks/test/rails.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/rails.test.mjs
@@ -117,6 +117,68 @@ test('edit to an exact-file rail → deny', () => {
   assert.equal(runRails(t, 'src/types/api.d.ts').verdict, 'deny');
 });
 
+// ---- completion expires a ticket's rails (issue #162) ----
+//
+// A ticket's `rails` are a PER-BUILD freeze: they stop that build from editing
+// its own frozen foundation while it runs. Once the ticket is `completed: true`
+// there is no in-flight build left to protect, so its rails expire — matching
+// scripts/rails-guard-ci.mjs (the commit-time gate, which already does this)
+// and the opencode/pi in-session checkers, which narrow to one active ticket.
+// The trust-root freeze is a SEPARATE mechanism and must survive expiry.
+
+test("a COMPLETED ticket's rail no longer freezes → allow", () => {
+  const t = '{"tickets":[{"id":"T1","completed":true,"rails":["packages/**"]}]}';
+  assert.equal(runRails(t, 'packages/fleet/package.json').verdict, 'allow');
+});
+
+test("an INCOMPLETE ticket's rail still denies (regression guard)", () => {
+  const t = '{"tickets":[{"id":"T1","completed":false,"rails":["packages/**"]}]}';
+  assert.equal(runRails(t, 'packages/fleet/package.json').verdict, 'deny');
+});
+
+test('the issue #162 repro: completed T37 freezes packages/**, active T42 rails packages/core/** only', () => {
+  const t = JSON.stringify({ tickets: [
+    { id: 'T37', completed: true, rails: ['packages/**', 'docs/ci/**'] },
+    { id: 'T42', rails: ['packages/core/**'] },
+  ] });
+  // T42's scope authorizes a brand-new sibling package — previously denied by T37.
+  assert.equal(runRails(t, 'packages/fleet/package.json').verdict, 'allow');
+  // T42's OWN rail is untouched by the fix.
+  assert.equal(runRails(t, 'packages/core/lib/x.mjs').verdict, 'deny');
+});
+
+test('trust root stays frozen even when EVERY declaring ticket is completed', () => {
+  const t = '{"tickets":[{"id":"T1","completed":true,"rails":["packages/**"]}]}';
+  assert.equal(runRails(t, '.adlc/tickets.json').verdict, 'deny');
+  assert.equal(runRails(t, '.adlc/current-ticket.json').verdict, 'deny');
+});
+
+// `completed` is a strict boolean gate: anything that is not exactly `true` is
+// NOT a completion, and the rail keeps freezing. Guards against a truthy-ish or
+// tampered value silently expiring a live rail.
+for (const [name, value] of [
+  ['string "true"', '"true"'],
+  ['number 1', '1'],
+  ['null', 'null'],
+  ['object', '{}'],
+  ['string "yes"', '"yes"'],
+]) {
+  test(`completed: ${name} is NOT a completion → rail still denies`, () => {
+    const t = `{"tickets":[{"id":"T1","completed":${value},"rails":["packages/**"]}]}`;
+    assert.equal(runRails(t, 'packages/fleet/package.json').verdict, 'deny');
+  });
+}
+
+test('a COMPLETED ticket with a malformed rails field still fails closed', () => {
+  const t = '{"tickets":[{"id":"T1","completed":true,"rails":"packages/**"}]}';
+  assert.equal(runRails(t, 'src/app.mjs').verdict, 'deny');
+});
+
+test('a COMPLETED ticket with a non-string rail entry still fails closed', () => {
+  const t = '{"tickets":[{"id":"T1","completed":true,"rails":["ok/**",42]}]}';
+  assert.equal(runRails(t, 'src/app.mjs').verdict, 'deny');
+});
+
 
 // ---- trust root: tickets.json is frozen once rails exist (structured edits) ----
 

--- a/plugins/adlc-claude-code/hooks/test/rails.test.mjs
+++ b/plugins/adlc-claude-code/hooks/test/rails.test.mjs
@@ -169,14 +169,46 @@ for (const [name, value] of [
   });
 }
 
+// Malformed rail data on a COMPLETED ticket must still fail closed — completion
+// must never become a way to smuggle an unvalidated store past the gate.
+//
+// These assert WHY it denied, not just that it denied. A bare `deny` assertion
+// is close to hollow here: this hook denies on many unrelated conditions (an
+// unreachable project dir, a symlink loop, an unextractable path), so a
+// verdict-only test still passes if the rail validation is gone entirely and
+// something else happens to deny.
+//
+// The reason is matched layer-AGNOSTICALLY. Two layers can legitimately reject
+// this input: the store reader (loadTicketStoreReadOnly → validate(), which is
+// what rejects today, before rails() iterates at all) and the hook's own
+// in-loop checks (defense-in-depth, currently unreachable through the reader).
+// Either is a correct fail-closed, so pinning one layer's exact wording would
+// fail the suite while the gate is working — a brittle change-detector. The
+// property under test is "denied BECAUSE the rails data is invalid", which is
+// what the alternation encodes.
+// NB: `out` is the raw JSON the hook prints, so any quotes inside a message are
+// backslash-escaped there. Match on unquoted fragments only.
+const RAILS_VALIDATION_DENIAL =
+  /rails must be an array of strings|non-string rail entry|has a non-array/;
+
 test('a COMPLETED ticket with a malformed rails field still fails closed', () => {
-  const t = '{"tickets":[{"id":"T1","completed":true,"rails":"packages/**"}]}';
-  assert.equal(runRails(t, 'src/app.mjs').verdict, 'deny');
+  const r = runRails('{"tickets":[{"id":"T1","completed":true,"rails":"packages/**"}]}', 'src/app.mjs');
+  assert.equal(r.verdict, 'deny');
+  assert.match(r.out, RAILS_VALIDATION_DENIAL);
 });
 
 test('a COMPLETED ticket with a non-string rail entry still fails closed', () => {
-  const t = '{"tickets":[{"id":"T1","completed":true,"rails":["ok/**",42]}]}';
-  assert.equal(runRails(t, 'src/app.mjs').verdict, 'deny');
+  const r = runRails('{"tickets":[{"id":"T1","completed":true,"rails":["ok/**",42]}]}', 'src/app.mjs');
+  assert.equal(r.verdict, 'deny');
+  assert.match(r.out, RAILS_VALIDATION_DENIAL);
+});
+
+test('a COMPLETED ticket with a non-array rails object still fails closed', () => {
+  const r = runRails('{"tickets":[{"id":"T1","completed":true,"rails":{"glob":"packages/**"}}]}', 'packages/x.mjs');
+  assert.equal(r.verdict, 'deny');
+  assert.match(r.out, RAILS_VALIDATION_DENIAL);
+  // Completion must never be reported as "schema-valid, nothing declared".
+  assert.doesNotMatch(r.out, /no rails declared/);
 });
 
 


### PR DESCRIPTION
## Summary

Fixes the Claude Code in-session rail hook unioning the `rails` of **every** ticket in the store, including tickets already marked `completed: true`. A completed ticket that declared a broad glob (`packages/**`, `plugins/adlc-claude-code/**`) therefore froze that subtree in every future session, denying work the active ticket explicitly authorized.

This made the hook the outlier among three enforcement layers on the same change:

| Layer | Rail set enforced | Completed filter |
|---|---|---|
| CC in-session hook | union of **ALL** tickets | **no** ← the bug |
| `scripts/rails-guard-ci.mjs` (commit-time) | per-ticket, skips completed | yes |
| opencode / cursor / antigravity checkers | single **active** ticket | n/a |

The only escape was `ADLC_RAILS_BYPASS=1`, habituating operators to the override on false positives and eroding the signal when a bypass is genuinely dangerous.

Implements **Option A** from #162: skip `completed === true` tickets when building the enforced rail set. Strictly `=== true` — a missing, truthy-ish, or tampered value is not a completion and the rail keeps freezing.

## The subtle part: the trust root

The early return keyed off `railDecls.length === 0` and ran **before** `.adlc/tickets.json` and `.adlc/current-ticket.json` were added to the frozen set. Filtering completed tickets into that same counter would have unfrozen the rail config itself as soon as the last railed ticket completed — letting a single edit rewrite enforcement away.

So `anyRailsDeclared` ("this repo uses rails at all") is now tracked separately from `railDecls` ("a rail is in force right now"). Trust roots key off the former. This is acceptance criterion 3 in the issue, and it is the one place a naive one-line `continue` would have opened a hole.

## Scope

Only `plugins/adlc-claude-code/**` changed. The sibling checkers already narrow to the active ticket and were left alone. `rails-guard-ci.mjs` is untouched and remains the unbypassable commit-time backstop.

The hook's in-loop `rails` validation branches are unreachable in practice (`loadTicketStoreReadOnly` validates and throws first) but are **left in place** as defense-in-depth against a reader-contract regression — removing a security check to match a comment is the wrong direction.

## Prosecution

The prosecutor returned two hits on the first commit; both are fixed in 74f3a9e.

1. **Hollow tests.** The two fail-closed tests asserted only `verdict === 'deny'`. This hook denies on many unrelated conditions (unreachable project dir, symlink loop, unextractable path), so they'd pass with the rails validation removed entirely. They now assert the denial *reason*, matched **layer-agnostically** — pinning one layer's exact wording failed the suite while the gate was working correctly (defense-in-depth catching it instead), which is a brittle change-detector. Verified by sandbox mutation in both directions:
   - reader validation relaxed, hook checks intact → **58/58 pass** (not brittle)
   - both layers' rails validation stripped → **4 fail** (not hollow)
2. **Two overclaiming comments** corrected: the expiry/validation ordering is not reachable (documented as defense-in-depth), and in-session vs commit-time do not unconditionally "agree" — CI reads `completed` from the **base ref** by design, the hook reads the working tree. Narrowed to "agree whenever `tickets.json` matches base", noting CI still denies where they diverge.

## Verification

| Gate | Result |
|---|---|
| `adversarial-review --base main --verify` (codex) | **approve**, exit 0 |
| prosecutor | 2 hits, both fixed |
| `adlc hollow-test` | **5/5 mutants killed, 0 survived** |
| rails suite | 58/58 |
| full CC hook suite | 101/101 |
| `scripts/test/rails-guard-ci.test.mjs` | 69/69 |
| `npm test` (full repo) | exit 0 |
| `node scripts/rails-guard-ci.mjs origin/main` | exit 0 |

Behavior verified against **real repo ticket state**:

```
plugins/adlc-claude-code/**  (completed T37) -> allow   (was deny)
packages/core/**             (live T42)      -> deny
scripts/rails-guard-ci.mjs   (live T48)      -> deny
.adlc/tickets.json           (trust root)    -> deny
```

## Notes for the reviewer

- **This bug blocked its own fix.** Completed T37 froze `plugins/adlc-claude-code/**`, so authoring the patch required a user-authorized audited bypass (recorded to `.adlc/manifest.jsonl`). The deployed plugin still carries the old hook — this takes effect once released and installed.
- **`ADLC_RAILS_BYPASS` leaks into the test harness.** Tests spawn the hook with `...process.env`, so with the var set, 43 deny-tests silently flip to passing-as-allow. Every run above used `env -u ADLC_RAILS_BYPASS`. A gate whose suite is disarmed by the same env var that disarms the gate is worth hardening separately (issue #155 family) — **not** addressed here.
- **`rails-guard-ci.mjs` fails locally on a clean tree** with `.adlc/manifest.jsonl cannot be created with evidence in a PR`. That file is gitignored and holds local bypass evidence; CI's fresh checkout has none, so CI is green. Pre-existing — reproduced with this branch's changes stashed.
- The adversarial reviewer ran read-only and could not execute tests (`EPERM` from `mkdtemp`); its approval is code-reading only. The empirical defect-finding came from the prosecutor and the sandbox mutation runs above.

## Test plan

- [x] `node --test plugins/adlc-claude-code/hooks/test/rails.test.mjs` — 58/58
- [x] `node --test plugins/adlc-claude-code/hooks/test/*.test.mjs` — 101/101
- [x] `node --test scripts/test/rails-guard-ci.test.mjs` — 69/69
- [x] `npm test` — exit 0
- [x] `adlc hollow-test --test-cmd "node --test plugins/adlc-claude-code/hooks/test/rails.test.mjs" --base origin/main` — 5/5 killed
- [x] `npx adversarial-review --base main --verify` — approve
- [x] Sandbox mutation: not-hollow and not-brittle, both directions

Fixes #162

https://claude.ai/code/session_01Un7DvX6igCxgd9KJw8gnbP
