### PR TITLE
docs: Copilot integration plan + 7-harness capability matrix

### DIFF
--- a/docs/copilot-integration-plan.md
+++ b/docs/copilot-integration-plan.md
@@ -1,0 +1,309 @@
+# Plan: Installing & Integrating ADLC into GitHub Copilot
+
+> Analysis of a 7th native integration (`plugins/adlc-copilot`), companion to
+> [claude-code.md](./integrations/claude-code.md), [codex.md](./integrations/codex.md),
+> [cursor.md](./integrations/cursor.md), [antigravity.md](./integrations/antigravity.md),
+> [opencode.md](./integrations/opencode.md), and [pi.md](./integrations/pi.md).
+> Written 2026-07-20 against the July-2026 Copilot documentation surface.
+> Status: **analysis / pre-ticket** — no code exists yet.
+> Side-by-side comparison of all seven harnesses:
+> [`integrations/harness-capability-matrix.md`](./integrations/harness-capability-matrix.md).
+
+## 1. Verdict up front
+
+GitHub Copilot is now **top-tier integrable** — the Copilot CLI ships a
+near-superset of Claude Code's extension surface and is deliberately
+cross-compatible with it (it reads `.claude/skills`, `CLAUDE.md`, and even
+`.claude/settings.json` hooks). Every primitive the ADLC contract needs exists
+natively:
+
+| ADLC primitive | Copilot CLI surface | Tier |
+| --- | --- | --- |
+| Rails-guard (deny a frozen-rail edit) | `preToolUse` hook — **deterministic deny** via exit 2 or stdout `{"permissionDecision":"deny"}`; non-zero exit **fails closed** | **Stronger than agy/Cursor** (both fail open) |
+| Plugin distribution | Native `plugin.json` bundling `agents/`, `skills/`, `commands/`, `hooks`, `mcpServers`; marketplace = repo with `.github/plugin/marketplace.json` (`copilot plugin marketplace add OWNER/REPO`, then `copilot plugin install NAME@MARKETPLACE`). Docs state the format is **shared between VS Code, Copilot CLI, and Claude Code** | Same shape as Codex/Claude Code — possibly the *same artifact* |
+| Phase-router + commands | Agent Skills (Anthropic-open-standard `SKILL.md`, user-invocable as `/` commands) | Skills drop in **unchanged** |
+| P5 prosecutor subagents | Custom agents (`*.agent.md`, `tools:` allowlist) run in isolated subagent contexts; VS Code `agents:` frontmatter spawns subagents | Verify fan-out (see §6) |
+| MCP (`adlc_gate`/`adlc_prosecute`) | `.mcp.json` in plugin / `~/.copilot/mcp-config.json` | Ships as-is |
+| Headless fleet worker | `copilot -p` + `--allow-tool`/`--deny-tool`/`--agent` | Easy adapter; no JSON output mode |
+| Commit-time guarantee | `rails-guard-ci.mjs` required check | **Already GitHub-native — covers the cloud coding agent too** |
+
+Two structural facts make this integration *cheaper* than agy or Cursor were:
+
+1. **The hook contract is Claude-Code-shaped.** Hook stdin is
+   `{tool_name, tool_input, tool_use_id}` (verified for VS Code hooks), the deny
+   schema is `permissionDecision`, and exit 2 denies — the existing
+   `@adlc/core` rails engine and the adlc-claude-code hook adapters port with
+   thin field-mapping, not a rewrite.
+2. **The unbypassable layer needs zero new *code*, but does need the same
+   verification every sibling doc already flags.** ADLC's real control is the
+   CI diff gate on GitHub — and Copilot's async cloud coding agent can *only*
+   act through PRs from `copilot/*` branches, treated as an outside
+   contributor, subject to branch protection and required checks. Our existing
+   `docs/ci/rails-guard.yml` gate therefore *can* govern the one Copilot
+   surface that has **no hooks at all** — but only once it is actually
+   configured as a **required** status check. `ci.yml` itself notes there is
+   no automated check that `rails-guard` was added as a required check, and on
+   a **private repo on GitHub's free plan it cannot be made blocking at all**
+   (see [`rails-guard-private-repo-fallback.md`](./ci/rails-guard-private-repo-fallback.md))
+   — a maintainer or admin-merge can go straight past a red run. Same caveat,
+   same fallback (fold the rail-freeze step into an already-required job), as
+   every sibling integration doc.
+
+## 2. The three Copilot surfaces (and how much ADLC each gets)
+
+### 2.1 Copilot CLI (`copilot`) — full native integration (the target)
+
+Everything in the contract lands here:
+
+- **Hooks** (14 events): `preToolUse` (rails-guard + build-gate),
+  `sessionStart` (preflight + ticket-context), `preCompact`,
+  `subagentStart`/`subagentStop` (ticket-context re-injection),
+  `postToolUse` (flail-detection), `agentStop` (gate-manifest audit +
+  adversarial-review trigger). Config: JSON `{"version":1,"hooks":{...}}` in
+  the plugin's `hooks.json`, repo `.github/hooks/*.json`, or user
+  `~/.copilot/hooks/`.
+- **Deny contract** (better than agy's): exit code 2 = deny (overrides
+  stdout); any other non-zero = **fail-closed deny**; stdout JSON
+  `{"permissionDecision":"deny","permissionDecisionReason":"..."}`.
+  ⚠️ The one fail-open path is **timeout** — the rails decision is a local
+  JSON read (fast), so set a generous `timeoutSec` and keep the hook
+  dependency-free, same zero-dependency guarantee as the CC plugin hooks.
+- **Skills**: the `adlc` phase-router, `adlc-init`, `adlc-ticket`,
+  `adlc-prosecute`, `adlc-distill`, `adlc-maintain` ship as `SKILL.md` skills.
+  Copilot CLI has no standalone `.prompt.md` slash commands, but the **plugin
+  manifest has a `commands` component key** (CLI plugin reference), so
+  plugin-bundled commands may work natively — probe the expected command-file
+  format (§6). Fallback if not: skills are user-invocable as `/` commands, so
+  "commands become skills" (the same collapse the agy integration made, in the
+  other direction).
+- **Custom agents**: the six prosecution lenses
+  (`adlc-prosecutor-{correctness,security,contract,diff,tests,verifier}`) as
+  `agents/*.agent.md` with read-only `tools:` allowlists.
+- **MCP**: the plugin's `.mcp.json` launches `adlc mcp-server` exposing
+  `adlc_gate`/`adlc_prosecute`, identical to Codex/CC.
+- **Install**: `copilot plugin marketplace add voodootikigod/adlc` +
+  `copilot plugin install adlc-copilot@adlc` (native; the marketplace is a
+  `.github/plugin/marketplace.json` in this repo — a third marketplace manifest
+  alongside `.claude-plugin/` and `.cursor-plugin/`). Direct local-path and
+  Git-URL installs also work (installed under
+  `~/.copilot/installed-plugins/<marketplace>/<name>` or `…/_direct/<source>/`).
+  Alternatively `npx plugins add voodootikigod/adlc` — the vendor-neutral
+  `plugins` installer (≥1.3.4) supports Copilot CLI as a target.
+- **Portability**: `${PLUGIN_ROOT}` is the documented token for referencing
+  paths inside the plugin dir (Copilot format); VS Code additionally expands
+  `${CLAUDE_PLUGIN_ROOT}` for Claude-format plugins. No agy-style `$HOME`
+  workaround needed.
+
+### 2.2 VS Code Copilot agent mode — same repo files, Preview hooks
+
+VS Code reads the same `.github/hooks/*.json`, `.github/agents/*.agent.md`,
+`.github/skills/`, and `.github/copilot-instructions.md`, and its `PreToolUse`
+hook deny (`hookSpecificOutput.permissionDecision: "deny"`) is documented as
+deterministic. Two caveats keep this a **secondary** surface:
+
+- VS Code hooks are **Preview** ("format and behavior might change") — fine to
+  ship files that light up there, wrong to make it the enforcement story.
+- IDE-side governance is local settings, not GitHub org policy.
+
+Design consequence: put the repo-facing artifacts (`.github/hooks`, agents,
+skills, instructions) in what `adlc init --harness copilot` scaffolds, so one
+scaffold serves both CLI and VS Code, and treat VS Code as advisory-plus until
+hooks GA.
+
+### 2.3 Copilot coding agent (cloud, issue→PR) — CI-gate-only by design
+
+The concept docs say the cloud agent consumes plugins, but hook *execution*
+there is unverified (documented runtimes are CLI + VS Code only — probe §6.9).
+Plan on no in-session layer; none is needed for the rails guarantee:
+
+- The agent pushes only to `copilot/*` and opens PRs as an outside
+  contributor → the **required `rails-guard` check + branch protection is the
+  entire enforcement story** — provided the check is actually made required
+  (verify, don't assume; see the private/free-plan caveat in §1).
+- Advisory lifecycle presence via `.github/copilot-instructions.md` /
+  `AGENTS.md` (phase-router summary, "run `adlc` gates before opening the PR")
+  and the same `.github/agents` + skills.
+- `copilot-setup-steps.yml` can preinstall `@adlc/cli` so the agent can
+  actually run gates — but note a failed setup step does **not** stop the
+  agent (not a gate).
+- P5: prosecute the agent's PR from the *outside* (a maintainer runs
+  `/adlc-prosecute` on the branch, or a future CI prosecution job) — same
+  posture as any human contributor's PR.
+
+## 3. Primitive mapping (ADLC phases → Copilot)
+
+| Phase | Copilot CLI surface | Mechanism |
+| --- | --- | --- |
+| P0 Triage | `adlc-ticket` skill | `.adlc/tickets.json` via `adlc` CLI |
+| P1 Interrogate | `adlc` router skill → `spec-lint`/`premortem`/`parallax` | `--prompt-only` (Copilot is the model — no API keys) |
+| P2 Decompose | `coldstart`/`model-router`/`merge-forecast` | `adlc` CLI |
+| **P3 Rail** | **`preToolUse` hook (deny)** + CI diff gate | `@adlc/core` rails engine; fail-closed on hook error |
+| P4 Build | `postToolUse` flail hook; build-gate in `preToolUse` | same dispatcher-order rule as Cursor: rails decision first, build-gate second |
+| P5 Prosecute | `adlc-prosecute` skill + six lens agents | fan-out if CLI subagent invocation supports it (§6 probe); else sequential-with-cross-model fallback (Cursor tier) |
+| P6 Integrate | human gate | `adlc gate-manifest` evidence |
+| P7 Distill | `adlc-distill` skill | `lesson-foundry`/`rejection-mining` |
+| Maintenance | `adlc-maintain` skill + CI cron | unchanged |
+
+Shared invariants carried over verbatim (engine is `@adlc/core`, not
+re-implemented): active-ticket resolution (`ADLC_TICKET` vs
+`.adlc/current-ticket.json`, conflict fails closed), `ADLC_P4_ENFORCEMENT=1`
+phase scoping, trust-root rails, symlink resolution, Bash-not-gated-in-session
+(CI catches it), rails-must-be-tracked-files.
+
+## 4. What we build
+
+### 4.0 Format decision: Copilot-format plugin vs reusing the Claude plugin
+
+The docs state the plugin format is **shared between VS Code, Copilot CLI, and
+Claude Code**, and VS Code auto-detects manifests at `.plugin/plugin.json`,
+`plugin.json`, `.github/plugin/plugin.json`, and `.claude-plugin/plugin.json`.
+That opens Option A: point Copilot at the existing `plugins/adlc-claude-code`
+artifact and skip a 7th plugin entirely. Recommend **Option B — a thin native
+`plugins/adlc-copilot`** anyway, because (a) hook *file layout* differs by
+format (Copilot: root `hooks.json`; Claude: `hooks/hooks.json`) and event names
+differ on the CLI (camelCase, `agentStop`), (b) the CC plugin's hooks assume
+Claude Code's stdin/stdout contract — close but unverified-identical on the
+Copilot CLI, and (c) sibling integrations each own their verified-contract
+appendix and smoke proofs. Share everything shareable (skills byte-identical,
+lens-agent content, `@adlc/core` engine, MCP entry) and keep the adapter layer
+per-harness — the established pattern. Revisit Option A if the live probe shows
+the CC plugin loads and denies correctly as-is.
+
+```
+plugins/adlc-copilot/
+├── plugin.json               # name, version, component pointers
+├── hooks.json                # preToolUse/sessionStart/postToolUse/agentStop/…
+├── hooks/                    # zero-dependency .mjs adapters over @adlc/core
+│   ├── adlc-rails-guard.mjs  # stdin field-map → rails decision → permissionDecision/exit 2
+│   └── …
+├── skills/                   # adlc, adlc-init, adlc-ticket, adlc-prosecute, adlc-distill, adlc-maintain
+├── agents/                   # adlc-prosecutor-*.agent.md (read-only tools:)
+├── .mcp.json                 # adlc mcp-server → adlc_gate / adlc_prosecute
+└── test/                     # contract tests incl. deny-shape + fail-closed pins
+```
+
+Plus repo ceremony (the standard 7th-integration checklist):
+
+- `.github/plugin/marketplace.json` — the Copilot marketplace manifest for
+  this repo (documented location), listing `adlc-copilot` →
+  `./plugins/adlc-copilot`.
+- `scripts/copilot-install-smoke.mjs` (offline manifest/hook/skill/agent/MCP
+  contract) + a live-install leg gated behind `ADLC_COPILOT_LIVE_INSTALL=1`,
+  mirroring `codex-install-smoke.mjs`, wired into `ci.yml`.
+- `packages/fleet/lib/adapters/copilot.mjs` — `copilot -p <prompt>` +
+  explicit `--allow-tool`/`--deny-tool` posture (no JSON output mode; text
+  `mapResult` like the cursor adapter).
+- `adlc init --harness copilot` — scaffold `.github/hooks/`, `.github/agents/`,
+  `.github/skills/`, instructions block, `copilot-setup-steps.yml` snippet.
+- `docs/integrations/copilot.md` + ADR + `docs/package-reference.md` entry.
+
+Reuse estimate: the skills are byte-identical to the CC plugin's (open
+standard); the lens agents are content-identical (format conversion
+`.md`→`.agent.md` frontmatter); the MCP config is identical; the hooks are the
+CC hook logic behind a new stdin/stdout adapter (~the same delta as
+adlc-antigravity's). Net-new work is the adapter layer, the smoke/live proofs,
+and the docs.
+
+## 5. Where Copilot is *stronger* than the siblings
+
+1. **Fail-closed hook errors.** A crashed rails-guard hook denies instead of
+   letting the write through (agy fails open; Cursor's deny has open
+   reliability reports). Only timeout fails open.
+2. **Three-tier enterprise enforcement.** No other integrated harness offers
+   any of these, let alone all three — worth a dedicated "enterprise rails"
+   section in the integration doc:
+   - **Machine policy tier**: `/etc/github-copilot/policy.d/*.json` hooks
+     cannot be disabled by user settings (`disableAllHooks`).
+   - **Enterprise-managed plugins** (public preview 2026-05-06): admins
+     auto-install plugins on authentication, with hooks and MCP configs that
+     are *"always enabled across your enterprise"* — i.e. the ADLC rails-guard
+     pushed to every developer's CLI as a non-disableable PreToolUse deny.
+   - **`strictKnownMarketplaces`** (public preview 2026-06-25, VS Code + CLI):
+     enterprise allowlist of plugin marketplaces, so untrusted plugins can't
+     be installed around the gate.
+3. **Hook-free category deny.** `--deny-tool=shell` (deny beats allow, even
+   under `--yolo`) gives fleet workers a deterministic no-shell posture — the
+   first harness where the "Bash can't be gated" gap can be closed by
+   *removing shell* rather than parsing it, for workers that don't need it.
+4. **The cloud agent is pre-gated.** The one agent surface without hooks is
+   also the one that can only merge through our existing CI gate.
+5. **Cross-tool config reads.** Copilot CLI reading `.claude/skills` and
+   `.claude/settings.json` means repos already carrying ADLC-for-Claude-Code
+   get partial Copilot coverage before the native plugin is even installed.
+
+## 6. Verify-before-build probes (the honesty gates)
+
+Ordered; each mirrors the agy appendix-V ritual — probe a real binary, pin the
+facts in the integration doc:
+
+1. **Live deny-proof**: does exit 2 / `permissionDecision:"deny"` actually
+   abort a file write in the current `copilot` release? Pin the stdin payload
+   field names for edit/write/shell tools (matcher tokens seen in docs:
+   `bash|edit`) and whether target paths are absolute.
+2. **Headless hooks**: do hooks fire under `copilot -p`? (agy's did — V6 —
+   and it's load-bearing for fleet.)
+3. **MCP under `-p`**: open issue (#633) reports MCP servers don't run in
+   non-interactive mode — decides whether fleet workers get `adlc_gate` or
+   shell-only.
+4. **Subagent fan-out**: can the main CLI session invoke the six lens agents
+   as isolated subagents in one prosecution loop (P5 full independence), or is
+   it user-driven `/agent` only (→ Cursor-tier sequential fallback +
+   `npx adversarial-review --providers` cross-model gate)?
+5. **Plugin-root expansion in hooks**: `${PLUGIN_ROOT}` is documented (and
+   `${CLAUDE_PLUGIN_ROOT}` in VS Code for Claude-format plugins), but the CLI
+   reference shows it for LSP config — confirm it expands inside `hooks`
+   command strings specifically.
+6. **Timeout behavior bound**: measure worst-case rails-decision latency in a
+   large repo vs `timeoutSec` to size the fail-open window honestly.
+7. **Marketplace resolution**: confirm `copilot plugin marketplace add`
+   accepts this repo with `.github/plugin/marketplace.json` pointing at a
+   monorepo subdir plugin, and that `copilot plugin update` tracks it.
+8. **Plugin `commands` component format**: the CLI plugin manifest supports a
+   `commands` key but standalone `.prompt.md` files are VS-Code-only — probe
+   what command-file format plugin commands expect (Claude-style command
+   `.md`?); fall back to skills if unusable.
+9. **Cloud-agent plugin hooks**: docs say plugins work with "Copilot CLI and
+   Copilot cloud agent," but hook *execution* is documented only for CLI +
+   VS Code — verify whether a plugin `preToolUse` deny fires in the async
+   coding agent before claiming any in-session layer there (until then, the
+   cloud story remains CI-gate-only, which is sufficient).
+10. **Claude-plugin drop-in**: try installing `plugins/adlc-claude-code`
+    directly (VS Code auto-detects `.claude-plugin/plugin.json`; CLI direct
+    install) — if its hooks load and deny, Option A in §4.0 gets cheaper.
+
+## 7. Gaps to document honestly (relative to doctrine)
+
+- **Cloud coding agent has no verified in-session rails layer** — it consumes
+  plugins, but hook execution there is unconfirmed; treat it as CI-gate-only.
+  Same first-time-rail scope limit as everywhere (a rail introduced and edited
+  in the same PR isn't caught until frozen on base).
+- **The CI-gate-only story for the cloud agent depends on `rails-guard` being
+  a required check, which is neither automatically verified nor always
+  possible.** `ci.yml` has no automated check that `rails-guard` was added as
+  a required status check, and on a private repo on GitHub's free plan it
+  cannot be made blocking at all (admin-merge can go straight past a red run)
+  — identical to the caveat every sibling integration doc already carries.
+  Verify branch protection explicitly in the Copilot install docs; don't let
+  "already built" read as "already enforced."
+- **Timeout fail-open** on CLI hooks (unlike non-zero exit) — small, but it's
+  the one in-session escape hatch; document it next to the Bash gap.
+- **No structured JSON output in `-p`** — fleet result parsing is text-tier.
+- **VS Code hooks are Preview** — repo files light up there, but enforcement
+  claims are CLI + CI only until GA.
+- **Build-gate**: same no-CI-backstop caveat as all siblings
+  (`.adlc/current-ticket.json` is untracked local state).
+
+## 8. Phased delivery sketch
+
+1. **Probe phase** (spike, no ship): the §6 list against a real `copilot`
+   binary (items 1–5, 8, 10 first; 9 needs a repo with the cloud agent
+   enabled); write the verified-contract appendix first, agy-style.
+2. **Plugin core**: hooks adapter + skills + agents + MCP + offline smoke.
+3. **Distribution**: marketplace entry, `plugins`-installer verification,
+   `adlc init --harness copilot`, live-install smoke in CI.
+4. **Fleet adapter + docs**: `copilot.mjs` adapter, `docs/integrations/copilot.md`,
+   ADR, cloud-coding-agent guidance (`copilot-setup-steps.yml` + required-check
+   posture).
+5. **P5 hardening**: fan-out if probe 4 confirms; else sequential + cross-model
+   review parity with Cursor, and revisit when the CLI grows programmatic
+   subagent orchestration.

--- a/docs/integrations/harness-capability-matrix.md
+++ b/docs/integrations/harness-capability-matrix.md
@@ -1,0 +1,113 @@
+# ADLC capability × harness matrix
+
+How each native integration implements the ADLC contract, side by side.
+Compiled 2026-07-20 from the integration docs in this directory, the plugin
+sources under `plugins/`, and (for Copilot) the July-2026 research in
+[`../copilot-integration-plan.md`](../copilot-integration-plan.md).
+
+**Columns:** CC = Claude Code · Codex · OC = OpenCode · Pi · Cursor · agy =
+Antigravity · Copilot = **planned, pre-probe** (nothing shipped).
+
+**Legend:** ✅ native/enforcing · ⚠️ partial, advisory, or unproven · ❌ absent
+· 🧪 planned/unverified (Copilot column, and any claim pending a live probe).
+
+Shared invariants are not repeated per row: every integration delegates
+rail/glob/ticket/shell primitives to `@adlc/core` (nothing re-implemented),
+resolves the active ticket via `ADLC_TICKET` / `.adlc/current-ticket.json`
+(conflict fails closed), scopes enforcement to `ADLC_P4_ENFORCEMENT=1`,
+freezes the trust-root files, resolves symlink aliases, and relies on the same
+commit-time CI diff gate (`rails-guard-ci.mjs`) as the real control — with the
+universal caveat that the CI gate only enforces if actually configured as a
+**required** check (impossible on private free-plan repos; fold into an
+existing required job instead).
+
+## A. Distribution & install
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Native plugin install | ✅ marketplace | ✅ git marketplace | ⚠️ npm pkg registered in `opencode.json` by scaffolder (no marketplace) | ✅ `pi install npm:@adlc/pi` | ✅ marketplace (publish step pending) | ⚠️ local-path only (3rd-party marketplace rejected by CLI) | 🧪 `.github/plugin/marketplace.json` + `copilot plugin install` |
+| `npx plugins add` universal-installer target | ✅ | ✅¹ | ❌ | ❌ | ✅ | ❌ (planned) | ✅ (target exists) |
+| Install smoke script in CI | ✅ offline | ✅ offline + live | ✅ offline + live matrix | ✅ live + weekly version matrix | ✅ offline | ✅ offline | 🧪 |
+
+¹ A `plugins`-installer Codex target exists, but the adlc docs recommend the native Codex marketplace path.
+
+## B. In-session rail enforcement (P3/P4)
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Structured-edit deny (Write/Edit) | ✅ enforcing | ✅ enforcing | ✅ enforcing by default | ✅ enforcing | ⚠️ deny emitted; host reliability unproven (the GA gate) | ⚠️ advisory (host fails open) | 🧪 deny documented (exit 2 / `permissionDecision`); probe pending |
+| Hook-crash failure mode | ⚠️ fail-open (only exit 2 blocks) | ⚠️ same convention² | ✅ fail-closed (throw aborts; unknown mutating tool denied) | ⚠️ n/d² | ⚠️ fail-open by config (`failClosed:false`) | ⚠️ fail-open (verified: non-zero exit ⇒ tool proceeds) | 🧪 fail-closed on non-zero; fail-open on **timeout** only |
+| Shell (Bash) gating in-session | ❌ intentional (CI catches) | ✅ shell classifier (vendored core copy, sync-pinned) | ✅ classifier + chained-command splitting | ✅ codex-parity ladder | ⚠️ advisory string-match, never denies | ❌ | 🧪 probe; unique option: `--deny-tool=shell` removes shell entirely for fleet workers |
+| Reactive write-restore backstop (tool-independent) | ❌ | ❌ | ✅ `file.edited` quarantine-restore | ✅ pre-tool snapshot restore (never `HEAD`) | ⚠️ `afterFileEdit` audit only, no restore | ❌ | ❌ (no equivalent event known) |
+| Build-gate (context-rot backstop) | ✅ enforcing | ✅ hook shipped | ✅ + disables post-compaction autocontinue | ✅ | ⚠️ advisory, default-off | ❌ | 🧪 |
+
+² CC's documented hook semantics: non-2 exit codes are non-blocking. Codex and Pi crash behavior is not pinned in this repo's docs — treat as unverified rather than assumed safe.
+
+## C. Context defense
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Ticket context re-injection | ✅ 5 events (SessionStart/PreCompact/PostCompact/Subagent*/Stop) | ✅ 8 events | ✅ per-turn system transform + rail names in tool descriptions | ✅ per-turn system-prompt append | ⚠️ `beforeSubmitPrompt` ships; narrower scope | ❌ (PreToolUse only) | 🧪 events exist (`sessionStart`, `preCompact`, `subagent*`) |
+| Compaction survival defense | ✅ | ✅ | ✅ compaction-prompt append + autocontinue disable | ✅ | ❌ | ❌ | 🧪 `preCompact` exists |
+| Flail detection | ✅ advisory | ✅ failure-signature recorder | ✅ advisory | ✅ | ✅ reminder | ❌ | 🧪 `postToolUse` exists |
+| Live ticket statusline/footer | ❌ | ❌ | ✅ toast statusline | ✅ footer pill + verdict widget | ❌ | ❌ | ❌ |
+
+## D. P5 prosecution
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 5-lens + verifier fresh-context fan-out | ✅ subagents | ✅ 6 agent TOMLs | ✅ isolated child sessions | ✅ child sessions (shared core lens roster) | ⚠️ sequential, one context (weakest independence) | ⚠️ single `prosecutor` agent, deterministic gates only | 🧪 custom agents exist; in-session fan-out is a probe |
+| Deterministic first-party P5 runner (code loop, not prose) | ⚠️ model-driven command; helpers unit-tested | ⚠️ MCP `adlc_prosecute` workflow | ✅ native tool (most deterministic of the six) | ✅ native tool | ❌ | ❌ | 🧪 |
+| Read-only enforcement on lenses | ✅ read-only tool lists | ✅ read-only TOMLs | ✅ wildcard-deny-first tools map | ✅ write-disabled children | ❌ | ⚠️ | 🧪 `tools:` allowlist exists |
+| Formal `adlc run p5` provenance | ⚠️ CLI runner path, not wired e2e | ✅ authoritative fixture | ⚠️ runner path | ⚠️ runner path | ⚠️ runner path | ⚠️ runner path | 🧪 |
+| P5 live proof in CI | ❌ | ⚠️ (install/hook/MCP live proof; not a deny/convergence proof) | ✅ seeded-defect convergence + write-disable, required | ✅ required (Node 22 leg) | ❌ | ❌ | 🧪 |
+
+## E. Gate access
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Model-callable gate tool | ✅ MCP (`adlc_gate`/`adlc_prosecute`) | ✅ MCP | ✅ native plugin tool | ✅ native tool | ❌ commands only | ❌ skill/CLI only | 🧪 MCP planned (headless-MCP caveat: issue #633) |
+| Keyless LLM-backed gates | ✅ `--prompt-only` | ✅ `--prompt-only` | ✅ live keyless child-session bridge | ✅ keyless via session model | ✅ `--prompt-only` | ✅ `--prompt-only` | 🧪 `--prompt-only` |
+| Commands / phase suite | ✅ `/adlc:*` (5) | ✅ `$adlc*` skills (6) | ✅ `/adlc-*` full suite | ✅ `/adlc-*` + `/ticket` + accept/rollback | ✅ `/adlc-*` full suite | ⚠️ commands auto-convert to skills | 🧪 plugin `commands` key exists; format is a probe (fallback: skills as `/` commands) |
+
+## F. Headless & fleet
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Fleet worker adapter | ✅ | ✅ | ✅ | ✅ | ✅ (`cursor-agent -p`) | ✅ | 🧪 `copilot -p` (text output only — no JSON mode) |
+| Headless in-session enforcement verified | ❌ not exercised | ⚠️ hook execution proven from installed cache | ✅ headless live-deny in CI | ✅ `pi --mode rpc` live-deny in CI | ❌ | ✅ probed (`--print` blocked a rail write) | 🧪 docs silent on `-p` hooks — load-bearing probe |
+
+## G. Governance
+
+| Capability | CC | Codex | OC | Pi | Cursor | agy | Copilot |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Unbypassable commit-time CI gate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ (same gate; governs the cloud coding agent's PRs) |
+| Admin/org-level in-session enforcement | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🧪 **unique**: machine `policy.d` hook tier + enterprise-managed plugins (always-on hooks) + `strictKnownMarketplaces` |
+
+## Reading the matrix — tiers
+
+1. **OpenCode & Pi — deepest deterministic enforcement.** Both gate shell
+   in-session, carry a reactive restore backstop, run P5 as first-party code
+   with write-disabled fresh contexts, and prove the deny live in required CI.
+   OpenCode edges ahead on fail-closed posture (unknown mutating tools denied);
+   Pi on TUI-native surface (footer pill, accept/rollback commands).
+2. **Codex & Claude Code — full surface, weaker proofs.** Complete hook/agent/
+   MCP coverage; Codex adds shell gating and the only formal `adlc run p5`
+   fixture. CC's gaps: no shell gating (intentional), no live deny proof in CI,
+   fail-open hook crashes.
+3. **Cursor — surface parity, enforcement unproven.** Full command suite but
+   the deny's host reliability is the open GA gate, P5 runs in one context,
+   and the shell/audit hooks are advisory.
+4. **Antigravity — advisory tier.** Fail-open host contract, single-lens P5,
+   no build-gate or context defense; leans hardest on the CI gate (by design).
+5. **Copilot (projected) — Codex/CC tier at launch, plus two firsts.** The
+   documented deny contract is stronger than agy/Cursor's (fail-closed on
+   crash), and it would be the only harness with admin-pushed, non-disableable
+   enforcement and a hooks-free shell-removal option for fleet workers. All 🧪
+   until the probe spike in the plan doc runs against a real binary.
+
+## Maintenance note
+
+Update this file when an integration ships a capability change (the same PR
+that changes `plugins/<harness>/` or its integration doc), and re-verify the
+Copilot column against the probe results before the build ticket closes.


### PR DESCRIPTION
## Summary

Analysis (no code) for a **7th native integration — GitHub Copilot** (`plugins/adlc-copilot`), verified against the July-2026 Copilot documentation surface, plus a side-by-side capability matrix of all existing integrations.

### `docs/copilot-integration-plan.md`
- **Verdict: top-tier integrable.** Copilot CLI now ships a near-superset of Claude Code's extension surface: 14 lifecycle hooks incl. `preToolUse` with deterministic deny (exit 2 / `permissionDecision`), **fail-closed on hook crash** (stronger than agy/Cursor; fail-open only on timeout), a native plugin system whose format is documented as **shared with Claude Code**, Anthropic-open-standard Agent Skills, custom agents with `tools:` allowlists, and MCP.
- Surface-by-surface mapping (CLI = full native target; VS Code = same repo files, Preview hooks; cloud coding agent = CI-gate-only), P0–P7 primitive mapping, plugin-format decision (§4.0), and the standard 7th-integration repo ceremony.
- **Three-tier enterprise enforcement story unique to Copilot**: machine `policy.d` hooks, enterprise-managed plugins with always-on hooks, `strictKnownMarketplaces`.
- **Ten verify-before-build probes** (§6) — live deny-proof, headless `-p` hooks, MCP-under-`-p` (issue #633), P5 subagent fan-out, etc. — to run against a real `copilot` binary before any build ticket.
- Adversarially reviewed (local Codex reviewer): the one surviving finding — the cloud-agent enforcement claim assumed `rails-guard` is a *required* check — is fixed inline with the same required-check verification + private/free-plan caveat every sibling doc carries.

### `docs/integrations/harness-capability-matrix.md`
Capability-by-capability comparison (distribution, rail enforcement, context defense, P5, gate access, headless/fleet, governance) across CC / Codex / OpenCode / Pi / Cursor / agy plus the planned 🧪 Copilot column. Cells grounded in the integration docs and the plugin sources (shell-gating, build-gate, and lens rosters verified by grep, not doc summaries). Includes a tier ranking and a maintenance note to update the file when a `plugins/<harness>/` capability changes.

## Test plan
- [x] Docs-only change — no code, no CI-affecting files
- [x] Internal links checked (plan doc ↔ matrix, sibling integration docs, `docs/ci/` references)
- [ ] TODO (pre-build, not this PR): run the §6 probe spike against a real `copilot` binary and update the 🧪 cells/probe results