### PR TITLE
fix(shell): split shell payloads on UNQUOTED separators only (#216)

### DIFF
--- a/packages/core/lib/shell.mjs
+++ b/packages/core/lib/shell.mjs
@@ -90,17 +90,83 @@ export function shellHasOpaqueMutation(text) {
 }
 
 /**
+ * Split a shell payload on UNQUOTED separators (`;` `&` `|` `&&` `||` newline).
+ *
+ * Splitting with a plain regex ignores quoting, so a read-only command carrying
+ * a quoted separator was shredded into fragments that could not match the
+ * allowlist (issue #216):
+ *
+ *   rg -n '"(prepack|prepare|postpack)"' package.json
+ *     -> ["rg -n '\"(prepack", "prepare", "postpack)\"' package.json"]
+ *
+ * `rg` IS allowlisted; the parse defeated the allowlist before it was consulted.
+ *
+ * Returns `null` when the payload cannot be parsed confidently (an unterminated
+ * quote), so the caller can FAIL CLOSED. That direction matters: the allowlist
+ * only inspects each segment's PREFIX, so a separator we fail to split on is
+ * fail-open — `cat x | rm -rf rail` left unsplit still starts with `cat`.
+ * Missing a real separator is the dangerous error, never the reverse.
+ */
+function splitOnUnquotedSeparators(text) {
+  const segments = [];
+  let current = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const c = text[i];
+    if (quote === null && c === '\\') {
+      current += c + (text[i + 1] ?? '');
+      i += 1;
+      continue;
+    }
+    if (quote === null && (c === "'" || c === '"')) {
+      quote = c;
+      current += c;
+      continue;
+    }
+    if (quote !== null) {
+      // Inside double quotes a backslash still escapes; inside single quotes
+      // everything is literal, so only consume an escape for the former.
+      if (quote === '"' && c === '\\') {
+        current += c + (text[i + 1] ?? '');
+        i += 1;
+        continue;
+      }
+      if (c === quote) quote = null;
+      current += c;
+      continue;
+    }
+    if ((c === '&' && text[i + 1] === '&') || (c === '|' && text[i + 1] === '|')) {
+      segments.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+    if (c === ';' || c === '&' || c === '|' || c === '\n') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += c;
+  }
+  if (quote !== null) return null; // unterminated quote — refuse to guess
+  segments.push(current);
+  return segments;
+}
+
+/**
  * Positively read-only only if EVERY command segment is individually a known
  * read-only command (empty string counts). Splitting on separators is
  * load-bearing: a read-only prefix must not shadow a later mutator — e.g.
- * `git status && curl -o rail` is NOT read-only.
+ * `git status && curl -o rail` is NOT read-only. The split is quote-aware, so a
+ * separator INSIDE a quoted argument is not mistaken for a command boundary.
  */
 export function shellIsPositivelyReadOnly(text) {
   const normalized = String(text ?? '').trim();
   if (normalized === '') return true;
   const readOnlyPrefix = /^(?:git\s+(?:status|diff|show|log|rev-parse|branch|ls-files)\b|pwd\b|ls\b|rg\b|grep\b|cat\b|sed\s+-n\b|head\b|tail\b|wc\b|nl\b|node\s+(?:--check|--test)\b|npm\s+(?:test|run\s+test)\b|adlc\s+(?:hollow-test|rails-guard|flail-detector|preflight|run\s+p[34])\b)/;
-  return normalized
-    .split(/(?:&&|\|\||[;&|\n])/)
+  const segments = splitOnUnquotedSeparators(normalized);
+  if (segments === null) return false; // unparseable → not positively read-only
+  return segments
     .map((s) => s.trim())
     .filter((s) => s !== '')
     .every((segment) => readOnlyPrefix.test(segment));

--- a/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-codex/hooks/adlc-rails-guard.mjs
@@ -190,12 +190,80 @@ function shellHasOpaqueMutation(text) {
   );
 }
 
+/**
+ * Split a shell payload on UNQUOTED separators (`;` `&` `|` `&&` `||` newline).
+ *
+ * Splitting with a plain regex (the pre-#216 behaviour) ignores quoting, so a
+ * read-only command carrying a quoted separator was shredded into fragments that
+ * could not match the allowlist:
+ *
+ *   rg -n '"(prepack|prepare|postpack)"' package.json
+ *     -> ["rg -n '\"(prepack", "prepare", "postpack)\"' package.json"]
+ *
+ * Only the first fragment starts with an allowlisted command, so `.every(...)`
+ * failed and the hook denied a purely read-only search. That blocked a mandatory
+ * cross-model review.
+ *
+ * Returns `null` when the payload cannot be parsed confidently (an unterminated
+ * quote), so the caller can FAIL CLOSED. That direction matters: the allowlist
+ * only inspects each segment's PREFIX, so a separator we fail to split on is
+ * fail-open — `cat x | rm -rf y` left unsplit still starts with `cat` and would
+ * be allowed. Missing a real separator is the dangerous error, never the
+ * reverse.
+ */
+function splitOnUnquotedSeparators(text) {
+  const segments = [];
+  let current = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const c = text[i];
+    if (quote === null && c === '\\') {
+      current += c + (text[i + 1] ?? '');
+      i += 1;
+      continue;
+    }
+    if (quote === null && (c === "'" || c === '"')) {
+      quote = c;
+      current += c;
+      continue;
+    }
+    if (quote !== null) {
+      // Inside double quotes a backslash still escapes; inside single quotes
+      // everything is literal, so only consume an escape for the former.
+      if (quote === '"' && c === '\\') {
+        current += c + (text[i + 1] ?? '');
+        i += 1;
+        continue;
+      }
+      if (c === quote) quote = null;
+      current += c;
+      continue;
+    }
+    if ((c === '&' && text[i + 1] === '&') || (c === '|' && text[i + 1] === '|')) {
+      segments.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+    if (c === ';' || c === '&' || c === '|' || c === '\n') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += c;
+  }
+  if (quote !== null) return null; // unterminated quote — refuse to guess
+  segments.push(current);
+  return segments;
+}
+
 function shellIsPositivelyReadOnly(text) {
   const normalized = String(text ?? '').trim();
   if (normalized === '') return true;
   const readOnlyPrefix = /^(?:git\s+(?:status|diff|show|log|rev-parse|branch|ls-files)\b|pwd\b|ls\b|rg\b|grep\b|cat\b|sed\s+-n\b|head\b|tail\b|wc\b|nl\b|node\s+(?:--check|--test)\b|npm\s+(?:test|run\s+test)\b|adlc\s+(?:hollow-test|rails-guard|flail-detector|preflight|run\s+p[34])\b)/;
-  return normalized
-    .split(/(?:&&|\|\||[;&|\n])/)
+  const segments = splitOnUnquotedSeparators(normalized);
+  if (segments === null) return false; // unparseable → not positively read-only
+  return segments
     .map((s) => s.trim())
     .filter((s) => s !== '')
     .every((segment) => readOnlyPrefix.test(segment));

--- a/plugins/adlc-codex/hooks/test/shell-quoting.test.mjs
+++ b/plugins/adlc-codex/hooks/test/shell-quoting.test.mjs
@@ -1,0 +1,139 @@
+// shell-quoting.test.mjs — issue #216.
+//
+// shellIsPositivelyReadOnly split the shell payload with a plain regex, ignoring
+// quoting. A read-only `rg` whose pattern contained an alternation was shredded
+// into fragments that could not match the allowlist, so the hook denied it:
+//
+//   rg -n '"(prepack|prepare|postpack)"' package.json
+//     -> ["rg -n '\"(prepack", "prepare", "postpack)\"' package.json"]
+//
+// `rg` IS allowlisted; the parse defeated the allowlist before it was consulted.
+// The practical cost was a blocked cross-model P5 review, which then looked like
+// a bug in the external reviewer rather than in this hook.
+//
+// The dangerous direction is the opposite one. The allowlist only inspects each
+// segment's PREFIX, so a separator the splitter MISSES is fail-open:
+// `cat x | rm -rf y` left unsplit still starts with `cat`. Half of these tests
+// exist to pin that, because a fix that merely stops over-splitting could easily
+// start under-splitting.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HOOK = join(dirname(fileURLToPath(import.meta.url)), '..', 'adlc-rails-guard.mjs');
+const ticket = { id: 'T1', title: 'Active', scope: ['src/**'], rails: ['test/**'], edges: [] };
+
+function withRepo(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-codex-quoting-'));
+  mkdirSync(join(root, '.adlc'), { recursive: true });
+  writeFileSync(join(root, '.adlc/tickets.json'), `${JSON.stringify({ tickets: [ticket] }, null, 2)}\n`);
+  writeFileSync(join(root, '.adlc/current-ticket.json'), '{"id":"T1"}\n');
+  try { return fn(root); }
+  finally { rmSync(root, { recursive: true, force: true }); }
+}
+
+/** Run the hook with a shell payload; returns { status, stderr }. */
+function shell(root, command) {
+  const { ADLC_P4_ENFORCEMENT: _e, ADLC_TICKET: _t, ADLC_TICKETS: _ts, ADLC_TICKET_STORE: _s, ADLC_RAILS_BYPASS: _b, ...base } = process.env;
+  return spawnSync(process.execPath, [HOOK], {
+    cwd: root,
+    env: base,
+    input: JSON.stringify({ tool_name: 'shell', tool_input: { command } }),
+    encoding: 'utf8',
+  });
+}
+
+
+const DENIED = 2;
+
+// --- the regression: read-only commands carrying quoted separators ----------
+
+test('a read-only rg with a quoted alternation is ALLOWED', () => {
+  withRepo((root) => {
+    // The exact command that was denied, costing a cross-model review.
+    const r = shell(root, `rg -n '"(prepack|prepare|postpack|prepublishOnly|prepublish)"' package.json packages plugins`);
+    assert.notEqual(r.status, DENIED,
+      `a quoted | inside an rg pattern must not deny:\n${r.stderr}`);
+  });
+});
+
+test('read-only commands with other quoted separators are ALLOWED', () => {
+  withRepo((root) => {
+    for (const command of [
+      `grep -n "a;b" file.txt`,
+      `rg 'x&y' .`,
+      `rg "one||two" .`,
+      `grep -n 'a && b' file.txt`,
+      `rg --json '{"k":"v|w"}' .`,
+      `cat 'weird|name.txt'`,
+    ]) {
+      const r = shell(root, command);
+      assert.notEqual(r.status, DENIED, `must not deny: ${command}\n${r.stderr}`);
+    }
+  });
+});
+
+// --- the dangerous direction: real separators must still split --------------
+
+// NOTE ON WHAT THIS HOOK ACTUALLY GUARDS: it is a RAIL guard, not a general
+// mutation guard. `shellHasMutation()` runs BEFORE the read-only check, and a
+// mutation to a non-rail path is legitimately allowed — so `cat x | rm -rf y`
+// is ALLOWED by design when `y` is not a rail. The deny cases below therefore
+// target `test/**`, the fixture's declared rail.
+
+test('an UNQUOTED pipeline touching a RAIL is still DENIED', () => {
+  withRepo((root) => {
+    // If the splitter missed the separator, the payload becomes one segment
+    // beginning with an allowlisted command — the fail-open direction.
+    for (const command of [
+      'cat x | rm -rf test/frozen.test.mjs',
+      'ls && rm -rf test/frozen.test.mjs',
+      'pwd; rm -rf test/frozen.test.mjs',
+      'grep x file & rm test/frozen.test.mjs',
+    ]) {
+      const r = shell(root, command);
+      assert.equal(r.status, DENIED, `must deny: ${command}\n${r.stderr}`);
+    }
+  });
+});
+
+test('a separator immediately after a CLOSING quote still splits', () => {
+  withRepo((root) => {
+    // The quote closes before the separator, so it is unquoted and must split.
+    const r = shell(root, `rg 'a|b' file; rm -rf test/frozen.test.mjs`);
+    assert.equal(r.status, DENIED, 'a real separator after a quoted region must still be seen');
+  });
+});
+
+test('an escaped quote does not swallow the rest of the payload', () => {
+  withRepo((root) => {
+    // If the backslash-escaped quote were treated as opening a string, the
+    // trailing rail mutation would be considered quoted and hidden.
+    const r = shell(root, `grep -n "he said \\"hi\\"" f.txt; rm -rf test/frozen.test.mjs`);
+    assert.equal(r.status, DENIED, 'an escaped quote must not hide a later rail mutation');
+  });
+});
+
+test('an UNTERMINATED quote fails closed', () => {
+  withRepo((root) => {
+    // Unparseable payloads must never be treated as positively read-only.
+    const r = shell(root, `rg 'unterminated`);
+    assert.equal(r.status, DENIED, 'a payload that cannot be parsed must not be allowed');
+  });
+});
+
+test('a plain read-only command is still ALLOWED (control)', () => {
+  withRepo((root) => {
+    // Denominator: proves the deny assertions above are not simply "everything
+    // is denied".
+    for (const command of ['git status', 'pwd', 'rg foo .', 'ls -la', 'npm test']) {
+      const r = shell(root, command);
+      assert.notEqual(r.status, DENIED, `must allow: ${command}\n${r.stderr}`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #216. Draft — an adversarial review pass is still to be run.

## The defect

`shellIsPositivelyReadOnly` split the shell payload with a plain regex, ignoring quoting. A read-only command carrying a quoted separator was shredded into fragments that could not match the allowlist:

```
rg -n '"(prepack|prepare|postpack|prepublishOnly|prepublish)"' package.json
  -> ["rg -n '\"(prepack", "prepare", "postpack)\"' package.json", ...]
```

`rg` **is** allowlisted — the parse defeated the allowlist before it was ever consulted. The practical cost was a **blocked cross-model P5 review**, which then presented as a bug in the external reviewer rather than in this hook, and was initially misdiagnosed as exactly that.

## The dangerous direction

The allowlist only inspects each segment's **prefix**, so a separator the splitter *misses* is fail-open: `cat x | rm -rf rail` left unsplit still begins with an allowlisted `cat`. A fix that merely stops over-splitting could easily start under-splitting.

So the new splitter returns `null` on an unterminated quote and the caller treats that as **not** positively read-only. Half the new tests pin that direction rather than the reported one.

## Why frozen core is touched

CONVENTIONS rule 2 freezes `packages/core`, but this classifier is **duplicated by design**: the codex hook cannot import npm packages at runtime, so it keeps a verbatim inline copy, and `packages/core/test/shell.test.mjs:146` pins the two together. Fixing the plugin alone is impossible — the drift test fails. Core is canonical, so the fix lands there and the hook mirrors it byte-for-byte.

**Worth a follow-up decision:** a drift-pinned verbatim duplicate means *every* fix to this classifier must edit frozen core, which makes rule 2 unenforceable for this file in practice.

## Verified behaviour

| command | read-only? |
|---|---|
| `rg -n '"(prepack\|prepare\|postpack)"' package.json` (the blocked one) | ✅ yes |
| `rg 'a\|b' .` / `grep -n "a;b" f` | ✅ yes |
| `cat x \| rm -rf y` | ❌ no |
| `git status && curl -o rail` (the case the docblock cites) | ❌ no |
| `rg 'a\|b' f; rm -rf y` (separator after a closing quote) | ❌ no |
| `grep -n "he said \"hi\"" f; rm -rf y` (escaped quote) | ❌ no |
| `rg 'unterminated` | ❌ no — fails closed |

## Tests

7 new tests drive the hook **end-to-end** (stdin → exit status) rather than calling the function directly, including a control set proving the deny assertions aren't simply "everything is denied".

Both halves proven load-bearing: reverting to the regex split fails 3 tests; making the unterminated-quote case fail open fails 1.

One test premise was wrong on the first attempt and worth recording — this hook is a **rail** guard, not a general mutation guard. `shellHasMutation()` runs *before* the read-only check, so `cat x | rm -rf y` is legitimately **allowed** when `y` isn't a rail. The deny cases therefore target the fixture's declared rail.

`npm test`: 46/46 segments green.

## Explicitly not addressed

An adjacent **pre-existing** hole: command substitution (`rg $(rm -rf rail)`) is classified read-only by both the old and new code, because the allowlist matches the segment prefix and never inspects substitutions. Unchanged by this PR. It deserves its own issue rather than a silent widening of the guard's behaviour in a PR about false denials.
