### PR TITLE
docs(rails-guard): correct comments describing the superseded comparator

### DIFF
--- a/packages/rails-guard/test/rails.test.mjs
+++ b/packages/rails-guard/test/rails.test.mjs
@@ -84,8 +84,8 @@ describe('checkRailEdits', () => {
 // including that the exemption is OFF unless a resolver is supplied.
 describe('checkRailEdits — version-only exemption (#228)', () => {
   const PKG = 'packages/build-gate/package.json';
-  // Formatted as JSON.stringify(o, null, 2) writes it — the exemption is a
-  // line-level text check, so a minified fixture would not exercise it.
+  // Formatted as JSON.stringify(o, null, 2) writes it — that is canonical form,
+  // which the exemption requires; a minified fixture would be refused outright.
   const mk = (version, main) =>
     JSON.stringify({ name: '@adlc/build-gate', version, main }, null, 2) + '\n';
   const before = mk('1.5.0', 'lib/i.mjs');

--- a/packages/rails-guard/test/version-only.test.mjs
+++ b/packages/rails-guard/test/version-only.test.mjs
@@ -1,9 +1,10 @@
 // version-only.test.mjs — #228: a lockstep version bump must not read as a rail edit.
 //
-// The exemption compares TEXT, not parsed JSON — see the header of
-// lib/version-only.mjs for why. Fixtures are therefore written exactly as
-// JSON.stringify(obj, null, 2) produces them, because that is what
-// scripts/release.mjs writes and the check is line-structural.
+// The exemption requires each side to be its own canonical re-serialisation,
+// then compares by structural PATH — see the header of lib/version-only.mjs for
+// why neither parsing alone nor comparing text alone was sufficient. Fixtures
+// are therefore written exactly as JSON.stringify(obj, null, 2) produces them,
+// because that is canonical form and what scripts/release.mjs writes.
 //
 // Most tests below assert `false`. That is deliberate: a change which merely
 // weakened the guard would satisfy "the release is unblocked" while silently
@@ -572,8 +573,11 @@ test('a non-object JSON document is NOT exempt', () => {
 });
 
 test('a dependency RANGE beyond npm limits is NOT exempt', () => {
-  // The equivalent version-side fixtures are rejected by the completeness pass,
-  // so only a range exercises splitRange's own validity check.
+  // NOTE what rejects this: the top-level VERSION check, not splitRange. The
+  // fixture moves both together because lockstep requires a range to equal the
+  // manifest version, which makes splitRange's own isVersion call unreachable —
+  // documented as such at its definition. This test pins the outcome, not that
+  // guard.
   const mk = (v, dep) => JSON.stringify({ version: v, dependencies: { '@adlc/core': dep } }, null, 2) + '\n';
   assert.equal(isVersionOnlyChange(mk('1.5.0', '^1.5.0'), mk('9007199254740992.0.0', '^9007199254740992.0.0'), PKG), false);
   assert.equal(isVersionOnlyChange(mk('1.5.0', '^1.5.0'), mk(`1.5.1-${'a'.repeat(266)}`, `^1.5.1-${'a'.repeat(266)}`), PKG), false);


### PR DESCRIPTION
Small follow-up to #234, which merged while these were in flight. Comments only — no behaviour change.

Cross-model round 7 flagged that several comments still describe the **line-level text comparator**, which is two designs out of date. The file header claimed the check is "line-structural"; it actually requires canonical form and then compares by structural path.

| location | was | now |
|---|---|---|
| `version-only.test.mjs` header | "the check is line-structural" | canonical form, then structural path |
| `rails.test.mjs:87` | "the exemption is a line-level text check" | canonical form; a minified fixture is refused outright |
| range-limit test | claimed to exercise `splitRange` validation | says what actually rejects it — the top-level version check |

That last one matters most. The test claimed to pin a guard it does not: `splitRange`'s own `isVersion` call is **unreachable**, because lockstep forces a range to equal the manifest version, which is already validated. The test pins the outcome, not the guard, and now says so.

A comment describing a design the code no longer has is the same failure as a test that pins nothing — it is what the next reader trusts *instead of* the source. That failure mode recurred four times across this ticket's review, which is why it is worth a follow-up rather than leaving it.

Historical references to the line-based design are left intact where they correctly describe what a prior round rejected.

## Test plan

- [x] `npm test` — 46/46 segments green
- [x] No source file touched; comments and one test comment only
- [ ] CI green