### PR TITLE
ci: add the diff-scoped mutation coverage gate (P7 defense)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,3 +263,48 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: node scripts/rails-guard-ci.mjs "origin/$BASE_REF"
+
+  mutation-gate:
+    # C4 hollow-test, diff-scoped. Catches a guard added without a test that
+    # notices it being removed — code that is correct but unverified.
+    #
+    # This exists because that failure recurred FIVE times inside a single ticket
+    # (#228 / #234): a structural check whose mechanism no test exercised, two
+    # symlink fixtures that passed for unrelated reasons, and completeness
+    # fixtures that all left the same side wrong. Three of the five were caught
+    # only by external review. Every one looks exactly like a surviving mutant.
+    #
+    # REQUIRED, not advisory. An optional coverage gate is one a refactor can
+    # quietly kill and still merge, which is the same reasoning the OpenCode
+    # live-deny proof is folded into the required test job for.
+    #
+    # PRs only: on a push to main the merge-base diff is empty and there is
+    # nothing to mutate.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # full history so the diff base resolves
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm install
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      - name: Mutation coverage gate
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        # hollow-test mutates in place and restores, so the tree must be clean.
+        run: |
+          git diff --quiet || { echo "working tree dirty before mutation gate"; exit 1; }
+          node scripts/mutation-gate.mjs "origin/$BASE_REF" --max 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,11 @@ jobs:
           node-version: 20
 
       - name: Install
-        run: npm install
+        # `npm ci` installs from the lockfile WITHOUT rewriting it. `npm install`
+        # can update package-lock.json, and hollow-test refuses to run on a dirty
+        # tree (it mutates files in place and restores them), so a rewritten
+        # lockfile would fail the gate on an unrelated change.
+        run: npm ci
 
       - name: Fetch base ref
         env:
@@ -304,7 +308,13 @@ jobs:
       - name: Mutation coverage gate
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
-        # hollow-test mutates in place and restores, so the tree must be clean.
+        # hollow-test enforces a clean tree itself, with a clearer message than a
+        # pre-check here would give — so the tree must arrive clean, which is why
+        # Install uses `npm ci` above. Guard only against a stray TRACKED-source
+        # edit (never the lockfile or untracked build output).
         run: |
-          git diff --quiet || { echo "working tree dirty before mutation gate"; exit 1; }
+          dirty=$(git diff --name-only -- '*.mjs' '*.js' '*.cjs' 'packages/**' 'plugins/**')
+          if [ -n "$dirty" ]; then
+            echo "tracked source is dirty before the mutation gate:"; echo "$dirty"; exit 1
+          fi
           node scripts/mutation-gate.mjs "origin/$BASE_REF" --max 12

--- a/packages/rails-guard/test/version-only.test.mjs
+++ b/packages/rails-guard/test/version-only.test.mjs
@@ -582,3 +582,17 @@ test('a dependency RANGE beyond npm limits is NOT exempt', () => {
   assert.equal(isVersionOnlyChange(mk('1.5.0', '^1.5.0'), mk('9007199254740992.0.0', '^9007199254740992.0.0'), PKG), false);
   assert.equal(isVersionOnlyChange(mk('1.5.0', '^1.5.0'), mk(`1.5.1-${'a'.repeat(266)}`, `^1.5.1-${'a'.repeat(266)}`), PKG), false);
 });
+
+test('npm MAX_LENGTH is an exact boundary, not an approximate one', () => {
+  // Found by the mutation gate: changing MAX_LENGTH from 256 to 257 survived the
+  // whole suite, because the nearest fixture used a 266-character version and
+  // could not tell the two limits apart. npm classifies anything over 256 as a
+  // dist-tag, so the boundary itself is load-bearing.
+  const mk = (v) => JSON.stringify({ metadata: { version: v } }, null, 2) + '\n';
+  const at256 = `1.5.1-${'a'.repeat(250)}`;   // exactly 256
+  const at257 = `1.5.1-${'a'.repeat(251)}`;   // one over
+  assert.equal(at256.length, 256);
+  assert.equal(at257.length, 257);
+  assert.equal(isVersionOnlyChange(mk('1.5.0'), mk(at256), MKT), true, '256 chars is a version');
+  assert.equal(isVersionOnlyChange(mk('1.5.0'), mk(at257), MKT), false, '257 chars is a dist-tag');
+});

--- a/scripts/mutation-gate.mjs
+++ b/scripts/mutation-gate.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// mutation-gate — CI wrapper that runs the diff-scoped mutation gate (C4) with a
+// test command scoped to the packages the diff actually touches.
+//
+// WHY THIS EXISTS. `adlc hollow-test` runs the test command ONCE PER MUTANT, so
+// the command's cost is multiplied. The full suite takes ~9.5 minutes here, which
+// makes even five mutants unshippable in CI. Scoping to the changed packages
+// brings a mutant down to seconds, which is what makes the gate practical at all.
+//
+// WHAT IT DEFENDS. A guard added without a test that notices its removal. That
+// failure recurred FIVE times inside a single ticket (#228 / #234) — a structural
+// check whose mechanism no test exercised, two symlink fixtures that passed for
+// unrelated reasons, and completeness fixtures that all left the same side wrong.
+// Three of the five were caught only by external review. Every one of them is
+// exactly what a surviving mutant looks like.
+//
+//   node scripts/mutation-gate.mjs [base-ref] [--max N]
+//
+// Exit: 0 = all mutants killed or nothing to mutate · 2 = a mutant survived ·
+//       1 = operational error.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const args = process.argv.slice(2);
+const base = args.find((a) => !a.startsWith('--')) || process.env.MUTATION_BASE || 'origin/main';
+const maxFlag = args.indexOf('--max');
+const max = maxFlag >= 0 ? args[maxFlag + 1] : '12';
+
+function fail(msg) {
+  console.error(`mutation-gate: ${msg}`);
+  process.exit(1);
+}
+
+function git(gitArgs) {
+  const r = spawnSync('git', gitArgs, { encoding: 'utf8', cwd: ROOT, timeout: 60000 });
+  if (r.error) fail(`git ${gitArgs[0]} failed: ${r.error.message}`);
+  return r;
+}
+
+// The base must resolve. `git diff <bad-ref>` fails loudly, but an unfetched base
+// in CI is an operational problem, not "nothing changed" — say so rather than
+// passing an empty diff.
+if (git(['rev-parse', '--verify', '--quiet', `${base}^{commit}`]).status !== 0) {
+  fail(`base ref '${base}' does not resolve — fetch it or pass the correct base`);
+}
+
+const diff = git(['diff', '--name-only', '-z', base, '--']);
+if (diff.status !== 0) fail('git diff failed');
+const changed = diff.stdout.split('\0').filter(Boolean);
+
+/**
+ * Map changed files to the test commands that cover them.
+ *
+ * Deliberately conservative: a file that maps to no known test directory
+ * contributes NO command, and if nothing maps we skip rather than mutate a file
+ * whose tests we cannot locate. A mutation run against the wrong test command
+ * would report confident nonsense in both directions.
+ */
+function testDirFor(file) {
+  let m;
+  if ((m = /^packages\/([^/]+)\//.exec(file))) {
+    const d = `packages/${m[1]}/test`;
+    return existsSync(join(ROOT, d)) ? d : null;
+  }
+  if ((m = /^plugins\/([^/]+)\/(hooks|lib|agents|mcp)\//.exec(file))) {
+    const d = `plugins/${m[1]}/${m[2]}/test`;
+    return existsSync(join(ROOT, d)) ? d : null;
+  }
+  if ((m = /^plugins\/([^/]+)\//.exec(file))) {
+    const d = `plugins/${m[1]}/test`;
+    return existsSync(join(ROOT, d)) ? d : null;
+  }
+  return null;
+}
+
+// Only source files are worth mutating; a mutated test proves nothing about the
+// code. hollow-test excludes test paths itself, but filtering here keeps the
+// test-command mapping honest about what is actually under test.
+const sources = changed.filter((f) =>
+  /\.(mjs|js|cjs)$/.test(f) && !/(^|\/)(test|tests)\//.test(f) && !/\.test\.mjs$/.test(f));
+
+if (sources.length === 0) {
+  console.log('mutation-gate: no source files changed — nothing to mutate.');
+  process.exit(0);
+}
+
+// NAME WHAT IS NOT COVERED. A gate that quietly opts out of a directory is the
+// same hollow-coverage failure it exists to prevent, so every skipped file is
+// printed with its reason rather than folded into a silent pass.
+//
+// `scripts/**` is out of scope on cost: its suite takes ~9.5 MINUTES, and
+// hollow-test reruns the command once per mutant, so a dozen mutants there is
+// ~2 hours. Bringing it in scope needs that suite to get faster first — tracked
+// separately, not papered over here.
+const covered = [];
+const skipped = [];
+for (const file of sources) {
+  const dir = testDirFor(file);
+  if (dir) covered.push([file, dir]);
+  else skipped.push(file);
+}
+
+console.log(`mutation-gate: base=${base} max=${max}`);
+if (skipped.length) {
+  console.log(`mutation-gate: NOT MUTATED (${skipped.length} file(s), no in-scope test suite):`);
+  for (const f of skipped) {
+    const why = f.startsWith('scripts/')
+      ? 'scripts/test is too slow to mutate (~9.5min/run)'
+      : 'no test directory maps to this path';
+    console.log(`  ${f}  — ${why}`);
+  }
+}
+
+if (covered.length === 0) {
+  console.log('mutation-gate: nothing in scope to mutate — passing, but see the list above.');
+  process.exit(0);
+}
+
+const dirs = [...new Set(covered.map(([, d]) => d))].sort();
+const targets = covered.map(([f]) => f);
+const testCmd = dirs.map((d) => `node --test ${d}/*.test.mjs`).join(' && ');
+console.log(`mutation-gate: mutating ${targets.length} file(s) → ${testCmd}`);
+
+// Pass the in-scope files as explicit --target rather than letting hollow-test
+// re-derive them from the diff: its diff would still include the paths listed as
+// skipped above, and mutating those would run the slow suite we just excluded.
+const bin = join(ROOT, 'packages', 'hollow-test', 'bin', 'hollow-test.mjs');
+const result = spawnSync(process.execPath, [
+  bin,
+  '--base', base,
+  '--test-cmd', testCmd,
+  '--max', String(max),
+  // Each suite must fit comfortably; the slowest in-scope one is seconds, but a
+  // mutant that hangs should be reported as a timeout rather than killing CI.
+  '--timeout-ms', '180000',
+  ...targets.flatMap((t) => ['--target', t]),
+], { stdio: 'inherit', cwd: ROOT, timeout: 1800000 });
+
+if (result.error) fail(`could not run hollow-test: ${result.error.message}`);
+if (result.signal) fail(`hollow-test timed out or was killed by ${result.signal}`);
+
+if (result.status === 2) {
+  console.error('');
+  console.error('mutation-gate: a mutant SURVIVED — some changed code has no test that notices it changing.');
+  console.error('This is the hollow-test failure mode: a guard can be correct and still be unverified.');
+  console.error('Either add a test that fails when that line is altered, or, if the line is genuinely');
+  console.error('redundant with a stronger check, say so in a comment AT ITS DEFINITION and re-run.');
+}
+process.exit(typeof result.status === 'number' ? result.status : 1);


### PR DESCRIPTION
Distilled from #228 / #234. That ticket had the **same failure recur five times**: a guard that was correct but that no test would notice being removed.

- a structural check whose mechanism no test exercised — deleting the single line it depended on failed **zero of 110 tests**
- a symlink fixture pointing at a non-JSON target, so an earlier validation step rejected it and the named guard was never reached
- a symlink fixture using a dangling link, so the read threw first
- completeness fixtures that all left the same side wrong, so an implementation checking only that side passed every one
- a pathspec fixture that passed with **both** guards removed

Three of the five were caught only by external review. Every one of them looks exactly like a surviving mutant — and `adlc hollow-test` already existed in this repo. It was just never wired to anything. This wires it.

## What it is

`scripts/mutation-gate.mjs` — a CI wrapper around `hollow-test` that scopes the test command to the packages the diff touched.

**Why the wrapper is the whole point.** `hollow-test` reruns the test command *once per mutant*, so the command's cost is multiplied. `npm test` is ~9.5 minutes here; twelve mutants against it is a two-hour job. Scoping to changed packages brings a mutant down to seconds:

```
8 mutants over the rails-guard change: 41 seconds
```

## It earned its place on the first run

Flagged `MAX_LENGTH = 256` as unpinned: the nearest fixture used a 266-character version and could not tell 256 from 257. npm classifies anything over 256 as a dist-tag, so that boundary is load-bearing. Now pinned exactly — and the gate reports **8/8 killed**.

## What it does NOT cover — stated out loud

`scripts/**` is excluded, on cost: its suite alone is the ~9.5 minutes. The gate **prints every skipped file with its reason** rather than folding it into a silent pass, because a gate that quietly opts out of a directory is the same hollow-coverage failure it exists to prevent. In-scope files are passed as explicit `--target`, so excluded paths cannot sneak back in through `hollow-test`'s own diff discovery.

Speeding up `scripts/test` so it can come in scope is a separate follow-up (to be filed).

## Design choices

- **Required, not advisory**, and **PR-only** (a push to `main` has an empty merge-base diff so there is nothing to mutate). An optional coverage gate is one a refactor can quietly kill while still merging — the same reasoning that folds the OpenCode live-deny proof into the required test job.
- Base ref that does not resolve is an **operational failure**, not "nothing changed" — it says so rather than passing an empty diff.
- A changed source file that maps to **no** in-scope test directory is printed, not silently dropped.

## Test plan

- [x] `node scripts/mutation-gate.mjs v1.5.1` — 8/8 killed after the boundary fix
- [x] No-source-change diff → clean skip, exit 0
- [x] `.github/workflows/ci.yml` parses (js-yaml)
- [x] `npm test` — 46/46 segments green
- [ ] The gate runs green on **this** PR (it mutates `scripts/mutation-gate.mjs` itself — a nice self-test, though that file maps to `scripts/test` and is therefore in the excluded set, so expect it to report itself skipped)