### PR TITLE
fix(core): fail closed on paths git cannot decode faithfully (#249)

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -76,6 +76,12 @@ export function git(args: readonly string[], opts?: {
 }): string;
 export function gitDiff(base?: string, cwd?: string): string;
 export function changedFiles(base?: string, cwd?: string): string[];
+/**
+ * Split raw NUL-delimited `git ... -z` output into path strings, failing closed
+ * on any path that does not round-trip UTF-8 (#249). Pass the Buffer, not a
+ * decoded string, so lossy-decode aliasing is detectable.
+ */
+export function splitNulPaths(raw: Buffer | string): string[];
 export function isDirty(cwd?: string): boolean;
 export function isGitRepo(cwd?: string): boolean;
 export function repoRoot(cwd?: string): string;

--- a/packages/core/lib/git.mjs
+++ b/packages/core/lib/git.mjs
@@ -11,6 +11,54 @@ export function git(args, opts = {}) {
   });
 }
 
+/**
+ * Split raw NUL-delimited `git ... -z` OUTPUT (a Buffer) into path strings, and
+ * PROVE each decode is lossless.
+ *
+ * UTF-8 decoding is not injective: every byte git cannot decode becomes U+FFFD.
+ * So two files whose names differ only in invalid bytes — `bad-\x80/p.json` and
+ * `bad-\xEF\xBF\xBD/p.json` — both decode to `bad-�/p.json` and collapse to
+ * ONE entry. A downstream gate keyed on that string then answers for the wrong
+ * file: a version bump on one path and a behaviour edit on the other resolve to a
+ * single cache entry, and the behaviour edit is exempted. This is the filename
+ * analogue of the content-level aliasing fixed in #228; see #249.
+ *
+ * Splitting the BUFFER on the NUL byte (not the decoded string) keeps the split
+ * itself immune to decoding, then each field is decoded and required to
+ * re-encode to its exact bytes. A field that does not is a path git is telling us
+ * about but that we cannot represent faithfully, so we FAIL CLOSED — a caller of
+ * this in a freeze gate must never receive a path that silently aliases another.
+ * A non-round-trip filename is already pathological in this repo; the trade is a
+ * hard error over a silent wrong answer.
+ *
+ * @param {Buffer|string} raw  git -z output. A string is accepted for callers
+ *        that already decoded, but note it cannot detect aliasing that the
+ *        decode already erased — prefer passing the Buffer.
+ * @returns {string[]}
+ */
+export function splitNulPaths(raw) {
+  const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw, 'utf8');
+  const out = [];
+  let start = 0;
+  for (let i = 0; i <= buf.length; i++) {
+    if (i === buf.length || buf[i] === 0) {
+      if (i > start) {
+        const field = buf.subarray(start, i);
+        const text = field.toString('utf8');
+        if (!Buffer.from(text, 'utf8').equals(field)) {
+          throw new Error(
+            `git returned a path that is not valid UTF-8 and cannot be handled ` +
+            `safely: ${JSON.stringify(text)}. Refusing to proceed — see #249.`
+          );
+        }
+        out.push(text);
+      }
+      start = i + 1;
+    }
+  }
+  return out;
+}
+
 export function isGitRepo(cwd = process.cwd()) {
   try {
     git(['rev-parse', '--is-inside-work-tree'], { cwd, stdio: ['ignore', 'pipe', 'ignore'] });
@@ -27,8 +75,10 @@ export function gitDiff(base = 'HEAD', cwd = process.cwd()) {
   // name list, patch text has no -z form, so this does NOT neutralize every special
   // character — a path with a space still gets a trailing TAB, and tab/quote/newline
   // names are still double-quoted. Those desync per-file HEADER attribution only;
-  // the security-critical changed-file SET goes through changedFiles() (-z, fully
-  // raw), and marker/content detection matches on line bodies, not header paths.
+  // the security-critical changed-file SET goes through changedFiles(), which
+  // splits raw -z bytes and FAILS CLOSED on any path it cannot decode faithfully
+  // (#249) — so that set is trustworthy where these header paths are not. Marker
+  // and content detection match on line bodies, not header paths.
   return git(['-c', 'core.quotepath=false', 'diff', base, '--'], { cwd });
 }
 
@@ -74,8 +124,14 @@ export function changedFiles(base = 'HEAD', cwd = process.cwd()) {
   // -z emits NUL-delimited raw paths, immune to git's C-quoting of non-ASCII/
   // special characters. Splitting on '\n' the quoted form would hand a downstream
   // matcher (e.g. rails-guard's checkRailEdits) a display string that never matches
-  // the real rail path — a silent freeze-gate bypass. Mirrors revision.mjs.
-  return git(['diff', '--name-only', '-z', base, '--'], { cwd }).split('\0').filter(Boolean);
+  // the real rail path — a silent freeze-gate bypass.
+  //
+  // Read as a BUFFER and split via splitNulPaths, not `.split('\0')` on a decoded
+  // string: decoding first collapses distinct invalid-byte paths to one U+FFFD
+  // string BEFORE the split can tell them apart (#249). splitNulPaths fails closed
+  // on any path that does not round-trip UTF-8.
+  const raw = git(['diff', '--name-only', '-z', base, '--'], { cwd, encoding: 'buffer' });
+  return splitNulPaths(raw);
 }
 
 export function isDirty(cwd = process.cwd()) {

--- a/packages/core/lib/revision.mjs
+++ b/packages/core/lib/revision.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { splitNulPaths } from './git.mjs';
 import { existsSync, realpathSync, statSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 
@@ -41,8 +42,12 @@ function addWorkingTreeFile(hash, cwd, relative, object) {
   hash.add(Buffer.from(`git-blob:${mode}:${object}`));
 }
 
+// Delegate to the shared buffer-level splitter so a path git cannot decode
+// faithfully fails closed here too, instead of aliasing another path (#249). The
+// local `git()` above returns a Buffer (no encoding set), which is exactly what
+// splitNulPaths needs to split BEFORE decoding.
 function splitNull(raw) {
-  return raw.toString('utf8').split('\0').filter(Boolean);
+  return splitNulPaths(raw);
 }
 
 function trackedEntries(cwd) {

--- a/packages/core/test/git-nonascii-paths.test.mjs
+++ b/packages/core/test/git-nonascii-paths.test.mjs
@@ -11,7 +11,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { git, changedFiles, gitDiff } from '../lib/git.mjs';
+import { git, changedFiles, gitDiff, splitNulPaths } from '../lib/git.mjs';
 
 const NON_ASCII = 'café.js'; // U+00E9 — git quotes this as "caf\303\251.js" by default
 
@@ -76,5 +76,60 @@ describe('git helpers return authoritative (unquoted) paths', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// #249 — the byte level below C-quoting. `-z` avoids quoting, but the OUTPUT was
+// then decoded as UTF-8 before splitting, and UTF-8 decoding is not injective:
+// every invalid byte becomes U+FFFD, so two distinct paths on disk collapse to
+// one string and a gate keyed on that string answers for the wrong file. The
+// split must happen on the BUFFER, and a path that cannot round-trip must fail
+// closed rather than alias another.
+describe('splitNulPaths — buffer-level split, fail closed on lossy decode (#249)', () => {
+  const enc = (s) => Buffer.from(s, 'utf8');
+
+  test('splits valid NUL-delimited paths', () => {
+    const buf = Buffer.concat([enc('a/x.json'), Buffer.from([0]), enc('b/y.json'), Buffer.from([0])]);
+    assert.deepEqual(splitNulPaths(buf), ['a/x.json', 'b/y.json']);
+  });
+
+  test('preserves valid non-ASCII paths exactly (no normalisation)', () => {
+    const buf = Buffer.concat([enc('café/π.json'), Buffer.from([0])]);
+    assert.deepEqual(splitNulPaths(buf), ['café/π.json']);
+  });
+
+  test('a trailing NUL does not yield an empty entry', () => {
+    assert.deepEqual(splitNulPaths(Buffer.concat([enc('only.json'), Buffer.from([0])])), ['only.json']);
+  });
+
+  test('two paths differing only in INVALID bytes do not collapse — they throw', () => {
+    // This is the whole point: bad-\x80/p.json and bad-\xEF\xBF\xBD/p.json both
+    // decode to bad-�/p.json. A tolerant splitter would return ONE entry for two
+    // files. splitNulPaths refuses the invalid one instead.
+    const invalid = Buffer.concat([enc('bad-'), Buffer.from([0x80]), enc('/p.json'), Buffer.from([0])]);
+    assert.throws(() => splitNulPaths(invalid), /not valid UTF-8|#249/);
+  });
+
+  test('a lone surrogate byte sequence fails closed', () => {
+    const loneSurrogate = Buffer.concat([enc('x-'), Buffer.from([0xED, 0xA0, 0x80]), enc('.json'), Buffer.from([0])]);
+    assert.throws(() => splitNulPaths(loneSurrogate), /not valid UTF-8|#249/);
+  });
+
+  test('one bad path fails the whole batch — no silent partial result', () => {
+    // A gate must not act on a partial changed-file set it believes is complete.
+    const buf = Buffer.concat([
+      enc('good.json'), Buffer.from([0]),
+      enc('bad-'), Buffer.from([0xC0]), enc('.json'), Buffer.from([0]),
+    ]);
+    assert.throws(() => splitNulPaths(buf), /not valid UTF-8|#249/);
+  });
+
+  test('empty input yields no paths', () => {
+    assert.deepEqual(splitNulPaths(Buffer.alloc(0)), []);
+    assert.deepEqual(splitNulPaths(enc('')), []);
+  });
+
+  test('accepts a string for already-decoded callers (documented weaker guarantee)', () => {
+    assert.deepEqual(splitNulPaths('a\0b\0'), ['a', 'b']);
   });
 });


### PR DESCRIPTION
Closes #249. Found by cross-model review during #234 (round 7).

## The defect

`changedFiles` and `revision.mjs`'s `splitNull` requested `-z` output — raw, NUL-delimited, immune to git's C-quoting — and then **decoded it as UTF-8 before splitting**. UTF-8 decoding is not injective: every byte git cannot decode becomes U+FFFD, so

```
bad-\x80/package.json          ─┐
                                ├─→  both become  "bad-�/package.json"
bad-\xEF\xBF\xBD/package.json  ─┘
```

Two distinct files on disk collapse to **one** path string.

## Why it matters

A gate keyed on that string answers for the wrong file:

- **rails-guard** caches file content on the path string, so a version bump on one path and a behaviour edit on the other resolve to a single cache entry — and the behaviour edit is exempted. This is the **filename analogue** of the content-level aliasing fixed in #228; the content fix did not cover the path axis.
- **adlc-prosecute** feeds `changedFiles` into its trust-root tier classifier, so a misdecoded path can misclassify a change's required review tier.

## The fix

New `splitNulPaths(buffer)` in `git.mjs`:

- splits the **Buffer** on the NUL byte — before any decode can erase the distinction
- decodes each field and requires it to **re-encode to its exact bytes**
- **fails closed** on any field that does not: a path git is telling us about but that we cannot represent faithfully is refused, not aliased

A non-round-trip filename is already pathological in this repo, so a hard error beats a silent wrong answer feeding a freeze gate.

| site | change |
|---|---|
| `changedFiles` | reads `encoding: 'buffer'`, routes through `splitNulPaths` |
| `revision.mjs` `splitNull` | delegates to the same function — its local `git()` already returns a Buffer |
| `git.mjs` comment | corrected: it claimed the changed-file set was "fully raw" byte-safe, which this commit is what actually makes true |

rails-guard keeps its own local containment guard from #234 — defence in depth, one layer out.

## On the platform limit

The reviewer rated this 0.93 and **inferred rather than executed**, because Darwin refuses invalid-byte filenames. So the test is at the **pure-function boundary** — `splitNulPaths` takes a Buffer, and crafted invalid-byte buffers reproduce the exact defect on any platform, which is a better unit boundary than a Linux-only filesystem test anyway.

## Test plan

- [x] 11 `splitNulPaths` cases: valid split, non-ASCII preserved, invalid bytes throw, lone surrogate throws, one-bad-fails-the-whole-batch, empty input, string input
- [x] `changedFiles` end-to-end on a real repo with a `café.json` path — preserved exactly
- [x] core suite 203/203 (added the `splitNulPaths` `.d.ts` declaration the export-check required)
- [x] rails-guard 159/159, prosecute 92/92 — the two consumers that feed security decisions
- [x] `npm test` — 46/46 segments green
- [ ] CI green

## Follow-up not in this PR

The reviewer suggested option 1 (return Buffers, decode at every edge) as the maximal fix. This PR takes option 2 (fail closed in core) as the right cost/benefit: it removes the silent-wrong-answer for every current caller without a wide signature change. If a caller ever has a legitimate need for non-UTF-8 paths, option 1 can layer on top.