### PR TITLE
feat(tickets): reject rails that freeze a manifest, at authoring time (#235)

### DIFF
--- a/packages/tickets/index.d.ts
+++ b/packages/tickets/index.d.ts
@@ -68,3 +68,9 @@ export function asTicketResult<T>(fn: () => T): { ok: true; value: T; warnings: 
 export function exitCodeFor(error: { kind?: TicketErrorKind }): 1 | 2;
 export function shouldOfferLegacyMigration(store: unknown, flags?: Record<string, unknown>, io?: { input?: { isTTY?: boolean }; output?: { isTTY?: boolean } }): boolean;
 export function offerLegacyMigration(store: LegacyTicketStore, root: string, flags?: Record<string, unknown>, dependencies?: Record<string, unknown>): Promise<LegacyTicketStore | DirectoryTicketStore>;
+
+// #235 — manifest-rail hygiene
+export const MANIFEST_BASENAMES: readonly string[];
+export function discoverManifests(root?: string): string[];
+export function coversManifest(glob: unknown, manifestPaths: readonly string[]): boolean;
+export function manifestCoveringRails(rails: unknown, manifestPaths: readonly string[]): string[];

--- a/packages/tickets/index.mjs
+++ b/packages/tickets/index.mjs
@@ -10,6 +10,7 @@ export * from './lib/lock.mjs';
 export * from './lib/durability.mjs';
 export * from './lib/transaction.mjs';
 export * from './lib/service.mjs';
+export * from './lib/manifest-rails.mjs';
 export * from './lib/archive.mjs';
 export * from './lib/migrate.mjs';
 export * from './lib/doctor.mjs';

--- a/packages/tickets/lib/manifest-rails.mjs
+++ b/packages/tickets/lib/manifest-rails.mjs
@@ -1,0 +1,112 @@
+// #235 — decide whether a rail glob would freeze a manifest file.
+//
+// A rail exists to freeze BEHAVIOUR during a build. A rail over `packages/x/**`
+// also freezes `packages/x/package.json`, which a lockstep release must rewrite —
+// the collision #228/#234 worked around. Rejecting such a rail at ticket-authoring
+// time is the complementary hygiene fix: steer authors to `packages/x/lib/**`.
+//
+// SELF-CONTAINED ON PURPOSE. `@adlc/core` depends on `@adlc/tickets`, so importing
+// `globMatch` from core here would create a dependency cycle. This module
+// reimplements the same tiny glob semantics; manifest-rails.test.mjs cross-checks
+// it against core's globMatch on a shared corpus so the two cannot diverge
+// silently.
+
+import { readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+export const MANIFEST_BASENAMES = Object.freeze(['package.json', 'plugin.json', 'marketplace.json']);
+
+// Directories a manifest a release rewrites never lives in, and which are large
+// or noisy. Skipping them keeps the walk fast and its results honest.
+const SKIP_DIRS = new Set(['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', '.next']);
+const MAX_DEPTH = 8; // release manifests sit shallow; deeper is not a release target
+
+/**
+ * The repo's ACTUAL manifest paths under `root`, as POSIX repo-relative strings —
+ * every file whose basename is a host manifest. Testing a rail against real paths
+ * is exact: `packages/x/**` matches `packages/x/package.json` and is flagged,
+ * while `packages/x/lib/**` matches no real manifest and is not, even though it
+ * could match a hypothetical `packages/x/lib/package.json` that no release
+ * touches.
+ *
+ * A filesystem walk (not `git ls-files`) so the check works in any checkout,
+ * including a temp dir or a non-git tree, and does not depend on what git happens
+ * to be tracking. Fails soft: an unreadable directory is skipped, and an
+ * unreadable root yields an empty list, so authoring degrades to "flag nothing"
+ * rather than throwing. This is hygiene, not a security boundary — the real
+ * freeze enforcement is rails-guard.
+ */
+export function discoverManifests(root = process.cwd()) {
+  const found = [];
+  const walk = (dir, depth) => {
+    if (depth > MAX_DEPTH) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        walk(join(dir, entry.name), depth + 1);
+      } else if (entry.isFile() && MANIFEST_BASENAMES.includes(entry.name)) {
+        found.push(relative(root, join(dir, entry.name)).split(sep).join('/'));
+      }
+    }
+  };
+  walk(root, 0);
+  return found;
+}
+
+/**
+ * Compile a rail glob to a RegExp with the SAME semantics as @adlc/core's
+ * globMatch: `**` spans any characters (including `/`), `*` spans any non-`/`,
+ * everything else literal.
+ */
+function globToRegExp(pattern) {
+  const body = pattern
+    .split(/(\*\*\/|\*\*|\*)/)
+    .map((part) => {
+      if (part === '**/') return '(?:.*/)?';
+      if (part === '**') return '.*';
+      if (part === '*') return '[^/]*';
+      return part.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+    })
+    .join('');
+  return new RegExp(`^${body}$`);
+}
+
+/**
+ * True when `glob` matches at least one manifest a lockstep release rewrites.
+ *
+ * @param {unknown} glob a rail glob
+ * @param {unknown} manifestPaths the manifest corpus to test against — the ticket
+ *        service passes `discoverManifests()`. REQUIRED: there is no default,
+ *        because a wrong default (guessed shapes, or an empty list) would silently
+ *        flag nothing or the wrong things. A caller with no manifests to check
+ *        should pass `[]` explicitly.
+ * @returns {boolean}
+ */
+export function coversManifest(glob, manifestPaths) {
+  if (!Array.isArray(manifestPaths)) {
+    throw new TypeError('coversManifest requires an explicit manifestPaths array (use discoverManifests())');
+  }
+  if (typeof glob !== 'string' || glob === '') return false;
+  let regex;
+  try {
+    regex = globToRegExp(glob);
+  } catch {
+    return false;
+  }
+  return manifestPaths.some((path) => regex.test(path));
+}
+
+/**
+ * The rails on `ticket` that cover a manifest, for a caller that wants to report
+ * exactly which globs are the problem.
+ */
+export function manifestCoveringRails(rails, manifestPaths) {
+  if (!Array.isArray(rails)) return [];
+  return rails.filter((rail) => coversManifest(rail, manifestPaths));
+}

--- a/packages/tickets/lib/service.mjs
+++ b/packages/tickets/lib/service.mjs
@@ -10,6 +10,7 @@ import { DirectoryTicketStore } from './stores/directory.mjs';
 import { LegacyTicketStore } from './stores/legacy.mjs';
 import { applyDirectoryTransaction, applyLegacyTransaction } from './transaction.mjs';
 import { validateTickets } from './schema.mjs';
+import { coversManifest, discoverManifests } from './manifest-rails.mjs';
 
 const publicPlan = (plan) => Object.fromEntries(Object.entries(plan).filter(([key]) => !key.startsWith('_')));
 const planContent = (plan) => Object.fromEntries(Object.entries(publicPlan(plan)).filter(([key]) => key !== 'planHash'));
@@ -71,10 +72,31 @@ export class TicketService {
     if (parsed.tickets.some((ticket) => ticket?.id === id)) throw conflict('ARCHIVE_COLLISION', `archive already contains ${id}`);
   }
 
+  // #235 — a rail must not freeze a manifest a lockstep release rewrites, or the
+  // ticket blocks every release for its whole life (the #228 collision). Reject
+  // such rails at AUTHORING time; #234 handles the release edit itself.
+  //
+  // `newRails` is the set to police — every rail on create, but only the
+  // NEWLY-INTRODUCED rails on update, so a legacy ticket that already declares a
+  // manifest-covering rail is grandfathered and its ordinary edits keep working.
+  #assertNoManifestRails(newRails) {
+    if (!Array.isArray(newRails) || newRails.length === 0) return;
+    const manifests = discoverManifests(this.root);
+    if (manifests.length === 0) return; // outside a repo → hygiene check no-ops
+    const offenders = newRails.filter((rail) => coversManifest(rail, manifests));
+    if (offenders.length === 0) return;
+    throw policy(
+      'RAIL_COVERS_MANIFEST',
+      `rail(s) would freeze a manifest a release must rewrite: ${offenders.join(', ')}. ` +
+      `Rail the source subtree instead (e.g. "packages/x/lib/**"), not the package root. See #235.`
+    );
+  }
+
   planCreate(input = {}) {
     const ticket = deepClone(input);
     if (!ticket.id) ticket.id = generateTicketId();
     this.#assertIdNotArchived(ticket.id);
+    this.#assertNoManifestRails(ticket.rails);
     return this.#plan('create', (tickets) => {
       if (tickets.some((item) => item.id === ticket.id)) throw conflict('TICKET_EXISTS', `ticket already exists: ${ticket.id}`);
       tickets.push(ticket);
@@ -89,6 +111,11 @@ export class TicketService {
       if (input.id !== id) throw policy('IDENTITY_CHANGE_REQUIRES_REASSIGN', 'update input id must match; use reassign for identity changes');
       if (expect && snapshot.ticketHashes[id] !== expect) throw conflict('STALE_TICKET', `ticket ${id} hash changed`);
       const before = tickets[index];
+      // Grandfather rails already on the ticket: only police rails this update
+      // ADDS. A pre-existing manifest-covering rail keeps working; a new one is
+      // rejected, so the class cannot grow.
+      const beforeRails = new Set(before.rails ?? []);
+      this.#assertNoManifestRails((input.rails ?? []).filter((rail) => !beforeRails.has(rail)));
       const sensitive = [];
       if ((before.rails ?? []).some((rail) => !(input.rails ?? []).includes(rail))) sensitive.push('rail-narrowing');
       if ((input.scope ?? []).some((scope) => !(before.scope ?? []).includes(scope))) sensitive.push('scope-widening');

--- a/packages/tickets/test/manifest-rails.test.mjs
+++ b/packages/tickets/test/manifest-rails.test.mjs
@@ -1,0 +1,138 @@
+// #235 — a rail glob must not freeze a manifest file.
+//
+// A rail over `packages/x/**` freezes that package's package.json along with its
+// code. That is almost never the author's intent, and it is the collision #228
+// spent seven review rounds working around: a lockstep release rewrites every
+// manifest, so any such rail fails every release. #234 exempts the release edit;
+// this stops the over-broad rail being written in the first place.
+//
+// The matcher is deliberately self-contained (no @adlc/core import) because core
+// depends on @adlc/tickets, so importing globMatch from core would create a
+// cycle. A cross-check test below asserts it agrees with core's globMatch on a
+// shared corpus, so the duplication cannot silently diverge.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { coversManifest, discoverManifests, MANIFEST_BASENAMES } from '../lib/manifest-rails.mjs';
+
+// A realistic manifest corpus, shaped like the repo's actual release-rewritten
+// manifests. Passed explicitly so these are pure unit tests: no git, no FS.
+const MANIFESTS = [
+  'package.json',
+  'packages/build-gate/package.json',
+  'packages/ticket-sync/package.json',
+  'plugins/adlc-codex/package.json',
+  'plugins/adlc-codex/.codex-plugin/plugin.json',
+  '.claude-plugin/marketplace.json',
+];
+const covers = (glob) => coversManifest(glob, MANIFESTS);
+
+// ---------------------------------------------------------- rails that COVER a manifest
+
+test('a directory rail covering a package.json is flagged', () => {
+  assert.equal(covers('packages/build-gate/**'), true);
+  assert.equal(covers('plugins/adlc-codex/**'), true);
+});
+
+test('a bare ** covers everything, including manifests', () => {
+  assert.equal(covers('**'), true);
+  assert.equal(covers('**/*'), true);
+});
+
+test('an exact manifest path is flagged', () => {
+  assert.equal(covers('packages/build-gate/package.json'), true);
+  assert.equal(covers('plugins/adlc-codex/.codex-plugin/plugin.json'), true);
+  assert.equal(covers('.claude-plugin/marketplace.json'), true);
+  assert.equal(covers('package.json'), true);
+});
+
+test('a rail matching manifests by wildcard basename is flagged', () => {
+  assert.equal(covers('packages/build-gate/*.json'), true);   // matches package.json
+  assert.equal(covers('**/package.json'), true);
+  assert.equal(covers('packages/*/package.json'), true);
+});
+
+test('a nested host manifest is covered by a directory rail', () => {
+  // plugins/adlc-codex/.codex-plugin/plugin.json lives two levels down.
+  assert.equal(covers('plugins/adlc-codex/**'), true);
+});
+
+// -------------------------------------------------------- rails that do NOT cover a manifest
+
+test('a rail scoped to a source subtree is not flagged', () => {
+  assert.equal(covers('packages/build-gate/lib/**'), false);
+  assert.equal(covers('packages/build-gate/test/**'), false);
+  assert.equal(covers('plugins/adlc-codex/hooks/**'), false);
+});
+
+test('a rail scoped by source extension is not flagged', () => {
+  assert.equal(covers('packages/build-gate/**/*.mjs'), false);
+  assert.equal(covers('packages/build-gate/lib/*.ts'), false);
+});
+
+test('a rail over a schemas or data dir is not flagged (no manifest lives there)', () => {
+  assert.equal(covers('packages/ticket-sync/schemas/**'), false);
+  assert.equal(covers('packages/build-gate/fixtures/**'), false);
+});
+
+test('a specific non-manifest json file is not flagged', () => {
+  assert.equal(covers('packages/build-gate/lib/config.json'), false);
+  assert.equal(covers('.adlc/config.json'), false);
+});
+
+// ---------------------------------------------------------------------- input hygiene
+
+test('a non-string or empty rail does not throw and is not flagged', () => {
+  assert.equal(covers(''), false);
+  assert.equal(covers(null), false);
+  assert.equal(covers(undefined), false);
+  assert.equal(covers(42), false);
+});
+
+test('coversManifest requires an explicit manifest corpus', () => {
+  assert.throws(() => coversManifest('packages/x/**'), /explicit manifestPaths/);
+});
+
+test('discoverManifests finds the real repo manifests and excludes node_modules', () => {
+  const found = discoverManifests();
+  assert.ok(found.includes('package.json'), 'root manifest present');
+  assert.ok(found.some((p) => /^packages\/[^/]+\/package\.json$/.test(p)), 'a package manifest present');
+  assert.ok(!found.some((p) => p.includes('node_modules/')), 'node_modules excluded');
+  // The whole point: a real package directory rail covers a real manifest.
+  assert.equal(coversManifest('packages/build-gate/**', found), true);
+  assert.equal(coversManifest('packages/build-gate/lib/**', found), false);
+});
+
+test('the manifest basename set is exactly the three host manifests', () => {
+  assert.deepEqual([...MANIFEST_BASENAMES].sort(), ['marketplace.json', 'package.json', 'plugin.json']);
+});
+
+// The self-contained glob compiler must agree with @adlc/core's globMatch on a
+// shared corpus. This is the safety net for reimplementing it here: if core's
+// semantics ever change, this test fails and points at the divergence. Importing
+// core in a TEST is fine — the cycle only matters for the package's runtime deps.
+test('the internal glob semantics agree with @adlc/core globMatch', async () => {
+  const { globMatch } = await import('@adlc/core');
+  const patterns = [
+    'packages/build-gate/**', 'packages/build-gate/lib/**', 'packages/*/package.json',
+    '**/package.json', '**', '**/*', 'packages/x/**/*.mjs', 'a/b/c.json',
+    'plugins/adlc-codex/.codex-plugin/plugin.json', 'packages/build-gate/*.json',
+  ];
+  const paths = [
+    'package.json', 'packages/build-gate/package.json', 'packages/build-gate/lib/x.mjs',
+    'plugins/adlc-codex/.codex-plugin/plugin.json', 'a/b/c.json', 'packages/x/y/z.mjs',
+    'packages/build-gate/lib/deep/nested.json', '.claude-plugin/marketplace.json',
+  ];
+  // Reach the internal compiler through coversManifest by using a single-path
+  // corpus: coversManifest(pattern, [path]) === globMatch(pattern, path).
+  for (const pattern of patterns) {
+    for (const path of paths) {
+      assert.equal(
+        coversManifest(pattern, [path]),
+        globMatch(pattern, path),
+        `divergence: glob "${pattern}" vs path "${path}"`
+      );
+    }
+  }
+});

--- a/packages/tickets/test/manifest-rails.test.mjs
+++ b/packages/tickets/test/manifest-rails.test.mjs
@@ -13,6 +13,9 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { coversManifest, discoverManifests, MANIFEST_BASENAMES } from '../lib/manifest-rails.mjs';
 
@@ -94,14 +97,31 @@ test('coversManifest requires an explicit manifest corpus', () => {
   assert.throws(() => coversManifest('packages/x/**'), /explicit manifestPaths/);
 });
 
-test('discoverManifests finds the real repo manifests and excludes node_modules', () => {
-  const found = discoverManifests();
-  assert.ok(found.includes('package.json'), 'root manifest present');
-  assert.ok(found.some((p) => /^packages\/[^/]+\/package\.json$/.test(p)), 'a package manifest present');
-  assert.ok(!found.some((p) => p.includes('node_modules/')), 'node_modules excluded');
-  // The whole point: a real package directory rail covers a real manifest.
-  assert.equal(coversManifest('packages/build-gate/**', found), true);
-  assert.equal(coversManifest('packages/build-gate/lib/**', found), false);
+test('discoverManifests walks a tree, finds manifests, excludes node_modules', () => {
+  // Build a fixture and pass its root EXPLICITLY. An earlier version called
+  // discoverManifests() with no argument and asserted the real repo layout was
+  // below cwd — true under `run-tests.mjs` (cwd = repo root) but false under
+  // `npm test --workspace @adlc/tickets` (cwd = packages/tickets), where CI
+  // caught it. The function is correct; the test must not assume cwd.
+  const root = mkdtempSync(join(tmpdir(), 'adlc-discover-'));
+  try {
+    mkdirSync(join(root, 'packages', 'build-gate', 'lib'), { recursive: true });
+    mkdirSync(join(root, 'plugins', 'x', '.claude-plugin'), { recursive: true });
+    mkdirSync(join(root, 'node_modules', 'dep'), { recursive: true });
+    writeFileSync(join(root, 'package.json'), '{}\n');
+    writeFileSync(join(root, 'packages', 'build-gate', 'package.json'), '{}\n');
+    writeFileSync(join(root, 'plugins', 'x', '.claude-plugin', 'plugin.json'), '{}\n');
+    writeFileSync(join(root, 'node_modules', 'dep', 'package.json'), '{}\n');
+
+    const found = discoverManifests(root);
+    assert.ok(found.includes('package.json'), 'root manifest present');
+    assert.ok(found.includes('packages/build-gate/package.json'), 'package manifest present');
+    assert.ok(found.includes('plugins/x/.claude-plugin/plugin.json'), 'nested host manifest present');
+    assert.ok(!found.some((p) => p.includes('node_modules')), 'node_modules excluded');
+
+    assert.equal(coversManifest('packages/build-gate/**', found), true);
+    assert.equal(coversManifest('packages/build-gate/lib/**', found), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
 test('the manifest basename set is exactly the three host manifests', () => {

--- a/packages/tickets/test/service.test.mjs
+++ b/packages/tickets/test/service.test.mjs
@@ -117,3 +117,66 @@ test('an explicitly configured absolute legacy store remains writable during the
     assert.equal(JSON.parse(readFileSync(external, 'utf8')).tickets[0].completed, true);
   } finally { rmSync(parent, { recursive: true, force: true }); }
 });
+
+test('#235 — planCreate rejects a rail that would freeze a manifest', () => {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-tickets-235-create-'));
+  try {
+    // Give the root a real manifest so discoverManifests has something to match.
+    mkdirSync(join(root, 'packages', 'x'), { recursive: true });
+    writeFileSync(join(root, 'packages', 'x', 'package.json'), '{"name":"x"}\n');
+    const path = writeDirectory(root, [ticket('A')]);
+    const service = new TicketService(new DirectoryTicketStore(path), { root });
+
+    assert.throws(
+      () => service.planCreate(ticket('NEW', { rails: ['packages/x/**'] })),
+      (error) => error.code === 'RAIL_COVERS_MANIFEST' && /packages\/x\/lib/.test(error.message)
+    );
+    // The source-scoped form is accepted.
+    const ok = service.planCreate(ticket('NEW', { rails: ['packages/x/lib/**'] }));
+    assert.equal(ok.ticketId, 'NEW');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('#235 — planUpdate grandfathers an EXISTING manifest rail but rejects a NEW one', () => {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-tickets-235-update-'));
+  try {
+    mkdirSync(join(root, 'packages', 'x'), { recursive: true });
+    writeFileSync(join(root, 'packages', 'x', 'package.json'), '{"name":"x"}\n');
+    mkdirSync(join(root, 'packages', 'y'), { recursive: true });
+    writeFileSync(join(root, 'packages', 'y', 'package.json'), '{"name":"y"}\n');
+    // A legacy ticket that ALREADY declares a manifest-covering rail.
+    const path = writeDirectory(root, [ticket('A', { rails: ['packages/x/**'] })]);
+    const service = new TicketService(new DirectoryTicketStore(path), { root });
+    const a = service.snapshot().get('A');
+
+    // An ordinary edit that keeps the existing rail must still work — the whole
+    // point of grandfathering. (rail-narrowing/none here, so no authorization.)
+    const ok = service.planUpdate('A', { ...a, title: 'Edited' },
+      { expect: service.snapshot().ticketHashes.A });
+    assert.equal(ok.ticketId, 'A');
+
+    // ADDING a second manifest-covering rail is rejected. authorized:true so this
+    // is not deflected by the scope/rail authorization path — the manifest check
+    // is independent of it.
+    assert.throws(
+      () => service.planUpdate('A', { ...a, rails: ['packages/x/**', 'packages/y/**'] },
+        { expect: service.snapshot().ticketHashes.A, authorized: true }),
+      (error) => error.code === 'RAIL_COVERS_MANIFEST' && /packages\/y/.test(error.message)
+    );
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('#235 — completing a legacy ticket with a manifest rail is unaffected', () => {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-tickets-235-complete-'));
+  try {
+    mkdirSync(join(root, 'packages', 'x'), { recursive: true });
+    writeFileSync(join(root, 'packages', 'x', 'package.json'), '{"name":"x"}\n');
+    const path = writeDirectory(root, [ticket('A', { rails: ['packages/x/**'] })]);
+    const service = new TicketService(new DirectoryTicketStore(path), { root });
+    // planComplete routes through its own path, not planUpdate, so the manifest
+    // check never sees it — a shipped ticket can always be closed out.
+    const plan = service.planComplete('A', { authorized: true });
+    const after = service.apply(plan);
+    assert.equal(after.get('A').completed, true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Closes #235. Option 3 from #228 — the complementary half of #234.

## The problem

A rail over `packages/x/**` freezes that package's `package.json` along with its code. A lockstep release must rewrite every manifest, so **any such rail fails every release** — the collision #228 spent seven review rounds working around. #234 exempts the release edit; this stops the over-broad rail being written in the first place, steering authors to `packages/x/lib/**`.

## The blocker in the issue is gone

The issue anticipated migrating live tickets that rail `packages/<x>/**`. Every one of them (T42/T43/T44, T49, T52) has since **completed**, so **zero live tickets are affected** — verified against the real store. No migration needed.

## Design

**Self-contained matcher, no dependency cycle.** `@adlc/core` depends on `@adlc/tickets`, so tickets cannot import `globMatch` from core. `lib/manifest-rails.mjs` reimplements the same tiny glob semantics, and a test **cross-checks it against core's `globMatch`** on a shared corpus so the two cannot silently diverge.

**Exact, not probe-guessed.** `coversManifest(glob, manifests)` tests the glob against the repo's **real** manifest paths. `discoverManifests` walks the tree (skipping `node_modules` et al) — 86 manifests in ~30ms, no git dependency, so it works in any checkout. Result:

```
packages/x/**       -> flagged   (matches the real packages/x/package.json)
packages/x/lib/**   -> fine      (matches no real manifest)
```

Even though `packages/x/lib/**` *could* match a hypothetical `lib/package.json`, no release rewrites one, so it is correctly not flagged.

## The `validateTickets` trap — avoided

The check lives in the authoring chokepoints (`TicketService.planCreate` / `planUpdate`), **not** in `validateTickets`, which runs against existing stores including from `rails-guard-ci` on the trusted base. Putting it there would throw on any legacy manifest-covering ticket and **brick the gate**. `schema.mjs` is untouched.

## Grandfathering

| path | behaviour |
|---|---|
| `planCreate` | polices **every** rail (all are new) |
| `planUpdate` | polices only **newly-introduced** rails — a pre-existing manifest rail keeps working |
| `planComplete` | its own path; a shipped ticket can always be closed out |

The update-grandfather case is proven by a test, since a naive implementation breaks it.

## Test plan

- [x] 14 matcher cases, including the `globMatch` cross-check
- [x] 3 service cases: create-reject, update-grandfather, complete-unaffected
- [x] CLI end-to-end: manifest rail rejected with a helpful message; `lib/**` accepted
- [x] Zero live tickets are newly-invalid — verified against the real store
- [x] `validateTickets` / `schema.mjs` untouched; `rails-guard-ci` still loads existing stores
- [x] tickets 101/101; core (the dependent package) 195/0; `@adlc/core` imports cleanly
- [ ] CI green

## Now all of #228 is addressed

- **#234** — exempt the version-only release edit (shipped)
- **#235** (this) — prevent the over-broad rail being authored
- **#228** — the umbrella, closable once this lands