### PR TITLE
fix(rails-guard): union staged and working-tree diffs to close the rail bypass

### DIFF
--- a/.adlc/tickets.json
+++ b/.adlc/tickets.json
@@ -1392,6 +1392,24 @@
         "packages/ticket-sync/test/github.test.mjs"
       ],
       "title": "Push + create: write-back, idempotent create, status outcomes"
+    },
+    {
+      "body": "Fixes voodootikigod/adlc#244. changedFiles(base) in packages/core/lib/git.mjs only diffs base-vs-working-tree, so staging a rail violation then reverting the working copy evades rails-guard. Union git diff <base> and git diff --cached <base> changed-file sets. Verification: node --test packages/core/test/*.test.mjs packages/rails-guard/test/*.test.mjs. allow-suppression: none",
+      "budget": "mid",
+      "category": "bug",
+      "duration": 1,
+      "edges": [],
+      "id": "T56",
+      "rails": [
+        "packages/rails-guard/test/version-only.test.mjs",
+        "packages/rails-guard/test/version-only-e2e.test.mjs"
+      ],
+      "scope": [
+        "packages/core/lib/git.mjs",
+        "packages/core/test/*.test.mjs",
+        "packages/rails-guard/**"
+      ],
+      "title": "rails-guard: union staged and working-tree diffs so a staged-then-reverted rail edit fails the gate"
     }
   ]
 }

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -67,6 +67,7 @@ export function resolveModel(
   env?: Record<string, string | undefined>
 ): string;
 
+export const GIT_MAX_BUFFER: number;
 export function git(args: readonly string[], opts?: {
   cwd?: string;
   stdio?: unknown;

--- a/packages/core/lib/git.mjs
+++ b/packages/core/lib/git.mjs
@@ -3,10 +3,15 @@
 
 import { execFileSync } from 'node:child_process';
 
+// Exported (rather than inlined) so a test can pin the exact value directly —
+// generating 64 MiB of real git output per mutation trial to observe this
+// behaviorally would make every CI run pay that cost.
+export const GIT_MAX_BUFFER = 64 * 1024 * 1024;
+
 export function git(args, opts = {}) {
   return execFileSync('git', args, {
     encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: GIT_MAX_BUFFER,
     ...opts,
   });
 }

--- a/packages/core/lib/git.mjs
+++ b/packages/core/lib/git.mjs
@@ -130,10 +130,20 @@ export function changedFiles(base = 'HEAD', cwd = process.cwd()) {
   // string: decoding first collapses distinct invalid-byte paths to one U+FFFD
   // string BEFORE the split can tell them apart (#249). splitNulPaths fails closed
   // on any path that does not round-trip UTF-8.
-  const raw = git(['diff', '--name-only', '-z', base, '--'], { cwd, encoding: 'buffer' });
-  return splitNulPaths(raw);
+  //
+  // Union the base-vs-working-tree diff with the base-vs-index (`--cached`) diff. A
+  // two-dot `git diff <base>` alone never consults the index, so a rail edit STAGED
+  // and then reverted in the working tree diffs empty — yet `git commit` records the
+  // staged blob. A gate reading a working-tree-only set would then pass a tree that
+  // is not the one being committed (#244). A path differing from base in EITHER place
+  // is changed. `--cached` catches a purely-staged edit; the plain diff catches an
+  // unstaged one; a Set de-duplicates the overlap. Both invocations go through the
+  // same buffer-safe split, so the #249 fidelity guarantee applies to each half.
+  const raw = (args) => git(args, { cwd, encoding: 'buffer' });
+  const worktree = splitNulPaths(raw(['diff', '--name-only', '-z', base, '--']));
+  const staged = splitNulPaths(raw(['diff', '--cached', '--name-only', '-z', base, '--']));
+  return [...new Set([...worktree, ...staged])];
 }
-
 export function isDirty(cwd = process.cwd()) {
   return git(['status', '--porcelain'], { cwd }).trim().length > 0;
 }

--- a/packages/core/test/core.test.mjs
+++ b/packages/core/test/core.test.mjs
@@ -8,7 +8,7 @@ import { execFileSync } from 'node:child_process';
 import * as corePublic from '../index.mjs';
 import { extractJson } from '../lib/llm.mjs';
 import { appendEntry, canonicalJson, readEntries, sha256, hashFiles, withLedgerLock } from '../lib/ledger.mjs';
-import { resolveBase, refExists } from '../lib/git.mjs';
+import { resolveBase, refExists, changedFiles } from '../lib/git.mjs';
 import {
   validateTicket, loadTickets, topoSort, computeFloat,
   globMatch, inScope, scopesOverlap,
@@ -343,6 +343,70 @@ test('resolveBase: returns null when no trunk candidate exists (callers must fai
     g('branch', '-m', 'main', 'work'); // rename away from main/master
     assert.equal(refExists('main', dir), false);
     assert.equal(resolveBase(dir), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('changedFiles: an ordinary unstaged working-tree edit is reported', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    g('add', '-A'); g('commit', '-qm', 'init');
+    const base = g('rev-parse', 'HEAD').trim();
+    writeFileSync(join(dir, 'a.txt'), 'two\n'); // edited, never staged
+    assert.deepEqual(changedFiles(base, dir), ['a.txt']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('changedFiles: a staged-then-reverted edit is still reported (#244 bypass)', () => {
+  // Stage a change, then restore the working-tree copy to baseline. base-vs-worktree
+  // diff sees nothing, but the index still holds the change and it is what a commit
+  // would record — so the changed-file SET must include it, or a rail check reading
+  // this set is deciding about a tree that is not the one being committed.
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    g('add', '-A'); g('commit', '-qm', 'init');
+    const base = g('rev-parse', 'HEAD').trim();
+    writeFileSync(join(dir, 'a.txt'), 'staged violation\n');
+    g('add', 'a.txt');            // change now lives in the index
+    writeFileSync(join(dir, 'a.txt'), 'one\n'); // working tree restored to baseline
+    // Sanity: the working-tree-only diff is empty, so the old contract missed this.
+    assert.equal(
+      g('diff', '--name-only', base, '--').trim(), '',
+      'fixture must have an empty base-vs-worktree diff to exercise the bypass'
+    );
+    assert.deepEqual(changedFiles(base, dir), ['a.txt']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('changedFiles: a file changed in BOTH index and worktree is reported once', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    g('add', '-A'); g('commit', '-qm', 'init');
+    const base = g('rev-parse', 'HEAD').trim();
+    writeFileSync(join(dir, 'a.txt'), 'staged\n');
+    g('add', 'a.txt');
+    writeFileSync(join(dir, 'a.txt'), 'staged then edited again\n'); // differs in both
+    assert.deepEqual(changedFiles(base, dir), ['a.txt'], 'union must de-duplicate');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('changedFiles: a clean tree at base reports nothing', () => {
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    g('add', '-A'); g('commit', '-qm', 'init');
+    const base = g('rev-parse', 'HEAD').trim();
+    assert.deepEqual(changedFiles(base, dir), []);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/core.test.mjs
+++ b/packages/core/test/core.test.mjs
@@ -412,6 +412,30 @@ test('changedFiles: a clean tree at base reports nothing', () => {
   }
 });
 
+test('changedFiles: does not throw when a tracked path collides with the base ref name', () => {
+  // Both the worktree AND staged `git diff` calls must keep their trailing `--`.
+  // Without it, `git diff <base>` is genuinely AMBIGUOUS the moment a tracked
+  // path shares a name with the ref — git refuses outright:
+  //   fatal: ambiguous argument 'main': both revision and filename
+  // `resolveBase()` in this same file defaults to trying the literal ref name
+  // 'main', so a repo with a top-level file or directory named `main` is not a
+  // contrived edge case. Mutation-tested: dropping either `--` survived the rest
+  // of this suite with zero failures before this test existed.
+  const { dir, g } = gitRepo();
+  try {
+    writeFileSync(join(dir, 'a.txt'), 'one\n');
+    g('add', '-A'); g('commit', '-qm', 'init');
+    mkdirSync(join(dir, 'main'));
+    writeFileSync(join(dir, 'main', 'file.txt'), 'colliding path\n'); // unstaged
+    writeFileSync(join(dir, 'a.txt'), 'two\n');
+    g('add', 'main/file.txt'); // staged, so the --cached half is exercised too
+    assert.doesNotThrow(() => changedFiles('main', dir));
+    assert.deepEqual(changedFiles('main', dir).sort(), ['a.txt', 'main/file.txt']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('resolveRevision: handles large tracked diffs without exec buffer failure', () => {
   const { dir, g } = gitRepo();
   try {

--- a/packages/core/test/git-nonascii-paths.test.mjs
+++ b/packages/core/test/git-nonascii-paths.test.mjs
@@ -11,7 +11,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { git, changedFiles, gitDiff, splitNulPaths } from '../lib/git.mjs';
+import { git, changedFiles, gitDiff, splitNulPaths, GIT_MAX_BUFFER } from '../lib/git.mjs';
 
 const NON_ASCII = 'café.js'; // U+00E9 — git quotes this as "caf\303\251.js" by default
 
@@ -77,6 +77,10 @@ describe('git helpers return authoritative (unquoted) paths', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('git() caps output at 64 MiB', () => {
+    assert.strictEqual(GIT_MAX_BUFFER, 64 * 1024 * 1024);
+  });
 });
 
 // #249 — the byte level below C-quoting. `-z` avoids quoting, but the OUTPUT was
@@ -102,12 +106,24 @@ describe('splitNulPaths — buffer-level split, fail closed on lossy decode (#24
     assert.deepEqual(splitNulPaths(Buffer.concat([enc('only.json'), Buffer.from([0])])), ['only.json']);
   });
 
+  test('a leading NUL does not yield an empty entry, and does not leak into the next path', () => {
+    const buf = Buffer.concat([Buffer.from([0]), enc('only.json'), Buffer.from([0])]);
+    assert.deepEqual(splitNulPaths(buf), ['only.json']);
+  });
+
   test('two paths differing only in INVALID bytes do not collapse — they throw', () => {
     // This is the whole point: bad-\x80/p.json and bad-\xEF\xBF\xBD/p.json both
     // decode to bad-�/p.json. A tolerant splitter would return ONE entry for two
     // files. splitNulPaths refuses the invalid one instead.
     const invalid = Buffer.concat([enc('bad-'), Buffer.from([0x80]), enc('/p.json'), Buffer.from([0])]);
     assert.throws(() => splitNulPaths(invalid), /not valid UTF-8|#249/);
+  });
+
+  test('the fail-closed error names UTF-8 specifically, not just #249', () => {
+    // The `|#249` alternation above also matches if this wording drifts (e.g. a
+    // typo'd encoding name), so pin the encoding name on its own here.
+    const invalid = Buffer.concat([enc('bad-'), Buffer.from([0x80]), enc('/p.json'), Buffer.from([0])]);
+    assert.throws(() => splitNulPaths(invalid), /not valid UTF-8/);
   });
 
   test('a lone surrogate byte sequence fails closed', () => {

--- a/packages/rails-guard/test/staged-diff-e2e.test.mjs
+++ b/packages/rails-guard/test/staged-diff-e2e.test.mjs
@@ -1,0 +1,78 @@
+// #244 end-to-end: drive the real rails-guard binary over a real git repo to prove
+// the staged-then-reverted rail bypass is closed.
+//
+// rails-guard resolved changed files with a base-vs-working-tree diff (two-dot, no
+// --cached), so a rail edit could be STAGED and then reverted in the working tree:
+// `git diff <base>` saw nothing and the gate passed, while `git commit` would still
+// record the staged violation. The changed-file set now unions the index, so a path
+// differing from base in EITHER place is a rail edit. This proves the whole gate —
+// git plumbing, resolver, exit codes — on the exact scenario from the issue.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'rails-guard.mjs');
+const RAIL = 'packages/build-gate/**';
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'rg-244-'));
+  const run = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  run('init', '-q', '-b', 'main');
+  run('config', 'user.email', 'test@test.invalid');
+  run('config', 'user.name', 'Test');
+  run('config', 'commit.gpgsign', 'false');
+  mkdirSync(join(dir, 'packages', 'build-gate', 'lib'), { recursive: true });
+  writeFileSync(join(dir, 'packages', 'build-gate', 'lib', 'tier.mjs'), 'export const tier = 1;\n');
+  run('add', '-A');
+  run('commit', '-q', '-m', 'base');
+  const baseSha = run('rev-parse', 'HEAD').trim();
+  return { dir, run, baseSha };
+}
+
+function guard(dir, base, rails) {
+  return spawnSync(process.execPath, [BIN, '--base', base, '--rails', rails], {
+    cwd: dir, encoding: 'utf8',
+  });
+}
+
+test('a rail edit STAGED then reverted in the working tree still FAILS (#244)', () => {
+  const { dir, run, baseSha } = makeRepo();
+  try {
+    const railed = join(dir, 'packages', 'build-gate', 'lib', 'tier.mjs');
+    writeFileSync(railed, 'export const tier = 99;\n'); // behaviour change under the rail
+    run('add', 'packages/build-gate/lib/tier.mjs');     // staged into the index
+    writeFileSync(railed, 'export const tier = 1;\n');   // working tree restored to base
+    // The bypass precondition: base-vs-worktree diff is empty, so the old two-dot
+    // contract saw nothing. The commit would still record the staged violation.
+    assert.equal(run('diff', '--name-only', baseSha, '--').trim(), '',
+      'fixture must leave an empty base-vs-worktree diff');
+    const res = guard(dir, baseSha, RAIL);
+    assert.equal(res.status, 2, `expected deny, got ${res.status}: ${res.stdout}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('an ordinary unstaged edit to a NON-railed file still PASSES (#244 no regression)', () => {
+  const { dir, run } = makeRepo();
+  try {
+    // A tracked file OUTSIDE every rail, edited but never staged — the normal build
+    // flow. It appears in the changed-file set, but not under the rail, so the gate
+    // must still pass: consulting the index must not reject plain unstaged edits.
+    mkdirSync(join(dir, 'packages', 'other', 'lib'), { recursive: true });
+    const nonRailed = join(dir, 'packages', 'other', 'lib', 'thing.mjs');
+    writeFileSync(nonRailed, 'export const x = 1;\n');
+    run('add', '-A'); run('commit', '-q', '-m', 'add non-railed file');
+    const base = run('rev-parse', 'HEAD').trim();
+    writeFileSync(nonRailed, 'export const x = 2;\n'); // unstaged edit
+    const res = guard(dir, base, RAIL);
+    assert.equal(res.status, 0, `expected pass, got ${res.status}: ${res.stderr}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

`changedFiles(base)` in `packages/core/lib/git.mjs` resolved the changed-file set with a two-dot `git diff --name-only -z <base> --` — **working tree only**, the index was never consulted. So a rail-violating edit could be **staged and then reverted in the working tree**: the diff saw nothing, the in-session `rails-guard` gate passed, and `git commit` still recorded the staged blob. The gate's verdict described a tree that was not the one being committed (voodootikigod/adlc#244).

**Fix (issue Option 1):** union the base-vs-working-tree diff with the base-vs-index (`--cached`) diff. A path differing from base in *either* place is treated as changed; a `Set` de-duplicates the overlap. This is the single core-contract change, so both consumers benefit:
- `packages/rails-guard/bin/rails-guard.mjs` — the rail-path-match check (`checkRailEdits`).
- `packages/prosecute/bin/adlc-prosecute.mjs` — trust-root tier classification (already unioned untracked files; now also catches staged-then-reverted trust-root edits).

The #234 version-only exemption path (`resolveContents`, which reads `git show base:<file>` vs the working tree directly) is untouched, so a genuine lockstep bump still passes.

## Acceptance criteria

- [x] **A rail edit that is staged and then reverted in the working tree FAILS the in-session gate** — new e2e test `packages/rails-guard/test/staged-diff-e2e.test.mjs` drives the real binary over the exact issue scenario (asserts base-vs-worktree diff is empty, then expects exit 2). Plus a core unit test at the `changedFiles` boundary.
- [x] **An ordinary unstaged edit to a non-railed file still passes** — e2e no-regression test (tracked non-railed file, unstaged edit → exit 0) and core unit tests for plain unstaged edits.
- [x] **The #234 version-only exemption still passes a genuine lockstep bump** — the full existing `version-only.test.mjs` / `version-only-e2e.test.mjs` suites pass unchanged; those files were left frozen (see note below).
- [x] **A test covers the staged-then-reverted case specifically** — both a core unit test and an e2e test.

## Tests

- `node scripts/run-tests.mjs`: **46/46 segments green** (whole monorepo).
- `node --test packages/core/test/*.test.mjs packages/rails-guard/test/*.test.mjs`: 360 pass, 0 fail, 1 skipped (win32-only).
- Real gate sanity check: `adlc rails-guard --base origin/main --ticket T56` → all checks passed.

## Rail-freeze note

Ticket T56 declares the two `version-only*.test.mjs` files as frozen rails. Rather than append the new e2e cases into `version-only-e2e.test.mjs` (which `rails-guard` correctly flagged as a rail edit), the new tests live in their own `staged-diff-e2e.test.mjs`, leaving the #234 rail files untouched.

## Adversarial review

The mandatory cross-model `adversarial-review` loop could **not** complete in this environment: no provider API keys are set, the local `codex` CLI intermittently `ETIMEDOUT` and never returned parseable JSON, and `agy`/`agent` reply conversationally rather than in the structured schema. One early `codex --verify` pass exited 0 (approve) before the CLI went flaky, but I am not relying on a run I could not fully capture. A Tier-2 authored self-review surfaced **one non-blocking, out-of-scope residual**: `gitDiff()` (patch text, feeding the suppression-marker check) is still worktree-only, so the *suppression-marker* gate retains the analogous staged-then-reverted gap. #244 and its acceptance criteria are scoped to the changed-file **set** (rail path match) only; the patch-text path is a separate concern and was deliberately left orthogonal (touching it would also risk desyncing the #234 working-tree comparator). Worth a follow-up ticket.

## Reviewer note — enforcement-tier change

This touches `@adlc/core` and `rails-guard`, which the ADLC gate map treats as **trust-root / enforcement-tier** code. Per the repo's own P5 policy, this needs **cross-model** adversarial review before merge, which I could not run here. **P6 (human merge) should treat this as requiring a second, independent reviewer.**

Ticket: **T56**

Closes #244