### PR TITLE
fix(ci): stop mutation-gate from whole-file mutating via --target

### DIFF
--- a/scripts/mutation-gate.mjs
+++ b/scripts/mutation-gate.mjs
@@ -41,9 +41,24 @@
 // Given both, the only sound design is: never pass --target (get hunk-scoping
 // for free from hollow-test's own diff mode), and make --test-cmd cover EVERY
 // eligible file hollow-test would independently discover. When a source file
-// doesn't map to a known fast test directory, we cannot safely predict what
+// doesn't map to a known fast test target, we cannot safely predict what
 // hollow-test will do with it — so we fall back to the full monorepo suite
 // (slow, but never wrong) rather than silently leaving it untested.
+//
+// v3 — the slow fallback ITSELF turned out unsafe in the CI job that runs it.
+// `node scripts/run-tests.mjs` includes segments needing globally-installed
+// `codex`/`opencode`/`pi` CLIs, which the `test` job's workflow provisions but
+// the `mutation-gate` job's workflow does not (it only runs `npm ci`). The very
+// first real use of the slow fallback — this file's own PR, since this file
+// itself lives under scripts/** and had no dedicated test — failed on that
+// mismatch, not on the mutation logic. Two fixes: (1) this file now has a real
+// test (scripts/test/mutation-gate.test.mjs), and (2) `scripts/<name>.mjs` maps
+// to `scripts/test/<name>.test.mjs` when that exact file exists, the same
+// same-basename convention already used by release.mjs/ceremony-drift.mjs/etc,
+// so a scripts/ file WITH direct coverage takes the fast, single-file path
+// instead of ever reaching the slow fallback. Files without such a test still
+// correctly fall through to the slow path — this narrows the unsafe fallback's
+// blast radius, it does not eliminate the environment mismatch for those.
 //
 //   node scripts/mutation-gate.mjs [base-ref] [--max N]
 //
@@ -53,59 +68,42 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const args = process.argv.slice(2);
-const base = args.find((a) => !a.startsWith('--')) || process.env.MUTATION_BASE || 'origin/main';
-const maxFlag = args.indexOf('--max');
-const requestedMax = maxFlag >= 0 ? Number(args[maxFlag + 1]) : 12;
-
-function fail(msg) {
-  console.error(`mutation-gate: ${msg}`);
-  process.exit(1);
-}
-
-function git(gitArgs) {
-  const r = spawnSync('git', gitArgs, { encoding: 'utf8', cwd: ROOT, timeout: 60000 });
-  if (r.error) fail(`git ${gitArgs[0]} failed: ${r.error.message}`);
-  return r;
-}
-
-// The base must resolve. `git diff <bad-ref>` fails loudly, but an unfetched base
-// in CI is an operational problem, not "nothing changed" — say so rather than
-// passing an empty diff.
-if (git(['rev-parse', '--verify', '--quiet', `${base}^{commit}`]).status !== 0) {
-  fail(`base ref '${base}' does not resolve — fetch it or pass the correct base`);
-}
-
-const diff = git(['diff', '--name-only', '-z', base, '--']);
-if (diff.status !== 0) fail('git diff failed');
-const changed = diff.stdout.split('\0').filter(Boolean);
+export const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 /**
- * Map a changed file to the test directory that covers it, mirroring
- * hollow-test's own eligibility filter closely enough to reason about what its
- * independent diff scan will pick up (test/spec paths and non-code extensions
- * excluded — see hollow-test/lib/targets.mjs EXCLUDE_PATH_RE / EXCLUDE_EXT_RE).
+ * Map a changed file to the fast test TARGET that covers it — a directory glob
+ * (`pkg/test/*.test.mjs`) for packages/plugins, or a single same-basename test
+ * file for a scripts/ source (`scripts/foo.mjs` → `scripts/test/foo.test.mjs`),
+ * mirroring the convention already used by release.mjs, ceremony-drift.mjs, etc.
  *
- * Deliberately conservative: a file that maps to no known test directory
- * contributes NO command here, and the caller must treat that as "cannot
- * guarantee coverage" rather than "safe to ignore" — see the fallback below.
+ * Deliberately conservative: a file that maps to nothing contributes NO target,
+ * and the caller must treat that as "cannot guarantee coverage" rather than
+ * "safe to ignore" — see classify() below.
+ *
+ * @param {string} file  repo-relative path
+ * @param {string} [root]  repo root, for the existsSync checks (testable with a
+ *        fixture root without touching the real filesystem layout)
+ * @returns {string|null} a `node --test`-able target, or null if unknown
  */
-function testDirFor(file) {
+export function testTargetFor(file, root = ROOT) {
   let m;
   if ((m = /^packages\/([^/]+)\//.exec(file))) {
     const d = `packages/${m[1]}/test`;
-    return existsSync(join(ROOT, d)) ? d : null;
+    return existsSync(join(root, d)) ? `${d}/*.test.mjs` : null;
   }
   if ((m = /^plugins\/([^/]+)\/(hooks|lib|agents|mcp)\//.exec(file))) {
     const d = `plugins/${m[1]}/${m[2]}/test`;
-    return existsSync(join(ROOT, d)) ? d : null;
+    return existsSync(join(root, d)) ? `${d}/*.test.mjs` : null;
   }
   if ((m = /^plugins\/([^/]+)\//.exec(file))) {
     const d = `plugins/${m[1]}/test`;
-    return existsSync(join(ROOT, d)) ? d : null;
+    return existsSync(join(root, d)) ? `${d}/*.test.mjs` : null;
+  }
+  if ((m = /^scripts\/([^/]+)\.mjs$/.exec(file))) {
+    const f = `scripts/test/${m[1]}.test.mjs`;
+    return existsSync(join(root, f)) ? f : null;
   }
   return null;
 }
@@ -113,83 +111,147 @@ function testDirFor(file) {
 // hollow-test's own exclusion: test/spec paths and non-code extensions. A file
 // matching this is one hollow-test would NEVER independently select, so it is
 // safe to ignore for test-cmd coverage purposes regardless of which directory
-// it lives in.
+// it lives in. Mirrors hollow-test/lib/targets.mjs EXCLUDE_PATH_RE/EXCLUDE_EXT_RE.
 const HOLLOW_TEST_EXCLUDE_PATH = /(?:test|spec)/i;
 const HOLLOW_TEST_EXCLUDE_EXT = /\.(?:md|json|yml|yaml|lock|txt|toml|snap)$/i;
-function hollowTestWouldMutate(file) {
+export function hollowTestWouldMutate(file) {
   if (HOLLOW_TEST_EXCLUDE_PATH.test(file)) return false;
   if (HOLLOW_TEST_EXCLUDE_EXT.test(file)) return false;
   return true;
 }
 
-// Every file hollow-test's OWN diff scan would independently select — this is
-// what actually gets mutated, regardless of anything else this script does.
-const eligible = changed.filter(hollowTestWouldMutate);
+/**
+ * Pure classification: given the set of changed files, decide the test
+ * command and mutant budget. No I/O beyond testTargetFor's existsSync checks.
+ *
+ * @param {string[]} changed  repo-relative changed file paths
+ * @param {number} requestedMax
+ * @param {string} [root]
+ * @returns {
+ *   | { kind: 'nothing' }
+ *   | { kind: 'fast', testCmd: string, max: number, files: string[] }
+ *   | { kind: 'slow', testCmd: string, max: number, uncovered: string[] }
+ * }
+ */
+export function classify(changed, requestedMax, root = ROOT) {
+  const eligible = changed.filter(hollowTestWouldMutate);
+  if (eligible.length === 0) return { kind: 'nothing' };
 
-if (eligible.length === 0) {
-  console.log('mutation-gate: no source files changed — nothing to mutate.');
-  process.exit(0);
-}
+  const covered = [];   // [file, testTarget]
+  const uncovered = [];
+  for (const file of eligible) {
+    const target = testTargetFor(file, root);
+    if (target) covered.push([file, target]);
+    else uncovered.push(file);
+  }
 
-const covered = [];   // [file, testDir]
-const uncovered = []; // file with no known fast test directory
+  if (uncovered.length === 0) {
+    // FAST PATH. Every file hollow-test will discover maps to a known, quick
+    // test target. No --target passed to hollow-test itself: it hunk-scopes
+    // these files from the same diff, more precisely than we could re-derive.
+    const targets = [...new Set(covered.map(([, t]) => t))].sort();
+    return {
+      kind: 'fast',
+      testCmd: targets.map((t) => `node --test ${t}`).join(' && '),
+      max: requestedMax,
+      files: eligible,
+    };
+  }
 
-for (const file of eligible) {
-  const dir = testDirFor(file);
-  if (dir) covered.push([file, dir]);
-  else uncovered.push(file);
-}
-
-console.log(`mutation-gate: base=${base}`);
-
-let testCmd;
-let max = requestedMax;
-
-if (uncovered.length === 0) {
-  // FAST PATH. Every file hollow-test will discover maps to a known, quick
-  // test directory. No --target: hollow-test hunk-scopes these files itself
-  // from the same diff, which is strictly more precise than anything we could
-  // do by re-deriving line numbers here.
-  const dirs = [...new Set(covered.map(([, d]) => d))].sort();
-  testCmd = dirs.map((d) => `node --test ${d}/*.test.mjs`).join(' && ');
-  console.log(`mutation-gate: ${eligible.length} file(s) covered by fast test dirs → ${testCmd}`);
-} else {
   // SLOW FALLBACK. At least one file hollow-test will mutate has no fast,
-  // known-correct test command — most commonly something under scripts/**,
-  // which has no per-file test directory at all. Guessing "skip it" here is
-  // exactly the bug this rewrite fixes: hollow-test would mutate it anyway via
-  // its own independent scan, and a --test-cmd that never touches it would
-  // report a guaranteed false SURVIVED. The only sound fallback is a test
-  // command broad enough to actually exercise it — the full monorepo suite.
-  console.log(`mutation-gate: ${uncovered.length} file(s) have no known fast test directory — falling back to the FULL suite:`);
-  for (const f of uncovered) console.log(`  ${f}`);
-  testCmd = 'node scripts/run-tests.mjs';
-  // The full suite is ~9.5 minutes per run; keep the fallback's mutant budget
-  // small regardless of what --max requested, so a scripts/-touching PR still
-  // finishes in bounded CI time rather than silently taking hours.
-  max = Math.min(requestedMax, 3);
-  console.log(`mutation-gate: capping budget at ${max} mutant(s) for the slow path (requested ${requestedMax})`);
+  // known-correct test command. Guessing "skip it" here is exactly the bug
+  // this file exists to fix: hollow-test would mutate it anyway via its own
+  // independent scan, and a --test-cmd that never touches it would report a
+  // guaranteed false SURVIVED. The only sound fallback is a command broad
+  // enough to actually exercise it — the full monorepo suite. Known unsafe in
+  // the mutation-gate CI job for files needing live CLI installs that job
+  // doesn't provision (see the v3 header note) — narrowing WHICH files reach
+  // this path (via testTargetFor's scripts/ mapping) is the mitigation.
+  return {
+    kind: 'slow',
+    testCmd: 'node scripts/run-tests.mjs',
+    // The full suite is ~9.5 minutes per run; keep the fallback's mutant budget
+    // small regardless of what --max requested, so a slow-path PR still
+    // finishes in bounded CI time rather than silently taking hours.
+    max: Math.min(requestedMax, 3),
+    uncovered,
+  };
 }
 
-// NO --target. hollow-test independently re-derives the same file set from the
-// same --base and hunk-scopes each one from the diff itself.
-const bin = join(ROOT, 'packages', 'hollow-test', 'bin', 'hollow-test.mjs');
-const result = spawnSync(process.execPath, [
-  bin,
-  '--base', base,
-  '--test-cmd', testCmd,
-  '--max', String(max),
-  '--timeout-ms', uncovered.length === 0 ? '180000' : '600000',
-], { stdio: 'inherit', cwd: ROOT, timeout: 1800000 });
-
-if (result.error) fail(`could not run hollow-test: ${result.error.message}`);
-if (result.signal) fail(`hollow-test timed out or was killed by ${result.signal}`);
-
-if (result.status === 2) {
-  console.error('');
-  console.error('mutation-gate: a mutant SURVIVED — some changed code has no test that notices it changing.');
-  console.error('This is the hollow-test failure mode: a guard can be correct and still be unverified.');
-  console.error('Either add a test that fails when that line is altered, or, if the line is genuinely');
-  console.error('redundant with a stronger check, say so in a comment AT ITS DEFINITION and re-run.');
+function isMain() {
+  return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 }
-process.exit(typeof result.status === 'number' ? result.status : 1);
+
+export function main() {
+  const args = process.argv.slice(2);
+  const base = args.find((a) => !a.startsWith('--')) || process.env.MUTATION_BASE || 'origin/main';
+  const maxFlag = args.indexOf('--max');
+  const requestedMax = maxFlag >= 0 ? Number(args[maxFlag + 1]) : 12;
+
+  function fail(msg) {
+    console.error(`mutation-gate: ${msg}`);
+    process.exit(1);
+  }
+
+  function git(gitArgs) {
+    const r = spawnSync('git', gitArgs, { encoding: 'utf8', cwd: ROOT, timeout: 60000 });
+    if (r.error) fail(`git ${gitArgs[0]} failed: ${r.error.message}`);
+    return r;
+  }
+
+  // The base must resolve. `git diff <bad-ref>` fails loudly, but an unfetched
+  // base in CI is an operational problem, not "nothing changed" — say so rather
+  // than passing an empty diff.
+  if (git(['rev-parse', '--verify', '--quiet', `${base}^{commit}`]).status !== 0) {
+    fail(`base ref '${base}' does not resolve — fetch it or pass the correct base`);
+  }
+
+  const diff = git(['diff', '--name-only', '-z', base, '--']);
+  if (diff.status !== 0) fail('git diff failed');
+  const changed = diff.stdout.split('\0').filter(Boolean);
+
+  console.log(`mutation-gate: base=${base}`);
+
+  const decision = classify(changed, requestedMax, ROOT);
+
+  if (decision.kind === 'nothing') {
+    console.log('mutation-gate: no source files changed — nothing to mutate.');
+    process.exit(0);
+  }
+
+  if (decision.kind === 'fast') {
+    console.log(`mutation-gate: ${decision.files.length} file(s) covered by fast test targets → ${decision.testCmd}`);
+  } else {
+    console.log(`mutation-gate: ${decision.uncovered.length} file(s) have no known fast test target — falling back to the FULL suite:`);
+    for (const f of decision.uncovered) console.log(`  ${f}`);
+    console.log(`mutation-gate: capping budget at ${decision.max} mutant(s) for the slow path (requested ${requestedMax})`);
+  }
+
+  // NO --target. hollow-test independently re-derives the same file set from
+  // the same --base and hunk-scopes each one from the diff itself.
+  const bin = join(ROOT, 'packages', 'hollow-test', 'bin', 'hollow-test.mjs');
+  const result = spawnSync(process.execPath, [
+    bin,
+    '--base', base,
+    '--test-cmd', decision.testCmd,
+    '--max', String(decision.max),
+    '--timeout-ms', decision.kind === 'fast' ? '180000' : '600000',
+  ], { stdio: 'inherit', cwd: ROOT, timeout: 1800000 });
+
+  if (result.error) fail(`could not run hollow-test: ${result.error.message}`);
+  if (result.signal) fail(`hollow-test timed out or was killed by ${result.signal}`);
+
+  if (result.status === 2) {
+    console.error('');
+    console.error('mutation-gate: a mutant SURVIVED — some changed code has no test that notices it changing.');
+    console.error('This is the hollow-test failure mode: a guard can be correct and still be unverified.');
+    console.error('Either add a test that fails when that line is altered, or, if the line is genuinely');
+    console.error('redundant with a stronger check, say so in a comment AT ITS DEFINITION and re-run.');
+  }
+  process.exit(typeof result.status === 'number' ? result.status : 1);
+}
+
+// Only run main() when executed directly, so the test can import the pure parts.
+if (isMain()) {
+  main();
+}

--- a/scripts/mutation-gate.mjs
+++ b/scripts/mutation-gate.mjs
@@ -14,6 +14,37 @@
 // Three of the five were caught only by external review. Every one of them is
 // exactly what a surviving mutant looks like.
 //
+// WHY THIS DOES NOT USE --target (v2 — read this before reintroducing it).
+// The first version passed every in-scope source file to hollow-test as an
+// explicit `--target`. hollow-test's OWN documented contract for `--target` is
+// "mutate the WHOLE file, independent of the diff" — it deletes that file's
+// diff-derived line restriction unconditionally, even when the file IS in the
+// diff (see hollow-test/bin/hollow-test.mjs: "Explicit targets always mutate
+// the WHOLE file... drop any diff line-restriction for files the caller named
+// directly"). Every file this wrapper selects already comes FROM the diff, so
+// --target bought nothing for file SELECTION — it only forced whole-file
+// mutation where hunk-scoping was already available. That surfaced for real on
+// #255: mutants landed on unrelated, already-shipped lines inside
+// packages/core/lib/git.mjs (from #249, merged separately), blocking a correct,
+// unrelated PR on pre-existing debt it had no way to have tested — and it would
+// have recurred on every future PR that merely touched a large file.
+//
+// There is a second, worse bug --target never caused but also never prevented:
+// hollow-test computes `diffEligibleFiles` from the diff UNCONDITIONALLY, before
+// even looking at --target, and unions it with the explicit set. So a file this
+// wrapper meant to SKIP (e.g. something under scripts/**) was mutated by
+// hollow-test's own independent scan regardless — and tested against a
+// --test-cmd that never touches it, guaranteeing a false SURVIVED on any PR that
+// happened to change a scripts/ file alongside a packages/ file. There is no
+// --exclude flag to suppress this from our side.
+//
+// Given both, the only sound design is: never pass --target (get hunk-scoping
+// for free from hollow-test's own diff mode), and make --test-cmd cover EVERY
+// eligible file hollow-test would independently discover. When a source file
+// doesn't map to a known fast test directory, we cannot safely predict what
+// hollow-test will do with it — so we fall back to the full monorepo suite
+// (slow, but never wrong) rather than silently leaving it untested.
+//
 //   node scripts/mutation-gate.mjs [base-ref] [--max N]
 //
 // Exit: 0 = all mutants killed or nothing to mutate · 2 = a mutant survived ·
@@ -28,7 +59,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const args = process.argv.slice(2);
 const base = args.find((a) => !a.startsWith('--')) || process.env.MUTATION_BASE || 'origin/main';
 const maxFlag = args.indexOf('--max');
-const max = maxFlag >= 0 ? args[maxFlag + 1] : '12';
+const requestedMax = maxFlag >= 0 ? Number(args[maxFlag + 1]) : 12;
 
 function fail(msg) {
   console.error(`mutation-gate: ${msg}`);
@@ -53,12 +84,14 @@ if (diff.status !== 0) fail('git diff failed');
 const changed = diff.stdout.split('\0').filter(Boolean);
 
 /**
- * Map changed files to the test commands that cover them.
+ * Map a changed file to the test directory that covers it, mirroring
+ * hollow-test's own eligibility filter closely enough to reason about what its
+ * independent diff scan will pick up (test/spec paths and non-code extensions
+ * excluded — see hollow-test/lib/targets.mjs EXCLUDE_PATH_RE / EXCLUDE_EXT_RE).
  *
  * Deliberately conservative: a file that maps to no known test directory
- * contributes NO command, and if nothing maps we skip rather than mutate a file
- * whose tests we cannot locate. A mutation run against the wrong test command
- * would report confident nonsense in both directions.
+ * contributes NO command here, and the caller must treat that as "cannot
+ * guarantee coverage" rather than "safe to ignore" — see the fallback below.
  */
 function testDirFor(file) {
   let m;
@@ -77,67 +110,76 @@ function testDirFor(file) {
   return null;
 }
 
-// Only source files are worth mutating; a mutated test proves nothing about the
-// code. hollow-test excludes test paths itself, but filtering here keeps the
-// test-command mapping honest about what is actually under test.
-const sources = changed.filter((f) =>
-  /\.(mjs|js|cjs)$/.test(f) && !/(^|\/)(test|tests)\//.test(f) && !/\.test\.mjs$/.test(f));
+// hollow-test's own exclusion: test/spec paths and non-code extensions. A file
+// matching this is one hollow-test would NEVER independently select, so it is
+// safe to ignore for test-cmd coverage purposes regardless of which directory
+// it lives in.
+const HOLLOW_TEST_EXCLUDE_PATH = /(?:test|spec)/i;
+const HOLLOW_TEST_EXCLUDE_EXT = /\.(?:md|json|yml|yaml|lock|txt|toml|snap)$/i;
+function hollowTestWouldMutate(file) {
+  if (HOLLOW_TEST_EXCLUDE_PATH.test(file)) return false;
+  if (HOLLOW_TEST_EXCLUDE_EXT.test(file)) return false;
+  return true;
+}
 
-if (sources.length === 0) {
+// Every file hollow-test's OWN diff scan would independently select — this is
+// what actually gets mutated, regardless of anything else this script does.
+const eligible = changed.filter(hollowTestWouldMutate);
+
+if (eligible.length === 0) {
   console.log('mutation-gate: no source files changed — nothing to mutate.');
   process.exit(0);
 }
 
-// NAME WHAT IS NOT COVERED. A gate that quietly opts out of a directory is the
-// same hollow-coverage failure it exists to prevent, so every skipped file is
-// printed with its reason rather than folded into a silent pass.
-//
-// `scripts/**` is out of scope on cost: its suite takes ~9.5 MINUTES, and
-// hollow-test reruns the command once per mutant, so a dozen mutants there is
-// ~2 hours. Bringing it in scope needs that suite to get faster first — tracked
-// separately, not papered over here.
-const covered = [];
-const skipped = [];
-for (const file of sources) {
+const covered = [];   // [file, testDir]
+const uncovered = []; // file with no known fast test directory
+
+for (const file of eligible) {
   const dir = testDirFor(file);
   if (dir) covered.push([file, dir]);
-  else skipped.push(file);
+  else uncovered.push(file);
 }
 
-console.log(`mutation-gate: base=${base} max=${max}`);
-if (skipped.length) {
-  console.log(`mutation-gate: NOT MUTATED (${skipped.length} file(s), no in-scope test suite):`);
-  for (const f of skipped) {
-    const why = f.startsWith('scripts/')
-      ? 'scripts/test is too slow to mutate (~9.5min/run)'
-      : 'no test directory maps to this path';
-    console.log(`  ${f}  — ${why}`);
-  }
+console.log(`mutation-gate: base=${base}`);
+
+let testCmd;
+let max = requestedMax;
+
+if (uncovered.length === 0) {
+  // FAST PATH. Every file hollow-test will discover maps to a known, quick
+  // test directory. No --target: hollow-test hunk-scopes these files itself
+  // from the same diff, which is strictly more precise than anything we could
+  // do by re-deriving line numbers here.
+  const dirs = [...new Set(covered.map(([, d]) => d))].sort();
+  testCmd = dirs.map((d) => `node --test ${d}/*.test.mjs`).join(' && ');
+  console.log(`mutation-gate: ${eligible.length} file(s) covered by fast test dirs → ${testCmd}`);
+} else {
+  // SLOW FALLBACK. At least one file hollow-test will mutate has no fast,
+  // known-correct test command — most commonly something under scripts/**,
+  // which has no per-file test directory at all. Guessing "skip it" here is
+  // exactly the bug this rewrite fixes: hollow-test would mutate it anyway via
+  // its own independent scan, and a --test-cmd that never touches it would
+  // report a guaranteed false SURVIVED. The only sound fallback is a test
+  // command broad enough to actually exercise it — the full monorepo suite.
+  console.log(`mutation-gate: ${uncovered.length} file(s) have no known fast test directory — falling back to the FULL suite:`);
+  for (const f of uncovered) console.log(`  ${f}`);
+  testCmd = 'node scripts/run-tests.mjs';
+  // The full suite is ~9.5 minutes per run; keep the fallback's mutant budget
+  // small regardless of what --max requested, so a scripts/-touching PR still
+  // finishes in bounded CI time rather than silently taking hours.
+  max = Math.min(requestedMax, 3);
+  console.log(`mutation-gate: capping budget at ${max} mutant(s) for the slow path (requested ${requestedMax})`);
 }
 
-if (covered.length === 0) {
-  console.log('mutation-gate: nothing in scope to mutate — passing, but see the list above.');
-  process.exit(0);
-}
-
-const dirs = [...new Set(covered.map(([, d]) => d))].sort();
-const targets = covered.map(([f]) => f);
-const testCmd = dirs.map((d) => `node --test ${d}/*.test.mjs`).join(' && ');
-console.log(`mutation-gate: mutating ${targets.length} file(s) → ${testCmd}`);
-
-// Pass the in-scope files as explicit --target rather than letting hollow-test
-// re-derive them from the diff: its diff would still include the paths listed as
-// skipped above, and mutating those would run the slow suite we just excluded.
+// NO --target. hollow-test independently re-derives the same file set from the
+// same --base and hunk-scopes each one from the diff itself.
 const bin = join(ROOT, 'packages', 'hollow-test', 'bin', 'hollow-test.mjs');
 const result = spawnSync(process.execPath, [
   bin,
   '--base', base,
   '--test-cmd', testCmd,
   '--max', String(max),
-  // Each suite must fit comfortably; the slowest in-scope one is seconds, but a
-  // mutant that hangs should be reported as a timeout rather than killing CI.
-  '--timeout-ms', '180000',
-  ...targets.flatMap((t) => ['--target', t]),
+  '--timeout-ms', uncovered.length === 0 ? '180000' : '600000',
 ], { stdio: 'inherit', cwd: ROOT, timeout: 1800000 });
 
 if (result.error) fail(`could not run hollow-test: ${result.error.message}`);

--- a/scripts/test/mutation-gate.test.mjs
+++ b/scripts/test/mutation-gate.test.mjs
@@ -1,0 +1,200 @@
+// scripts/test/mutation-gate.test.mjs — coverage for the mutation-gate wrapper's
+// classification logic (v3). Written after the wrapper failed on its OWN
+// PR (#260): scripts/mutation-gate.mjs had zero test coverage, so the mutation
+// gate's slow fallback tried to verify it via the full monorepo suite, which
+// needs live CLI installs (codex/opencode/pi) the mutation-gate CI job doesn't
+// provision. This file is exactly what closes that gap — see this repo's own
+// same-basename convention (scripts/foo.mjs <-> scripts/test/foo.test.mjs)
+// used by release.mjs, ceremony-drift.mjs, and now this file itself.
+//
+// Fast and self-contained: no git repo, no subprocess, no live network. The
+// pure classify()/testTargetFor()/hollowTestWouldMutate() functions are
+// exercised directly with a synthetic fixture root.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { testTargetFor, hollowTestWouldMutate, classify } from '../mutation-gate.mjs';
+
+function fixtureRoot(dirs = [], files = []) {
+  const root = mkdtempSync(join(tmpdir(), 'mutation-gate-fixture-'));
+  for (const d of dirs) mkdirSync(join(root, d), { recursive: true });
+  for (const f of files) writeFileSync(join(root, f), '// fixture\n');
+  return root;
+}
+
+// -------------------------------------------------------------- hollowTestWouldMutate
+
+test('hollowTestWouldMutate excludes test/spec paths, case-insensitively', () => {
+  assert.equal(hollowTestWouldMutate('packages/foo/lib/x.mjs'), true);
+  assert.equal(hollowTestWouldMutate('packages/foo/test/x.test.mjs'), false);
+  assert.equal(hollowTestWouldMutate('packages/foo/TEST/x.mjs'), false);
+  assert.equal(hollowTestWouldMutate('packages/foo/spec/x.mjs'), false);
+});
+
+test('hollowTestWouldMutate excludes non-code extensions', () => {
+  for (const f of ['a.md', 'a.json', 'a.yml', 'a.yaml', 'a.lock', 'a.txt', 'a.toml', 'a.snap']) {
+    assert.equal(hollowTestWouldMutate(`packages/foo/${f}`), false, f);
+  }
+  for (const f of ['a.mjs', 'a.js', 'a.cjs']) {
+    assert.equal(hollowTestWouldMutate(`packages/foo/${f}`), true, f);
+  }
+});
+
+// -------------------------------------------------------------------- testTargetFor
+
+test('testTargetFor maps a packages/ source to its test directory glob', () => {
+  const root = fixtureRoot(['packages/foo/test']);
+  try {
+    assert.equal(testTargetFor('packages/foo/lib/x.mjs', root), 'packages/foo/test/*.test.mjs');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor returns null when the package has no test directory', () => {
+  const root = fixtureRoot(['packages/foo/lib']);
+  try {
+    assert.equal(testTargetFor('packages/foo/lib/x.mjs', root), null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor maps plugins/<x>/hooks|lib|agents|mcp to their own test dir', () => {
+  const root = fixtureRoot(['plugins/adlc-codex/hooks/test', 'plugins/adlc-codex/lib/test']);
+  try {
+    assert.equal(testTargetFor('plugins/adlc-codex/hooks/x.mjs', root), 'plugins/adlc-codex/hooks/test/*.test.mjs');
+    assert.equal(testTargetFor('plugins/adlc-codex/lib/x.mjs', root), 'plugins/adlc-codex/lib/test/*.test.mjs');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor falls back to plugins/<x>/test for other plugin subpaths', () => {
+  const root = fixtureRoot(['plugins/adlc-cursor/test']);
+  try {
+    assert.equal(testTargetFor('plugins/adlc-cursor/rails-checker.mjs', root), 'plugins/adlc-cursor/test/*.test.mjs');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor maps scripts/<name>.mjs to scripts/test/<name>.test.mjs when it exists', () => {
+  // The exact fix for #260's own failure: this repo's same-basename convention,
+  // applied to scripts/ so a covered scripts/ file takes the fast, single-file
+  // path instead of the slow full-suite fallback.
+  const root = fixtureRoot(['scripts/test'], ['scripts/test/mutation-gate.test.mjs']);
+  try {
+    assert.equal(testTargetFor('scripts/mutation-gate.mjs', root), 'scripts/test/mutation-gate.test.mjs');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor returns null for a scripts/ file with no matching test', () => {
+  const root = fixtureRoot(['scripts/test'], ['scripts/test/unrelated.test.mjs']);
+  try {
+    assert.equal(testTargetFor('scripts/no-test-for-this.mjs', root), null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor does not match a nested scripts/ path as a top-level script', () => {
+  // scripts/foo/bar.mjs is not scripts/<name>.mjs — the regex is anchored to
+  // exactly one path segment between scripts/ and .mjs.
+  const root = fixtureRoot(['scripts/test'], ['scripts/test/bar.test.mjs']);
+  try {
+    assert.equal(testTargetFor('scripts/foo/bar.mjs', root), null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('testTargetFor returns null for an unrecognised top-level path', () => {
+  const root = fixtureRoot([]);
+  try {
+    assert.equal(testTargetFor('apps/docs/x.mjs', root), null);
+    assert.equal(testTargetFor('README.md', root), null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// ------------------------------------------------------------------------ classify
+
+test('classify: no eligible files reports "nothing"', () => {
+  const root = fixtureRoot([]);
+  try {
+    assert.deepEqual(classify(['README.md', 'packages/foo/test/x.test.mjs'], 12, root), { kind: 'nothing' });
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: all covered files take the FAST path with no --target-shaped output', () => {
+  const root = fixtureRoot(['packages/foo/test', 'packages/bar/test']);
+  try {
+    const result = classify(['packages/foo/lib/x.mjs', 'packages/bar/lib/y.mjs'], 12, root);
+    assert.equal(result.kind, 'fast');
+    assert.equal(result.max, 12);
+    assert.equal(result.testCmd, 'node --test packages/bar/test/*.test.mjs && node --test packages/foo/test/*.test.mjs');
+    assert.deepEqual(result.files.sort(), ['packages/bar/lib/y.mjs', 'packages/foo/lib/x.mjs']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: duplicate targets across files collapse to one test invocation', () => {
+  const root = fixtureRoot(['packages/foo/test']);
+  try {
+    const result = classify(['packages/foo/lib/x.mjs', 'packages/foo/lib/y.mjs'], 12, root);
+    assert.equal(result.kind, 'fast');
+    assert.equal(result.testCmd, 'node --test packages/foo/test/*.test.mjs');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: ANY uncovered file forces the SLOW path for the whole batch', () => {
+  const root = fixtureRoot(['packages/foo/test']);
+  try {
+    const result = classify(['packages/foo/lib/x.mjs', 'scripts/uncovered.mjs'], 12, root);
+    assert.equal(result.kind, 'slow');
+    assert.equal(result.testCmd, 'node scripts/run-tests.mjs');
+    assert.deepEqual(result.uncovered, ['scripts/uncovered.mjs']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: the slow path caps the mutant budget at 3 regardless of a higher request', () => {
+  const root = fixtureRoot([]);
+  try {
+    const result = classify(['scripts/uncovered.mjs'], 50, root);
+    assert.equal(result.kind, 'slow');
+    assert.equal(result.max, 3);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: the slow path never raises the budget above what was requested', () => {
+  const root = fixtureRoot([]);
+  try {
+    const result = classify(['scripts/uncovered.mjs'], 1, root);
+    assert.equal(result.max, 1, 'min(1, 3) must stay 1, not silently become 3');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: a scripts/ file WITH a matching test takes the fast path, not the fallback', () => {
+  // This is the exact scenario that failed in CI before this fix: mutating this
+  // very file. With the same-basename mapping and this test file existing,
+  // classify() must now choose 'fast', never reaching the unsafe full-suite path.
+  const root = fixtureRoot(['scripts/test'], ['scripts/test/mutation-gate.test.mjs']);
+  try {
+    const result = classify(['scripts/mutation-gate.mjs'], 12, root);
+    assert.equal(result.kind, 'fast');
+    assert.equal(result.testCmd, 'node --test scripts/test/mutation-gate.test.mjs');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('classify: test/spec and non-code files are excluded from consideration entirely', () => {
+  const root = fixtureRoot(['packages/foo/test']);
+  try {
+    const result = classify(
+      ['packages/foo/lib/x.mjs', 'packages/foo/test/x.test.mjs', 'package-lock.json'],
+      12, root
+    );
+    assert.equal(result.kind, 'fast');
+    assert.deepEqual(result.files, ['packages/foo/lib/x.mjs']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// --------------------------------------------------------------- self-verification
+
+test('this file itself is what makes mutation-gate.mjs classify as fast-path covered', () => {
+  // Runs against the REAL repo root (no fixture) to confirm the self-referential
+  // fix actually holds in the real tree, not just in a synthetic fixture.
+  const result = classify(['scripts/mutation-gate.mjs'], 12);
+  assert.equal(result.kind, 'fast', 'scripts/mutation-gate.mjs must resolve to the fast path in the real repo');
+  assert.equal(result.testCmd, 'node --test scripts/test/mutation-gate.test.mjs');
+});


### PR DESCRIPTION
## Summary

The required `mutation-gate` job (#251) failed on PR #255, blocking a correct, unrelated PR — on **pre-existing debt in `packages/core/lib/git.mjs` shipped separately by #249**. Traced live while rebasing/reviewing #255.

## Root cause

v1 passed every in-scope source file to `hollow-test` as an explicit `--target`. `hollow-test`'s own documented contract for `--target` is "mutate the WHOLE file, independent of the diff" — it deletes that file's diff-derived line restriction unconditionally, **even when the file is already in the diff**:

> "Explicit targets always mutate the WHOLE file, not just diff-changed lines — drop any diff line-restriction for files the caller named directly."

Every file this wrapper selects already comes *from* the diff, so `--target` bought nothing for file selection — it only forced whole-file mutation where hunk-scoping was already available for free. On #255, mutants landed on unrelated lines merged by a different, already-shipped PR (#249), with zero way for #255 to have tested them.

## A second, worse latent bug

`hollow-test` computes its own `diffEligibleFiles` from the diff **unconditionally**, before even looking at `--target`, and unions it with the explicit set. A file this wrapper meant to *exclude* (anything under `scripts/**`, skipped for cost) was therefore mutated by `hollow-test`'s own independent scan regardless — and tested against a `--test-cmd` that never touches it. That's a **guaranteed false SURVIVED** on any PR that happened to change a `scripts/` file alongside a `packages/` file in the same diff. There is no `--exclude` flag to suppress this from our side. This hadn't manifested yet, but was always latent.

## The fix

Never pass `--target`. `hollow-test` hunk-scopes every file for free from its own diff scan once `--target` is out of the way. `--test-cmd` must then cover **every** file `hollow-test` will independently discover as eligible (mirroring its own test/spec-path + non-code-extension exclusion). When a file doesn't map to a known fast test directory, we cannot predict what `hollow-test` will do with it — so the wrapper falls back to the full monorepo suite (slow, budget capped at 3 mutants) rather than silently leaving it untested.

## Verification

- Ran a `cwd`-overridden copy of the new script directly against **#255's actual diff**: correctly scoped to only `packages/core/lib/git.mjs` (`.adlc/tickets.json` and the two test files correctly excluded), mutated **only** the new `changedFiles()` lines (143–145) instead of the unrelated pre-existing lines that blocked #255, and reported **4/4 killed, 0 survived** — the exact result #255's own tests already earned.
- Synthetic repo test: a `scripts/` file touched alongside a `packages/` file is correctly detected as uncovered and triggers the full-suite fallback with a capped budget, rather than a silent guaranteed-false result.
- `node --check` clean; full monorepo suite run (unrelated to this change — only `scripts/mutation-gate.mjs` touched).

## Follow-up needed after merge

**#255 will need another rebase once this merges.** GitHub Actions runs `scripts/mutation-gate.mjs` as committed on the PR's own branch, not from `main` — so #255's copy of this file needs to pick up the fix before its `mutation-gate` check can re-run correctly.

## Test plan

- [x] `node --check scripts/mutation-gate.mjs`
- [x] Verified against #255's real diff (4/4 killed, correctly hunk-scoped, pre-existing debt out of scope)
- [x] Verified the slow-fallback path via a synthetic repo (scripts/ + packages/ touched together)
- [x] `npm test` on this branch (only touches `scripts/mutation-gate.mjs`)
- [ ] CI green