### PR TITLE
fix(ci): recognize the bot author gh reports, so the drift tracker updates (#265)

### DIFF
--- a/.adlc/tickets.json
+++ b/.adlc/tickets.json
@@ -1268,6 +1268,24 @@
       "title": "A version-only manifest edit must not read as a rail edit (#228)"
     },
     {
+      "body": "Fixes voodootikigod/adlc#244. changedFiles(base) in packages/core/lib/git.mjs only diffs base-vs-working-tree, so staging a rail violation then reverting the working copy evades rails-guard. Union git diff <base> and git diff --cached <base> changed-file sets. Verification: node --test packages/core/test/*.test.mjs packages/rails-guard/test/*.test.mjs. allow-suppression: none",
+      "budget": "mid",
+      "category": "bug",
+      "duration": 1,
+      "edges": [],
+      "id": "T56",
+      "rails": [
+        "packages/rails-guard/test/version-only.test.mjs",
+        "packages/rails-guard/test/version-only-e2e.test.mjs"
+      ],
+      "scope": [
+        "packages/core/lib/git.mjs",
+        "packages/core/test/*.test.mjs",
+        "packages/rails-guard/**"
+      ],
+      "title": "rails-guard: union staged and working-tree diffs so a staged-then-reverted rail edit fails the gate"
+    },
+    {
       "body": "Fixes #194. `adlc-init` did not initialize a ticket store and there was no store-init command, so a brand-new ADLC repo could not create its first ticket: `detectTicketStore` throws STORE_NOT_FOUND when neither backend exists. Root cause: packages/init had no dependency on @adlc/tickets, so nothing in the init path could create a store. The migration doc also described an `adlc-init` migration prompt that never existed.\n\n=== FIX ===\n\nAdd `@adlc/tickets` as a dependency of packages/init and, during scaffold(), provision the ticket store via the canonical `initializeTicketStores(root)` from @adlc/tickets — the same initializer the approved @adlc/core scaffold-hygiene path uses. On a fresh repo it creates the directory store (`.adlc/tickets/`) and archive store (`.adlc/ticket-archive/`), each with a canonical `.store.json` manifest, so `adlc ticket create --write` succeeds immediately after init. Reusing the shared initializer keeps every ticket-store filesystem write inside @adlc/tickets (the boundary guard scripts/test/ticket-store-boundary.test.mjs stays honest) and avoids a divergent second copy of store-detection logic in packages/init.\n\n=== STORE-STATE SAFETY (hardened through cross-model adversarial-review) ===\n\nscaffold() surfaces every non-fresh/broken state instead of asserting false success:\n- Fresh repo -> create directory + archive stores; result.created lists both manifests (asserted, per the T55 hollow-test lesson).\n- Existing legacy `.adlc/tickets.json` -> no-op; reports the legacy path (which exists) as 'unchanged', not the absent directory manifest.\n- Ambiguous dual store (both backends present) -> initializeTicketStores throws AMBIGUOUS_STORE; caught and recorded as a warning without aborting the rest of scaffold. Any OTHER provisioning error is re-thrown (fail loud) rather than swallowed, so a genuine I/O failure cannot silently recreate STORE_NOT_FOUND.\n- Pre-existing store (active AND archive, symmetrically) -> confirmed to actually load() before being reported 'unchanged'; a bare/manifest-less or corrupt-manifest store becomes a warning, never a healthy 'unchanged'.\n- An already-symlinked store path is rejected (preflight) and also caught by the load() health check. Note: write-time O_NOFOLLOW atomicity for the store manifest lives in @adlc/tickets' shared durability layer; closing the residual check-then-write race there is tracked separately, out of scope for #194.\n- CLI: `adlc-init` reports ok:false and exits non-zero when it leaves the store in a warned (broken/ambiguous) state, and prints warnings in text mode, so automation keying off ok/exit is not told a broken store is a success.\n\n=== GITIGNORE ===\n\ninit's ADLC_GITIGNORE_LINES gained `!.adlc/tickets/**`, `!.adlc/ticket-archive/`, `!.adlc/ticket-archive/**`, aligning init with the canonical @adlc/core stanza so the archive the store makes reachable is tracked rather than silently git-ignored and lost.\n\n=== ACCEPTANCE CRITERIA ===\n\nAC1. A fresh repo produces a usable ticket store; `adlc ticket create --write` succeeds immediately after init and the ticket reads back via the tickets API. Proven end-to-end in packages/init/test/scaffold.test.mjs (scaffold -> real adlc-tickets create --write child process -> loadTicketSnapshot), which also asserts both provisioned manifests are recorded.\nAC2. docs/ticket-store-migration.md matches real `adlc-init` behavior: init creates the directory store on a fresh repo and leaves an existing legacy store untouched; it no longer claims `adlc-init` shows a migration prompt.\nAC3. Idempotent no-clobber and broken-state safety: re-running init on a legacy repo does NOT create `.adlc/tickets/`; a second scaffold reports the store 'unchanged'; ambiguous, manifest-less, and corrupt-manifest stores are each surfaced as warnings (and the CLI reports ok:false / exits non-zero), never as success. Covered in packages/init/test/scaffold.test.mjs; the store-init contract (fresh create, STORE_EXISTS, legacy no-op, AMBIGUOUS_STORE) is pinned in packages/tickets/test/init.test.mjs, which previously had no direct coverage.\nAC4. The scaffolded `.gitignore` does not ignore `.adlc/ticket-archive/`. Pinned in packages/init/test/scaffold.test.mjs.\n\n=== RAILS ===\n\nThe two test files that encode the behavioral contract are frozen:\n- packages/init/test/scaffold.test.mjs\n- packages/tickets/test/init.test.mjs\n\nImplementation (packages/init/lib/scaffold.mjs, packages/init/lib/gitignore-defaults.mjs, packages/init/bin/adlc-init.mjs) is intentionally NOT railed. Ticket authored after implementation; the fix and its tests were hardened across a cross-model adversarial-review loop before merge.\n\nBlocks #171 (S5 acceptance) and #177 (S8 release gate).",
       "budget": "mid",
       "category": "bug",
@@ -1283,6 +1301,23 @@
         "docs/ticket-store-migration.md"
       ],
       "title": "adlc-init creates a usable ticket store on a fresh repo (#194)"
+    },
+    {
+      "body": "Fixes voodootikigod/adlc#265. MANAGED_AUTHORS in scripts/ceremony-drift.mjs defaults to the REST actor name 'github-actions[bot]', but `gh issue list --json author` returns the GraphQL actor rendered as 'app/github-actions'. findExistingIssue applies that author filter on BOTH the labeled fast path and the unlabeled sweep, so the job never recognizes its own tracker and decideAction takes the 'open' branch on every push to main — 12 duplicate issues in two days. Normalize actor logins (strip the 'app/' prefix and '[bot]' suffix, compare case-insensitively) so every rendering of the same bot compares equal. The existing tests fabricate the login they assert against, sharing the wrong string with the production default, so they pass on a value gh never emits; replace those fixtures with the recorded `gh --json author` payload shape and assert the default MANAGED_AUTHORS accepts 'app/github-actions'. Verification: node --test scripts/test/ceremony-drift.test.mjs scripts/test/ceremony-drift-exit.test.mjs. allow-suppression: none",
+      "budget": "mid",
+      "category": "bug",
+      "duration": 1,
+      "edges": [],
+      "id": "T58",
+      "rails": [
+        "scripts/test/ceremony-drift.test.mjs"
+      ],
+      "scope": [
+        "scripts/ceremony-drift.mjs",
+        "scripts/test/ceremony-drift.test.mjs",
+        "scripts/test/ceremony-drift-exit.test.mjs"
+      ],
+      "title": "ceremony-drift: recognize the bot author gh actually reports, so the tracker updates instead of duplicating"
     },
     {
       "body": "Build the foundation of @adlc/ticket-sync per docs/superpowers/specs/2026-06-27-external-ticketing-sync-design.md (sections 'Schema bedrock', 'Hard constraints', field-definition table). Create packages/ticket-sync as a zero-runtime-dependency package (CONVENTIONS rule 1; Node 18+ built-ins only) WITHOUT editing packages/core (CONVENTIONS rule 2 — core is frozen). Deliver: lib/schema.mjs (single declarative field definition = source of truth), lib/validate.mjs (definition-driven validator over the rich schema), lib/canonical.mjs (canonical JSON: sorted keys, LF, stable number formatting, CRLF-insensitive equality), scripts/gen-schema.mjs (emits schemas/adlc-ticket.schema.json, adlc-block.schema.json, adlc-config.schema.json, adlc-sync-state.schema.json from the definition), and the committed schema files.\n\nAcceptance criteria (each verifiable):\n1. `npm test` green for packages/ticket-sync/test/{schema,validate,canonical}.test.mjs.\n2. Drift gate: test regenerates schemas in-memory and asserts byte-equality with the committed schemas/*.json; editing the definition without regenerating fails the test (verify by mutating the definition in a scratch run).\n3. Cross-validator agreement: a corpus of tickets core's validateTicket accepts is also accepted by the rich validator on shared fields (asymmetric subset direction).\n4. No file under packages/core is modified (verify: `git diff --name-only main...HEAD -- packages/core` is empty).\n5. Package declares zero runtime dependencies (verify: no 'dependencies' beyond @adlc/* in package.json).",
@@ -1409,24 +1444,6 @@
         "packages/ticket-sync/test/github.test.mjs"
       ],
       "title": "Push + create: write-back, idempotent create, status outcomes"
-    },
-    {
-      "body": "Fixes voodootikigod/adlc#244. changedFiles(base) in packages/core/lib/git.mjs only diffs base-vs-working-tree, so staging a rail violation then reverting the working copy evades rails-guard. Union git diff <base> and git diff --cached <base> changed-file sets. Verification: node --test packages/core/test/*.test.mjs packages/rails-guard/test/*.test.mjs. allow-suppression: none",
-      "budget": "mid",
-      "category": "bug",
-      "duration": 1,
-      "edges": [],
-      "id": "T56",
-      "rails": [
-        "packages/rails-guard/test/version-only.test.mjs",
-        "packages/rails-guard/test/version-only-e2e.test.mjs"
-      ],
-      "scope": [
-        "packages/core/lib/git.mjs",
-        "packages/core/test/*.test.mjs",
-        "packages/rails-guard/**"
-      ],
-      "title": "rails-guard: union staged and working-tree diffs so a staged-then-reverted rail edit fails the gate"
     }
   ]
 }

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -441,6 +441,52 @@ export function renderIssueTitle(needsCeremony) {
  * not guaranteed) rather than throwing mid-run.
  * @param {{number: number, title?: string, body?: unknown}[]} issues
  */
+/**
+ * Reduce every rendering of one actor to a single identity (#265).
+ *
+ * GitHub names the same App actor three ways, and which one you get depends on
+ * the API you asked and the gh version that formatted it:
+ *
+ *   github-actions[bot]   REST, and older gh
+ *   app/github-actions    GraphQL via `gh issue list --json author` (current)
+ *   github-actions        the bare GraphQL Bot `login`
+ *
+ * Comparing raw strings therefore matched a name nothing in this job actually
+ * receives: the author filter rejected the tracker gh reports, findExistingIssue
+ * returned null on BOTH paths, and decideAction opened a duplicate on every push
+ * to main. Normalizing at the comparison — rather than correcting the constant to
+ * today's rendering — is what makes the next gh formatting change a non-event.
+ */
+export function normalizeActorLogin(login) {
+  return String(login ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^app\//, '')
+    .replace(/\[bot\]$/, '');
+}
+
+/** True when a login is written in one of GitHub's bot-actor forms. */
+const isBotFormLogin = (login) => /^app\//.test(String(login ?? '')) || /\[bot\]$/.test(String(login ?? ''));
+
+/**
+ * Authorship check for the unlabeled sweep.
+ *
+ * Name equality alone is NOT sufficient once the '[bot]' suffix is stripped: a
+ * human account literally named `github-actions` would then normalize onto the
+ * managed identity and could have its issue seized by a job holding
+ * `issues: write`. The exact-match comparison this replaces did not have that
+ * hole, so bot-ness is required alongside the name — a fix must not widen the
+ * authorization it was meant to repair. `is_bot` absent means not provably a
+ * bot, which fails closed.
+ */
+function isManagedAuthor(author, authors) {
+  const login = author?.login;
+  if (!login) return false;
+  const normalized = normalizeActorLogin(login);
+  if (!authors.some((a) => normalizeActorLogin(a) === normalized)) return false;
+  return author?.is_bot === true || isBotFormLogin(login);
+}
+
 export function selectTrackingIssue(issues, { authors = null, requireMarker = true } = {}) {
   // The marker is the identity on the UNLABELED sweep, where nothing else
   // distinguishes this job's issue. On the labeled path it must NOT be required:
@@ -459,7 +505,10 @@ export function selectTrackingIssue(issues, { authors = null, requireMarker = tr
   // closed by a job holding `issues: write`, and would let a forged issue divert
   // management away from the real tracker. So on the unlabeled sweep the author
   // must also be one this job could plausibly have created the issue as.
-  if (authors) candidates = candidates.filter((i) => authors.includes(i?.author?.login));
+  // Compared through normalizeActorLogin, never as raw strings — see #265, where
+  // an exact-string match against a name gh does not emit made this filter reject
+  // the job's own tracker and open a duplicate on every run.
+  if (authors) candidates = candidates.filter((i) => isManagedAuthor(i?.author, authors));
 
   // Ambiguity fails closed rather than picking one. Two marked issues means
   // something is wrong (a forgery, or a genuine duplicate); guessing could
@@ -527,7 +576,7 @@ const GH_MAX_BUFFER = 128 * 1024 * 1024;
 // authorization signal. The unlabeled sweep has no such signal and must verify
 // authorship instead — see selectTrackingIssue. Overridable for tests and for
 // repos whose automation runs under a different identity.
-const MANAGED_AUTHORS = (process.env.ADLC_DRIFT_AUTHORS ?? 'github-actions[bot]')
+export const MANAGED_AUTHORS = (process.env.ADLC_DRIFT_AUTHORS ?? 'github-actions[bot]')
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);

--- a/scripts/ceremony-drift.mjs
+++ b/scripts/ceremony-drift.mjs
@@ -469,19 +469,33 @@ export function normalizeActorLogin(login) {
 const isBotFormLogin = (login) => /^app\//.test(String(login ?? '')) || /\[bot\]$/.test(String(login ?? ''));
 
 /**
- * Authorship check for the unlabeled sweep.
+ * Authorship check for the unlabeled sweep. Two acceptance routes, deliberately
+ * NOT equally strict, because they carry different risk.
  *
- * Name equality alone is NOT sufficient once the '[bot]' suffix is stripped: a
- * human account literally named `github-actions` would then normalize onto the
- * managed identity and could have its issue seized by a job holding
- * `issues: write`. The exact-match comparison this replaces did not have that
- * hole, so bot-ness is required alongside the name — a fix must not widen the
- * authorization it was meant to repair. `is_bot` absent means not provably a
- * bot, which fails closed.
+ * EXACT match against a configured entry is explicit operator intent. It accepts
+ * only what someone literally wrote into ADLC_DRIFT_AUTHORS, widens nothing, and
+ * so needs no further evidence. This route is load-bearing: the override is
+ * documented for "repos whose automation runs under a different identity", which
+ * in practice is usually a dedicated MACHINE USER — reported with
+ * `is_bot: false`. Demanding bot-ness here would reject that configured author
+ * and recreate #265 under the override.
+ *
+ * NORMALIZED match is the route that widens: it accepts logins nobody configured,
+ * on the strength of one login aliasing onto another. That is exactly where
+ * impersonation becomes possible — stripping '[bot]' means a human account named
+ * `github-actions` would alias onto the managed bot and could have its issue
+ * seized by a job holding `issues: write`. The exact-string comparison this
+ * replaces did not have that hole, and a fix must not widen the authorization it
+ * was meant to repair, so bot evidence is required on this route only. `is_bot`
+ * absent means not provably a bot, which fails closed.
  */
 function isManagedAuthor(author, authors) {
   const login = author?.login;
   if (!login) return false;
+
+  const lower = String(login).trim().toLowerCase();
+  if (authors.some((a) => String(a).trim().toLowerCase() === lower)) return true;
+
   const normalized = normalizeActorLogin(login);
   if (!authors.some((a) => normalizeActorLogin(a) === normalized)) return false;
   return author?.is_bot === true || isBotFormLogin(login);

--- a/scripts/test/ceremony-drift-exit.test.mjs
+++ b/scripts/test/ceremony-drift-exit.test.mjs
@@ -27,7 +27,18 @@ import { spawnSync, execFileSync } from 'node:child_process';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'ceremony-drift.mjs');
-const BOT = 'github-actions[bot]';
+// The login `gh` ACTUALLY reports for the Actions bot, recorded from this repo:
+//
+//   $ gh issue view 264 --json author
+//   {"author":{"is_bot":true,"login":"app/github-actions"}}
+//
+// This was 'github-actions[bot]' — the REST actor name, which `gh issue list
+// --json author` never emits. Every stub here therefore fed the reporter an
+// author it does not receive in production, and the end-to-end "never a
+// duplicate" assertions below passed while the real job opened a duplicate on
+// every push to main (#265). A stub is only evidence if it lies the way the
+// outside world does; hard-code the recorded payload, not a plausible one.
+const BOT = 'app/github-actions';
 
 /**
  * Build a throwaway git repo whose drift state is exactly what the test wants.
@@ -111,7 +122,7 @@ esac
 exit 0`;
 
 const marked = (extra) =>
-  `[{"number":42,"title":"stale","body":"<!-- adlc:ceremony-drift --> old","author":{"login":"${extra}"}}]`;
+  `[{"number":42,"title":"stale","body":"<!-- adlc:ceremony-drift --> old","author":{"is_bot":true,"login":"${extra}"}}]`;
 
 // ---- operational failure must be LOUD ----
 
@@ -237,8 +248,8 @@ test('a FORGED marker from another author is not adopted', () => {
 test('two marked issues fail closed rather than guessing which to overwrite', () => {
   withRepo({ drift: true }, (repo) => {
     const two =
-      `[{"number":42,"title":"a","body":"<!-- adlc:ceremony-drift --> a","author":{"login":"${BOT}"}},` +
-      `{"number":43,"title":"b","body":"<!-- adlc:ceremony-drift --> b","author":{"login":"${BOT}"}}]`;
+      `[{"number":42,"title":"a","body":"<!-- adlc:ceremony-drift --> a","author":{"is_bot":true,"login":"${BOT}"}},` +
+      `{"number":43,"title":"b","body":"<!-- adlc:ceremony-drift --> b","author":{"is_bot":true,"login":"${BOT}"}}]`;
     const r = runWith(stubUnlabeled(two), { repo });
     assert.notEqual(r.status, 0, 'ambiguous match must not silently pick one');
     assert.match(r.stderr, /ambiguous tracking issue/);

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -302,6 +302,30 @@ test('an exact configured match is case-insensitive and needs no is_bot field', 
   assert.equal(selectTrackingIssue(issues, { authors: ['release-machine'] })?.number, 9);
 });
 
+// `is_bot` is not guaranteed to be present on every API surface, so the login
+// SHAPE is the fallback bot evidence: GitHub emits the `app/` prefix and the
+// `[bot]` suffix only for App actors. Each form must qualify on its own.
+//
+// Caught as a surviving `logic-swap` mutant (`||` → `&&`) on isBotFormLogin:
+// every other fixture here sets `is_bot: true`, which short-circuits the check
+// before it is ever reached, so the function was entirely unexercised. Each case
+// below matches only through NORMALIZATION and omits `is_bot`, which is the one
+// path where the shape is load-bearing.
+test('each bot-login form is sufficient evidence on its own, without is_bot', () => {
+  // 'app/' prefix arm: configured as the [bot] form, reported as the app/ form.
+  assert.equal(
+    selectTrackingIssue([{ number: 9, body: `${MARKER} real`, author: { login: 'app/github-actions' } }],
+      { authors: ['github-actions[bot]'] })?.number,
+    9
+  );
+  // '[bot]' suffix arm: configured as the app/ form, reported as the [bot] form.
+  assert.equal(
+    selectTrackingIssue([{ number: 9, body: `${MARKER} real`, author: { login: 'github-actions[bot]' } }],
+      { authors: ['app/github-actions'] })?.number,
+    9
+  );
+});
+
 // The author object is API-shaped data, not a guaranteed contract — the same
 // reason bodies are tolerated below. An issue with no author (or an author with
 // no login) carries NO authorization evidence at all, so under an active filter

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -274,6 +274,73 @@ test('a human account whose name normalizes to the bot is still rejected', () =>
   }
 });
 
+// ADLC_DRIFT_AUTHORS is documented as overridable "for repos whose automation
+// runs under a different identity" — commonly a dedicated MACHINE USER, which
+// GitHub reports with `is_bot: false`. Requiring bot-ness unconditionally would
+// reject that configured author and recreate #265 under the override: duplicate
+// opens while drift exists, and a stale tracker left open once it clears.
+//
+// So the two acceptance routes are deliberately not equally strict. An EXACT
+// match against a configured entry is explicit operator intent and needs no
+// further evidence. Only the NORMALIZED route widens the match beyond what was
+// configured, and only there can one login alias onto another — so only there is
+// bot evidence required.
+test('an exactly-configured non-bot author is accepted (the machine-user override)', () => {
+  const issues = [{ number: 9, body: `${MARKER} real`, author: { is_bot: false, login: 'release-machine' } }];
+  assert.equal(selectTrackingIssue(issues, { authors: ['release-machine'] })?.number, 9);
+  // ...and still closes the loop end-to-end: found means updated, not duplicated.
+  const decision = decideAction({
+    drift: [{ id: 'T1', blocker: 'rails-freeze', rails: ['a.test.mjs'], reason: 'shipped' }],
+    existingIssue: selectTrackingIssue(issues, { authors: ['release-machine'] }),
+  });
+  assert.equal(decision.action, 'update');
+  assert.equal(decision.number, 9);
+});
+
+test('an exact configured match is case-insensitive and needs no is_bot field', () => {
+  const issues = [{ number: 9, body: `${MARKER} real`, author: { login: 'Release-Machine' } }];
+  assert.equal(selectTrackingIssue(issues, { authors: ['release-machine'] })?.number, 9);
+});
+
+// The author object is API-shaped data, not a guaranteed contract — the same
+// reason bodies are tolerated below. An issue with no author (or an author with
+// no login) carries NO authorization evidence at all, so under an active filter
+// it must be rejected rather than treated as anonymous-and-therefore-fine.
+// Caught as a surviving `bool-flip` mutant on the `if (!login) return false`
+// guard: the guard was correct but nothing noticed when it stopped being.
+test('an author with no usable login is rejected under an authors filter', () => {
+  for (const author of [undefined, null, {}, { login: '' }, { login: '   ' }, { is_bot: true }]) {
+    const issues = [{ number: 9, body: `${MARKER} real`, author }];
+    assert.equal(
+      selectTrackingIssue(issues, { authors: MANAGED_AUTHORS }),
+      null,
+      `author ${JSON.stringify(author)} carries no authorization and must be rejected`
+    );
+  }
+});
+
+// An empty/whitespace ADLC_DRIFT_AUTHORS entry must not become a wildcard that
+// matches the empty-login case above. The production constant already filters
+// blanks; this pins the comparison itself so both halves cannot fail together.
+test('a blank configured author never matches a blank login', () => {
+  const issues = [{ number: 9, body: `${MARKER} forged`, author: { login: '' } }];
+  assert.equal(selectTrackingIssue(issues, { authors: ['', '  '] }), null);
+});
+
+// The exact-match route must not become a backdoor: it accepts only logins that
+// are literally configured, so an unconfigured account is still rejected even
+// when it is a bot.
+test('an unconfigured author is rejected however it is shaped', () => {
+  for (const author of [
+    { is_bot: true, login: 'app/some-other-bot' },
+    { is_bot: true, login: 'attacker[bot]' },
+    { is_bot: false, login: 'untrusted-user' },
+  ]) {
+    const issues = [{ number: 9, body: `${MARKER} forged`, author }];
+    assert.equal(selectTrackingIssue(issues, { authors: ['release-machine'] }), null);
+  }
+});
+
 // The whole point of the fix: with a tracker present, the job must UPDATE it.
 // #265 was not a lookup curiosity — it changed decideAction's branch from
 // 'update' to 'open' on every run, which is what produced the duplicates.

--- a/scripts/test/ceremony-drift.test.mjs
+++ b/scripts/test/ceremony-drift.test.mjs
@@ -17,6 +17,7 @@ import {
   decideAction,
   selectTrackingIssue,
   MARKER,
+  MANAGED_AUTHORS,
 } from '../ceremony-drift.mjs';
 
 // Heuristic evidence: scope globs already resolve. Indistinguishable from an
@@ -218,8 +219,74 @@ test('an authors filter rejects a forged marker from another author', () => {
 });
 
 test('an authors filter accepts the managed author', () => {
-  const issues = [{ number: 9, body: `${MARKER} real`, author: { login: 'github-actions[bot]' } }];
+  const issues = [{ number: 9, body: `${MARKER} real`, author: { is_bot: true, login: 'github-actions[bot]' } }];
   assert.equal(selectTrackingIssue(issues, { authors: ['github-actions[bot]'] }).number, 9);
+});
+
+// REGRESSION (#265). Every fixture above hand-writes 'github-actions[bot]', the
+// same string the production default hard-coded — so they agreed with each other
+// while both disagreed with reality. `gh issue list --json author` returns the
+// GraphQL actor, which gh renders 'app/github-actions'; recorded verbatim:
+//
+//   $ gh issue view 264 --json author
+//   {"author":{"is_bot":true,"login":"app/github-actions"}}
+//
+// The filter therefore rejected the job's OWN tracker on both lookup paths, and
+// ceremony-drift opened a duplicate on every push to main (12 in two days).
+// These assert against the recorded payload AND the shipped default, so a future
+// edit cannot leave the constant wrong about the outside world unnoticed.
+const GH_RECORDED_BOT_AUTHOR = { is_bot: true, login: 'app/github-actions' };
+
+test('the default managed-author set accepts the author gh actually reports', () => {
+  const issues = [{ number: 9, body: `${MARKER} real`, author: GH_RECORDED_BOT_AUTHOR }];
+  assert.equal(selectTrackingIssue(issues, { authors: MANAGED_AUTHORS })?.number, 9);
+});
+
+// One bot, several renderings across gh versions and the REST/GraphQL split. All
+// must resolve to the same identity, so the tracker survives gh changing how it
+// formats an App actor — the exact class of change that caused #265.
+test('every rendering of the same bot actor is one identity', () => {
+  for (const login of ['app/github-actions', 'github-actions[bot]', 'github-actions', 'GitHub-Actions[bot]']) {
+    const issues = [{ number: 9, body: `${MARKER} real`, author: { is_bot: true, login } }];
+    assert.equal(
+      selectTrackingIssue(issues, { authors: MANAGED_AUTHORS })?.number,
+      9,
+      `login '${login}' should resolve to the managed bot`
+    );
+  }
+});
+
+// Normalization strips the '[bot]' suffix, which ALONE would let a human account
+// literally named 'github-actions' seize the tracker — a privilege escalation the
+// pre-#265 exact-match comparison did not have. Bot-ness is required alongside
+// the name so this fix cannot widen the authorization it was meant to repair.
+test('a human account whose name normalizes to the bot is still rejected', () => {
+  for (const author of [
+    { is_bot: false, login: 'github-actions' },
+    { login: 'github-actions' }, // is_bot absent → not provably a bot → reject
+  ]) {
+    const issues = [{ number: 9, body: `${MARKER} forged`, author }];
+    assert.equal(
+      selectTrackingIssue(issues, { authors: MANAGED_AUTHORS }),
+      null,
+      `author ${JSON.stringify(author)} must not be accepted as the managed bot`
+    );
+  }
+});
+
+// The whole point of the fix: with a tracker present, the job must UPDATE it.
+// #265 was not a lookup curiosity — it changed decideAction's branch from
+// 'update' to 'open' on every run, which is what produced the duplicates.
+test('a recognized tracker updates in place instead of opening a duplicate', () => {
+  const drift = [{ id: 'T1', blocker: 'rails-freeze', rails: ['a.test.mjs'], reason: 'shipped' }];
+  const existing = selectTrackingIssue(
+    [{ number: 230, title: 'stale title', body: `${MARKER} stale`, author: GH_RECORDED_BOT_AUTHOR }],
+    { authors: MANAGED_AUTHORS }
+  );
+  assert.ok(existing, 'the tracker gh reports must be found');
+  const decision = decideAction({ drift, existingIssue: existing });
+  assert.equal(decision.action, 'update');
+  assert.equal(decision.number, 230);
 });
 
 // Guessing between two marked issues risks overwriting or closing the wrong one,


### PR DESCRIPTION
Fixes #265. Ticket T58.

## The defect

`ceremony-drift` promises one self-maintaining tracking issue. It opened 12 in two days — one per push to `main`.

`MANAGED_AUTHORS` defaulted to `github-actions[bot]`, the **REST** actor name. `gh issue list --json author` returns the **GraphQL** actor, which gh renders `app/github-actions`:

```
$ gh issue view 264 --json author
{"author":{"is_bot":true,"login":"app/github-actions"}}
```

`findExistingIssue` passes that filter to `selectTrackingIssue` on **both** lookup paths — the labeled fast path and the unlabeled sweep. Neither could match, `findExistingIssue` returned `null`, and `decideAction` took the `open` branch every run:

```
ceremony-drift: 11 ticket(s) awaiting the completion ceremony
ceremony-drift: opened https://github.com/voodootikigod/adlc/issues/264
```

Every run exited 0, so nothing surfaced the malfunction. The `ambiguous tracking issue` guard never fired either — it counts candidates *after* the author filter, which was always empty.

## Why the tests did not catch it

They fabricated the login they asserted against:

```js
const issues = [{ number: 9, body: `${MARKER} real`, author: { login: "github-actions[bot]" } }];
assert.equal(selectTrackingIssue(issues, { authors: ["github-actions[bot]"] }).number, 9);
```

The fixture and the production default shared the same wrong string, so they agreed with each other while both disagreed with `gh`. `ceremony-drift-exit.test.mjs` had the same fabricated login in its `gh` stub — so even the end-to-end `assert.doesNotMatch(r.calls, /issue create/)` ("never a duplicate") passed while production duplicated on every push. A stub is only evidence if it lies the way the outside world does.

## The fix

- `normalizeActorLogin` strips the `app/` prefix and `[bot]` suffix and lowercases, so every rendering of one actor is one identity. Normalizing at the comparison rather than correcting the constant to today's rendering is what makes the next gh formatting change a non-event.
- **Bot-ness is required alongside the name.** Stripping `[bot]` alone would let a human account literally named `github-actions` normalize onto the managed identity and have its issue seized by a job holding `issues: write` — a hole the exact-match comparison did not have. `is_bot` absent means not provably a bot, which fails closed.
- Fixtures replaced with the recorded `gh --json author` payload, in both the unit and the end-to-end suite.

## Evidence the tests are load-bearing

Reintroducing the exact-string comparison:

```
not ok 8  - an UNLABELED tracker authored by the bot is adopted, relabeled, and updated
not ok 35 - the default managed-author set accepts the author gh actually reports
not ok 36 - every rendering of the same bot actor is one identity
not ok 38 - a recognized tracker updates in place instead of opening a duplicate
# pass 80  # fail 6
```

Removing the bot-ness requirement:

```
not ok 21 - a human account whose name normalizes to the bot is still rejected
# pass 69  # fail 1
```

Full suite: `46/46 segments passed`, 138 tests, 0 failures.

## Cleanup already performed

The 11 duplicates (#245, #246, #247, #250, #254, #256, #257, #259, #261, #262, #264) are closed as not-planned with a pointer comment. **#230 is retained as the canonical tracker**, label and marker intact, so the corrected lookup finds and updates it in place rather than opening a 13th.

## Follow-up (not in this PR)

The ceremony itself — completing the 11 shipped rail-freezing tickets — lands separately on the protected-base path, per the precedent in #199, #221, #227.

## Test plan

- [x] `node --test scripts/test/ceremony-drift.test.mjs scripts/test/ceremony-drift-exit.test.mjs` — 86 pass
- [x] `npm test` — 46/46 segments
- [x] Mutation-verified: both the defect and the escalation guard are caught
- [ ] After merge: confirm the next `ceremony-drift` run logs `updated issue #230` rather than `opened`