### PR TITLE
spec(adlc): shape the rail START lifecycle (#159) and trust-root ceremony (#141)

### DIFF
--- a/.adlc/specs/rails-start-lifecycle.md
+++ b/.adlc/specs/rails-start-lifecycle.md
@@ -1,0 +1,296 @@
+# Rails need a START lifecycle: freeze from build-start, not from authoring
+
+Closes #159.
+
+## Problem
+
+A ticket's rails freeze their paths for **every** PR from the moment the ticket
+exists in the store. `scripts/rails-guard-ci.mjs:329-335` builds the union from
+every base ticket that is not completed:
+
+```js
+const rails = [];
+for (const t of baseTickets) {
+  if (t.completed === true) continue; // done → auto-expire (T36)
+  for (const r of t.rails ?? []) rails.push(r);
+}
+```
+
+There is no notion of *when the build began*. T36 (#130) gave rails an END —
+`completed: true` expires them. Nothing gives them a START. The window is
+therefore `[authoring, completion]` when it should be `[build-start, completion]`.
+
+(#159's "Relationship" section says the completion side is #141. That is a stale
+cross-reference: the completion side shipped as **T36 / #130**. #141 is the
+trust-root ceremony, which is the *mechanism* problem, not the lifecycle mirror.
+Worth correcting on the issue.)
+
+### Harm A — a ticket cannot author its own rails
+
+Declaring a test file as a rail blocks writing that test file. The rail is
+supposed to freeze a test *once it exists*; instead it freezes the path before
+anything is there.
+
+Observed building **T58** (the ceremony-drift bot-author fix) on 2026-07-22. The
+ticket declared `rails: ["scripts/test/ceremony-drift.test.mjs"]` at authoring,
+and the first attempt to write that test was denied:
+
+```
+scripts/test/ceremony-drift.test.mjs is a frozen rail declared by ticket T58
+(rails: "scripts/test/ceremony-drift.test.mjs"). Edits to frozen rails are
+blocked during build.
+```
+
+The workaround was to narrow the rails to `[]`, author the test, then re-freeze
+— and to repeat that cycle on **every review round** that added a test (an
+adversarial-review finding, then two surviving mutants). Three narrow/re-freeze
+cycles for one ticket, each requiring `--authorize` on a `rail-narrowing`.
+
+Nothing was bypassed and every cycle is recorded, so this is friction rather than
+a hole. But the recorded history now shows a ticket that repeatedly un-froze its
+own rails, which is indistinguishable in the log from the thing rails exist to
+prevent. The audit trail is *noisier for having followed the rules*.
+
+### Harm B — the honest response is to declare no rails
+
+#159 reports that T39 and T40 both shipped with `rails: []` and a note to
+"declare at P3", because declaring up front would freeze those paths for
+unrelated PRs before the build started. That defeats the point of authoring
+rails with the ticket, and it is the *documented* workaround, not a mistake.
+
+The in-session hook states the current behavior plainly
+(`plugins/adlc-claude-code/hooks/adlc-hook.mjs:250`):
+
+```js
+const status = ticket.completed === true ? 'completed'
+  : rails.length > 0 ? 'rail protection auto-active' : 'no rails declared';
+```
+
+`auto-active` — on declaration.
+
+### Why this is worth fixing now
+
+Measured against the store on `main` at 1.6.0: the active rail union is **30
+paths**, and **every one of them belongs to a ticket that has already shipped**
+(the twelve in PR #285). Not one frozen path corresponds to a build in flight.
+
+That is the steady state this design produces. Rails accumulate from authoring,
+expire only through an admin ceremony, and the union therefore trends toward
+"everything ever declared" rather than "what is being built right now." #159 and
+#141 are the two ends of the same lifecycle, and the union is broken at both.
+
+## Build
+
+1. **Add a `started` field and gate the union on it.** In the
+   `rails-guard-ci.mjs` union, skip tickets that have not started:
+
+   ```js
+   if (t.completed === true) continue; // T36 — window closed
+   if (t.started !== true) continue;   // NEW  — window not open
+   ```
+
+   Strict boolean `true` only, matching T36's fail-closed treatment of
+   `completed` (not `"true"`, not truthy).
+
+2. **Make `started` self-service, and irreversible.** This is the trust
+   asymmetry that makes the change safe, and it must be argued explicitly in the
+   code comment the way T36's trust anchor is:
+
+   - `started: true` only ever **adds** freeze. Granting it takes privilege away
+     from the setter, so an ordinary PR may set it — via a new narrow exemption
+     `isStartAnnotationOnly`, built exactly like `isCompletionAnnotationOnly`
+     (add-only on a pristine field, strict `=== true`, everything else
+     byte-identical).
+   - **Un-starting is already denied.** Removing the field or setting it `false`
+     is a field change to an existing base ticket, which
+     `assertBaseTicketContractsPreserved` denies. So the transition is one-way
+     without an admin, for free.
+   - **No new unfreeze privilege is created.** The union only shrinks for tickets
+     that never started, and a never-started ticket is *exactly equivalent to
+     today's `rails: []`* — which any author may already write. The guard's floor
+     is unchanged. This argument is the crux of the review; state it in the spec
+     comment, not just the PR.
+
+   Note the asymmetry with `isCompletionAnnotationOnly`, which bails when
+   `baseRails.length > 0` (rails-guard-ci.mjs:147) because completing a railed
+   ticket *unfreezes*. Starting one *freezes*, so the railed case is the case
+   that must be allowed. Getting this backwards inverts the security property.
+
+3. **Close the honesty gap the change opens.** With opt-in start, a ticket could
+   declare rails, never start, build to completion, and read in the store as
+   protected while having frozen nothing. Require that a ticket with non-empty
+   rails may only be completed if it was started — enforced both in
+   `adlc ticket complete` and in the completion path — so "declared rails" and
+   "rails that bound something" cannot diverge silently.
+
+4. **Add `adlc ticket start <id> --write`,** mirroring `adlc ticket complete`, as
+   the sanctioned P3 transition. Dry-run by default like every other writer.
+
+5. **Teach the in-session hook the same window.** `adlc-hook.mjs` must not freeze
+   an un-started ticket's rails, and must permit the start annotation to reach
+   the store even when rails exist (today the hook freezes the ticket store
+   itself once any rail is declared, which would block the very transition).
+   Harm A is a hook-level failure; fixing only CI leaves it in place.
+
+6. **Grandfather every ticket that predates the field (premortem F2 — blocking).**
+   Absent `started` must NOT mean "never started" for tickets authored before this
+   change, or merging it silently expires the entire existing rail union in one
+   step. Measured on `main` at 1.6.0 that is **all 30 frozen paths at once** — a
+   mass unfreeze arriving as a side effect of a lifecycle change rather than as a
+   reviewed ceremony, and one that would quietly moot PR #285.
+
+   Bump the store `formatVersion` and treat tickets written under the old version
+   as started. Only tickets authored after the bump participate in the opt-in
+   window. **Sequencing:** if #285 lands first the union is already empty and the
+   hazard is moot — but the grandfather clause is required regardless, because
+   correctness must not depend on merge order.
+
+   **The obvious bump collides with existing code (coldstart gap).**
+   `rails-guard-ci.mjs` already treats `formatVersion` as a two-value migration
+   signal:
+
+   ```js
+   const isMigration = baseSnapshot.formatVersion === 0 && headSnapshot.formatVersion === 1;  // :348
+   } else if (baseSnapshot.formatVersion !== headSnapshot.formatVersion) {                     // :377
+   ```
+
+   A bump to `2` falls into the second branch and is treated as an illegal
+   version change, so the grandfather mechanism as stated would deny every PR.
+   Resolve explicitly: either extend the migration handling to a version
+   *ladder* rather than a hardcoded 0→1 pair, or carry the grandfather signal
+   per-ticket (e.g. a provenance field written at authoring) and leave
+   `formatVersion` alone. Prefer the per-ticket signal — it keeps the store
+   version meaning "layout", not "policy epoch".
+
+7. **Make start automatic at P3, not a remembered step (premortem F4).** An
+   opt-in flag that is only enforced at completion (AC7) fails at the worst
+   possible moment: the work is done and the fix needs a ticket-store change. The
+   build-gate/hook path that already knows a build is beginning should perform the
+   transition, leaving `adlc ticket start` as the explicit escape hatch rather
+   than the primary interface.
+
+8. **Support recovery in one PR (premortem F1).** A ticket that reaches
+   completion without having started must be fixable on the ordinary path. As
+   specified, a PR adding both `started: true` and `completed: true` matches
+   *neither* narrow exemption and is denied — so the recovery for forgetting to
+   start is an admin ceremony, which is exactly the trap #141 describes. Either
+   admit an explicit `isStartThenCompleteAnnotationOnly` (add-only on both
+   pristine fields, strict `=== true`, nothing else changed) or state plainly
+   that recovery requires two sequential PRs. Do not leave it unstated.
+
+9. **Never emit `started` at authoring (premortem F3).** If `adlc ticket create`
+   writes the field, the window collapses back to `[authoring, completion]` and
+   this whole change is a no-op with extra steps.
+
+10. **Record an ADR** covering the full `[start, completion]` window, the
+    argument in step 2, and the grandfather rule in step 6.
+
+## Acceptance criteria
+
+- **AC1 — an un-started ticket freezes nothing.** With a base store containing a
+  ticket that declares `rails: ["a/b.test.mjs"]` and no `started` field, a PR
+  editing `a/b.test.mjs` passes. VERIFY: `node --test
+  scripts/test/rails-guard-ci.test.mjs --test-name-pattern='un-started'` exits 0,
+  and the same test fails against the pre-fix `rails-guard-ci.mjs`.
+
+- **AC2 — a started ticket freezes exactly as today.** Same fixture with
+  `started: true` in base denies the same edit with exit 2. VERIFY: as AC1, with
+  `--test-name-pattern='started freezes'`.
+
+- **AC3 — start is strict and fail-closed.** `started` values `"true"`, `1`,
+  `{}`, and `null` all leave the ticket un-started rather than starting it, and
+  none crashes the gate. VERIFY: table-driven case in the same file,
+  `--test-name-pattern='started strictness'`.
+
+- **AC4 — a PR may start a ticket, including a railed one.** A PR whose only
+  ticket-store change adds `started: true` to an existing railed base ticket
+  passes `assertBaseTicketContractsPreserved`. VERIFY:
+  `--test-name-pattern='start annotation exempt'`.
+
+- **AC5 — a PR may not un-start, and may not smuggle.** Removing `started`,
+  setting it `false`, or adding `started: true` *together with any other field
+  change* (including a rails change) is denied. This is the security boundary;
+  it must have a case per variant. VERIFY:
+  `--test-name-pattern='start annotation bounded'`.
+
+- **AC6 — starting cannot unfreeze another ticket's path.** With ticket A started
+  and freezing `x.mjs`, a PR that starts ticket B still cannot edit `x.mjs`.
+  VERIFY: `--test-name-pattern='start does not unfreeze'`.
+
+- **AC7 — a railed ticket cannot be completed without having started.**
+  `adlc ticket complete <id>` on a ticket with non-empty rails and no `started`
+  fails with a distinct exit code and message; with `started: true` it succeeds.
+  VERIFY: `node --test packages/tickets/test/*.test.mjs
+  --test-name-pattern='complete requires start'` exits 0.
+
+- **AC8 — `adlc ticket start` exists and is dry-run by default.** `adlc ticket
+  start T1` reports the change and writes nothing; `--write` applies it; starting
+  an already-started ticket is a no-op rather than an error. VERIFY:
+  `--test-name-pattern='ticket start'` in the same suite.
+
+- **AC9 — the hook lets a ticket author its own rails (Harm A, end to end).**
+  Driving `adlc-hook.mjs` with a PreToolUse Write to a declared-but-un-started
+  rail path returns allow; after `started: true`, the identical call returns
+  deny. This is the T58 scenario and must be asserted as such. VERIFY:
+  `node --test plugins/adlc-claude-code/test/*.test.mjs
+  --test-name-pattern='un-started rail is writable'` exits 0.
+
+- **AC10 — the hook permits the start transition itself.** With rails declared,
+  `adlc ticket start --write` succeeds in-session — the store freeze does not
+  block the annotation. VERIFY: `--test-name-pattern='start transition allowed'`.
+
+- **AC13 — pre-existing tickets keep freezing (premortem F2, blocking).** Loading
+  a store written under the previous `formatVersion`, every ticket with rails and
+  no `started` field still freezes its paths. Asserted against a fixture built
+  from the real 1.6.0 store, so the 30-path union cannot silently evaporate.
+  VERIFY: `node --test scripts/test/rails-guard-ci.test.mjs
+  --test-name-pattern='grandfathered tickets still freeze'` exits 0, and the test
+  fails if the grandfather clause is removed.
+
+- **AC14 — start+complete recovery is decided, not accidental (premortem F1).**
+  A PR adding both `started: true` and `completed: true` to a pristine railed
+  ticket either passes (if the composite exemption is implemented) or is denied
+  with a message naming the two-PR recovery. Whichever is chosen, it is asserted
+  — the failure mode is this case being undefined. VERIFY:
+  `--test-name-pattern='start then complete'`.
+
+- **AC16 — the P3 transition is automatic (Build step 7).** Beginning a build
+  against a ticket with declared rails and no `started` field performs the start
+  transition without the operator invoking `adlc ticket start`. Build step 7 was
+  a requirement with no acceptance criterion until this was added — the gap that
+  would have shipped the flag while leaving it a remembered step. VERIFY:
+  `node --test packages/build-gate/test/*.test.mjs
+  --test-name-pattern='build start performs the rail start transition'` exits 0.
+
+- **AC17 — the version ladder still admits the legacy migration.** With the
+  grandfather mechanism in place, the existing 0→1 directory-store migration path
+  still passes and a genuine unexpected version change is still denied. VERIFY:
+  `node --test scripts/test/rails-guard-ci.test.mjs
+  --test-name-pattern='formatVersion'` exits 0.
+
+- **AC15 — authoring never starts (premortem F3).** `adlc ticket create` output
+  contains no `started` field for any input, including one that supplies it.
+  VERIFY: `node --test packages/tickets/test/*.test.mjs
+  --test-name-pattern='create never starts'` exits 0.
+
+- **AC11 — no regression, and the real union shrinks correctly.** `npm test`
+  exits 0, and the computed rail union on this repo is unchanged for started
+  tickets. VERIFY: `npm test` exits 0.
+
+- **AC12 — decision recorded.** An ADR under `docs/adr/` states the
+  `[start, completion]` window and the "no new unfreeze privilege" argument, and
+  is referenced from the union comment in `rails-guard-ci.mjs`. VERIFY: the ADR
+  file exists and `grep` finds its number in `scripts/rails-guard-ci.mjs`.
+
+## Out of scope
+
+- Migrating existing tickets. Every ticket in the store today predates `started`;
+  they are handled by the completion ceremony (#141 / PR #285), not by
+  backfilling a start flag onto shipped work.
+- Deriving start from the gate-manifest. The manifest is explicitly not trusted
+  by this gate (rails-guard-ci.mjs:318-320 — no signing key, and append-only does
+  not stop a two-PR forged append). Start must live in the ticket store, where
+  `assertBaseTicketContractsPreserved` already protects it.
+- Deriving start from the diff (rails bind once a PR touches the ticket's
+  `scope`). Rejected: the rail file is normally *inside* scope, so this
+  reintroduces Harm A exactly.

--- a/.adlc/specs/trust-root-ceremony.md
+++ b/.adlc/specs/trust-root-ceremony.md
@@ -1,0 +1,261 @@
+# Trust-root change ceremony: an authorized path CI recognizes, not an admin override
+
+Closes #141.
+
+## Problem
+
+Landing a legitimate change to a trust root means driving a required check red on
+purpose and clicking admin-merge. The audit trail records that someone used
+`--admin`; it records nothing about *this change having been reviewed and
+authorized*. Worse, it trains operators to override a red security gate, which is
+the reflex the gate exists to prevent.
+
+### The precise gap
+
+`assertBaseTicketContractsPreserved` (rails-guard-ci.mjs:154-163) denies any field
+change to an existing base ticket. There is already one narrow exemption, and it
+is deliberately scoped to exclude the case that matters
+(rails-guard-ci.mjs:145-152):
+
+```js
+function isCompletionAnnotationOnly(baseTicket, headTicket) {
+  const baseRails = Array.isArray(baseTicket.rails) ? baseTicket.rails : [];
+  if (baseRails.length > 0) return false;  // railed → could unfreeze → not exempt
+  ...
+```
+
+A **rails-less** ticket may be completed in an ordinary PR, because completing it
+grants zero privilege — there is nothing to unfreeze. A **railed** ticket may
+not, because completing it expires rails. That reasoning is correct and must not
+be relaxed. The consequence is that the completion ceremony — the one operation
+that clears rail drift — is structurally impossible on the normal path.
+
+Live instance, 2026-07-22. PR #285 completes twelve shipped railed tickets. Every
+check passes except `rails-guard`, reproduced locally:
+
+```
+$ node scripts/rails-guard-ci.mjs origin/main
+rails-guard-ci: base ticket T-01KXPD8KJ9H6M6DFA83Y82A1Z1 contract cannot change
+in .adlc/tickets.json in a PR
+```
+
+This is the gate working as designed. There is no way to express "authorized" to
+it, so the only exit is admin-merge — the fourth time (#199, #221, #227, #285).
+
+### Why the drift is not self-limiting
+
+The active rail union on `main` at 1.6.0 is 30 paths, and all 30 belong to
+already-shipped tickets. Rails can only be cleared through a ceremony that can
+only land by overriding a red check, so the friction on clearing drift is
+strictly higher than the friction on creating it. The union ratchets upward.
+That is the structural reason this matters beyond audit-trail hygiene.
+
+## Build
+
+The authorization signal must satisfy four properties. Each rules out an
+otherwise-obvious design:
+
+1. **Unforgeable by the PR.** For `pull_request`, the workflow definition comes
+   from the PR head, so a PR can rewrite its own authorizer. This is why
+   `docs/ci/rails-guard.yml` is hash-pinned in
+   `scripts/test/rails-guard-workflow-hashes.json`.
+2. **Not self-applicable.** The PR author must not be able to authorize their own
+   trust-root change.
+3. **Bound to a revision.** Approve → CI green → push must not stay authorized.
+4. **No signing key in PR CI.** Manifest-signature approaches were rejected for
+   exactly this reason in the #104/T36 discussion; do not reintroduce them.
+
+### Design
+
+**A. A separate authorizer workflow.** Add `.github/workflows/trust-root-auth.yml`
+on `pull_request_target` (types `labeled`, `unlabeled`, `synchronize`,
+`reopened`) plus `pull_request_review`. `pull_request_target` runs the **base
+branch's** definition, satisfying property 1 without a second hash fixture.
+
+It **must not check out or execute PR code** — API calls only. That is the one
+rule that makes `pull_request_target` safe, and it should be stated in the
+workflow header the way the `persist-credentials: false` rationale is in
+`ceremony-drift.yml`. Permissions: `pull-requests: read`, `checks: write`,
+nothing else.
+
+It asserts all of:
+
+- the `trust-root-change` label is present;
+- the actor who applied it (issue timeline API, `labeled` event) has `write` or
+  `admin` permission **and is not the PR author** (property 2);
+- an `APPROVED` review exists from a user with `write`/`admin`, not the author,
+  whose `commit_id` equals the current head SHA (property 3);
+
+then publishes a check run `trust-root-authorized` against that head SHA —
+`success` when all hold, `failure` otherwise, with the reason in the summary.
+
+**B. Teach `rails-guard-ci.mjs` the authorized path — re-deriving, not trusting
+a flag.** Where it would `deny()` for a trust-root reason, it authorizes only if
+it can itself confirm the underlying facts.
+
+> **This is the load-bearing decision, and the obvious design is wrong.** The
+> tempting version — "look for a `success` check run named
+> `trust-root-authorized` on this SHA" — is forgeable. For a same-repo PR,
+> `GITHUB_TOKEN` carries `checks: write` by default, so a PR can add a workflow
+> step that creates a check run with that exact name on its own head SHA and
+> authorize itself. A check-run name is not an authorization; it is a string any
+> writer can produce.
+>
+> So the check run is a **cache, never the authority**. `rails-guard-ci.mjs`
+> re-queries the label applier and the approving reviewer through the API and
+> re-derives the decision. If it also reads the check run, it must additionally
+> pin the producing `app.id` **and** the originating workflow path — and even
+> then the re-derivation is what authorizes.
+
+Found and re-derived → record to the gate manifest and exit 0. Absent, failed,
+bound to a different SHA, or contradicted by re-derivation → deny exactly as
+today. Fail closed on any API error: an unreachable API is not authorization.
+
+**B0. There is no CODEOWNERS file yet — this is a prerequisite, and a human
+decision (coldstart gap).** `ls CODEOWNERS .github/CODEOWNERS` returns nothing in
+this repository today, so B2 below is unimplementable until one exists. Creating
+it is not a mechanical step: it declares *who is authorized to approve trust-root
+changes*, which is a governance choice the maintainer must make, not something a
+build agent can infer. The file must at minimum cover `scripts/rails-guard-ci.mjs`,
+`docs/ci/rails-guard.yml`, `scripts/test/rails-guard-workflow-hashes.json`, and
+`.adlc/tickets.json`. Treat it as a blocking input to this ticket.
+
+**B2. Authorization is CODEOWNERS, not `write`.** `write` covers every
+contributor with push access; a trust root warrants the narrower bar #141 asked
+for. Both the label applier and the approving reviewer must match a CODEOWNERS
+entry covering the changed trust-root path, and must not be the PR author.
+
+**B3. Same-repo branches only.** A fork PR's head SHA does not exist in the base
+repository, so a check run cannot bind to it and the review/label state cannot be
+tied to a revision the base repo can resolve. A trust-root PR from a fork is
+denied with an explicit "open this from a branch in this repository" message
+rather than failing obscurely.
+
+**C. Record it.** `adlc gate-manifest record trust-root-change` with the
+authorizing actors, the label applier, the approving reviewer, and the SHA — so
+the ceremony produces *better* evidence than the admin click it replaces, which
+is the point.
+
+**D. Require stale-review dismissal.** Property 3 depends on
+`dismiss_stale_reviews` being on for `main`. Document it as a prerequisite and
+assert the SHA binding in tests regardless, so the gate does not silently depend
+on a setting nobody re-checks.
+
+### Rejected alternatives
+
+- **Signed manifest entries** — needs a key in PR CI (property 4).
+- **Trusting the manifest directly** — rails-guard-ci.mjs:318-320 already
+  explains why it cannot: no signing key, and append-only does not stop a two-PR
+  forged append.
+- **A label alone, read from the `pull_request` event payload** — self-applicable
+  by any author with write access, and the payload is not re-validated against
+  who applied it.
+- **Widening `isCompletionAnnotationOnly` to railed tickets** — this is the hole
+  the exemption was carefully written to avoid; it would let any PR unfreeze any
+  rail.
+
+## Acceptance criteria
+
+- **AC1 — authorized railed completion passes.** A fixture PR whose only change
+  adds `completed: true` to a railed base ticket, with a `trust-root-authorized`
+  success check bound to its head SHA, exits 0. VERIFY: `node --test
+  scripts/test/rails-guard-ci.test.mjs --test-name-pattern='authorized trust-root'`
+  exits 0, and fails against the pre-fix gate.
+
+- **AC2 — the same PR without authorization stays denied.** Identical fixture,
+  no check run, exits 2 with the current message. VERIFY:
+  `--test-name-pattern='unauthorized trust-root'`.
+
+- **AC3 — authorization does not transfer across revisions.** A success check
+  bound to SHA `A` does not authorize head SHA `B`. VERIFY:
+  `--test-name-pattern='authorization is revision-bound'`.
+
+- **AC4 — a failed or neutral check is not authorization.** Check runs with
+  conclusion `failure`, `neutral`, `cancelled`, `skipped`, and `action_required`
+  each leave the PR denied. VERIFY:
+  `--test-name-pattern='only success authorizes'`.
+
+- **AC5 — API failure fails closed.** With the check-run lookup erroring or
+  timing out, the gate denies rather than allowing. VERIFY:
+  `--test-name-pattern='authorization lookup fails closed'`.
+
+- **AC6 — the author cannot authorize themselves.** Given a label applied by the
+  PR author, or an approval whose reviewer is the author, the authorizer emits
+  `failure`. Both variants needed — they are separate checks. VERIFY:
+  `node --test scripts/test/trust-root-auth.test.mjs
+  --test-name-pattern='self-authorization'` exits 0.
+
+- **AC7 — an unprivileged actor cannot authorize.** Label applied, or approval
+  given, by a user with only `read` permission → `failure`. VERIFY:
+  `--test-name-pattern='requires write permission'`.
+
+- **AC8 — the authorizer never executes PR code.** `trust-root-auth.yml`
+  contains no `actions/checkout`, no `run:` step that executes anything from the
+  PR, and requests only `pull-requests: read` and `checks: write`. This is the
+  `pull_request_target` safety property and must be asserted statically, not
+  reviewed by eye. VERIFY: `node --test scripts/test/trust-root-auth.test.mjs
+  --test-name-pattern='authorizer takes no PR code'` exits 0.
+
+- **AC9 — the ceremony is recorded.** After an authorized run, `adlc
+  gate-manifest show` contains a `trust-root-change` entry naming the label
+  applier, the approving reviewer, and the SHA. VERIFY:
+  `--test-name-pattern='ceremony recorded'`.
+
+- **AC10 — the live instance, end to end.** PR #285's exact diff passes under the
+  ceremony with authorization and fails without it. This is the change that
+  motivated the work; a fixture that resembles it is not sufficient. VERIFY: a
+  test replaying #285's ticket-store diff against both states, asserted in
+  `scripts/test/rails-guard-ci.test.mjs`.
+
+- **AC13 — a forged check run does not authorize (premortem F5).** A
+  `trust-root-authorized` success check run created by an actor other than the
+  authorizer workflow — same name, same SHA, correct conclusion, but no
+  underlying CODEOWNERS label/approval — leaves the PR denied. This is the
+  headline attack; without this case the feature is a self-service unfreeze.
+  VERIFY: `node --test scripts/test/rails-guard-ci.test.mjs
+  --test-name-pattern='forged authorization check'` exits 0.
+
+- **AC14 — authorization is re-derived, not read.** With the check run absent but
+  a valid CODEOWNERS label and approval present, the gate still authorizes;
+  with the check run present but the label applier no longer a CODEOWNER, it
+  denies. Together these prove the check run is a cache and not the authority.
+  VERIFY: `--test-name-pattern='authorization is re-derived'`.
+
+- **AC17 — CODEOWNERS exists and covers every trust root (prerequisite B0).** A
+  `CODEOWNERS` file exists and every trust-root path this ceremony can authorize
+  is matched by an entry; a trust root with no owner is a configuration error the
+  gate reports rather than silently treating as unauthorizable. VERIFY:
+  `node --test scripts/test/trust-root-auth.test.mjs
+  --test-name-pattern='every trust root has an owner'` exits 0.
+
+- **AC15 — CODEOWNERS, not write (premortem F6).** A label applier or approver
+  with `write` permission who matches no CODEOWNERS entry for the changed path
+  does not authorize. VERIFY: `node --test scripts/test/trust-root-auth.test.mjs
+  --test-name-pattern='codeowners required'` exits 0.
+
+- **AC16 — fork PRs are refused explicitly (premortem F7).** A trust-root change
+  proposed from a fork exits 2 with a message naming the same-repo requirement,
+  not with an internal error. VERIFY:
+  `--test-name-pattern='fork trust-root refused'`.
+
+- **AC11 — no regression in the existing deny paths.** Every current
+  `assertBaseTicketContractsPreserved` denial (removal, field change, rails
+  change, non-`true` completion) still denies with no authorization present.
+  VERIFY: existing cases in `scripts/test/rails-guard-ci.test.mjs` continue to
+  pass; `npm test` exits 0.
+
+- **AC12 — decision recorded.** An ADR under `docs/adr/` states the four
+  properties, why `pull_request_target` is used and why it takes no PR code, and
+  the rejected alternatives. VERIFY: the ADR exists and is referenced from
+  `trust-root-auth.yml`'s header.
+
+## Out of scope
+
+- Replacing `ADLC_RAILS_BYPASS`. The in-session audited bypass stays; this adds
+  a reviewer-gated CI path alongside it.
+- Applying the ceremony to trust roots beyond the ticket-store contract
+  (`rails-guard-ci.mjs` itself, `docs/ci/rails-guard.yml`, the hash fixture).
+  The mechanism is built to generalize, but each additional root needs its own
+  threat argument and should land separately.
+- Branch-protection configuration itself, which is a repo setting rather than
+  code. Documented as a prerequisite (design D) and asserted only indirectly.

--- a/.adlc/specs/trust-root-ceremony.md
+++ b/.adlc/specs/trust-root-ceremony.md
@@ -59,8 +59,12 @@ otherwise-obvious design:
    from the PR head, so a PR can rewrite its own authorizer. This is why
    `docs/ci/rails-guard.yml` is hash-pinned in
    `scripts/test/rails-guard-workflow-hashes.json`.
-2. **Not self-applicable.** The PR author must not be able to authorize their own
-   trust-root change.
+2. **Not self-applicable — where that is achievable.** The PR author must not be
+   able to authorize their own trust-root change *whenever another eligible owner
+   exists*. On a single-owner repository this property is unreachable (see B1:
+   GitHub forbids self-approval outright), so it is enforced conditionally rather
+   than assumed. Writing it as an absolute is what made the first draft of this
+   spec authorize nothing.
 3. **Bound to a revision.** Approve → CI green → push must not stay authorized.
 4. **No signing key in PR CI.** Manifest-signature approaches were rejected for
    exactly this reason in the #104/T36 discussion; do not reintroduce them.
@@ -81,10 +85,13 @@ nothing else.
 It asserts all of:
 
 - the `trust-root-change` label is present;
-- the actor who applied it (issue timeline API, `labeled` event) has `write` or
-  `admin` permission **and is not the PR author** (property 2);
-- an `APPROVED` review exists from a user with `write`/`admin`, not the author,
-  whose `commit_id` equals the current head SHA (property 3);
+- the actor who applied it (issue timeline API, `labeled` event) is a CODEOWNER
+  for the changed trust-root path;
+- the label event's SHA is the current head SHA — re-applied on every push, so
+  authorization cannot survive a `synchronize` (property 3);
+- **in multi-owner mode only** (see B2): the applier is not the PR author, and an
+  `APPROVED` review exists from a CODEOWNER who is not the author, whose
+  `commit_id` equals the current head SHA (property 2).
 
 then publishes a check run `trust-root-authorized` against that head SHA —
 `success` when all hold, `failure` otherwise, with the reason in the summary.
@@ -111,19 +118,59 @@ Found and re-derived → record to the gate manifest and exit 0. Absent, failed,
 bound to a different SHA, or contradicted by re-derivation → deny exactly as
 today. Fail closed on any API error: an unreachable API is not authorization.
 
-**B0. There is no CODEOWNERS file yet — this is a prerequisite, and a human
-decision (coldstart gap).** `ls CODEOWNERS .github/CODEOWNERS` returns nothing in
-this repository today, so B2 below is unimplementable until one exists. Creating
-it is not a mechanical step: it declares *who is authorized to approve trust-root
-changes*, which is a governance choice the maintainer must make, not something a
-build agent can infer. The file must at minimum cover `scripts/rails-guard-ci.mjs`,
+**B0. CODEOWNERS defines the eligible set.** Added by this work, covering
+`scripts/rails-guard-ci.mjs`, `scripts/test/rails-guard-ci.test.mjs`,
 `docs/ci/rails-guard.yml`, `scripts/test/rails-guard-workflow-hashes.json`, and
-`.adlc/tickets.json`. Treat it as a blocking input to this ticket.
+`.adlc/tickets.json`. It documents the trust surface independently of whether the
+ceremony is built — an unowned trust root is a gap either way.
 
-**B2. Authorization is CODEOWNERS, not `write`.** `write` covers every
-contributor with push access; a trust root warrants the narrower bar #141 asked
-for. Both the label applier and the approving reviewer must match a CODEOWNERS
-entry covering the changed trust-root path, and must not be the PR author.
+**B1. Separation of duties is NOT available here, and the spec must not pretend
+otherwise.** This repository has exactly one collaborator
+(`gh api repos/voodootikigod/adlc/collaborators` → `voodootikigod`, admin; 192 of
+the last 200 commits by one author). Two clauses in the original draft of this
+spec were therefore unsatisfiable:
+
+- *"the label applier is not the PR author"* — there is nobody else to apply it.
+- *"an `APPROVED` review from a user who is not the author"* — **GitHub
+  structurally forbids approving your own pull request.** Not a policy toggle;
+  it cannot be done.
+
+As drafted, this ceremony would authorize nothing, leaving a red check with *no*
+path through it — strictly worse than the admin override it replaces. The
+requirement must scale with the size of the eligible set, not assume it.
+
+What separation of duties would have bought is genuinely unavailable, and no
+design recovers it; a second identity the same person controls is theatre, not a
+control. What remains available, and is the actual justification for building
+this:
+
+- the required check stays **green**, so operators are not trained to override a
+  red gate — the primary harm in #141;
+- authorization is **revision-bound** — it names a SHA, and pushing invalidates
+  it, which an admin click has no notion of;
+- it is **recorded** with actor, SHA and reason, rather than an opaque
+  "someone used `--admin`";
+- it is **narrowly scoped** to one trust-root change, not "bypass the gate".
+
+**B2. Authorization is CODEOWNERS, and its strictness is derived from the
+eligible-owner count.** `write` covers every contributor with push access; a trust
+root warrants the narrower bar #141 asked for. Beyond that, the gate computes the
+number of distinct CODEOWNERS eligible for the changed path and selects a mode:
+
+- **Single-owner mode (one eligible owner).** The owner may authorize their own
+  change by applying the label. No approving review is required, because none can
+  exist. The manifest entry MUST record `mode: single-owner` so the evidence never
+  overstates what was verified — this is the difference between an honest audit
+  trail and a misleading one.
+- **Multi-owner mode (two or more).** The full rule engages automatically: the
+  label applier and the approving reviewer must both be CODEOWNERS, and neither
+  may be the PR author.
+
+Mode is derived at evaluation time from the CODEOWNERS file, so adding a second
+owner turns separation of duties on with no code change, no config flag, and no
+migration. There is no way to select the weaker mode while a stronger one is
+available — which is the property that keeps this from becoming a permanent
+loophole.
 
 **B3. Same-repo branches only.** A fork PR's head SHA does not exist in the base
 repository, so a check run cannot bind to it and the review/label state cannot be
@@ -179,15 +226,32 @@ on a setting nobody re-checks.
   timing out, the gate denies rather than allowing. VERIFY:
   `--test-name-pattern='authorization lookup fails closed'`.
 
-- **AC6 — the author cannot authorize themselves.** Given a label applied by the
-  PR author, or an approval whose reviewer is the author, the authorizer emits
-  `failure`. Both variants needed — they are separate checks. VERIFY:
-  `node --test scripts/test/trust-root-auth.test.mjs
+- **AC6 — in multi-owner mode the author cannot authorize themselves.** With two
+  or more eligible CODEOWNERS, a label applied by the PR author, or an approval
+  whose reviewer is the author, emits `failure`. Both variants needed — they are
+  separate checks. VERIFY: `node --test scripts/test/trust-root-auth.test.mjs
   --test-name-pattern='self-authorization'` exits 0.
 
-- **AC7 — an unprivileged actor cannot authorize.** Label applied, or approval
-  given, by a user with only `read` permission → `failure`. VERIFY:
-  `--test-name-pattern='requires write permission'`.
+- **AC7 — an actor outside CODEOWNERS cannot authorize.** Label applied, or
+  approval given, by a user with `read` or even `write` permission who matches no
+  CODEOWNERS entry for the changed path → `failure`. VERIFY:
+  `--test-name-pattern='requires code ownership'`.
+
+- **AC18 — mode is derived from the eligible-owner count, and only ever
+  ratchets up.** With one eligible CODEOWNER the owner may self-authorize by
+  label and no review is required; with a second owner added to CODEOWNERS and
+  nothing else changed, the identical PR now requires a distinct applier and an
+  approving review. No flag, env var, or ticket field can select single-owner
+  mode while two or more owners are eligible — that would make the weaker mode a
+  permanent loophole. VERIFY: `node --test scripts/test/trust-root-auth.test.mjs
+  --test-name-pattern='owner-count mode'` exits 0, with a case per direction and
+  a case asserting the weaker mode is unselectable.
+
+- **AC19 — single-owner authorization is recorded as such.** The manifest entry
+  for an authorization granted in single-owner mode carries `mode: single-owner`
+  and no reviewer field, so the evidence never implies a second pair of eyes that
+  did not exist. An entry claiming a reviewer in single-owner mode is a defect.
+  VERIFY: `--test-name-pattern='single-owner evidence is honest'`.
 
 - **AC8 — the authorizer never executes PR code.** `trust-root-auth.yml`
   contains no `actions/checkout`, no `run:` step that executes anything from the
@@ -221,7 +285,7 @@ on a setting nobody re-checks.
   denies. Together these prove the check run is a cache and not the authority.
   VERIFY: `--test-name-pattern='authorization is re-derived'`.
 
-- **AC17 — CODEOWNERS exists and covers every trust root (prerequisite B0).** A
+- **AC17 — CODEOWNERS exists and covers every trust root (B0).** A
   `CODEOWNERS` file exists and every trust-root path this ceremony can authorize
   is matched by an entry; a trust root with no owner is a configuration error the
   gate reports rather than silently treating as unauthorizable. VERIFY:

--- a/.adlc/tickets.json
+++ b/.adlc/tickets.json
@@ -1353,6 +1353,27 @@
       "title": "Schema bedrock: definition-driven validator + generated JSON Schemas"
     },
     {
+      "body": "Implements .adlc/specs/trust-root-ceremony.md as the contract; closes voodootikigod/adlc#141. isCompletionAnnotationOnly (scripts/rails-guard-ci.mjs:147) bails when baseRails.length > 0, so completing a RAILED ticket — the one operation that clears rail drift — is structurally impossible on the normal path and has now been admin-merged four times (#199, #221, #227, #285). Add a CODEOWNERS-gated, revision-bound authorization the gate re-derives itself. BLOCKING constraint from premortem: a same-repo PR's GITHUB_TOKEN carries checks:write by default, so a check run named trust-root-authorized is forgeable on its own head SHA — the check run must be a cache, never the authority, and rails-guard-ci must re-query the label applier and approving reviewer and re-derive the decision. Authorization bar is CODEOWNERS (not write), same-repo branches only, fail closed on any API error. The authorizer runs on pull_request_target and must take no PR code. No signing key in PR CI (T36 rationale). UNBLOCKED: CODEOWNERS now exists covering the five trust-root paths. The coldstart gap turned out to be deeper than a missing file - this repo has ONE collaborator, and GitHub structurally forbids approving your own PR, so the original two-person rule was unsatisfiable and would have authorized nothing (a red check with no path through it, strictly worse than the admin override it replaces). Authorization strictness is now DERIVED from the eligible-CODEOWNER count: single-owner mode permits self-authorization by label with no review and records mode:single-owner so the evidence never implies a second reviewer; multi-owner mode auto-engages full separation of duties when a second owner is added, with no flag able to select the weaker mode while a stronger one is available. Solo, this ceremony buys auditability and keeps the required check green - NOT separation of duties, which is unavailable here. Acceptance is AC1-AC19 in the spec.",
+      "budget": "frontier",
+      "category": "feature",
+      "duration": 3,
+      "edges": [],
+      "id": "T60",
+      "rails": [],
+      "scope": [
+        "scripts/rails-guard-ci.mjs",
+        "scripts/test/rails-guard-ci.test.mjs",
+        "scripts/test/trust-root-auth.test.mjs",
+        ".github/workflows/trust-root-auth.yml",
+        "docs/ci/**",
+        "packages/gate-manifest/**",
+        "docs/adr/**",
+        ".adlc/specs/trust-root-ceremony.md",
+        "CODEOWNERS"
+      ],
+      "title": "Trust-root change ceremony: an authorized path CI recognizes, not an admin override"
+    },
+    {
       "body": "hollowTestWouldMutate (scripts/mutation-gate.mjs:117) decides what counts as mutable source by EXCLUDING a fixed set of non-source extensions (md|json|yml|yaml|lock|txt|toml|snap). Any path with no extension therefore falls through and is treated as source: CODEOWNERS, LICENSE, Dockerfile, Makefile, .gitignore, .nvmrc all return true. A PR touching any of them has no fast test target, so the gate falls back to the FULL suite on the slow path. Observed on PR #287: adding CODEOWNERS produced 'mutation-gate: 1 file(s) have no known fast test target - falling back to the FULL suite: CODEOWNERS'. hollow-test can only mutate JS-family source, and the gate's own workflow step already filters '*.mjs' '*.js' '*.cjs' 'packages/**' 'plugins/**' - so the script and the workflow disagree about what source is. Invert to an include-list of JS-family extensions. Verification: node --test scripts/test/mutation-gate.test.mjs. allow-suppression: none ADVERSARIAL-REVIEW (HIGH, test-integrity): the first fix narrowed to mjs|cjs|js only, which SILENTLY SKIPPED the repo's 49 tracked non-test .ts/.tsx source files — hollow-test's own filterTargetFiles accepts them, so classify() returned kind:'nothing' and the required gate exited 0 without running. That trades a false positive for a false negative, strictly the worse direction. Root cause of BOTH bugs is the same predicate duplicated in packages/hollow-test/lib/targets.mjs:10 and scripts/mutation-gate.mjs — they drifted. Fix is one exported predicate shared by both, include-listing the JS and TS families, with a cross-contract test proving the two selectors agree.",
       "budget": "mid",
       "category": "bug",
@@ -1475,6 +1496,32 @@
         "packages/ticket-sync/test/github.test.mjs"
       ],
       "title": "Push + create: write-back, idempotent create, status outcomes"
+    },
+    {
+      "body": "Implements .adlc/specs/rails-start-lifecycle.md as the contract; closes voodootikigod/adlc#159. Rails currently freeze from the moment a ticket exists: the union in scripts/rails-guard-ci.mjs skips only completed tickets (T36/#130 gave rails an END, nothing gives them a START). Two harms: a ticket cannot author its own rails (observed three narrow/re-freeze cycles building T58), and the documented workaround is to declare rails:[] (T39/T40). Add a `started` field gating the union, self-service via a narrow isStartAnnotationOnly exemption and irreversible because un-starting is already denied by assertBaseTicketContractsPreserved. BLOCKING constraint from premortem: grandfather tickets predating the field via a formatVersion bump — absent `started` must not mean never-started, or merging expires all 30 currently-frozen paths at once. Also required: decide start+complete recovery explicitly, never emit `started` at authoring, and drive the transition from P3 rather than a remembered step. Coldstart gaps folded in: packages/build-gate/** added to scope because the automatic P3 transition lives there, and the formatVersion grandfather mechanism collides with the existing 0->1 migration gate (rails-guard-ci.mjs:348,377) so the spec now prefers a per-ticket provenance signal. Acceptance is AC1-AC17 in the spec. Suppressions are denied. Backfilling started onto shipped tickets, manifest-derived start, and diff-derived start are out of scope (rationale in the spec).",
+      "budget": "frontier",
+      "category": "feature",
+      "duration": 3,
+      "edges": [
+        {
+          "contract": "T59 owns the START half of the rail lifecycle; T60 owns the authorized-ceremony mechanism. Independently grabbable — but if T59 lands first its grandfather clause must keep T60's motivating drift frozen, and if T60 lands first the union is already empty. Neither may depend on the other's merge order.",
+          "to": "T60"
+        }
+      ],
+      "id": "T59",
+      "rails": [],
+      "scope": [
+        "scripts/rails-guard-ci.mjs",
+        "scripts/test/rails-guard-ci.test.mjs",
+        "packages/tickets/**",
+        "packages/rails-guard/**",
+        "packages/build-gate/**",
+        "plugins/adlc-claude-code/hooks/adlc-hook.mjs",
+        "plugins/adlc-claude-code/test/**",
+        "docs/adr/**",
+        ".adlc/specs/rails-start-lifecycle.md"
+      ],
+      "title": "Rails START lifecycle: freeze from build-start, not from authoring"
     }
   ]
 }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,43 @@
+# Code owners for the ADLC trust roots.
+#
+# WHAT THIS FILE IS FOR. These paths are the trust roots: the gate that enforces
+# rails, the CI definition that runs it, the fixture that pins that definition's
+# integrity, and the ticket store the gate reads its rail set from. A change to
+# any of them can disable rail enforcement for every other change, which is why
+# `rails-guard-ci.mjs` denies its own modification and why landing a legitimate
+# change to one currently requires an admin override of a red required check
+# (issue #141, ticket T60).
+#
+# This file names who is authorized to approve such a change. It documents the
+# trust surface whether or not the T60 ceremony is built — an unowned trust root
+# is a gap regardless of what enforces ownership.
+#
+# SINGLE-OWNER REPOSITORY. There is exactly one eligible owner today. Two
+# consequences worth stating plainly, so nobody later mistakes this file for a
+# separation-of-duties control:
+#
+#   1. GitHub structurally forbids approving your own pull request. Any rule
+#      requiring "an approval from someone other than the author" is therefore
+#      unsatisfiable here — not disabled by policy, impossible.
+#   2. Separation of duties is consequently NOT available on this repository. The
+#      T60 ceremony buys auditability (revision-bound, recorded, narrowly scoped)
+#      and keeps the required check green so operators are not trained to
+#      override red gates. It does not buy a second pair of eyes.
+#
+# Adding a second owner below is what turns separation of duties on: T60 derives
+# its mode from the number of eligible owners for the changed path, so the
+# stricter rule engages automatically with no code change and no migration.
+
+# The rail gate itself, and the tests that hold it honest.
+/scripts/rails-guard-ci.mjs                        @voodootikigod
+/scripts/test/rails-guard-ci.test.mjs              @voodootikigod
+
+# The CI definition that runs the gate, and the fixture pinning its integrity.
+# A PR can rewrite workflow files it ships, so the hash fixture is what makes
+# the definition tamper-evident; the two must be owned together.
+/docs/ci/rails-guard.yml                           @voodootikigod
+/scripts/test/rails-guard-workflow-hashes.json     @voodootikigod
+
+# The ticket store. The gate reads its rail set from the BASE version of this
+# file, so a change here changes what is enforced everywhere.
+/.adlc/tickets.json                                @voodootikigod


### PR DESCRIPTION
Shaping only — two specs and two tickets, no implementation. Closes nothing yet; T59 and T60 carry the work.

## Why these are one PR

They are the two ends of the same lifecycle, and neither is coherent alone.

- **#159 — the START side.** Rails freeze from the moment a ticket exists. T36 (#130) gave rails an END; nothing gives them a beginning.
- **#141 — the mechanism that makes the drift unclearable.** `isCompletionAnnotationOnly` (rails-guard-ci.mjs:147) bails on `baseRails.length > 0`, so completing a *railed* ticket — the one operation that clears rail drift — cannot land on the normal path.

Together: rails accumulate from authoring, and can only be cleared by overriding a red required check. Friction on clearing drift is structurally higher than friction on creating it, so the union ratchets upward.

**The measurement that makes this concrete.** The active rail union on `main` at 1.6.0 is **30 paths, and all 30 belong to tickets that already shipped** (the twelve in #285). Not one frozen path corresponds to a build in flight. That is not an accident — it is the steady state this design produces.

## Correction to #159

Its Relationship section cites #141 as the completion side. That is stale: completion shipped as **T36 / #130**. #141 is the mechanism problem, not the lifecycle mirror. Worth fixing on the issue.

## Gates run, findings folded back in

| Gate | Result |
|---|---|
| `spec-lint` | 34/34 acceptance criteria verified, 0 wishes |
| `premortem` (`--prompt-only`) | 7 findings, **2 blocking** |
| `coldstart` (`--prompt-only`) | 3 gaps, **1 blocking** |

Findings were folded into the specs, not appended as caveats.

### Blocking — premortem

**Shipping #159 before #285 silently expires all 30 frozen paths at once.** A mass unfreeze arriving as a side effect of a lifecycle change rather than a reviewed ceremony, quietly mooting #285. Absent `started` must therefore *not* mean "never started" for pre-existing tickets. The grandfather clause is required regardless of merge order — correctness must not depend on it.

**A `trust-root-authorized` check run is forgeable.** This was my first design, and it is wrong: a same-repo PR's `GITHUB_TOKEN` carries `checks: write` by default, so a PR can create a check run with that exact name on its own head SHA and authorize itself. A check-run name is not an authorization; it is a string any writer can produce. The check run is now explicitly **a cache, never the authority** — `rails-guard-ci.mjs` re-queries the label applier and approving reviewer and re-derives the decision.

### Blocking — coldstart

**This repo has no CODEOWNERS file** (`ls CODEOWNERS .github/CODEOWNERS` → nothing), so #141's authorization bar is unimplementable until one exists. Authoring it declares *who may approve trust-root changes* — a governance decision for you, not something a build agent can infer. Recorded as a blocking input on T60, and **the one thing I need from you before T60 can start.**

### Other findings folded in

- Build step 7 (automatic P3 transition) was a requirement with **no acceptance criterion** — it would have shipped the flag while leaving it a remembered step. Now AC16, and `packages/build-gate/**` added to T59's scope, since that is where the transition lives.
- The prescribed `formatVersion` bump **collides with existing code**: rails-guard-ci.mjs:348 hardcodes `base===0 && head===1` and :377 denies any other version change, so bumping to `2` would deny every PR. Now AC17, and the spec prefers a per-ticket provenance signal so store version keeps meaning "layout", not "policy epoch".
- Authorization bar tightened from `write` to CODEOWNERS (write covers every contributor with push access).
- Fork PRs refused explicitly — a fork's head SHA does not exist in the base repo, so nothing can bind to it.
- Start+complete recovery in one PR matches *neither* narrow exemption. Left as a decided choice with an AC either way; the failure mode was it being undefined.

## The security argument for `started` (the crux of T59)

`started: true` only ever **adds** freeze, so granting it takes privilege away from the setter — an ordinary PR may set it. Un-starting is already denied by `assertBaseTicketContractsPreserved`, so the transition is one-way for free. And no new unfreeze privilege is created: the union only shrinks for tickets that never started, and a never-started ticket is *exactly equivalent to today's `rails: []`*, which any author may already write. The floor is unchanged.

Note the deliberate asymmetry with completion: `isCompletionAnnotationOnly` bails on railed tickets because completing one *unfreezes*. Starting one *freezes*, so the railed case is precisely the case that must be allowed. Getting this backwards inverts the security property.

## Test plan

- [x] `adlc spec-lint` both specs — 34/34 verified, 0 wishes
- [x] `adlc premortem --prompt-only` both — findings folded in
- [x] `adlc coldstart --prompt-only` T59/T60 — gaps folded in
- [x] `adlc ticket create/update` — T59, T60 authored; scope-widening authorized and recorded
- [ ] Implementation lands under T59 and T60 separately
- [ ] **Blocked on you:** CODEOWNERS ownership decision before T60 starts