### PR TITLE
tokenomics: cut prosecute-run duplication, plugin footprint, and coldstart caching (Phase 2)

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -92,6 +92,41 @@ logic is unit-tested at `plugins/adlc-claude-code/lib/prosecutor.mjs`
 complementary: `prosecutor` supplies mechanical evidence, `/adlc:adlc-prosecute`
 supplies independent model judgment with cross-lens verification.
 
+**Context hygiene of the lens agents** (issue #276): each of the five
+`agents/prosecutor-{correctness,security,contract,diff,tests}.md` files
+declares only what makes it different — its lens focus. The refute charter,
+output schema, and tool-access constraints those five (plus the verifier)
+share are defined once, in `commands/adlc-prosecute.md` step 1, and included
+in every Task prompt from there, rather than duplicated in each agent file.
+This is a maintainability property (one place to update the schema) more than
+a runtime token saving — fresh-context subagents (E4) still each need the
+full contract, whether it arrives via their fixed system prompt or the
+per-call task prompt; moving it doesn't eliminate it, it just stops five
+files from drifting independently.
+
+Similarly, the trust-root tier explanation (when a same-model P5 pass isn't
+enough — cross-model gating, ADR-0007/T39) is canonical in
+`skills/adlc/references/trust-root.md`, loaded on demand. `agents/prosecutor.md`
+points there instead of restating it. `skills/adlc/SKILL.md` keeps its own full
+copy: that file is generated from a template shared across all six harness
+ports (`scripts/router/router-model.mjs`), so it can't assume a
+claude-code-only `references/` file exists — the other five harnesses have no
+such directory. Progressive-disclosure restructuring of SKILL.md's body itself
+(splitting per-phase detail into `references/p0-p7.md`-style files) would need
+to happen at that generator layer to stay in sync across all six harnesses,
+and is deliberately out of scope here (see issue #277) rather than attempted
+as a same-session, higher-risk change.
+
+Six of the seven prosecution agents (`prosecutor-{correctness,security,contract,
+diff,tests,verifier}`) carry a one-line `description` in their frontmatter
+("P5 … lens subagent; invoked by /adlc:adlc-prosecute — do not invoke
+directly.") rather than the fuller prose the same field had before — they are
+only ever invoked programmatically, by exact name, from `/adlc:adlc-prosecute`,
+never model-selected by description matching, so a longer description was pure
+always-loaded-session cost with no discovery benefit. `prosecutor` (the
+user-facing one, model-selected by intent — "prosecute this", "is this safe to
+merge") keeps its full descriptive text.
+
 ### Hooks (automatic)
 
 | Hook | Event | Behavior |

--- a/docs/ticket-store-threat-model.md
+++ b/docs/ticket-store-threat-model.md
@@ -35,6 +35,18 @@ Threats and defenses:
   representation.
 - Legacy and directory backends coexist to create split-brain state. Detection requires
   exactly one active backend; both-present and incomplete-journal states fail closed.
+- A stale or fabricated coldstart cache entry suppresses a real P2 audit. Cache lookups
+  (`packages/coldstart/lib/cache.mjs`) bind to `ticketHash` (the same domain-separated hash
+  this store computes) AND the resolved model id — a hit requires an exact content+model
+  match, so editing a ticket or switching `ADLC_MODEL_CHEAP` is itself sufficient to
+  invalidate a stale entry; there is no separate expiry mechanism to bypass for that case.
+  Entries deliberately do NOT bind to `storeHash`: a coldstart verdict is a property of one
+  ticket's own content, not of the store as a whole, so an unrelated ticket's addition must
+  not invalidate an already-computed executability result. Residual risk: an attacker with
+  write access to `.adlc/manifest.jsonl` could inject a fabricated PASS entry with a matching
+  hash+model to suppress a real gap — this is the same tamper surface every unsigned manifest
+  entry carries, closed the same way (HMAC signing via `ADLC_MANIFEST_KEY`), with `--force`
+  and `--max-age 0` as an operator escape hatch when a cache entry is suspect.
 
 Residual risks are explicit: same-shard Git conflicts remain real; filesystem writes are
 recoverable rather than truly atomic; out-of-band shell mutation is ultimately caught by

--- a/docs/tools/coldstart.md
+++ b/docs/tools/coldstart.md
@@ -42,8 +42,20 @@ coldstart --all     [options]
 |------|---------|-------------|
 | `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file |
 | `--all` | off | Run the gate on every ticket in the file |
+| `--force` | off | Bypass the cache entirely and re-audit every target ticket |
+| `--max-age <days>` | `30` | Treat a cached verdict older than this as stale; `0` treats every cache entry as stale |
 | `--prompt-only` | off | Print the exact prompt(s) and exit 0 — no LLM call made |
 | `--json` | off | Machine-readable JSON output for orchestrators |
+
+### Caching
+
+A real (non-`--prompt-only`) audit records `{ticketHash, model, gaps}` into
+`.adlc/manifest.jsonl`. A later run for the SAME ticket skips the LLM call
+when it finds a matching entry: same content hash AND same *resolved* model
+id — switching `ADLC_MODEL_CHEAP` invalidates the cache even though `--tier`
+stays the same. `--force` bypasses the cache; `--max-age <days>` (default 30)
+bounds how old a cache entry may be before it's treated as stale. Caching
+never applies to `--prompt-only` or the `ADLC_GATE_MOCK_RESPONSE` test seam.
 
 ---
 

--- a/packages/coldstart/README.md
+++ b/packages/coldstart/README.md
@@ -23,6 +23,8 @@ coldstart --all     [options]
 |------|---------|-------------|
 | `--tickets <path>` | `.adlc/tickets.json` | Path to the tickets file |
 | `--all` | off | Run the gate on every ticket in the file |
+| `--force` | off | Bypass the cache entirely and re-audit every target ticket |
+| `--max-age <days>` | `30` | Treat a cached verdict older than this as stale; `0` treats every cache entry as stale |
 | `--prompt-only` | off | Print the exact prompt(s) and exit 0 — no LLM call made |
 | `--record-verdict <file\|->` | — | With `--prompt-only`: read the operator's answer from `<file>` (or stdin when `-`) and record it into `.adlc/manifest.jsonl` via `gate-manifest` — see below |
 | `--json` | off | Machine-readable JSON output for orchestrators |
@@ -54,6 +56,38 @@ coldstart T1 --prompt-only
 # Use a custom tickets file
 coldstart T3 --tickets path/to/tickets.json
 ```
+
+---
+
+## Caching
+
+A real (non-`--prompt-only`) audit records `{ticketHash, model, gaps}` into
+`.adlc/manifest.jsonl` after it runs. The NEXT run, for the SAME ticket, skips
+the LLM call entirely when it finds a matching entry: same `ticketHash` (the
+ticket's content is unchanged — editing anything about it produces a
+different hash) and same *resolved* model id (not just the same `--tier` —
+switching `ADLC_MODEL_CHEAP` invalidates the cache even though `--tier cheap`
+stays the same flag). A cached run reports `"cached": true` in `--json`
+output and `(cached)` in the human-readable report.
+
+```sh
+# First run audits for real and records the verdict
+coldstart --all
+
+# Second run, nothing changed: instant, no LLM calls
+coldstart --all
+
+# Force a fresh audit regardless of any cache entry
+coldstart --all --force
+
+# Don't trust anything cached more than a week ago
+coldstart --all --max-age 7
+```
+
+Caching only applies to the real LLM path — `--prompt-only` (with or without
+`--record-verdict`) is unaffected, and the `ADLC_GATE_MOCK_RESPONSE` test
+seam never reads or writes the cache (a mocked verdict must never be able to
+shadow, or be shadowed by, a real one).
 
 ---
 

--- a/packages/coldstart/bin/coldstart.mjs
+++ b/packages/coldstart/bin/coldstart.mjs
@@ -12,16 +12,18 @@ import {
 } from '@adlc/core';
 
 import { buildPrompt, SYSTEM_PROMPT } from '../lib/prompt.mjs';
-import { checkAll, aggregateCheckAllUsage } from '../lib/gate.mjs';
+import { checkAll, resolveExpectedModel } from '../lib/gate.mjs';
+import { buildCacheData } from '../lib/cache.mjs';
 import { renderReport, buildJsonOutput, allPass } from '../lib/report.mjs';
 import { activeTickets } from '../lib/active-tickets.mjs';
+import { ticketHash } from '@adlc/tickets';
 // lib/verdict.mjs (and the @adlc/gate-manifest package it pulls in) is
 // imported lazily, only when --record-verdict is actually used — see below —
 // so plain --prompt-only runs never pay for or depend on it. The real
 // (non-prompt-only) path below also imports gate-manifest lazily, for the
 // same reason: only pay for it on the path that has something to record.
 
-const USAGE = 'usage: coldstart <ticket-id> [--tickets path] [--all] [--tier cheap|mid|frontier] [--prompt-only] [--record-verdict <file|->] [--json]';
+const USAGE = 'usage: coldstart <ticket-id> [--tickets path] [--all] [--tier cheap|mid|frontier] [--force] [--max-age <days>] [--prompt-only] [--record-verdict <file|->] [--json]';
 
 const { values, positionals } = parseArgs({
   usage: USAGE,
@@ -29,6 +31,8 @@ const { values, positionals } = parseArgs({
     tickets: { type: 'string', default: '.adlc/tickets.json' },
     all: { type: 'boolean', default: false },
     tier: { type: 'string', default: 'cheap' },
+    force: { type: 'boolean', default: false },
+    'max-age': { type: 'string', default: '30' },
     'prompt-only': { type: 'boolean', default: false },
     'record-verdict': { type: 'string' },
     json: { type: 'boolean', default: false },
@@ -44,11 +48,22 @@ if (values['record-verdict'] !== undefined && !values['prompt-only']) {
   opError('--record-verdict requires --prompt-only');
 }
 
+const maxAgeDays = Number(values['max-age']);
+if (!Number.isFinite(maxAgeDays) || maxAgeDays < 0) {
+  opError(`--max-age must be a non-negative number of days, got: ${values['max-age']}`);
+}
+// 0 means "treat every cache entry as stale" (issue #278), not "no limit" —
+// distinguish that from the sentinel `null` findCachedVerdict/checkAll use
+// for "no age limit", which nothing here ever produces (a numeric flag with
+// a numeric default always yields a finite ms value, never null).
+const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+
 const promptOnlyMode = values['prompt-only'];
 const jsonMode = values['json'];
 const ticketsPath = values['tickets'];
 const runAll = values['all'];
 const tier = values['tier'];
+const force = values['force'];
 
 // ── Load tickets ─────────────────────────────────────────────────────────────
 
@@ -127,29 +142,35 @@ if (!provider) {
 }
 
 // ── Execute gate ─────────────────────────────────────────────────────────────
+// Content-addressed caching (issue #278): a ticket whose hash matches a
+// prior gate-manifest entry for the SAME resolved model, recorded within
+// --max-age days, is served from that entry — no LLM call. --force bypasses.
 
 let results;
 try {
-  results = await checkAll(targets, tier);
+  results = await checkAll(targets, tier, { force, maxAgeMs, dir: undefined });
 } catch (err) {
   opError(`LLM call failed: ${err.message}`);
 }
 
-// ── Record usage evidence (issue #272) ───────────────────────────────────────
-// One aggregate entry per invocation (not per ticket) — a coldstart run over
-// --all is one gate execution with N model calls, not N gate executions.
-// Silently skipped when no result reported usage (agy provider, or the
-// ADLC_GATE_MOCK_RESPONSE test seam) — never a fabricated/zeroed entry.
+// ── Record usage + cache evidence (issues #272, #278) ───────────────────────
+// One gate-manifest entry PER TICKET actually audited — a cache HIT reuses
+// prior evidence rather than manufacturing a duplicate entry for the same
+// verification, and a cache hit is what makes a later run's lookup possible
+// in the first place, so recording must be per-ticket, not aggregated across
+// the whole --all run the way the pre-#278 design did.
 
-const usage = aggregateCheckAllUsage(results);
-if (usage) {
+const auditedResults = results.filter((r) => !r.cached && !r.mocked);
+if (auditedResults.length > 0) {
   const { record } = await import('@adlc/gate-manifest/lib/record.mjs');
-  const ticket = runAll ? undefined : targets[0].id;
-  record({
-    gate: 'coldstart',
-    ticket,
-    rawData: JSON.stringify({ usage, ticketIds: targets.map((t) => t.id), tier }),
-  });
+  const model = resolveExpectedModel(tier);
+  for (const result of auditedResults) {
+    const ticket = targets.find((t) => t.id === result.id);
+    const data = { tier };
+    if (model) data.cache = buildCacheData({ ticketHash: ticketHash(ticket), model, gaps: result.gaps });
+    if (result.usage) data.usage = result.usage;
+    record({ gate: 'coldstart', ticket: result.id, rawData: JSON.stringify(data) });
+  }
 }
 
 // ── Output ───────────────────────────────────────────────────────────────────

--- a/packages/coldstart/bin/coldstart.mjs
+++ b/packages/coldstart/bin/coldstart.mjs
@@ -13,11 +13,10 @@ import {
 
 import { buildPrompt, SYSTEM_PROMPT } from '../lib/prompt.mjs';
 import { checkAll, resolveExpectedModel } from '../lib/gate.mjs';
-import { buildCacheData } from '../lib/cache.mjs';
+import { buildRecordPlan } from '../lib/cache.mjs';
 import { renderReport, buildJsonOutput, allPass } from '../lib/report.mjs';
 import { activeTickets } from '../lib/active-tickets.mjs';
 import { USAGE, OPTIONS, parseMaxAgeDays } from '../lib/cli-options.mjs';
-import { ticketHash } from '@adlc/tickets';
 // lib/verdict.mjs (and the @adlc/gate-manifest package it pulls in) is
 // imported lazily, only when --record-verdict is actually used — see below —
 // so plain --prompt-only runs never pay for or depend on it. The real
@@ -141,20 +140,14 @@ try {
 // prior evidence rather than manufacturing a duplicate entry for the same
 // verification, and a cache hit is what makes a later run's lookup possible
 // in the first place, so recording must be per-ticket, not aggregated across
-// the whole --all run the way the pre-#278 design did.
+// the whole --all run the way the pre-#278 design did. buildRecordPlan
+// returns [] when there's nothing to record (every result cached/mocked);
+// looping over that is already a no-op, so there is no separate "is there
+// anything to record?" branch here to leave untested.
 
-const auditedResults = results.filter((r) => !r.cached && !r.mocked);
-if (auditedResults.length > 0) {
-  const { record } = await import('@adlc/gate-manifest/lib/record.mjs');
-  const model = resolveExpectedModel(tier);
-  for (const result of auditedResults) {
-    const ticket = targets.find((t) => t.id === result.id);
-    const data = { tier };
-    if (model) data.cache = buildCacheData({ ticketHash: ticketHash(ticket), model, gaps: result.gaps });
-    if (result.usage) data.usage = result.usage;
-    record({ gate: 'coldstart', ticket: result.id, rawData: JSON.stringify(data) });
-  }
-}
+const { record } = await import('@adlc/gate-manifest/lib/record.mjs');
+const recordPlan = buildRecordPlan(results, targets, { model: resolveExpectedModel(tier), tier });
+for (const entry of recordPlan) record(entry);
 
 // ── Output ───────────────────────────────────────────────────────────────────
 

--- a/packages/coldstart/bin/coldstart.mjs
+++ b/packages/coldstart/bin/coldstart.mjs
@@ -16,7 +16,7 @@ import { checkAll, resolveExpectedModel } from '../lib/gate.mjs';
 import { buildCacheData } from '../lib/cache.mjs';
 import { renderReport, buildJsonOutput, allPass } from '../lib/report.mjs';
 import { activeTickets } from '../lib/active-tickets.mjs';
-import { USAGE, OPTIONS } from '../lib/cli-options.mjs';
+import { USAGE, OPTIONS, parseMaxAgeDays } from '../lib/cli-options.mjs';
 import { ticketHash } from '@adlc/tickets';
 // lib/verdict.mjs (and the @adlc/gate-manifest package it pulls in) is
 // imported lazily, only when --record-verdict is actually used — see below —
@@ -35,15 +35,11 @@ if (values['record-verdict'] !== undefined && !values['prompt-only']) {
   opError('--record-verdict requires --prompt-only');
 }
 
-const maxAgeDays = Number(values['max-age']);
-if (!Number.isFinite(maxAgeDays) || maxAgeDays < 0) {
-  opError(`--max-age must be a non-negative number of days, got: ${values['max-age']}`);
+const maxAgeResult = parseMaxAgeDays(values['max-age']);
+if (!maxAgeResult.ok) {
+  opError(maxAgeResult.error);
 }
-// 0 means "treat every cache entry as stale" (issue #278), not "no limit" —
-// distinguish that from the sentinel `null` findCachedVerdict/checkAll use
-// for "no age limit", which nothing here ever produces (a numeric flag with
-// a numeric default always yields a finite ms value, never null).
-const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+const maxAgeMs = maxAgeResult.maxAgeMs;
 
 const promptOnlyMode = values['prompt-only'];
 const jsonMode = values['json'];

--- a/packages/coldstart/bin/coldstart.mjs
+++ b/packages/coldstart/bin/coldstart.mjs
@@ -16,6 +16,7 @@ import { checkAll, resolveExpectedModel } from '../lib/gate.mjs';
 import { buildCacheData } from '../lib/cache.mjs';
 import { renderReport, buildJsonOutput, allPass } from '../lib/report.mjs';
 import { activeTickets } from '../lib/active-tickets.mjs';
+import { USAGE, OPTIONS } from '../lib/cli-options.mjs';
 import { ticketHash } from '@adlc/tickets';
 // lib/verdict.mjs (and the @adlc/gate-manifest package it pulls in) is
 // imported lazily, only when --record-verdict is actually used — see below —
@@ -23,21 +24,7 @@ import { ticketHash } from '@adlc/tickets';
 // (non-prompt-only) path below also imports gate-manifest lazily, for the
 // same reason: only pay for it on the path that has something to record.
 
-const USAGE = 'usage: coldstart <ticket-id> [--tickets path] [--all] [--tier cheap|mid|frontier] [--force] [--max-age <days>] [--prompt-only] [--record-verdict <file|->] [--json]';
-
-const { values, positionals } = parseArgs({
-  usage: USAGE,
-  options: {
-    tickets: { type: 'string', default: '.adlc/tickets.json' },
-    all: { type: 'boolean', default: false },
-    tier: { type: 'string', default: 'cheap' },
-    force: { type: 'boolean', default: false },
-    'max-age': { type: 'string', default: '30' },
-    'prompt-only': { type: 'boolean', default: false },
-    'record-verdict': { type: 'string' },
-    json: { type: 'boolean', default: false },
-  },
-});
+const { values, positionals } = parseArgs({ usage: USAGE, options: OPTIONS });
 
 const VALID_TIERS = ['cheap', 'mid', 'frontier'];
 if (!VALID_TIERS.includes(values.tier)) {

--- a/packages/coldstart/lib/cache.mjs
+++ b/packages/coldstart/lib/cache.mjs
@@ -6,6 +6,8 @@
 // fixture arrays, no real gate-manifest I/O); gate.mjs wires it to the real
 // ledger and to ticketHash().
 
+import { ticketHash as computeTicketHash } from '@adlc/tickets';
+
 export const GATE_NAME = 'coldstart';
 
 /**
@@ -52,4 +54,33 @@ export function findCachedVerdict(entries, { ticketHash, model, maxAgeMs = null,
     return { gaps: Array.isArray(cache.gaps) ? cache.gaps : [] };
   }
   return null;
+}
+
+/**
+ * Build the list of gate-manifest record() calls a coldstart run should
+ * make: one per ticket that was actually audited this run — never for a
+ * cache hit (it reuses prior evidence, recording again would just duplicate
+ * it) and never for the ADLC_GATE_MOCK_RESPONSE test seam (`mocked: true` —
+ * no real call was made, nothing real to report). Returns `[]` when there
+ * is nothing to record, which the caller can iterate directly with no
+ * separate "is there anything to record?" branch to test.
+ *
+ * @param {Array<{id:string, gaps:object[], usage:object|null, cached?:boolean, mocked?:boolean}>} results
+ * @param {object[]} targets - the ticket objects checkAll was run against, same order/ids as results
+ * @param {object} opts
+ * @param {string|null} opts.model - resolveExpectedModel's output; null means no provider was configured, so no cache data can be keyed
+ * @param {string} opts.tier
+ * @returns {Array<{gate:string, ticket:string, rawData:string}>}
+ */
+export function buildRecordPlan(results, targets, { model, tier }) {
+  const targetsById = new Map(targets.map((t) => [t.id, t]));
+  return results
+    .filter((r) => !r.cached && !r.mocked)
+    .map((result) => {
+      const ticket = targetsById.get(result.id);
+      const data = { tier };
+      if (model) data.cache = buildCacheData({ ticketHash: computeTicketHash(ticket), model, gaps: result.gaps });
+      if (result.usage) data.usage = result.usage;
+      return { gate: GATE_NAME, ticket: result.id, rawData: JSON.stringify(data) };
+    });
 }

--- a/packages/coldstart/lib/cache.mjs
+++ b/packages/coldstart/lib/cache.mjs
@@ -1,0 +1,55 @@
+// cache.mjs — content-addressed gate-result cache (issue #278).
+//
+// ADLC Principle 10: "every artifact the next agent reads is a cache" — a
+// coldstart PASS/FAIL for a given ticket-hash is valid exactly as long as
+// that hash is unchanged. Pure lookup logic lives here (testable with plain
+// fixture arrays, no real gate-manifest I/O); gate.mjs wires it to the real
+// ledger and to ticketHash().
+
+export const GATE_NAME = 'coldstart';
+
+/**
+ * Build the `data.cache` shape recorded into a gate-manifest entry for one
+ * audited ticket.
+ *
+ * @param {object} opts
+ * @param {string} opts.ticketHash
+ * @param {string} opts.model - resolved model id, not the abstract tier
+ * @param {object[]} opts.gaps
+ * @returns {{ticketHash:string, model:string, gaps:object[]}}
+ */
+export function buildCacheData({ ticketHash, model, gaps }) {
+  return { ticketHash, model, gaps: gaps ?? [] };
+}
+
+/**
+ * Find the most recent cached coldstart verdict matching `ticketHash` +
+ * `model` among manifest entries already scoped to one ticket (the caller
+ * filters by `ticket` when loading — see gate.mjs's loadCacheEntriesFn).
+ *
+ * Walks newest-first so a later re-audit (e.g. after `--force`) shadows an
+ * older entry for the same hash+model rather than the lookup depending on
+ * array order elsewhere.
+ *
+ * @param {object[]} entries - manifest entries (as returned by gate-manifest's loadFiltered)
+ * @param {object} opts
+ * @param {string} opts.ticketHash
+ * @param {string} opts.model
+ * @param {number|null} [opts.maxAgeMs] - null = no age limit
+ * @param {number} [opts.now] - ms since epoch; defaults to Date.now()
+ * @returns {{gaps:object[]}|null}
+ */
+export function findCachedVerdict(entries, { ticketHash, model, maxAgeMs = null, now = Date.now() } = {}) {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.gate !== GATE_NAME) continue;
+    const cache = entry.data?.cache;
+    if (!cache || cache.ticketHash !== ticketHash || cache.model !== model) continue;
+    if (maxAgeMs != null) {
+      const ageMs = now - Date.parse(entry.ts);
+      if (!Number.isFinite(ageMs) || ageMs > maxAgeMs) continue;
+    }
+    return { gaps: Array.isArray(cache.gaps) ? cache.gaps : [] };
+  }
+  return null;
+}

--- a/packages/coldstart/lib/cli-options.mjs
+++ b/packages/coldstart/lib/cli-options.mjs
@@ -1,0 +1,18 @@
+// cli-options.mjs — the coldstart CLI's usage string and parseArgs option
+// config, extracted from bin/coldstart.mjs so their DEFAULT VALUES are
+// directly unit-testable (the bin itself is not importable — it runs on
+// load). This is what a mutation gate exercises against: flip `force`'s
+// default to true and a test importing this file must fail.
+
+export const USAGE = 'usage: coldstart <ticket-id> [--tickets path] [--all] [--tier cheap|mid|frontier] [--force] [--max-age <days>] [--prompt-only] [--record-verdict <file|->] [--json]';
+
+export const OPTIONS = {
+  tickets: { type: 'string', default: '.adlc/tickets.json' },
+  all: { type: 'boolean', default: false },
+  tier: { type: 'string', default: 'cheap' },
+  force: { type: 'boolean', default: false },
+  'max-age': { type: 'string', default: '30' },
+  'prompt-only': { type: 'boolean', default: false },
+  'record-verdict': { type: 'string' },
+  json: { type: 'boolean', default: false },
+};

--- a/packages/coldstart/lib/cli-options.mjs
+++ b/packages/coldstart/lib/cli-options.mjs
@@ -16,3 +16,21 @@ export const OPTIONS = {
   'record-verdict': { type: 'string' },
   json: { type: 'boolean', default: false },
 };
+
+/**
+ * Validate and convert the `--max-age` flag (days) to milliseconds.
+ * 0 is valid and means "treat every cache entry as stale" (issue #278) — a
+ * DIFFERENT thing than the `null` sentinel checkAll/findCachedVerdict use
+ * for "no age limit"; this function never returns null, only a finite ms
+ * value or an error.
+ *
+ * @param {string} raw - the raw --max-age flag value
+ * @returns {{ok: true, maxAgeMs: number} | {ok: false, error: string}}
+ */
+export function parseMaxAgeDays(raw) {
+  const days = Number(raw);
+  if (!Number.isFinite(days) || days < 0) {
+    return { ok: false, error: `--max-age must be a non-negative number of days, got: ${raw}` };
+  }
+  return { ok: true, maxAgeMs: days * 24 * 60 * 60 * 1000 };
+}

--- a/packages/coldstart/lib/gate.mjs
+++ b/packages/coldstart/lib/gate.mjs
@@ -1,8 +1,11 @@
 // Orchestration logic for the coldstart gate.
 // Calls the LLM (or returns prompt for --prompt-only), parses results.
 
-import { complete as coreComplete, extractJson as coreExtractJson } from '@adlc/core';
+import { complete as coreComplete, extractJson as coreExtractJson, detectProvider, resolveModel } from '@adlc/core';
+import { ticketHash } from '@adlc/tickets';
+import { loadFiltered } from '@adlc/gate-manifest/lib/show.mjs';
 import { buildPrompt, SYSTEM_PROMPT } from './prompt.mjs';
+import { findCachedVerdict } from './cache.mjs';
 
 /**
  * Build a checkTicket function bound to specific complete/extractJson
@@ -57,26 +60,102 @@ export async function checkTicket(ticket, tier = 'cheap') {
       // Ignored: fallback to {}
     }
     const gaps = Array.isArray(parsed?.gaps) ? parsed.gaps : [];
-    // No real LLM call was made — nothing to report (never fabricate usage).
-    return { id: ticket.id, gaps, usage: null };
+    // No real LLM call was made — nothing to report (never fabricate usage),
+    // and `mocked: true` tells the caller never to cache this result either
+    // (issue #278): a mocked verdict must not be able to shadow, or later
+    // BE shadowed by, a real audit of the same ticket content.
+    return { id: ticket.id, gaps, usage: null, mocked: true };
   }
   return buildCheckTicket(coreComplete, coreExtractJson, tier)(ticket);
 }
 
 /**
- * Run cold-start checks for every ticket in the array.
- * Returns an array of { id, gaps, usage } in the same order. `usage` is
- * `{inputTokens, outputTokens, cachedTokens, provider, model, tier}` when
- * the provider reported it, else null (mock/agy paths, or a provider that
- * didn't return a usage block).
- * Throws on the first LLM error (fail-fast for operational errors).
+ * Resolve the model id that a real (non-mock) checkTicket call for this tier
+ * would use, WITHOUT making an LLM call — the same resolution complete()
+ * does internally (detectProvider + resolveModel), surfaced so the cache
+ * layer can key on it and so a recorded verdict can be looked up again
+ * later. Returns null when no provider is configured (mirrors complete()'s
+ * own fail path — with no provider there's nothing to key a cache on, and
+ * checkTicket will throw its own clear error when actually called).
+ *
+ * @param {string} tier
+ * @param {object} [env]
+ * @returns {string|null}
  */
-export async function checkAll(tickets, tier = 'cheap') {
+export function resolveExpectedModel(tier, env = process.env) {
+  const provider = detectProvider(env);
+  if (!provider) return null;
+  return resolveModel(provider, { tier }, env);
+}
+
+/**
+ * Run cold-start checks for every ticket in the array.
+ * Returns an array of { id, gaps, usage, cached } in the same order. `usage`
+ * is `{inputTokens, outputTokens, cachedTokens, provider, model, tier}` when
+ * the provider reported it, else null (mock/agy paths, cache hits, or a
+ * provider that didn't return a usage block). `cached: true` means the
+ * verdict was reused from a prior gate-manifest entry, not freshly audited.
+ * Throws on the first LLM error (fail-fast for operational errors).
+ *
+ * Content-addressed caching (issue #278): a ticket whose content hash
+ * (`ticketHash` — the same domain-separated hash `@adlc/tickets` uses for
+ * store binding, so a coldstart cache entry and a ticket-store snapshot
+ * agree on what "unchanged" means) matches a prior gate-manifest entry for
+ * the SAME resolved model skips the LLM call entirely and reuses that
+ * entry's gaps. Caching is keyed on the RESOLVED model id, not the abstract
+ * tier — switching `ADLC_MODEL_CHEAP` changes what "cheap" resolves to, and
+ * a cache entry from the old model must not silently cover the new one.
+ *
+ * @param {object[]} tickets
+ * @param {string} [tier]
+ * @param {object} [opts]
+ * @param {boolean} [opts.force] - skip the cache entirely, re-audit everything
+ * @param {number|null} [opts.maxAgeMs] - cache entries older than this are treated as stale; null = no age limit
+ * @param {number} [opts.now] - injectable clock (ms since epoch) for tests
+ * @param {string} [opts.dir] - gate-manifest ledger directory, default ADLC_DIR
+ * @param {Function} [opts.checkTicketFn] - injectable (ticket) => Promise<{id,gaps,usage}>, default checkTicket bound to `tier`
+ * @param {Function} [opts.loadCacheEntriesFn] - injectable (ticketId) => manifest entries[], default reads the real gate-manifest ledger
+ * @param {Function} [opts.resolveModelFn] - injectable () => string|null, default resolveExpectedModel(tier)
+ */
+export async function checkAll(tickets, tier = 'cheap', opts = {}) {
+  const {
+    force = false,
+    maxAgeMs = null,
+    now = Date.now(),
+    dir,
+    checkTicketFn = (ticket) => checkTicket(ticket, tier),
+    loadCacheEntriesFn = (ticketId) => defaultLoadCacheEntries(ticketId, dir),
+    resolveModelFn = () => resolveExpectedModel(tier),
+  } = opts;
+
+  // The ADLC_GATE_MOCK_RESPONSE test seam (checkTicket, above) exists to make
+  // the CLI's output/exit-code paths deterministic and network-free — a
+  // cache hit silently overriding that would make mock-driven tests
+  // order-dependent on whatever a PRIOR real audit happened to cache for the
+  // same ticket content. Caching is a real-execution optimization; defer to
+  // the mock seam rather than compete with it.
+  const mockSeamActive = process.env.ADLC_GATE_MOCK_RESPONSE !== undefined && process.env.NODE_ENV === 'test';
+  const model = (force || mockSeamActive) ? null : resolveModelFn();
+
   const results = [];
   for (const ticket of tickets) {
-    results.push(await checkTicket(ticket, tier));
+    if (!force && model) {
+      const hash = ticketHash(ticket);
+      const entries = loadCacheEntriesFn(ticket.id);
+      const cached = findCachedVerdict(entries, { ticketHash: hash, model, maxAgeMs, now });
+      if (cached) {
+        results.push({ id: ticket.id, gaps: cached.gaps, usage: null, cached: true });
+        continue;
+      }
+    }
+    const result = await checkTicketFn(ticket);
+    results.push({ ...result, cached: false });
   }
   return results;
+}
+
+function defaultLoadCacheEntries(ticketId, dir) {
+  return loadFiltered({ ticket: ticketId, dir }).entries;
 }
 
 /**

--- a/packages/coldstart/lib/report.mjs
+++ b/packages/coldstart/lib/report.mjs
@@ -12,11 +12,12 @@
  */
 export function renderReport(results) {
   const lines = [];
-  for (const { id, gaps } of results) {
+  for (const { id, gaps, cached } of results) {
+    const suffix = cached ? ' (cached)' : '';
     if (gaps.length === 0) {
-      lines.push(`[PASS] ${id}: ticket is fully executable`);
+      lines.push(`[PASS] ${id}: ticket is fully executable${suffix}`);
     } else {
-      lines.push(`[FAIL] ${id}: ${gaps.length} gap(s)`);
+      lines.push(`[FAIL] ${id}: ${gaps.length} gap(s)${suffix}`);
       for (const gap of gaps) {
         lines.push(`  - ${gap.what}: ${gap.why_blocking}`);
       }
@@ -33,10 +34,11 @@ export function buildJsonOutput(results) {
   const allPass = results.every((r) => r.gaps.length === 0);
   return {
     ok: allPass,
-    results: results.map(({ id, gaps }) => ({
+    results: results.map(({ id, gaps, cached }) => ({
       id,
       pass: gaps.length === 0,
       gaps,
+      cached: Boolean(cached),
     })),
   };
 }

--- a/packages/coldstart/package.json
+++ b/packages/coldstart/package.json
@@ -32,7 +32,8 @@
   ],
   "dependencies": {
     "@adlc/core": "1.6.0",
-    "@adlc/gate-manifest": "1.6.0"
+    "@adlc/gate-manifest": "1.6.0",
+    "@adlc/tickets": "1.6.0"
   },
   "scripts": {
     "test": "node --test test/*.test.mjs"

--- a/packages/coldstart/test/cache.test.mjs
+++ b/packages/coldstart/test/cache.test.mjs
@@ -3,7 +3,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { findCachedVerdict, buildCacheData, GATE_NAME } from '../lib/cache.mjs';
+import { findCachedVerdict, buildCacheData, buildRecordPlan, GATE_NAME } from '../lib/cache.mjs';
 
 function entry({ gate = GATE_NAME, ts = '2026-01-01T00:00:00.000Z', cache } = {}) {
   return { gate, ts, data: { cache } };
@@ -84,4 +84,65 @@ test('findCachedVerdict: walks newest-first — a later re-audit shadows an olde
   ];
   const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm' });
   assert.deepEqual(result.gaps, []);
+});
+
+// ── buildRecordPlan (issue #278 / mutation-gate follow-up on PR #291) ─────
+
+test('buildRecordPlan: no results → empty plan (nothing to record)', () => {
+  assert.deepEqual(buildRecordPlan([], [], { model: 'm', tier: 'cheap' }), []);
+});
+
+test('buildRecordPlan: a cached result is excluded — reusing prior evidence is not new evidence', () => {
+  const targets = [{ id: 'T1', title: 't' }];
+  const results = [{ id: 'T1', gaps: [], usage: null, cached: true }];
+  assert.deepEqual(buildRecordPlan(results, targets, { model: 'm', tier: 'cheap' }), []);
+});
+
+test('buildRecordPlan: a mocked result is excluded — no real call was made', () => {
+  const targets = [{ id: 'T1', title: 't' }];
+  const results = [{ id: 'T1', gaps: [], usage: null, mocked: true }];
+  assert.deepEqual(buildRecordPlan(results, targets, { model: 'm', tier: 'cheap' }), []);
+});
+
+test('buildRecordPlan: exactly one freshly-audited result produces exactly one plan entry', () => {
+  const targets = [{ id: 'T1', title: 't' }];
+  const results = [{ id: 'T1', gaps: [], usage: null, cached: false }];
+  const plan = buildRecordPlan(results, targets, { model: 'claude-haiku-4-5', tier: 'cheap' });
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].gate, GATE_NAME);
+  assert.equal(plan[0].ticket, 'T1');
+  const data = JSON.parse(plan[0].rawData);
+  assert.equal(data.tier, 'cheap');
+  assert.equal(data.cache.model, 'claude-haiku-4-5');
+  assert.deepEqual(data.cache.gaps, []);
+});
+
+test('buildRecordPlan: a mix of cached/mocked/fresh results only plans entries for the fresh ones', () => {
+  const targets = [{ id: 'T1', title: 'a' }, { id: 'T2', title: 'b' }, { id: 'T3', title: 'c' }];
+  const results = [
+    { id: 'T1', gaps: [], usage: null, cached: true },
+    { id: 'T2', gaps: [], usage: null, mocked: true },
+    { id: 'T3', gaps: [{ what: 'X', why_blocking: 'Y' }], usage: null, cached: false },
+  ];
+  const plan = buildRecordPlan(results, targets, { model: 'm', tier: 'cheap' });
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].ticket, 'T3');
+});
+
+test('buildRecordPlan: with no provider configured (model is null), the plan still records usage/tier but omits cache data', () => {
+  const targets = [{ id: 'T1', title: 't' }];
+  const results = [{ id: 'T1', gaps: [], usage: null, cached: false }];
+  const plan = buildRecordPlan(results, targets, { model: null, tier: 'cheap' });
+  assert.equal(plan.length, 1);
+  const data = JSON.parse(plan[0].rawData);
+  assert.equal('cache' in data, false);
+});
+
+test('buildRecordPlan: includes usage when the result reported it', () => {
+  const targets = [{ id: 'T1', title: 't' }];
+  const usage = { inputTokens: 100, outputTokens: 20, cachedTokens: 0, provider: 'anthropic', model: 'claude-haiku-4-5', tier: 'cheap' };
+  const results = [{ id: 'T1', gaps: [], usage, cached: false }];
+  const plan = buildRecordPlan(results, targets, { model: 'claude-haiku-4-5', tier: 'cheap' });
+  const data = JSON.parse(plan[0].rawData);
+  assert.deepEqual(data.usage, usage);
 });

--- a/packages/coldstart/test/cache.test.mjs
+++ b/packages/coldstart/test/cache.test.mjs
@@ -1,0 +1,87 @@
+// cache.test.mjs — issue #278: pure unit tests for findCachedVerdict/buildCacheData.
+// No I/O — plain fixture arrays standing in for manifest entries.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findCachedVerdict, buildCacheData, GATE_NAME } from '../lib/cache.mjs';
+
+function entry({ gate = GATE_NAME, ts = '2026-01-01T00:00:00.000Z', cache } = {}) {
+  return { gate, ts, data: { cache } };
+}
+
+test('buildCacheData shapes a cache record from ticketHash/model/gaps', () => {
+  const data = buildCacheData({ ticketHash: 'H1', model: 'claude-haiku-4-5', gaps: [{ what: 'X', why_blocking: 'Y' }] });
+  assert.deepEqual(data, { ticketHash: 'H1', model: 'claude-haiku-4-5', gaps: [{ what: 'X', why_blocking: 'Y' }] });
+});
+
+test('buildCacheData defaults gaps to [] when omitted', () => {
+  const data = buildCacheData({ ticketHash: 'H1', model: 'm' });
+  assert.deepEqual(data.gaps, []);
+});
+
+test('findCachedVerdict: no entries → null', () => {
+  assert.equal(findCachedVerdict([], { ticketHash: 'H1', model: 'm' }), null);
+});
+
+test('findCachedVerdict: matching gate/hash/model → hit, returns cached gaps', () => {
+  const entries = [entry({ cache: { ticketHash: 'H1', model: 'm', gaps: [{ what: 'X', why_blocking: 'Y' }] } })];
+  const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm' });
+  assert.deepEqual(result, { gaps: [{ what: 'X', why_blocking: 'Y' }] });
+});
+
+test('findCachedVerdict: different ticketHash → miss', () => {
+  const entries = [entry({ cache: { ticketHash: 'H1', model: 'm', gaps: [] } })];
+  assert.equal(findCachedVerdict(entries, { ticketHash: 'H2', model: 'm' }), null);
+});
+
+test('findCachedVerdict: different model (e.g. ADLC_MODEL_CHEAP changed) → miss', () => {
+  const entries = [entry({ cache: { ticketHash: 'H1', model: 'claude-haiku-4-5', gaps: [] } })];
+  assert.equal(findCachedVerdict(entries, { ticketHash: 'H1', model: 'claude-3-5-haiku' }), null);
+});
+
+test('findCachedVerdict: entries from a different gate are ignored', () => {
+  const entries = [entry({ gate: 'rails-guard', cache: { ticketHash: 'H1', model: 'm', gaps: [] } })];
+  assert.equal(findCachedVerdict(entries, { ticketHash: 'H1', model: 'm' }), null);
+});
+
+test('findCachedVerdict: entries with no data.cache (e.g. a --record-verdict entry) are ignored, not thrown on', () => {
+  const entries = [{ gate: GATE_NAME, ts: '2026-01-01T00:00:00.000Z', data: { promptOnly: true, verdict: 'PASS' } }];
+  assert.equal(findCachedVerdict(entries, { ticketHash: 'H1', model: 'm' }), null);
+});
+
+test('findCachedVerdict: within maxAgeMs → hit', () => {
+  const entries = [entry({ ts: '2026-01-01T00:00:00.000Z', cache: { ticketHash: 'H1', model: 'm', gaps: [] } })];
+  const now = Date.parse('2026-01-01T00:00:00.000Z') + 1000; // 1s later
+  const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm', maxAgeMs: 5000, now });
+  assert.notEqual(result, null);
+});
+
+test('findCachedVerdict: past maxAgeMs → treated as stale, miss', () => {
+  const entries = [entry({ ts: '2026-01-01T00:00:00.000Z', cache: { ticketHash: 'H1', model: 'm', gaps: [] } })];
+  const now = Date.parse('2026-01-01T00:00:00.000Z') + 10_000; // 10s later
+  const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm', maxAgeMs: 5000, now });
+  assert.equal(result, null);
+});
+
+test('findCachedVerdict: maxAgeMs 0 → every entry is stale regardless of age', () => {
+  const entries = [entry({ ts: '2026-01-01T00:00:00.000Z', cache: { ticketHash: 'H1', model: 'm', gaps: [] } })];
+  const now = Date.parse('2026-01-01T00:00:00.000Z') + 1; // 1ms later, still > 0
+  const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm', maxAgeMs: 0, now });
+  assert.equal(result, null);
+});
+
+test('findCachedVerdict: null maxAgeMs (default) never expires', () => {
+  const entries = [entry({ ts: '2020-01-01T00:00:00.000Z', cache: { ticketHash: 'H1', model: 'm', gaps: [] } })];
+  const now = Date.parse('2030-01-01T00:00:00.000Z'); // 10 years later
+  const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm', maxAgeMs: null, now });
+  assert.notEqual(result, null);
+});
+
+test('findCachedVerdict: walks newest-first — a later re-audit shadows an older entry for the same hash+model', () => {
+  const entries = [
+    entry({ ts: '2026-01-01T00:00:00.000Z', cache: { ticketHash: 'H1', model: 'm', gaps: [{ what: 'old', why_blocking: 'stale gap' }] } }),
+    entry({ ts: '2026-01-02T00:00:00.000Z', cache: { ticketHash: 'H1', model: 'm', gaps: [] } }), // re-audited clean later
+  ];
+  const result = findCachedVerdict(entries, { ticketHash: 'H1', model: 'm' });
+  assert.deepEqual(result.gaps, []);
+});

--- a/packages/coldstart/test/checkall-cache.test.mjs
+++ b/packages/coldstart/test/checkall-cache.test.mjs
@@ -1,0 +1,160 @@
+// checkall-cache.test.mjs — issue #278: checkAll's content-addressed caching,
+// exercised with injected checkTicketFn/loadCacheEntriesFn/resolveModelFn so
+// these are fast, offline, deterministic call-count assertions — no network,
+// no real gate-manifest files. See coldstart-cache-e2e.test.mjs for the
+// real-ledger, real-record()-round-trip version of the same behavior.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkAll } from '../lib/gate.mjs';
+import { ticketHash } from '@adlc/tickets';
+
+const MODEL = 'claude-haiku-4-5';
+
+/**
+ * An in-memory stand-in for the gate-manifest ledger: a plain array the test
+ * controls directly, plus a call-counting checkTicketFn that "records" into
+ * it exactly like the real bin does after a real audit.
+ */
+function makeFixture({ model = MODEL } = {}) {
+  const ledger = []; // manifest-entry-shaped objects, keyed loosely by ticket via .ticket
+  let callCount = 0;
+  const callsFor = [];
+
+  const checkTicketFn = async (ticket) => {
+    callCount++;
+    callsFor.push(ticket.id);
+    // Deterministic "verdict": pass unless the ticket's title contains "gap".
+    const gaps = /gap/i.test(ticket.title ?? '') ? [{ what: 'X', why_blocking: 'Y' }] : [];
+    return { id: ticket.id, gaps, usage: null };
+  };
+
+  const record = (ticket, gaps, modelUsed = model) => {
+    ledger.push({ gate: 'coldstart', ticket: ticket.id, ts: new Date().toISOString(), data: { cache: { ticketHash: ticketHash(ticket), model: modelUsed, gaps } } });
+  };
+
+  const loadCacheEntriesFn = (ticketId) => ledger.filter((e) => e.ticket === ticketId);
+  const resolveModelFn = () => model;
+
+  return {
+    get callCount() { return callCount; },
+    callsFor,
+    record,
+    checkTicketFn,
+    loadCacheEntriesFn,
+    resolveModelFn,
+  };
+}
+
+test('two consecutive checkAll runs over an unchanged store call checkTicketFn only on the first run', async () => {
+  const fx = makeFixture();
+  const tickets = [{ id: 'T1', title: 'Login form' }, { id: 'T2', title: 'Checkout flow' }];
+
+  const first = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn,
+    loadCacheEntriesFn: fx.loadCacheEntriesFn,
+    resolveModelFn: fx.resolveModelFn,
+  });
+  for (const [i, ticket] of tickets.entries()) fx.record(ticket, first[i].gaps);
+  assert.equal(fx.callCount, 2, 'first run audits both tickets fresh');
+
+  const second = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn,
+    loadCacheEntriesFn: fx.loadCacheEntriesFn,
+    resolveModelFn: fx.resolveModelFn,
+  });
+  assert.equal(fx.callCount, 2, 'second run over the SAME tickets must not call checkTicketFn again');
+  assert.ok(second.every((r) => r.cached === true), 'every result on the second run must be served from cache');
+  assert.deepEqual(second.map((r) => r.gaps), first.map((r) => r.gaps), 'cached gaps must match what was recorded');
+});
+
+test('editing one ticket re-audits only that ticket on the second run', async () => {
+  const fx = makeFixture();
+  const tickets = [{ id: 'T1', title: 'Login form' }, { id: 'T2', title: 'Checkout flow' }];
+
+  const first = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+  for (const [i, ticket] of tickets.entries()) fx.record(ticket, first[i].gaps);
+  assert.equal(fx.callCount, 2);
+
+  // T1's content changes (different hash); T2 stays identical.
+  const editedTickets = [{ id: 'T1', title: 'Login form, now with 2FA' }, { id: 'T2', title: 'Checkout flow' }];
+  const second = await checkAll(editedTickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+
+  assert.equal(fx.callCount, 3, 'only the edited ticket should trigger a fresh audit');
+  assert.deepEqual(fx.callsFor, ['T1', 'T2', 'T1'], 'the re-audit call must be for the edited ticket, T1');
+  assert.equal(second.find((r) => r.id === 'T1').cached, false);
+  assert.equal(second.find((r) => r.id === 'T2').cached, true);
+});
+
+test('--force re-audits everything even when every ticket has a fresh cache hit available', async () => {
+  const fx = makeFixture();
+  const tickets = [{ id: 'T1', title: 'Login form' }];
+
+  const first = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+  fx.record(tickets[0], first[0].gaps);
+  assert.equal(fx.callCount, 1);
+
+  const forced = await checkAll(tickets, 'cheap', {
+    force: true,
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+  assert.equal(fx.callCount, 2, '--force must bypass the cache entirely');
+  assert.equal(forced[0].cached, false);
+});
+
+test('--max-age 0 treats every cache entry as stale — re-audits despite an unchanged ticket', async () => {
+  const fx = makeFixture();
+  const tickets = [{ id: 'T1', title: 'Login form' }];
+
+  const first = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+  fx.record(tickets[0], first[0].gaps);
+  assert.equal(fx.callCount, 1);
+
+  const withMaxAgeZero = await checkAll(tickets, 'cheap', {
+    maxAgeMs: 0,
+    now: Date.now() + 1, // strictly after the recorded entry's timestamp
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+  assert.equal(fx.callCount, 2, '--max-age 0 must not honor even a just-written cache entry');
+  assert.equal(withMaxAgeZero[0].cached, false);
+});
+
+test('a cache entry recorded under one model does not cover a run under a different resolved model (ADLC_MODEL_CHEAP changed)', async () => {
+  const fx = makeFixture({ model: 'claude-haiku-4-5' });
+  const tickets = [{ id: 'T1', title: 'Login form' }];
+
+  const first = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn, loadCacheEntriesFn: fx.loadCacheEntriesFn, resolveModelFn: fx.resolveModelFn,
+  });
+  fx.record(tickets[0], first[0].gaps, 'claude-haiku-4-5');
+  assert.equal(fx.callCount, 1);
+
+  // Simulate ADLC_MODEL_CHEAP now resolving to a different model id.
+  const second = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn,
+    loadCacheEntriesFn: fx.loadCacheEntriesFn,
+    resolveModelFn: () => 'gemini-2.5-flash',
+  });
+  assert.equal(fx.callCount, 2, 'a model change must invalidate the cache, even for an unchanged ticket');
+  assert.equal(second[0].cached, false);
+});
+
+test('when no provider is configured (resolveModelFn returns null), the cache is skipped and checkTicketFn still runs (existing no-provider error path is untouched)', async () => {
+  const fx = makeFixture();
+  const tickets = [{ id: 'T1', title: 'Login form' }];
+  const result = await checkAll(tickets, 'cheap', {
+    checkTicketFn: fx.checkTicketFn,
+    loadCacheEntriesFn: fx.loadCacheEntriesFn,
+    resolveModelFn: () => null,
+  });
+  assert.equal(fx.callCount, 1);
+  assert.equal(result[0].cached, false);
+});

--- a/packages/coldstart/test/cli-options.test.mjs
+++ b/packages/coldstart/test/cli-options.test.mjs
@@ -1,0 +1,48 @@
+// cli-options.test.mjs — exercises the REAL parseArgs default-resolution for
+// coldstart's CLI options (not injected/mocked), so a mutation to a default
+// value in lib/cli-options.mjs is actually caught (mutation-gate CI finding
+// on PR #291: bin/coldstart.mjs's inline options object had zero test
+// coverage for its own default values — force:true and max-age:'31' both
+// survived mutation).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from '@adlc/core';
+import { USAGE, OPTIONS } from '../lib/cli-options.mjs';
+
+test('--force defaults to false when omitted (caching stays ON by default)', () => {
+  const { values } = parseArgs({ options: OPTIONS, args: ['T1'] });
+  assert.equal(values.force, false);
+});
+
+test('--force is true when the flag is passed', () => {
+  const { values } = parseArgs({ options: OPTIONS, args: ['T1', '--force'] });
+  assert.equal(values.force, true);
+});
+
+test('--max-age defaults to "30" (days) when omitted', () => {
+  const { values } = parseArgs({ options: OPTIONS, args: ['T1'] });
+  assert.equal(values['max-age'], '30');
+});
+
+test('--max-age is overridable', () => {
+  const { values } = parseArgs({ options: OPTIONS, args: ['T1', '--max-age', '7'] });
+  assert.equal(values['max-age'], '7');
+});
+
+test('other existing defaults are unchanged (tickets path, tier, all, prompt-only, json)', () => {
+  const { values } = parseArgs({ options: OPTIONS, args: ['T1'] });
+  assert.equal(values.tickets, '.adlc/tickets.json');
+  assert.equal(values.tier, 'cheap');
+  assert.equal(values.all, false);
+  assert.equal(values['prompt-only'], false);
+  assert.equal(values.json, false);
+});
+
+test('USAGE documents every flag the options config actually declares', () => {
+  for (const flag of Object.keys(OPTIONS)) {
+    assert.match(USAGE, new RegExp(`--${flag}\\b`), `USAGE string is missing --${flag}`);
+  }
+  assert.match(USAGE, /--force/);
+  assert.match(USAGE, /--max-age <days>/);
+});

--- a/packages/coldstart/test/cli-options.test.mjs
+++ b/packages/coldstart/test/cli-options.test.mjs
@@ -8,7 +8,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseArgs } from '@adlc/core';
-import { USAGE, OPTIONS } from '../lib/cli-options.mjs';
+import { USAGE, OPTIONS, parseMaxAgeDays } from '../lib/cli-options.mjs';
 
 test('--force defaults to false when omitted (caching stays ON by default)', () => {
   const { values } = parseArgs({ options: OPTIONS, args: ['T1'] });
@@ -45,4 +45,45 @@ test('USAGE documents every flag the options config actually declares', () => {
   }
   assert.match(USAGE, /--force/);
   assert.match(USAGE, /--max-age <days>/);
+});
+
+// ── parseMaxAgeDays ─────────────────────────────────────────────────────────
+
+test('parseMaxAgeDays: "0" is VALID — "treat every cache entry as stale", not an error', () => {
+  const result = parseMaxAgeDays('0');
+  assert.equal(result.ok, true);
+  assert.equal(result.maxAgeMs, 0);
+});
+
+test('parseMaxAgeDays: "30" (the default) converts to 30 days in ms', () => {
+  const result = parseMaxAgeDays('30');
+  assert.equal(result.ok, true);
+  assert.equal(result.maxAgeMs, 30 * 24 * 60 * 60 * 1000);
+});
+
+test('parseMaxAgeDays: "1" converts to exactly one day in ms (boundary against an off-by-one)', () => {
+  const result = parseMaxAgeDays('1');
+  assert.equal(result.ok, true);
+  assert.equal(result.maxAgeMs, 24 * 60 * 60 * 1000);
+});
+
+test('parseMaxAgeDays: a negative number is rejected', () => {
+  const result = parseMaxAgeDays('-1');
+  assert.equal(result.ok, false);
+  assert.match(result.error, /--max-age must be a non-negative number of days/);
+});
+
+test('parseMaxAgeDays: a non-numeric string is rejected', () => {
+  const result = parseMaxAgeDays('abc');
+  assert.equal(result.ok, false);
+  assert.match(result.error, /--max-age must be a non-negative number of days/);
+});
+
+test('parseMaxAgeDays: "Infinity" is rejected, not silently treated as "no limit"', () => {
+  assert.equal(parseMaxAgeDays('Infinity').ok, false);
+});
+
+test('parseMaxAgeDays: "NaN" and other unparseable text are rejected', () => {
+  assert.equal(parseMaxAgeDays('NaN').ok, false);
+  assert.equal(parseMaxAgeDays('thirty').ok, false);
 });

--- a/packages/coldstart/test/coldstart-cache-e2e.test.mjs
+++ b/packages/coldstart/test/coldstart-cache-e2e.test.mjs
@@ -1,0 +1,110 @@
+// coldstart-cache-e2e.test.mjs — issue #278: the real gate-manifest ledger
+// round-trip. checkall-cache.test.mjs proves the caching LOGIC with injected
+// fixtures; this proves the actual record() -> loadFiltered() ->
+// findCachedVerdict() wiring works against real files, the same way
+// bin/coldstart.mjs uses it. checkTicketFn is still injected (a call-counting
+// stub) — no network — but the manifest reads/writes are real.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkAll } from '../lib/gate.mjs';
+import { buildCacheData } from '../lib/cache.mjs';
+import { ticketHash } from '@adlc/tickets';
+import { record } from '@adlc/gate-manifest/lib/record.mjs';
+
+function makeTmp() {
+  return mkdtempSync(join(tmpdir(), 'coldstart-cache-e2e-'));
+}
+
+function cleanTmp(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function makeCallCountingCheckTicketFn() {
+  let count = 0;
+  const fn = async (ticket) => {
+    count++;
+    return { id: ticket.id, gaps: [], usage: null };
+  };
+  fn.count = () => count;
+  return fn;
+}
+
+test('real gate-manifest round-trip: a run over an unchanged ticket, against a REAL prior manifest entry, is a cache hit', async () => {
+  const dir = makeTmp();
+  try {
+    const ticket = { id: 'T1', title: 'Login form', body: 'Create login.' };
+    const model = 'claude-haiku-4-5';
+
+    // Simulate a prior real coldstart run having recorded a PASS.
+    record({
+      gate: 'coldstart',
+      ticket: ticket.id,
+      dir,
+      rawData: JSON.stringify({ tier: 'cheap', cache: buildCacheData({ ticketHash: ticketHash(ticket), model, gaps: [] }) }),
+    });
+
+    const checkTicketFn = makeCallCountingCheckTicketFn();
+    const results = await checkAll([ticket], 'cheap', {
+      dir,
+      checkTicketFn,
+      resolveModelFn: () => model,
+    });
+
+    assert.equal(checkTicketFn.count(), 0, 'a real cache hit against the real ledger must skip checkTicketFn entirely');
+    assert.equal(results[0].cached, true);
+    assert.deepEqual(results[0].gaps, []);
+  } finally {
+    cleanTmp(dir);
+  }
+});
+
+test('real gate-manifest round-trip: a genuinely unrecorded ticket runs fresh, then a second checkAll call against the same dir sees it in the ledger', async () => {
+  const dir = makeTmp();
+  try {
+    const ticket = { id: 'T1', title: 'Login form', body: 'Create login.' };
+    const model = 'claude-haiku-4-5';
+    const checkTicketFn = makeCallCountingCheckTicketFn();
+
+    const first = await checkAll([ticket], 'cheap', { dir, checkTicketFn, resolveModelFn: () => model });
+    assert.equal(checkTicketFn.count(), 1, 'nothing recorded yet — must run fresh');
+    assert.equal(first[0].cached, false);
+
+    // Mirror what bin/coldstart.mjs does after checkAll returns: record the result.
+    record({
+      gate: 'coldstart',
+      ticket: ticket.id,
+      dir,
+      rawData: JSON.stringify({ tier: 'cheap', cache: buildCacheData({ ticketHash: ticketHash(ticket), model, gaps: first[0].gaps }) }),
+    });
+
+    const second = await checkAll([ticket], 'cheap', { dir, checkTicketFn, resolveModelFn: () => model });
+    assert.equal(checkTicketFn.count(), 1, 'the second checkAll call must find the just-recorded entry and skip the LLM call');
+    assert.equal(second[0].cached, true);
+  } finally {
+    cleanTmp(dir);
+  }
+});
+
+test('real gate-manifest round-trip: a recorded --record-verdict entry (no data.cache) is not mistaken for a cache hit', async () => {
+  const dir = makeTmp();
+  try {
+    const ticket = { id: 'T1', title: 'Login form' };
+    const model = 'claude-haiku-4-5';
+
+    // A --prompt-only --record-verdict entry has data.verdict, not data.cache.
+    record({ gate: 'coldstart', ticket: ticket.id, dir, rawData: JSON.stringify({ promptOnly: true, verdict: 'PASS: looks fine.' }) });
+
+    const checkTicketFn = makeCallCountingCheckTicketFn();
+    const results = await checkAll([ticket], 'cheap', { dir, checkTicketFn, resolveModelFn: () => model });
+
+    assert.equal(checkTicketFn.count(), 1, 'a promptOnly/record-verdict entry must never be treated as a cache hit');
+    assert.equal(results[0].cached, false);
+  } finally {
+    cleanTmp(dir);
+  }
+});

--- a/packages/coldstart/test/coldstart.test.mjs
+++ b/packages/coldstart/test/coldstart.test.mjs
@@ -175,6 +175,28 @@ describe('renderReport', () => {
     const t2Pos = report.indexOf('T2');
     assert.ok(t1Pos < t2Pos, 'T1 should appear before T2');
   });
+
+  // ── cached marker (issue #278) ──────────────────────────────────────────
+
+  test('a cached PASS result is marked "(cached)"', () => {
+    const report = renderReport([{ id: 'T1', gaps: [], cached: true }]);
+    assert.ok(report.includes('(cached)'), 'cached result must be marked');
+  });
+
+  test('a cached FAIL result is marked "(cached)"', () => {
+    const report = renderReport([{ id: 'T1', gaps: [{ what: 'X', why_blocking: 'Y' }], cached: true }]);
+    assert.ok(report.includes('(cached)'), 'cached result must be marked');
+  });
+
+  test('a freshly-audited result (cached: false) is NOT marked "(cached)"', () => {
+    const report = renderReport([{ id: 'T1', gaps: [], cached: false }]);
+    assert.ok(!report.includes('(cached)'), 'fresh result must not be marked cached');
+  });
+
+  test('a result with no cached field at all (legacy shape) renders without the marker', () => {
+    const report = renderReport([{ id: 'T1', gaps: [] }]);
+    assert.ok(!report.includes('(cached)'));
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/coldstart/test/resolve-expected-model.test.mjs
+++ b/packages/coldstart/test/resolve-expected-model.test.mjs
@@ -1,0 +1,37 @@
+// resolve-expected-model.test.mjs — exercises resolveExpectedModel's REAL
+// implementation (detectProvider + resolveModel from @adlc/core), not an
+// injected stand-in. Every other test in this package injects a fake
+// resolveModelFn into checkAll, which is correct for testing checkAll's own
+// logic in isolation — but it meant resolveExpectedModel's actual body had
+// zero coverage (mutation-gate CI finding on PR #291: replacing its body
+// with `return null` survived, which would silently disable caching for
+// every ticket whenever a provider WAS configured).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveExpectedModel } from '../lib/gate.mjs';
+
+test('resolveExpectedModel returns the cheap-tier model id when an anthropic key is configured', () => {
+  const model = resolveExpectedModel('cheap', { ANTHROPIC_API_KEY: 'test-key' });
+  assert.equal(model, 'claude-haiku-4-5');
+});
+
+test('resolveExpectedModel returns the mid-tier model id for tier "mid"', () => {
+  const model = resolveExpectedModel('mid', { ANTHROPIC_API_KEY: 'test-key' });
+  assert.equal(model, 'claude-sonnet-4-6');
+});
+
+test('resolveExpectedModel respects an ADLC_MODEL_CHEAP override — the same override that must invalidate the cache', () => {
+  const model = resolveExpectedModel('cheap', { ANTHROPIC_API_KEY: 'test-key', ADLC_MODEL_CHEAP: 'claude-3-5-haiku' });
+  assert.equal(model, 'claude-3-5-haiku');
+});
+
+test('resolveExpectedModel returns null when no provider is configured (nothing to cache-key on)', () => {
+  const model = resolveExpectedModel('cheap', {});
+  assert.equal(model, null);
+});
+
+test('resolveExpectedModel picks the correct model for a non-anthropic provider (openai)', () => {
+  const model = resolveExpectedModel('cheap', { OPENAI_API_KEY: 'test-key' });
+  assert.equal(model, 'gpt-5-mini');
+});

--- a/plugins/adlc-claude-code/agents/prosecutor-contract.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-contract.md
@@ -1,26 +1,14 @@
 ---
 name: prosecutor-contract
-description: P5 contract lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for API/schema/type conformance drift against the declared contract in a change diff. Read-only; never invoke to edit code.
+description: P5 contract lens subagent; invoked by /adlc:adlc-prosecute — do not invoke directly.
 tools: Read, Grep, Glob
 ---
 
 # Contract conformance (ADLC P5 prosecution lens)
 
-You are a hostile pre-merge reviewer. Your only job is to **break confidence in
-the change**, not validate it. Review the change under one lens: **Contract
-conformance**.
+Lens focus: API/schema/type drift, backwards-incompatible changes, undocumented
+response shape changes, and violations of the ticket's declared contract or
+shared types.
 
-Hunt specifically for: API/schema/type drift, backwards-incompatible changes,
-undocumented response shape changes, and violations of the ticket's declared
-contract or shared types.
-
-For each finding, return an object with: `severity` (critical|high|medium|low),
-`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
-`title`, `body`, `evidence` (quoted verbatim from the diff), and
-`recommendation`. Output only a JSON array of findings (empty array if none). Do
-not soften or speculate beyond the evidence — a finding you cannot ground in the
-diff does not belong.
-
-You have no Edit/Write/Bash tools by design: this lens only reads the diff and
-surrounding code (via Read/Grep/Glob) and reasons about it. It never changes
-anything and never shells out.
+Full contract (refute charter, output schema, tool constraints) lives in
+`/adlc:adlc-prosecute` step 1 — this file only declares what THIS lens hunts for.

--- a/plugins/adlc-claude-code/agents/prosecutor-correctness.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-correctness.md
@@ -1,25 +1,13 @@
 ---
 name: prosecutor-correctness
-description: P5 correctness lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for logic errors, broken invariants, and wrong results in a change diff. Read-only; never invoke to edit code.
+description: P5 correctness lens subagent; invoked by /adlc:adlc-prosecute — do not invoke directly.
 tools: Read, Grep, Glob
 ---
 
 # Correctness (ADLC P5 prosecution lens)
 
-You are a hostile pre-merge reviewer. Your only job is to **break confidence in
-the change**, not validate it. Review the change under one lens: **Correctness**.
+Lens focus: logic errors, off-by-one and boundary mistakes, broken invariants,
+incorrect results, mishandled error/empty/null cases, and state that can desync.
 
-Hunt specifically for: logic errors, off-by-one and boundary mistakes, broken
-invariants, incorrect results, mishandled error/empty/null cases, and state that
-can desync.
-
-For each finding, return an object with: `severity` (critical|high|medium|low),
-`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
-`title`, `body`, `evidence` (quoted verbatim from the diff), and
-`recommendation`. Output only a JSON array of findings (empty array if none). Do
-not soften or speculate beyond the evidence — a finding you cannot ground in the
-diff does not belong.
-
-You have no Edit/Write/Bash tools by design: this lens only reads the diff and
-surrounding code (via Read/Grep/Glob) and reasons about it. It never changes
-anything and never shells out.
+Full contract (refute charter, output schema, tool constraints) lives in
+`/adlc:adlc-prosecute` step 1 — this file only declares what THIS lens hunts for.

--- a/plugins/adlc-claude-code/agents/prosecutor-diff.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-diff.md
@@ -1,26 +1,15 @@
 ---
 name: prosecutor-diff
-description: P5 spec-vs-implementation diff lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for divergence between the spec/acceptance criteria and the actual implementation. Read-only; never invoke to edit code.
+description: P5 spec-vs-implementation lens subagent; invoked by /adlc:adlc-prosecute — do not invoke directly.
 tools: Read, Grep, Glob
 ---
 
 # Spec-vs-implementation diff (ADLC P5 prosecution lens)
 
-You are a hostile pre-merge reviewer. Your only job is to **break confidence in
-the change**, not validate it. Review the change under one lens:
-**Spec-vs-implementation diff**.
+Lens focus: places where the implementation diverges from the spec/acceptance
+criteria, behavior changes not reflected in the spec, and scope creep beyond
+the ticket. Also read the ticket/spec, not just the diff — this lens's whole
+job is comparing the two.
 
-Hunt specifically for: places where the implementation diverges from the
-spec/acceptance criteria, behavior changes not reflected in the spec, and scope
-creep beyond the ticket.
-
-For each finding, return an object with: `severity` (critical|high|medium|low),
-`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
-`title`, `body`, `evidence` (quoted verbatim from the diff), and
-`recommendation`. Output only a JSON array of findings (empty array if none). Do
-not soften or speculate beyond the evidence — a finding you cannot ground in the
-diff does not belong.
-
-You have no Edit/Write/Bash tools by design: this lens only reads the diff, the
-ticket/spec, and surrounding code (via Read/Grep/Glob) and reasons about it. It
-never changes anything and never shells out.
+Full contract (refute charter, output schema, tool constraints) lives in
+`/adlc:adlc-prosecute` step 1 — this file only declares what THIS lens hunts for.

--- a/plugins/adlc-claude-code/agents/prosecutor-security.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-security.md
@@ -1,25 +1,14 @@
 ---
 name: prosecutor-security
-description: P5 security lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for auth/trust-boundary holes, injection, secrets, and unsafe data flow in a change diff. Read-only; never invoke to edit code.
+description: P5 security lens subagent; invoked by /adlc:adlc-prosecute — do not invoke directly.
 tools: Read, Grep, Glob
 ---
 
 # Security (ADLC P5 prosecution lens)
 
-You are a hostile pre-merge reviewer. Your only job is to **break confidence in
-the change**, not validate it. Review the change under one lens: **Security**.
-
-Hunt specifically for: auth and trust-boundary holes, injection (SQL/shell/path),
-secrets in code or logs, SSRF, unsafe deserialization, missing input validation at
+Lens focus: auth and trust-boundary holes, injection (SQL/shell/path), secrets
+in code or logs, SSRF, unsafe deserialization, missing input validation at
 boundaries, and who-controls-the-control bypasses.
 
-For each finding, return an object with: `severity` (critical|high|medium|low),
-`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
-`title`, `body`, `evidence` (quoted verbatim from the diff), and
-`recommendation`. Output only a JSON array of findings (empty array if none). Do
-not soften or speculate beyond the evidence — a finding you cannot ground in the
-diff does not belong.
-
-You have no Edit/Write/Bash tools by design: this lens only reads the diff and
-surrounding code (via Read/Grep/Glob) and reasons about it. It never changes
-anything and never shells out.
+Full contract (refute charter, output schema, tool constraints) lives in
+`/adlc:adlc-prosecute` step 1 — this file only declares what THIS lens hunts for.

--- a/plugins/adlc-claude-code/agents/prosecutor-tests.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-tests.md
@@ -1,26 +1,16 @@
 ---
 name: prosecutor-tests
-description: P5 test-audit lens — one of five independent prosecution subagents invoked by /adlc:adlc-prosecute. Hunts for hollow/mock-only tests and missing coverage of the change's core behavior. Read-only; never invoke to edit code.
+description: P5 test-audit lens subagent; invoked by /adlc:adlc-prosecute — do not invoke directly.
 tools: Read, Grep, Glob
 ---
 
 # Test audit (ADLC P5 prosecution lens)
 
-You are a hostile pre-merge reviewer. Your only job is to **break confidence in
-the change**, not validate it. Review the change under one lens: **Test audit**.
+Lens focus: tests that assert nothing meaningful, mock-only verifications,
+tests that would pass against a broken implementation, missing coverage of the
+change's core behavior, and suppressed/skipped assertions. This lens reasons
+about the diff and test files by reading them — it does not run the test suite
+itself (that is `adlc hollow-test`'s job, via the `prosecutor` subagent).
 
-Hunt specifically for: tests that assert nothing meaningful, mock-only
-verifications, tests that would pass against a broken implementation, missing
-coverage of the change's core behavior, and suppressed/skipped assertions.
-
-For each finding, return an object with: `severity` (critical|high|medium|low),
-`file`, `line_start`, `line_end` (post-change line numbers; 0,0 = file-level),
-`title`, `body`, `evidence` (quoted verbatim from the diff), and
-`recommendation`. Output only a JSON array of findings (empty array if none). Do
-not soften or speculate beyond the evidence — a finding you cannot ground in the
-diff does not belong.
-
-You have no Edit/Write/Bash tools by design: this lens only reads the diff and
-test files (via Read/Grep/Glob) and reasons about it — it does not run the test
-suite itself (that is `adlc hollow-test`'s job, via the `prosecutor` subagent).
-It never changes anything and never shells out.
+Full contract (refute charter, output schema, tool constraints) lives in
+`/adlc:adlc-prosecute` step 1 — this file only declares what THIS lens hunts for.

--- a/plugins/adlc-claude-code/agents/prosecutor-verifier.md
+++ b/plugins/adlc-claude-code/agents/prosecutor-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: prosecutor-verifier
-description: P5 verifier/reproducer — invoked independently by /adlc:adlc-prosecute, once per deduped finding, to adversarially confirm or refute it. Read-only; never invoke to edit code.
+description: P5 verifier subagent; invoked by /adlc:adlc-prosecute — do not invoke directly.
 tools: Read, Grep, Glob
 ---
 

--- a/plugins/adlc-claude-code/agents/prosecutor.md
+++ b/plugins/adlc-claude-code/agents/prosecutor.md
@@ -117,33 +117,12 @@ adlc gate-manifest record prosecution --files <changed files>
 ## Trust-root tier — a same-model SHIP is NOT the end
 
 You are a **same-model** prosecutor by default: you validate the author's own
-tests, which encode the author's blind spot. For the **trust-root tier** that is
-not enough. If the change under prosecution touches any of —
-
-- an enforcement package (`packages/rails-guard|prosecute|gate-manifest|build-gate/`),
-- a gated-artifact producer (`packages/ticket-prune|ticket-sync/`),
-- a declared rails deny-path of any ticket, or
-- a trust-root file (`scripts/rails-guard-ci.mjs`, `docs/ci/rails-guard.yml`,
-  `scripts/test/rails-guard-workflow-hashes.json`, `.adlc/tickets.json`)
-
-— then **after you reach a CLEAR verdict you MUST SURFACE**: *"same-model P5
-passed; this tier REQUIRES a cross-model adversarial approve from a DISTINCT
-provider before `adlc prosecute --base <ref>` will exit 0."* Do not present the
-same-model SHIP as sufficient. Run the cross-model pass (shell to the local
-`codex` CLI, or `npx adversarial-review --base <ref>`), and once it approves,
-record the attestation so the gate clears:
-
-```
-adlc prosecute record-cross-model --ticket <id> \
-  --provider codex --author-provider claude --verdict approve \
-  --input <passes.json>
-```
-
-The recorded `revision` is resolved the same way the gate resolves it (pass the
-same `--input`/`--revision` you use for the gate run), so the attestation binds
-to the revision the gate checks. `--provider` MUST differ from `--author-provider`
-— a same-model "review" is refused at record time and rejected by the gate. See
-ADR-0007 (gated for the trust-root tier) and `packages/prosecute/lib/tier.mjs`.
+tests, which encode the author's blind spot. That is not enough for the
+**trust-root tier** — enforcement packages, gated-artifact producers, rails
+deny-paths, and a handful of trust-root files. See
+`../skills/adlc/references/trust-root.md` for the exact trigger list, the
+required surfacing language, and the `record-cross-model` mechanics (T39) —
+load it when the change you're prosecuting might hit this tier.
 
 **Note:** this subagent's own `gate-manifest record prosecution` entry carries
 `gate: "prosecution"`, which alone does not satisfy `adlc run p5` — that requires
@@ -153,11 +132,7 @@ prosecute` → `adlc run p5`), not exclusive to any one CLI or agent tool.
 
 For the full adversarial engine — independent fan-out across lenses, cross-lens
 dedupe, and independent verifier refutation with loop-until-dry convergence — use
-`/adlc:adlc-prosecute`, which invokes the `prosecutor-{correctness,security,contract,
-diff,tests,verifier}` subagents. That command replicates the same fan-out →
-dedupe → independent-verify → repeat-until-two-dry-rounds shape as the OpenCode
-integration's own `adlc-prosecute` command (invoked bare there, since OpenCode
-has no plugin-namespace convention), so Claude Code no longer needs to punt to a
-different harness to run the multi-lens loop; it can additionally feed its
-surviving findings to the `adlc prosecute` runner path for formal `adlc run p5`
-phase assertion when that is required.
+`/adlc:adlc-prosecute` instead, which invokes the
+`prosecutor-{correctness,security,contract,diff,tests,verifier}` subagents; it
+can additionally feed its surviving findings to the `adlc prosecute` runner
+path for formal `adlc run p5` phase assertion when that is required.

--- a/plugins/adlc-claude-code/commands/adlc-prosecute.md
+++ b/plugins/adlc-claude-code/commands/adlc-prosecute.md
@@ -19,12 +19,32 @@ loop-until-dry convergence — using Claude Code subagents instead of OpenCode's
 
 ## 1. Fan out the lenses
 
-Invoke these five prosecution subagents **independently** via the Task tool, each
-given the full change diff for **$ARGUMENTS**: `prosecutor-correctness`,
-`prosecutor-security`, `prosecutor-contract`, `prosecutor-diff`,
-`prosecutor-tests`. Each returns a JSON array of findings (possibly empty) —
-`severity`, `file`, `line_start`, `line_end`, `title`, `body`, `evidence`,
-`recommendation`. Collect every finding from every lens into one list.
+Invoke these five prosecution subagents **independently** via the Task tool:
+`prosecutor-correctness`, `prosecutor-security`, `prosecutor-contract`,
+`prosecutor-diff`, `prosecutor-tests`. Each agent file declares only what makes
+it different (its lens focus) — the framing, output schema, and tool
+constraints below are identical across all five and live here once instead of
+duplicated in every agent file. Include the full change diff for
+**$ARGUMENTS** plus this block, verbatim, in every one of the five Task prompts:
+
+> You are a hostile pre-merge reviewer. Your only job is to break confidence in
+> the change, not validate it. Review it under your one assigned lens.
+>
+> For each finding, return an object with: `severity`
+> (critical|high|medium|low), `file`, `line_start`, `line_end` (post-change
+> line numbers; 0,0 = file-level), `title`, `body`, `evidence` (a short,
+> one-line pointer to the exact spot — the specific expression or line
+> fragment, NOT a quoted diff hunk; the verifier re-reads the file directly,
+> so a full quote here is pure duplication), and `recommendation`. Output
+> only a JSON array of findings (empty array if none). Do not soften or
+> speculate beyond the evidence — a finding you cannot ground in the diff
+> does not belong.
+>
+> You have no Edit/Write/Bash tools by design: reason from Read/Grep/Glob
+> only. Never change anything, never shell out.
+
+Each returns a JSON array of findings (possibly empty). Collect every finding
+from every lens into one list.
 
 ## 2. Dedupe
 

--- a/plugins/adlc-claude-code/lib/test/plugin-footprint.test.mjs
+++ b/plugins/adlc-claude-code/lib/test/plugin-footprint.test.mjs
@@ -1,0 +1,91 @@
+// plugin-footprint.test.mjs — issue #277: the plugin's always-loaded
+// footprint (every frontmatter `description` field + the plugin.json
+// description + the MCP tool schemas), before any command is invoked.
+//
+// HONEST STATUS: the issue's target was ≤~500 tokens. This test asserts what
+// was actually achieved (a real, verified reduction from the ~1,006-token
+// baseline the tokenomics review measured), not the aspirational target.
+// The remaining gap is NOT closed here because closing it would mean cutting
+// into content that is functionally load-bearing, not incidental waste:
+//   - SKILL.md's description/body are generated from a template shared
+//     across six harness ports (scripts/router/router-model.mjs) and used
+//     for skill-trigger discovery — cutting trigger phrases risks real
+//     discoverability loss, and doing it safely needs generator-level work
+//     (see docs/integrations/claude-code.md's note on issue #277).
+//   - The MCP tool schemas' bulk is the required JSON structure (the gate
+//     enum, property definitions) an MCP client needs to call the tools
+//     correctly — not prose that can be trimmed.
+// What WAS cut, safely: the 6 programmatic prosecution agents' descriptions,
+// which are never used for discovery (they're invoked by exact name, not
+// model-selected) and were pure always-loaded cost.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, '..', '..');
+const REPO_ROOT = join(PLUGIN_ROOT, '..', '..');
+
+function frontmatterField(path, field) {
+  const text = readFileSync(path, 'utf8');
+  const re = new RegExp(`^${field}:\\s*(.*)$`, 'm');
+  const m = text.match(re);
+  return m ? m[1].trim() : '';
+}
+
+const PROGRAMMATIC_AGENTS = [
+  'prosecutor-correctness.md',
+  'prosecutor-security.md',
+  'prosecutor-contract.md',
+  'prosecutor-diff.md',
+  'prosecutor-tests.md',
+  'prosecutor-verifier.md',
+];
+
+test('the 6 programmatically-invoked prosecution agents have a short, uniform description shape', () => {
+  for (const f of PROGRAMMATIC_AGENTS) {
+    const desc = frontmatterField(join(PLUGIN_ROOT, 'agents', f), 'description');
+    assert.ok(desc.length <= 100, `${f} description is ${desc.length} chars, expected <=100 (was 187-256 before #277)`);
+    assert.match(desc, /invoked by \/adlc:adlc-prosecute/, `${f} description should say it's invoked by the command, not model-selected`);
+    assert.match(desc, /do not invoke directly/, `${f} description should discourage direct invocation`);
+  }
+});
+
+test('prosecutor.md (the one user-facing, model-selected agent) keeps a fully descriptive description', () => {
+  const desc = frontmatterField(join(PLUGIN_ROOT, 'agents', 'prosecutor.md'), 'description');
+  // Deliberately NOT shortened — this is the one agent a user or the main
+  // session picks by intent-matching, so its description needs real content.
+  assert.ok(desc.length > 200, 'prosecutor.md description should stay descriptive (it is model-selected, unlike the 6 programmatic lenses)');
+});
+
+test('always-loaded footprint: agent descriptions total dropped by more than half vs. the pre-#277 baseline', () => {
+  const agentFiles = [
+    'prosecutor.md',
+    ...PROGRAMMATIC_AGENTS,
+  ];
+  const total = agentFiles.reduce(
+    (sum, f) => sum + frontmatterField(join(PLUGIN_ROOT, 'agents', f), 'description').length,
+    0
+  );
+  const BASELINE_CHARS = 1680; // ~420 tokens, per the tokenomics review's measurement
+  assert.ok(
+    total < BASELINE_CHARS * 0.6,
+    `agent description total is ${total} chars — expected a >40% reduction from the ${BASELINE_CHARS}-char baseline`
+  );
+});
+
+test('SKILL.md and MCP schemas are NOT claimed as reduced — they are generated/protocol-required and out of this pass\'s scope', () => {
+  // This test exists to make the scope decision explicit and machine-checked,
+  // not to assert a specific size — it documents that touching these two
+  // pieces needs the router-model generator (SKILL.md) or would break MCP
+  // client calls (schemas), and is deferred rather than silently skipped.
+  const skillPath = join(PLUGIN_ROOT, 'skills', 'adlc', 'SKILL.md');
+  const generatorPath = join(REPO_ROOT, 'scripts', 'router', 'router-model.mjs');
+  const skill = readFileSync(skillPath, 'utf8');
+  const generator = readFileSync(generatorPath, 'utf8');
+  assert.match(skill, /<!-- ADLC_CC_SENTINEL_PHASE_ROUTER_V1 -->/, 'SKILL.md must still carry the generated-file sentinel');
+  assert.match(generator, /Routes agentic development work to the right/, 'the generator, not SKILL.md directly, is where this content is authored');
+});

--- a/plugins/adlc-claude-code/lib/test/prosecutor-lens-dedup.test.mjs
+++ b/plugins/adlc-claude-code/lib/test/prosecutor-lens-dedup.test.mjs
@@ -1,0 +1,111 @@
+// prosecutor-lens-dedup.test.mjs — issue #276: the 5 lens agent files must
+// carry only their differentiator (lens focus), not the ~85% shared
+// boilerplate (refute charter, output schema, tool constraints) that now
+// lives once in commands/adlc-prosecute.md step 1. And the trust-root tier
+// explanation must exist in exactly one canonical file, not triplicated
+// across SKILL.md / prosecutor.md / adlc-prosecute.md.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, '..', '..');
+
+const LENS_FILES = [
+  'prosecutor-correctness.md',
+  'prosecutor-security.md',
+  'prosecutor-contract.md',
+  'prosecutor-diff.md',
+  'prosecutor-tests.md',
+].map((f) => join(PLUGIN_ROOT, 'agents', f));
+
+function read(path) {
+  return readFileSync(path, 'utf8');
+}
+
+/**
+ * Every substring of `len` characters that appears in `text`. Used to find
+ * the longest common substring between two files without pulling in a diff
+ * library — a sliding window plus a Set is enough at this file size.
+ */
+function hasCommonSubstring(a, b, len) {
+  const windows = new Set();
+  for (let i = 0; i + len <= a.length; i++) windows.add(a.slice(i, i + len));
+  for (let i = 0; i + len <= b.length; i++) {
+    if (windows.has(b.slice(i, i + len))) return true;
+  }
+  return false;
+}
+
+test('no two lens agent files share a 200+ character block (the shared contract lives in adlc-prosecute.md, not duplicated per-lens)', () => {
+  const bodies = LENS_FILES.map((f) => [f, read(f)]);
+  for (let i = 0; i < bodies.length; i++) {
+    for (let j = i + 1; j < bodies.length; j++) {
+      const [fileA, textA] = bodies[i];
+      const [fileB, textB] = bodies[j];
+      assert.equal(
+        hasCommonSubstring(textA, textB, 200),
+        false,
+        `${fileA} and ${fileB} share a 200+ char block — the shared prosecution contract must live in commands/adlc-prosecute.md, not be duplicated per-lens`
+      );
+    }
+  }
+});
+
+test('every lens file points to /adlc:adlc-prosecute for the shared contract instead of restating it', () => {
+  for (const f of LENS_FILES) {
+    const text = read(f);
+    assert.match(text, /\/adlc:adlc-prosecute/, `${f} must reference the command that supplies the shared contract`);
+    // The old duplicated schema line must be gone from every lens file.
+    assert.doesNotMatch(text, /quoted verbatim from the diff/, `${f} must not restate the old verbatim-evidence instruction`);
+  }
+});
+
+test('the shared prosecution contract (schema + tool constraints) is defined in commands/adlc-prosecute.md', () => {
+  const command = read(join(PLUGIN_ROOT, 'commands', 'adlc-prosecute.md'));
+  assert.match(command, /severity[\s\S]*critical\|high\|medium\|low/);
+  assert.match(command, /You have no Edit\/Write\/Bash tools by design/);
+});
+
+// ── trust-root tier: de-duplicated where it's actually possible (issue #276) ──
+//
+// SKILL.md is a GENERATED file — six harness router files (claude-code,
+// antigravity, codex, pi, opencode, cursor) are rendered from one shared
+// template in scripts/router/router-model.mjs (see router-drift.test.mjs).
+// Its trust-root paragraph is intentionally shared cross-harness content,
+// not an accidental duplicate within this one plugin — pointing it at a
+// claude-code-only references/ file would break the other five harnesses,
+// which have no such file. So SKILL.md keeps its full copy; prosecutor.md
+// (which is NOT generated, genuinely claude-code-specific) is the one that
+// gets de-duplicated down to a pointer. The review's claimed third site
+// (commands/adlc-prosecute.md) never existed in the current codebase.
+
+const TRUST_ROOT_MARKER = 'cross-model-review';
+
+test('the trust-root tier reference doc carries the actionable mechanics (record-cross-model)', () => {
+  const referencePath = join(PLUGIN_ROOT, 'skills', 'adlc', 'references', 'trust-root.md');
+  const reference = read(referencePath);
+  assert.match(reference, new RegExp(TRUST_ROOT_MARKER));
+  assert.match(reference, /record-cross-model/);
+});
+
+test('prosecutor.md (non-generated) points to the trust-root reference doc instead of restating it', () => {
+  const prosecutor = read(join(PLUGIN_ROOT, 'agents', 'prosecutor.md'));
+  assert.match(prosecutor, /references\/trust-root\.md/);
+  assert.doesNotMatch(prosecutor, /record-cross-model --ticket/, 'prosecutor.md must not restate the record-cross-model invocation — it should point to references/trust-root.md instead');
+});
+
+test('commands/adlc-prosecute.md does not carry its own copy of the trust-root explanation (it never did — review claim was stale)', () => {
+  const command = read(join(PLUGIN_ROOT, 'commands', 'adlc-prosecute.md'));
+  assert.doesNotMatch(command, new RegExp(TRUST_ROOT_MARKER));
+});
+
+// ── prosecutor.md meta-commentary removed (issue #276 item 4) ─────────────
+
+test('prosecutor.md no longer narrates the OpenCode integration provenance history', () => {
+  const prosecutor = read(join(PLUGIN_ROOT, 'agents', 'prosecutor.md'));
+  assert.doesNotMatch(prosecutor, /OpenCode integration/);
+});

--- a/plugins/adlc-claude-code/skills/adlc/references/trust-root.md
+++ b/plugins/adlc-claude-code/skills/adlc/references/trust-root.md
@@ -1,0 +1,53 @@
+---
+title: Trust-root tier — cross-model gating
+description: When a same-model P5 SHIP is not enough, and what to do about it.
+---
+
+# Trust-root tier
+
+A same-model P5 pass validates the author's own tests, which encode the
+author's blind spot. For most changes that's sufficient. For the
+**trust-root tier** it is not.
+
+## When this applies
+
+If the change under prosecution touches any of —
+
+- an enforcement package (`packages/rails-guard|prosecute|gate-manifest|build-gate/`),
+- a gated-artifact producer (`packages/ticket-prune|ticket-sync/`),
+- a declared rails deny-path of any ticket, or
+- a trust-root file (`scripts/rails-guard-ci.mjs`, `docs/ci/rails-guard.yml`,
+  `scripts/test/rails-guard-workflow-hashes.json`, `.adlc/tickets.json`)
+
+— then a clean **same-model** P5 is not the end of the story.
+
+## What to do
+
+After reaching a same-model CLEAR verdict, **surface it explicitly**: *"same-model
+P5 passed; this tier REQUIRES a cross-model adversarial approve from a DISTINCT
+provider before `adlc prosecute --base <ref>` will exit 0."* Do not present the
+same-model SHIP as sufficient on its own.
+
+1. Run the cross-model pass: shell to the local `codex` CLI, or
+   `npx adversarial-review --base <ref>`.
+2. Once it approves, record the attestation so the gate clears:
+
+   ```
+   adlc prosecute record-cross-model --ticket <id> \
+     --provider codex --author-provider claude --verdict approve \
+     --input <passes.json>
+   ```
+
+The recorded `revision` is resolved the same way the gate resolves it (pass the
+same `--input`/`--revision` you use for the gate run), so the attestation binds
+to the revision the gate checks. `--provider` MUST differ from
+`--author-provider` — a same-model "review" is refused at record time and
+rejected by the gate.
+
+## Mechanically enforced, not advisory
+
+This is **gated**, not just recommended: the P5 prosecute runner (given
+`--base <ref>`) exits 2 until the manifest holds a `cross-model-review` approve
+from a provider distinct from the author, bound to the reviewed revision. See
+ADR-0007 and `packages/prosecute/lib/tier.mjs` for the enforcement mechanism
+(T39).


### PR DESCRIPTION
## Summary

Phase 2 of the tokenomics review (`docs/tokenomics-review.md`) tracked under #282. Closes #276, #277, #278.

Two of the three issues turned out to need real scope corrections after investigation — documented honestly in each commit rather than silently forced through or silently dropped:

- **#276 + #277 (landed together — same files)** — The 5 prosecution lens agents now declare only their lens focus; the shared refute charter/output schema/tool constraints live once in `commands/adlc-prosecute.md` instead of duplicated 5×. Important correction: this is a **maintainability** win (one place to update the schema), not a proven runtime token reduction — fresh-context subagents still need the full contract every call, whether via system prompt or per-call task prompt; moving it doesn't eliminate it. Said so explicitly rather than claiming a savings that doesn't hold up. What IS a real runtime reduction: the `evidence` field's content requirement shrank from "quoted verbatim from the diff" to a one-line pointer (the verifier already re-reads from disk, never trusts the quote), and `prosecutor.md` lost its trust-root duplication (now points to a new canonical `references/trust-root.md`) and its OpenCode-provenance meta-commentary tail. The 6 programmatically-invoked lens agents also got their descriptions cut ~63% (1,392 → 518 chars) since they're invoked by exact name, never model-selected — pure always-loaded waste.
- **Discovered mid-implementation:** `SKILL.md` is a *generated* file — six harness router files (claude-code, antigravity, codex, pi, opencode, cursor) render from one shared template (`scripts/router/router-model.mjs`), caught by an existing drift gate the first time I hand-edited it directly. SKILL.md's own progressive-disclosure restructuring (issue #277's item 2) and the sibling-port propagation (item 4) both need to happen at that generator layer to stay in sync across all six harnesses — genuinely bigger, more careful work than fits safely in this pass. Neither is covered by #277's actual acceptance criteria, so both are documented as deliberately deferred rather than attempted risky/incomplete.
- **#278** — coldstart now records `{ticketHash, model, gaps}` per audited ticket and skips the LLM call on a later run when it finds a matching entry (same content hash, same *resolved* model — switching `ADLC_MODEL_CHEAP` invalidates even at the same `--tier`). `--force` bypasses; `--max-age <days>` (default 30, `0` = everything stale) bounds entry age. Recording moved from one aggregate manifest entry per invocation to one per ticket, which is what makes per-ticket lookup possible — and as a side effect fixes `adlc spend --ticket <id>` filtering for `--all` runs, which previously recorded `ticket: undefined`. Threat-model note added: cache entries bind to ticketHash + model (not storeHash, deliberately — a coldstart verdict is a per-ticket property), residual tamper risk is the same one every unsigned manifest entry already carries.

**Also investigated and correctly scoped down (documented, not silently dropped):**
- #276's proposed 3rd trust-root duplication site (`commands/adlc-prosecute.md`) never existed in the current codebase — verified by grep before touching anything, not assumed from the original review.
- model-ratchet's equivalent caching (#278 proposed-change item 3) isn't implemented — no acceptance criterion covers it.

## Test plan

- [x] `node scripts/run-tests.mjs` — 46/46 segments green, run on the final committed state
- [x] `scripts/test/router-drift.test.mjs` — confirms the generated SKILL.md still matches its generator (caught and fixed a hand-edit mistake before it shipped)
- [x] `plugins/adlc-claude-code/lib/test/prosecutor-lens-dedup.test.mjs` — no 200+ char block shared across lens files; trust-root text canonical in one place; meta-commentary removed
- [x] `plugins/adlc-claude-code/lib/test/plugin-footprint.test.mjs` — 6 programmatic agent descriptions ≤100 chars, `prosecutor` stays descriptive
- [x] `packages/coldstart/test/cache.test.mjs` — pure `findCachedVerdict`/`buildCacheData` unit coverage (hash/model/age matching)
- [x] `packages/coldstart/test/checkall-cache.test.mjs` — injected call-counting: unchanged store → 1 call total across 2 runs; editing one ticket → only it re-audits; `--force`; `--max-age 0`; model-change invalidation
- [x] `packages/coldstart/test/coldstart-cache-e2e.test.mjs` — same behavior against a REAL gate-manifest ledger (temp dir), not just injected fixtures
- [x] Regression-tested the mock-seam/cache interaction: a first implementation let mocked test runs pollute the cache across a shared tmpDir; fixed by excluding `ADLC_GATE_MOCK_RESPONSE` runs from both cache lookup and cache recording