### PR TITLE
chore: make the local gate set match CI, and record the agent working lessons (T71)

### DIFF
--- a/.adlc/tickets.json
+++ b/.adlc/tickets.json
@@ -1436,111 +1436,6 @@
       "title": "fleet: make checkFlail actually read flail-detector's real contract (verdict + exit 2)"
     },
     {
-      "body": "Implement lib/block.mjs in @adlc/ticket-sync per the spec sections 'The block' and 'Validity Gate' (block cases). The block is JSON (JSON.parse — no YAML, zero-dep) wrapped in reserved HTML-comment sentinels `<!-- adlc:begin v=1 key=<uuid> -->` ... `<!-- adlc:end -->`. parseBlock(body) returns {prefix, block, suffix, version, key, formatErrors}; serializeBlock(prose{prefix,suffix}, fields) reproduces the body. Field validation delegates to T1's validator (no second schema). Depends on T1.\n\nAcceptance criteria:\n1. packages/ticket-sync/test/block.test.mjs green covering: lossless round-trip (prefix AND suffix prose preserved verbatim); missing/duplicate/unbalanced sentinels -> fail closed with an error naming the offending line; garbled JSON -> fail closed; present-but-invalid block (e.g. malformed rails) -> fail closed (NEVER degrade to 'no rails'); `$schema` key excluded from canonical equality; sentinel `v` greater than supported max -> fail closed.\n2. A human-authored ```json fence in prose outside the sentinels is ignored.\n3. Body model {prefix, block, suffix} is preserved across a parse->serialize cycle.",
-      "category": "feature",
-      "completed": true,
-      "duration": 1,
-      "edges": [
-        {
-          "to": "T8"
-        }
-      ],
-      "id": "T7",
-      "rails": [
-        "packages/ticket-sync/lib/schema.mjs",
-        "packages/ticket-sync/lib/validate.mjs",
-        "packages/ticket-sync/lib/canonical.mjs",
-        "packages/ticket-sync/scripts/gen-schema.mjs",
-        "packages/ticket-sync/schemas/**",
-        "packages/ticket-sync/test/schema.test.mjs",
-        "packages/ticket-sync/test/validate.test.mjs",
-        "packages/ticket-sync/test/canonical.test.mjs"
-      ],
-      "scope": [
-        "packages/ticket-sync/lib/block.mjs",
-        "packages/ticket-sync/test/block.test.mjs"
-      ],
-      "title": "Fenced JSON block codec (parse/serialize, fail-closed)"
-    },
-    {
-      "body": "Implement `adlc ticket pull` (dry-run by default; --write applies) per the spec data-flow 'Pull', 'Sidecar', 'Validity Gate', 'Sync vs the rails trust root', and 'Lock + atomic write'. Deliver: lib/gh.mjs (execFile wrapper — argv only, no shell, C4), lib/providers/github.mjs (read/map), lib/provider.mjs (interface, no registry), lib/reconcile.mjs (pure 3-way base/local/remote; base from sidecar syncedHash; missing/corrupt base fails safe to CONFLICT), lib/config.mjs (+ adlc-config validation, repo auto-detect, issue selector), lib/store.mjs (writeTicketsAtomic + mkdir lock sharing .adlc/tickets.lock; sidecar .adlc/ticket-sync.state.json gitignored rebuildable cache), lib/rails-guard-sync.mjs (rails superset / scope subset guard + forensic record), and register the `ticket` tool in packages/cli/lib/registry.mjs. Single repo-qualified id space gh:owner/repo#n, owner/repo lowercased to match loadTickets equality; unresolved edges FAIL CLOSED (no silent drop); pagination explicit (truncation -> exit 1, never deletion). Depends on T2.\n\nAcceptance criteria:\n1. test/{reconcile,github,config,store,validity,rails-guard-sync}.test.mjs green; all offline via an injected gh runner with canned --json fixtures.\n2. reconcile: remote-only/local-only/both-changed(conflict)/both-equal(converged); local-only ticket survives pull; out-of-selection survives.\n3. Validity Gate: id normalization unifies T<n>/gh: spellings; an unresolved edges[].to fails closed (exit 2), not dropped; resolution-checked set == bytes written.\n4. rails-guard-sync: rails non-superset and scope-widen refused without --allow-rail-narrowing; forensic record written.\n5. pull is dry-run without --write (verify no file mutation); exit codes 0/1/2 per matrix.",
-      "category": "feature",
-      "completed": true,
-      "duration": 3,
-      "edges": [
-        {
-          "to": "T9"
-        }
-      ],
-      "id": "T8",
-      "rails": [
-        "packages/ticket-sync/lib/schema.mjs",
-        "packages/ticket-sync/lib/validate.mjs",
-        "packages/ticket-sync/lib/canonical.mjs",
-        "packages/ticket-sync/lib/block.mjs",
-        "packages/ticket-sync/scripts/gen-schema.mjs",
-        "packages/ticket-sync/schemas/**",
-        "packages/ticket-sync/test/schema.test.mjs",
-        "packages/ticket-sync/test/validate.test.mjs",
-        "packages/ticket-sync/test/canonical.test.mjs",
-        "packages/ticket-sync/test/block.test.mjs"
-      ],
-      "scope": [
-        "packages/ticket-sync/lib/gh.mjs",
-        "packages/ticket-sync/lib/provider.mjs",
-        "packages/ticket-sync/lib/providers/github.mjs",
-        "packages/ticket-sync/lib/reconcile.mjs",
-        "packages/ticket-sync/lib/config.mjs",
-        "packages/ticket-sync/lib/store.mjs",
-        "packages/ticket-sync/lib/rails-guard-sync.mjs",
-        "packages/ticket-sync/bin/ticket-sync.mjs",
-        "packages/ticket-sync/test/reconcile.test.mjs",
-        "packages/ticket-sync/test/github.test.mjs",
-        "packages/ticket-sync/test/config.test.mjs",
-        "packages/ticket-sync/test/store.test.mjs",
-        "packages/ticket-sync/test/validity.test.mjs",
-        "packages/ticket-sync/test/rails-guard-sync.test.mjs",
-        "packages/cli/lib/registry.mjs"
-      ],
-      "title": "Pull: GitHub read adapter, 3-way reconcile, Validity Gate, sidecar, store"
-    },
-    {
-      "body": "Implement `adlc ticket push` and `adlc ticket sync` (dry-run by default; --write applies) per the spec data-flow 'Push'. Deliver: lib/outcomes.mjs (reduce .adlc/manifest.jsonl -> per-ticket status: latest-per-gate, verdict=latest P5 entry, no P5 -> no pass label), lib/status-render.mjs (labels mutually-exclusive within statusLabels + a canonical timestamp-free status comment; both display-only, never authoritative), and github write ops (updateIssueBody, ensureLabels, upsertStatusComment, createIssue). Create is idempotent: stable sentinel key, adopt off the already-paginated pull list (not the eventually-consistent search index), persist {nodeId,number} into pendingCreates before id-reassignment, >1 key match fails closed; on create reassign id T<n>->gh:owner/repo#n, rewrite every edges[].to store-wide, migrate manifest evidence to the new id. Transfer/renumber reuses the same reassign+edge-rewrite path. Depends on T3.\n\nAcceptance criteria:\n1. test/outcomes.test.mjs green: multiple verdicts (latest wins), none (no fabricated pass), per-gate latest.\n2. test/github.test.mjs idempotency: push twice against a recording fake -> second run makes no mutating calls; create adoption finds an existing keyed issue; a simulated lost local write does NOT duplicate; id reassignment rewrites edge references.\n3. push is dry-run without --write; partial failure -> per-issue result list, exit 1.",
-      "category": "feature",
-      "completed": true,
-      "duration": 3,
-      "edges": [
-        {
-          "to": "T10"
-        }
-      ],
-      "id": "T9",
-      "rails": [
-        "packages/ticket-sync/lib/schema.mjs",
-        "packages/ticket-sync/lib/validate.mjs",
-        "packages/ticket-sync/lib/canonical.mjs",
-        "packages/ticket-sync/lib/block.mjs",
-        "packages/ticket-sync/lib/gh.mjs",
-        "packages/ticket-sync/lib/provider.mjs",
-        "packages/ticket-sync/lib/reconcile.mjs",
-        "packages/ticket-sync/lib/rails-guard-sync.mjs",
-        "packages/ticket-sync/lib/config.mjs",
-        "packages/ticket-sync/lib/store.mjs",
-        "packages/ticket-sync/lib/pull.mjs",
-        "packages/ticket-sync/scripts/gen-schema.mjs",
-        "packages/ticket-sync/schemas/**"
-      ],
-      "scope": [
-        "packages/ticket-sync/lib/outcomes.mjs",
-        "packages/ticket-sync/lib/status-render.mjs",
-        "packages/ticket-sync/lib/providers/github.mjs",
-        "packages/ticket-sync/bin/ticket-sync.mjs",
-        "packages/ticket-sync/test/outcomes.test.mjs",
-        "packages/ticket-sync/test/github.test.mjs"
-      ],
-      "title": "Push + create: write-back, idempotent create, status outcomes"
-    },
-    {
       "body": "Fixes voodootikigod/adlc#293. packages/hollow-test/lib/runner.mjs scores `killed = trial.timedOut || (trial.status !== 0)`, so ANY non-zero exit counts as a kill - including a parse failure. A mutant that renders the file syntactically invalid is therefore credited as successfully killed when nothing was tested. Demonstrated on ordinary JavaScript: null-return rewrites a multiline `return {` to `return null;` and leaves the object's remaining lines behind. At the common per-file quota of one, that invalid mutant can be the only trial, so the required gate reports success having exercised no assertion - a false green from the tool built to detect false greens. This is language-independent; the JS/TS allow-list narrowing in #289 removed the most frequent trigger (Promise<unknown> -> Promise>=unknown>) but not the cause. Validate that the mutated file parses before running the test command, using `node --check` so no new runtime dependency is added to a published package. An invalid mutant is DISCARDED - neither killed nor survived - and reported. If every mutant for a run is invalid the gate must fail operationally rather than pass, since it proved nothing. Verification: node --test packages/hollow-test/test/*.test.mjs. allow-suppression: none Report surfaces (lib/report.mjs) are in scope because invalid and undetermined trials need their own buckets - rendering them as 'survived' asserts a test outcome for a test that never ran. (Authored as T62; renumbered to T63 after #304 landed a different T62 on main — fleet checkFlail — while this branch was open.)",
       "budget": "frontier",
       "category": "bug",
@@ -1779,6 +1674,33 @@
       "title": "Cursor DX: /adlc-init one-flow onboarding + marketplace publish checklist execution"
     },
     {
+      "body": "Implement lib/block.mjs in @adlc/ticket-sync per the spec sections 'The block' and 'Validity Gate' (block cases). The block is JSON (JSON.parse — no YAML, zero-dep) wrapped in reserved HTML-comment sentinels `<!-- adlc:begin v=1 key=<uuid> -->` ... `<!-- adlc:end -->`. parseBlock(body) returns {prefix, block, suffix, version, key, formatErrors}; serializeBlock(prose{prefix,suffix}, fields) reproduces the body. Field validation delegates to T1's validator (no second schema). Depends on T1.\n\nAcceptance criteria:\n1. packages/ticket-sync/test/block.test.mjs green covering: lossless round-trip (prefix AND suffix prose preserved verbatim); missing/duplicate/unbalanced sentinels -> fail closed with an error naming the offending line; garbled JSON -> fail closed; present-but-invalid block (e.g. malformed rails) -> fail closed (NEVER degrade to 'no rails'); `$schema` key excluded from canonical equality; sentinel `v` greater than supported max -> fail closed.\n2. A human-authored ```json fence in prose outside the sentinels is ignored.\n3. Body model {prefix, block, suffix} is preserved across a parse->serialize cycle.",
+      "category": "feature",
+      "completed": true,
+      "duration": 1,
+      "edges": [
+        {
+          "to": "T8"
+        }
+      ],
+      "id": "T7",
+      "rails": [
+        "packages/ticket-sync/lib/schema.mjs",
+        "packages/ticket-sync/lib/validate.mjs",
+        "packages/ticket-sync/lib/canonical.mjs",
+        "packages/ticket-sync/scripts/gen-schema.mjs",
+        "packages/ticket-sync/schemas/**",
+        "packages/ticket-sync/test/schema.test.mjs",
+        "packages/ticket-sync/test/validate.test.mjs",
+        "packages/ticket-sync/test/canonical.test.mjs"
+      ],
+      "scope": [
+        "packages/ticket-sync/lib/block.mjs",
+        "packages/ticket-sync/test/block.test.mjs"
+      ],
+      "title": "Fenced JSON block codec (parse/serialize, fail-closed)"
+    },
+    {
       "body": "GitHub issue #309. Follow-on to #284 / T62 (PR #304, merged).\n\n## Problem\n\n`checkFlail` returns `{ flail, signals, failedOpen? }`. `failedOpen` marks the\n§12 backstop: the detector could not produce a trustworthy verdict, so the gate\ndeclines to cut the build short.\n\nNOTHING READS IT. `scheduler.mjs:74` and `:84` consult `.flail` alone:\n\n```js\nif (canRetry() && (await effects.flail({ ticket })).flail) {\n  return fail('flail-detector diagnosed a genuine flail — skipping the second strike');\n}\n```\n\nA repo-wide search finds `failedOpen` only at its construction in gates.mjs and\nin test assertions. So at runtime EVERY fail-open is indistinguishable from a\ngenuine clean verdict:\n\n- the detector is not installed or is unspawnable (spawn error)\n- an operational error (exit 1)\n- output that will not parse\n- a document whose `verdict` we no longer recognize (schema drift)\n- `statusDir` is unwritable so no transcript exists (appendLog is best-effort\n  by design and swallows the failure)\n\nEach silently reports \"this session is fine, keep building\". Mistype statusDir,\nor run where @adlc/flail-detector fails to resolve, and every ticket in every\nrun gets a clean flail verdict forever with no log line and no evidence entry.\n\nThis is the SAME FAILURE CLASS as #284 — a supervision control that stops\nworking while reporting normally. #284 fixed why the gate was blind; this is\nabout noticing when it goes blind again.\n\n## Required behavior\n\nThe fail-open POLICY must not change. An unverifiable signal must not cut a\nbuild's normal retry short; the two-strike cap remains the backstop. `flail`\nstays `false` and the build still gets its retry. The ONLY change is that the\nfail-open becomes observable.\n\n1. `checkFlail`'s fail-open carries a machine-readable `reason`, one of:\n   - `spawn-error`         — exec threw without a usable detector verdict\n   - `operational-error`   — the detector ran and exited non-zero, not exit 2\n   - `unparseable`         — stdout was not JSON\n   - `unrecognized-verdict`— parsed, but `verdict` was not 'flail'|'clean',\n                             or `signals` was not an array\n2. The scheduler emits an operator-visible warning via its injected `log` when a\n   consultation fails open, naming the ticket and the reason.\n3. A genuine `clean` verdict emits NO warning — no crying wolf on the happy path.\n4. The scheduler's effects-contract JSDoc is updated from\n   `flail({ticket}) -> { flail }` to the real widened shape.\n\n## Acceptance criteria\n\n1. Each of the four `reason` values is produced by its own branch, covered by a\n   unit test per branch. Verify: `node --test packages/fleet/test/`.\n2. A fail-open during `advanceTicket` emits a warning through the injected `log`\n   naming BOTH the ticket id and the reason. Verify by asserting on captured log\n   output, not on the returned object — the point is operator visibility.\n3. A genuine clean verdict emits no fail-open warning. Verify by asserting the\n   captured log contains no such line.\n4. THE POLICY IS UNCHANGED: on a fail-open the ticket still consumes its normal\n   retry and is NOT failed early. Assert explicitly, so this can never drift\n   into fail-closed — that would let a missing detector kill real work.\n5. A genuine flail verdict still short-circuits the second strike exactly as\n   before (no regression in the #284 behavior).\n6. `node --test packages/fleet/test/*.test.mjs` exits 0.\n7. `adlc hollow-test` reports no surviving non-equivalent mutants on the changed\n   lines.\n\n## Constraints\n\n- Do NOT change the fail-open policy to fail closed.\n- Do NOT change flail-detector; its contract is the frozen rail.\n- Preserve `checkFlail`'s exported signature and the `{adlcBin, exec}` options.\n- fleet is ESM (.mjs), node:test, no external test deps.\n- `scheduler.mjs` already receives an injected `log` (default no-op) — use it\n  rather than console.*, so the warning is testable.",
       "category": "bugfix",
       "duration": 1,
@@ -1794,6 +1716,102 @@
         "packages/fleet/test/**"
       ],
       "title": "fleet: make a fail-open flail consultation observable, so the gate cannot go blind silently"
+    },
+    {
+      "body": "Implement `adlc ticket pull` (dry-run by default; --write applies) per the spec data-flow 'Pull', 'Sidecar', 'Validity Gate', 'Sync vs the rails trust root', and 'Lock + atomic write'. Deliver: lib/gh.mjs (execFile wrapper — argv only, no shell, C4), lib/providers/github.mjs (read/map), lib/provider.mjs (interface, no registry), lib/reconcile.mjs (pure 3-way base/local/remote; base from sidecar syncedHash; missing/corrupt base fails safe to CONFLICT), lib/config.mjs (+ adlc-config validation, repo auto-detect, issue selector), lib/store.mjs (writeTicketsAtomic + mkdir lock sharing .adlc/tickets.lock; sidecar .adlc/ticket-sync.state.json gitignored rebuildable cache), lib/rails-guard-sync.mjs (rails superset / scope subset guard + forensic record), and register the `ticket` tool in packages/cli/lib/registry.mjs. Single repo-qualified id space gh:owner/repo#n, owner/repo lowercased to match loadTickets equality; unresolved edges FAIL CLOSED (no silent drop); pagination explicit (truncation -> exit 1, never deletion). Depends on T2.\n\nAcceptance criteria:\n1. test/{reconcile,github,config,store,validity,rails-guard-sync}.test.mjs green; all offline via an injected gh runner with canned --json fixtures.\n2. reconcile: remote-only/local-only/both-changed(conflict)/both-equal(converged); local-only ticket survives pull; out-of-selection survives.\n3. Validity Gate: id normalization unifies T<n>/gh: spellings; an unresolved edges[].to fails closed (exit 2), not dropped; resolution-checked set == bytes written.\n4. rails-guard-sync: rails non-superset and scope-widen refused without --allow-rail-narrowing; forensic record written.\n5. pull is dry-run without --write (verify no file mutation); exit codes 0/1/2 per matrix.",
+      "category": "feature",
+      "completed": true,
+      "duration": 3,
+      "edges": [
+        {
+          "to": "T9"
+        }
+      ],
+      "id": "T8",
+      "rails": [
+        "packages/ticket-sync/lib/schema.mjs",
+        "packages/ticket-sync/lib/validate.mjs",
+        "packages/ticket-sync/lib/canonical.mjs",
+        "packages/ticket-sync/lib/block.mjs",
+        "packages/ticket-sync/scripts/gen-schema.mjs",
+        "packages/ticket-sync/schemas/**",
+        "packages/ticket-sync/test/schema.test.mjs",
+        "packages/ticket-sync/test/validate.test.mjs",
+        "packages/ticket-sync/test/canonical.test.mjs",
+        "packages/ticket-sync/test/block.test.mjs"
+      ],
+      "scope": [
+        "packages/ticket-sync/lib/gh.mjs",
+        "packages/ticket-sync/lib/provider.mjs",
+        "packages/ticket-sync/lib/providers/github.mjs",
+        "packages/ticket-sync/lib/reconcile.mjs",
+        "packages/ticket-sync/lib/config.mjs",
+        "packages/ticket-sync/lib/store.mjs",
+        "packages/ticket-sync/lib/rails-guard-sync.mjs",
+        "packages/ticket-sync/bin/ticket-sync.mjs",
+        "packages/ticket-sync/test/reconcile.test.mjs",
+        "packages/ticket-sync/test/github.test.mjs",
+        "packages/ticket-sync/test/config.test.mjs",
+        "packages/ticket-sync/test/store.test.mjs",
+        "packages/ticket-sync/test/validity.test.mjs",
+        "packages/ticket-sync/test/rails-guard-sync.test.mjs",
+        "packages/cli/lib/registry.mjs"
+      ],
+      "title": "Pull: GitHub read adapter, 3-way reconcile, Validity Gate, sidecar, store"
+    },
+    {
+      "body": "Implement `adlc ticket push` and `adlc ticket sync` (dry-run by default; --write applies) per the spec data-flow 'Push'. Deliver: lib/outcomes.mjs (reduce .adlc/manifest.jsonl -> per-ticket status: latest-per-gate, verdict=latest P5 entry, no P5 -> no pass label), lib/status-render.mjs (labels mutually-exclusive within statusLabels + a canonical timestamp-free status comment; both display-only, never authoritative), and github write ops (updateIssueBody, ensureLabels, upsertStatusComment, createIssue). Create is idempotent: stable sentinel key, adopt off the already-paginated pull list (not the eventually-consistent search index), persist {nodeId,number} into pendingCreates before id-reassignment, >1 key match fails closed; on create reassign id T<n>->gh:owner/repo#n, rewrite every edges[].to store-wide, migrate manifest evidence to the new id. Transfer/renumber reuses the same reassign+edge-rewrite path. Depends on T3.\n\nAcceptance criteria:\n1. test/outcomes.test.mjs green: multiple verdicts (latest wins), none (no fabricated pass), per-gate latest.\n2. test/github.test.mjs idempotency: push twice against a recording fake -> second run makes no mutating calls; create adoption finds an existing keyed issue; a simulated lost local write does NOT duplicate; id reassignment rewrites edge references.\n3. push is dry-run without --write; partial failure -> per-issue result list, exit 1.",
+      "category": "feature",
+      "completed": true,
+      "duration": 3,
+      "edges": [
+        {
+          "to": "T10"
+        }
+      ],
+      "id": "T9",
+      "rails": [
+        "packages/ticket-sync/lib/schema.mjs",
+        "packages/ticket-sync/lib/validate.mjs",
+        "packages/ticket-sync/lib/canonical.mjs",
+        "packages/ticket-sync/lib/block.mjs",
+        "packages/ticket-sync/lib/gh.mjs",
+        "packages/ticket-sync/lib/provider.mjs",
+        "packages/ticket-sync/lib/reconcile.mjs",
+        "packages/ticket-sync/lib/rails-guard-sync.mjs",
+        "packages/ticket-sync/lib/config.mjs",
+        "packages/ticket-sync/lib/store.mjs",
+        "packages/ticket-sync/lib/pull.mjs",
+        "packages/ticket-sync/scripts/gen-schema.mjs",
+        "packages/ticket-sync/schemas/**"
+      ],
+      "scope": [
+        "packages/ticket-sync/lib/outcomes.mjs",
+        "packages/ticket-sync/lib/status-render.mjs",
+        "packages/ticket-sync/lib/providers/github.mjs",
+        "packages/ticket-sync/bin/ticket-sync.mjs",
+        "packages/ticket-sync/test/outcomes.test.mjs",
+        "packages/ticket-sync/test/github.test.mjs"
+      ],
+      "title": "Push + create: write-back, idempotent create, status outcomes"
+    },
+    {
+      "body": "ADLC P7 (distill) for the #284 / #309 session.\n\n## Problem\n\nCONTRIBUTING step 2 told contributors to run `npm test` before pushing. CI\nblocks a PR on THREE required gates:\n\n  npm test                                  (suite)\n  node scripts/rails-guard-ci.mjs origin/main   (rail-freeze + trust root)\n  node scripts/mutation-gate.mjs origin/main    (mutation coverage)\n\nTwo of the three were documented nowhere and had no local entry point, so doing\nexactly what CONTRIBUTING said still left a contributor surprised by CI.\n\nWorse, there is an active trap: `adlc rails-guard` and\n`scripts/rails-guard-ci.mjs` sound interchangeable and are not. The CI script\nadditionally forbids any change to an EXISTING ticket's contract in\n.adlc/tickets.json (the rail trust root). The weaker check is the more\ndiscoverable one.\n\nThis is not hypothetical. In the #309 session a branch reused a ticket id that a\nconcurrent session had already claimed on main, silently rewriting that ticket's\ncontract. `adlc rails-guard` reported \"all checks passed\" throughout; CI\nrejected the PR. The gate did its job — the local workflow was the defect.\n\n## Deterministic defense (preferred over prose)\n\n1. `scripts/preflight.mjs` + `npm run preflight` — runs all three PR-blocking\n   gates in CI's order, cheapest first, stopping at the first failure, after\n   fetching the base ref (a stale origin/<base> makes both diff gates compare\n   against the wrong tree and pass for the wrong reason).\n2. CONTRIBUTING step 2 points at preflight and names the three gates.\n3. `adlc rails-guard`'s clean-pass output carries a stderr advisory naming the\n   stricter CI gate, so the friendlier command stops reading as full clearance.\n   STDERR and human-mode only — stdout and the --json contract are untouched.\n\n## Prose defense (only for what a script cannot encode)\n\n`AGENTS.md` at the repo root — harness-agnostic, because this repo ships seven\nharness plugins and a Claude-specific file would contradict that. Limited to\nnon-derivable, session-proven lessons: preflight vs npm test; ticket ids must be\nre-read after a fetch AND checked against open PRs; never `git checkout --` a\nfile to undo a mutation experiment (it discards uncommitted work); check for a\nconcurrent agent session mutating the checkout; PRs are squash-merged so a\nstacked base needs cherry-pick, not rebase.\n\n## Acceptance criteria\n\n1. `npm run preflight` exists and runs exactly the gates CI blocks on. Verify by\n   a test that reads .github/workflows/ci.yml and asserts each CI gate marker\n   has a corresponding command in preflight — so CI growing a gate reds the\n   test rather than silently outdating the script.\n2. preflight fetches the base ref before the diff-based gates, and fails\n   (non-zero, with a clear message) when the base cannot be resolved rather than\n   comparing against nothing. Verify by driving the real script with an\n   unresolvable --base.\n3. preflight stops at the first failing gate and exits non-zero.\n4. A clean `adlc rails-guard` run emits a stderr advisory naming\n   scripts/rails-guard-ci.mjs, the .adlc/tickets.json rule that differs, and\n   `npm run preflight`. Verify by driving the real bin.\n5. The advisory does NOT appear on stdout and does NOT appear in --json mode;\n   `--json` output still parses. Verify by driving the real bin both ways.\n6. CONTRIBUTING names `npm run preflight`.\n7. `npm test` green; `npm run preflight` green.\n\n## Constraints\n\n- rails-guard is an ENFORCEMENT package (trust-root tier): the change there must\n  be output-only, with no effect on exit codes, violation detection, the --json\n  document, or the manifest record. Per ADLC P5 this tier also requires a\n  cross-model review recorded before merge — flag it rather than self-approving.\n- Do not restate in AGENTS.md what CONVENTIONS.md or the code already encode.",
+      "category": "chore",
+      "duration": 1,
+      "edges": [],
+      "id": "T71",
+      "rails": [],
+      "scope": [
+        "scripts/preflight.mjs",
+        "scripts/test/**",
+        "packages/rails-guard/bin/**",
+        "packages/rails-guard/test/**",
+        "AGENTS.md",
+        "CONTRIBUTING.md",
+        "package.json"
+      ],
+      "title": "Make the local gate set match CI, and record the working lessons agents cannot derive"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,19 @@ session. Choosing an id from a snapshot taken earlier silently **overwrites
 someone else's ticket**, which is exactly what the gate rejects. Re-read shared
 mutable state at the moment you use it, not when you start.
 
+### Resolving a `.adlc/tickets.json` conflict during a rebase
+
+`--ours` and `--theirs` are **inverted in a rebase**: `--ours` is upstream, and
+`--theirs` is the commit being replayed. `git checkout --theirs` therefore keeps
+*your* stale store and silently drops tickets that landed on the base — which
+the rail-freeze gate then rejects as removals. Name the ref explicitly instead
+of relying on the side words, then re-add your ticket:
+
+```sh
+git checkout origin/main -- .adlc/tickets.json
+adlc ticket create --input <file> --write
+```
+
 ## Undoing an experiment: copy, don't `git checkout`
 
 Mutation testing and gate-bite checks mean deliberately breaking a file and
@@ -58,6 +71,17 @@ here.
 ```sh
 cp packages/x/lib/y.mjs /tmp/y.bak    # then mutate, test
 cp /tmp/y.bak packages/x/lib/y.mjs    # restore exactly what you had
+```
+
+`git stash` has a sharper edge: this repo carries **long-lived stashes from other
+branches**. `git stash push` on a clean tree saves nothing, so a later
+`git stash pop` silently pops *someone else's* entry. Never pair a bare
+push/pop around a checkout. If you already did, the entry is recoverable:
+
+```sh
+git fsck --unreachable | grep commit | awk '{print $3}' \
+  | xargs -n1 git log -1 --format='%H %s' | grep 'On <branch>'
+git stash store -m "<original message>" <sha>
 ```
 
 ## Check whether the checkout is already busy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# Working in this repo (agents)
+
+Harness-agnostic on purpose: this repo ships plugins for seven agent harnesses,
+so the guidance lives here rather than in a tool-specific file.
+
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) and [CONVENTIONS.md](./CONVENTIONS.md)
+first — they carry the package contract and coding rules. This file only records
+things that are **not derivable** from the code, and that have actually gone
+wrong.
+
+## Before you push: `npm run preflight`
+
+Not `npm test`. CI blocks a PR on three gates, and the suite is only one:
+
+| gate | what it asks |
+| --- | --- |
+| tests | does the workspace suite pass |
+| rail-freeze | did the diff edit a frozen rail, **or change an existing ticket** |
+| mutation-gate | do the changed lines have tests that notice them breaking |
+
+`npm run preflight` runs all three, in CI's order, against a freshly fetched
+base.
+
+**`adlc rails-guard` is not the CI check.** They sound interchangeable and are
+not: `scripts/rails-guard-ci.mjs` additionally forbids any change to an existing
+ticket's contract in `.adlc/tickets.json`. A clean `adlc rails-guard` has
+already been reported as "ready to merge" on a branch CI then rejected. The
+weaker check is the more discoverable one — prefer `npm run preflight`.
+
+## `.adlc/tickets.json` is the rail trust root
+
+Anything that can rewrite the ticket store can weaken its own rails, so CI
+freezes it: a PR may **add** a ticket, never alter an existing one.
+
+The practical consequence is about ticket **ids**. They are claimed by whoever
+writes first, including a concurrent session in another worktree:
+
+```sh
+git fetch origin main          # immediately before, not at task start
+adlc ticket list --json        # re-read; the id you scouted may be taken
+gh pr list --json number       # ...and ids claimed by OPEN PRs are not on main yet
+adlc ticket create --input <file> --write
+```
+
+Checking `main` alone is not enough: an id added by an open PR is invisible
+there until it merges, including a PR you opened yourself earlier in the same
+session. Choosing an id from a snapshot taken earlier silently **overwrites
+someone else's ticket**, which is exactly what the gate rejects. Re-read shared
+mutable state at the moment you use it, not when you start.
+
+## Undoing an experiment: copy, don't `git checkout`
+
+Mutation testing and gate-bite checks mean deliberately breaking a file and
+reverting it. `git checkout -- <file>` reverts to **HEAD**, discarding
+uncommitted work in that file — which has already destroyed in-progress edits
+here.
+
+```sh
+cp packages/x/lib/y.mjs /tmp/y.bak    # then mutate, test
+cp /tmp/y.bak packages/x/lib/y.mjs    # restore exactly what you had
+```
+
+## Check whether the checkout is already busy
+
+Other agent sessions and `mutation-gate` runs mutate tracked files in place, so
+a dirty tree may not be the user's edit and may change under you mid-task:
+
+```sh
+ps -Ao pid,etime,command | grep -E "hollow-test|mutation-gate" | grep -v grep
+```
+
+If something is running, work in a worktree (`.worktrees/<name>`, see
+[rules on worktrees](https://github.com/voodootikigod/adlc)) and leave the main
+checkout alone. Note the Bash tool's working directory can reset between calls —
+confirm `pwd` before trusting a `git status`.
+
+## Stacking a PR
+
+PRs here are **squash-merged**, so a base branch disappears and its commits are
+rewritten into one. Before building on another PR, check it is still open
+(`gh pr view <n> --json state`). If it merged, rebuilding is a cherry-pick of
+your own unique commits onto fresh `main`, not a rebase — a rebase replays the
+pre-squash commits and conflicts throughout.
+
+## The ADLC gates apply to this repo too
+
+This repo is the toolkit, and it uses it: author a ticket (P0), check
+executability (`adlc coldstart <id> --prompt-only`, P2), and prosecute before
+merge (`/adlc:adlc-prosecute`, P5). Two rules that carry real weight:
+
+- **Fail-open vs fail-closed is a deliberate choice, never an accident.** Several
+  gates fail open on purpose so an unverifiable signal cannot kill real work.
+  When you touch one, assert the direction in a test so it cannot drift.
+- **A mock cannot catch drift in the thing it imitates.** #284 shipped because
+  every fixture mocked a tool's output in a shape that tool has never produced.
+  For contract tests, drive the real binary, and export the production adapter
+  so tests use *it* rather than a copy of it.
+
+Changes under `packages/rails-guard`, `prosecute`, `gate-manifest`, or
+`build-gate` are trust-root tier: a same-model P5 is not sufficient, and a
+cross-model review must be recorded before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,13 @@ npm install        # installs the workspace
 npm test           # runs every package's test suite
 ```
 
+To run every gate that blocks a PR (what CI enforces):
+
+```sh
+npm run preflight              # tests + rail-freeze + mutation gate, vs origin/main
+npm run preflight -- --base <ref>
+```
+
 To run a single package's tests:
 
 ```sh
@@ -113,7 +120,19 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
 
 1. Fork the repo and create a branch (`feat/<name>`, `fix/<name>`, …).
-2. Make your change with tests; run `npm test`.
+2. Make your change with tests, then run `npm run preflight` — **not just
+   `npm test`**. CI blocks a PR on three gates and the suite is only one of
+   them; preflight runs all three locally, in CI's order:
+
+   | gate | what it checks |
+   | --- | --- |
+   | tests | the full workspace suite |
+   | rail-freeze | no frozen rail edited, and no *existing* ticket changed in `.adlc/tickets.json` |
+   | mutation-gate | changed code has tests that notice it being broken |
+
+   Note `adlc rails-guard` is **not** the CI check — `scripts/rails-guard-ci.mjs`
+   is stricter, and a clean `adlc rails-guard` has already been mistaken for
+   clearance on a branch CI then rejected.
 3. Push and open a PR against `main` using the PR template.
 4. Keep PRs focused — one logical change per PR.
 5. A maintainer will review; address feedback and we'll merge once green.

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "private": true,
   "type": "module",
   "version": "1.6.0",
-  "description": "Agentic Development Lifecycle toolkit — gate-shaped, zero-dependency CLIs",
+  "description": "Agentic Development Lifecycle toolkit \u2014 gate-shaped, zero-dependency CLIs",
   "workspaces": [
     "packages/*",
     "apps/*"
   ],
   "scripts": {
     "test": "node scripts/run-tests.mjs",
+    "preflight": "node scripts/preflight.mjs",
     "release": "node scripts/release.mjs"
   },
   "engines": {

--- a/packages/rails-guard/bin/rails-guard.mjs
+++ b/packages/rails-guard/bin/rails-guard.mjs
@@ -250,6 +250,14 @@ if (values.json) {
 } else {
   if (violations.length === 0) {
     console.log('rails-guard: all checks passed');
+    // A clean pass here is NOT full pre-merge clearance, and reading it as such
+    // has already cost a red CI run: this command answers "did the diff edit a
+    // frozen rail path?", while the CI gate additionally rejects any change to
+    // an EXISTING ticket's contract in the trust root. A branch that reused a
+    // ticket id another branch had claimed passed this check and failed that
+    // one. Advisory, on stderr, so piping stdout is unaffected.
+    console.error('note: CI also runs scripts/rails-guard-ci.mjs, which is stricter ' +
+      '(it rejects changes to existing tickets in .adlc/tickets.json). Run `npm run preflight` for the full set.');
   } else {
     console.error(formatViolations(violations));
   }

--- a/packages/rails-guard/test/ci-gate-advisory.test.mjs
+++ b/packages/rails-guard/test/ci-gate-advisory.test.mjs
@@ -1,0 +1,60 @@
+// `adlc rails-guard` passing is not full pre-merge clearance.
+//
+// This command answers "did the diff edit a frozen rail path?". The CI gate,
+// scripts/rails-guard-ci.mjs, additionally rejects any change to an EXISTING
+// ticket's contract in .adlc/tickets.json — the rail trust root. The two names
+// are near-identical and the weaker check is the more discoverable one, which
+// has already produced a branch reported as merge-ready off a clean
+// `rails-guard` run and then rejected by CI.
+//
+// The advisory goes to STDERR so anything piping stdout is unaffected.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(HERE, '../bin/rails-guard.mjs');
+const REPO = resolve(HERE, '../../..');
+
+/** A clean pass: comparing HEAD against itself can touch no rail. */
+const ARGS = ['--base', 'HEAD', '--rails', 'no/such/path/**'];
+const runClean = (extra = []) => spawnSync(process.execPath, [BIN, ...ARGS, ...extra], { cwd: REPO, encoding: 'utf8' });
+
+test('a clean pass still points at the stricter CI gate', async () => {
+  const r = runClean();
+
+  assert.equal(r.status, 0, `precondition: this must be a clean pass (${r.stderr})`);
+  assert.match(r.stdout, /all checks passed/);
+  assert.match(r.stderr, /rails-guard-ci\.mjs/, 'the stricter CI gate must be named');
+  assert.match(r.stderr, /stricter/i);
+});
+
+test('the advisory names the trust-root rule that differs', async () => {
+  const r = runClean();
+
+  // Naming the actual extra rule is the point — "run something else too" without
+  // saying what it checks is what left the distinction invisible in the first place.
+  assert.match(r.stderr, /\.adlc\/tickets\.json/);
+  assert.match(r.stderr, /npm run preflight/, 'and the one command that covers both');
+});
+
+test('the advisory does not pollute stdout or the JSON contract', async () => {
+  const human = runClean();
+  assert.doesNotMatch(human.stdout, /rails-guard-ci/, 'stdout stays pipeable');
+
+  const json = runClean(['--json']);
+  assert.equal(json.status, 0);
+  const parsed = JSON.parse(json.stdout); // must not throw — machine contract intact
+  assert.equal(parsed.tool, 'rails-guard');
+  assert.doesNotMatch(json.stderr, /rails-guard-ci/, 'machine mode stays silent');
+});
+
+test('preflight is a real script, so the advisory does not point at nothing', async () => {
+  const pkg = JSON.parse(readFileSync(resolve(REPO, 'package.json'), 'utf8'));
+
+  assert.ok(pkg.scripts?.preflight, 'the advisory tells the reader to run this');
+});

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// preflight — run every gate that BLOCKS a pull request, locally, in one command.
+//
+// WHY THIS EXISTS. CONTRIBUTING told contributors to run `npm test` before
+// pushing, but CI blocks a PR on three independent required gates: the test
+// suite, the rail-freeze trust-root check, and the diff-scoped mutation gate.
+// Two of the three were documented nowhere and had no local entry point, so
+// doing exactly what CONTRIBUTING said still left you surprised by CI.
+//
+// WHAT IT DEFENDS — the near-miss that motivated it. `adlc rails-guard` and
+// `scripts/rails-guard-ci.mjs` sound interchangeable and are not: the CI script
+// additionally forbids any change to an EXISTING ticket's contract in
+// .adlc/tickets.json (the rail trust root). A PR authored against a stale view
+// of the ticket store reused an id another branch had already claimed, silently
+// rewriting that ticket's contract. The friendlier `adlc rails-guard` reported
+// "all checks passed" the whole time, because it answers a different and weaker
+// question. The weaker check was the more discoverable one — so the fix is to
+// make the STRONGER set the thing you actually run.
+//
+// Gates run in CI's order, cheapest first, and the run STOPS at the first
+// failure: a red suite makes the later gates' output noise.
+//
+// Live-canary jobs (codex/opencode) are deliberately excluded — they need
+// network and provider credentials, so they cannot be a local precondition.
+// Everything here is hermetic.
+
+import { spawnSync, execFileSync } from 'node:child_process';
+
+const BASE = process.argv.includes('--base')
+  ? process.argv[process.argv.indexOf('--base') + 1]
+  : 'main';
+
+/** Gates that block a PR, in the order CI runs them. */
+const GATES = [
+  {
+    name: 'tests',
+    why: 'the full workspace suite',
+    argv: ['node', ['scripts/run-tests.mjs']],
+  },
+  {
+    name: 'rail-freeze',
+    why: 'no frozen rail edited, and no EXISTING ticket contract changed',
+    argv: ['node', ['scripts/rails-guard-ci.mjs', `origin/${BASE}`]],
+  },
+  {
+    name: 'mutation-gate',
+    why: 'changed code has tests that notice it being broken',
+    argv: ['node', ['scripts/mutation-gate.mjs', '--base', BASE]],
+  },
+];
+
+/**
+ * The rail-freeze and mutation gates both diff against `origin/<base>`. A stale
+ * or missing remote ref makes them compare against the wrong tree and quietly
+ * pass — the exact "green locally, red in CI" gap this script exists to close.
+ */
+function refreshBase() {
+  try {
+    execFileSync('git', ['fetch', '--no-tags', 'origin', `${BASE}:refs/remotes/origin/${BASE}`], { stdio: 'pipe' });
+    return true;
+  } catch (e) {
+    console.error(`preflight: could not fetch origin/${BASE} — gates would compare against a stale base.`);
+    console.error(`  ${String(e.stderr ?? e.message).trim()}`);
+    return false;
+  }
+}
+
+console.log(`preflight: running the ${GATES.length} gates that block a PR (base: origin/${BASE})\n`);
+
+if (!refreshBase()) process.exit(1);
+
+const started = Date.now();
+for (const [i, gate] of GATES.entries()) {
+  console.log(`── [${i + 1}/${GATES.length}] ${gate.name} — ${gate.why}`);
+  const [cmd, args] = gate.argv;
+  const r = spawnSync(cmd, args, { stdio: 'inherit' });
+
+  if (r.error) {
+    console.error(`\npreflight: FAILED to run ${gate.name}: ${r.error.message}`);
+    process.exit(1);
+  }
+  if (r.status !== 0) {
+    console.error(`\n✖ preflight: ${gate.name} FAILED (exit ${r.status}) — this gate blocks the PR.`);
+    if (gate.name === 'rail-freeze') {
+      console.error('  Note: this is STRICTER than `adlc rails-guard`. As well as frozen-rail');
+      console.error('  edits it rejects any change to an existing ticket in .adlc/tickets.json.');
+      console.error('  A ticket id claimed by another branch is the usual cause — re-read the');
+      console.error('  store after fetching and pick a genuinely free id.');
+    }
+    process.exit(r.status);
+  }
+  console.log(`✔ ${gate.name}\n`);
+}
+
+console.log(`✔ preflight: all ${GATES.length} PR-blocking gates passed in ${Math.round((Date.now() - started) / 1000)}s`);

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -25,46 +25,72 @@
 // Everything here is hermetic.
 
 import { spawnSync, execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
-const BASE = process.argv.includes('--base')
-  ? process.argv[process.argv.indexOf('--base') + 1]
-  : 'main';
+/** Base branch name (not a ref) — `--base <name>`, default `main`. */
+export function parseBase(argv) {
+  const i = argv.indexOf('--base');
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : 'main';
+}
 
-/** Gates that block a PR, in the order CI runs them. */
-const GATES = [
-  {
-    name: 'tests',
-    why: 'the full workspace suite',
-    argv: ['node', ['scripts/run-tests.mjs']],
-  },
-  {
-    name: 'rail-freeze',
-    why: 'no frozen rail edited, and no EXISTING ticket contract changed',
-    argv: ['node', ['scripts/rails-guard-ci.mjs', `origin/${BASE}`]],
-  },
-  {
-    name: 'mutation-gate',
-    why: 'changed code has tests that notice it being broken',
-    argv: ['node', ['scripts/mutation-gate.mjs', '--base', BASE]],
-  },
-];
+/**
+ * The gates that block a PR, in the order CI runs them.
+ *
+ * Each argv MIRRORS ci.yml exactly. That is load-bearing, and getting it subtly
+ * wrong is the very failure this script exists to prevent: mutation-gate reads
+ * its base as the first NON-FLAG positional (`args.find(a => !a.startsWith('--'))`,
+ * defaulting to `origin/main`), so passing `--base main` would silently hand it
+ * the bare branch name and diff against a different ref than CI does.
+ */
+export function buildGates(base) {
+  return [
+    {
+      name: 'tests',
+      why: 'the full workspace suite',
+      argv: ['node', ['scripts/run-tests.mjs']],
+    },
+    {
+      name: 'rail-freeze',
+      why: 'no frozen rail edited, and no EXISTING ticket contract changed',
+      argv: ['node', ['scripts/rails-guard-ci.mjs', `origin/${base}`]],
+    },
+    {
+      name: 'mutation-gate',
+      why: 'changed code has tests that notice it being broken',
+      argv: ['node', ['scripts/mutation-gate.mjs', `origin/${base}`, '--max', '12']],
+    },
+  ];
+}
+
+const BASE = parseBase(process.argv);
+const GATES = buildGates(BASE);
 
 /**
  * The rail-freeze and mutation gates both diff against `origin/<base>`. A stale
  * or missing remote ref makes them compare against the wrong tree and quietly
  * pass — the exact "green locally, red in CI" gap this script exists to close.
  */
-function refreshBase() {
+export function refreshBase(base = BASE, run = defaultFetch) {
   try {
-    execFileSync('git', ['fetch', '--no-tags', 'origin', `${BASE}:refs/remotes/origin/${BASE}`], { stdio: 'pipe' });
+    run(base);
     return true;
   } catch (e) {
-    console.error(`preflight: could not fetch origin/${BASE} — gates would compare against a stale base.`);
+    console.error(`preflight: could not fetch origin/${base} — gates would compare against a stale base.`);
     console.error(`  ${String(e.stderr ?? e.message).trim()}`);
     return false;
   }
 }
 
+function defaultFetch(base) {
+  execFileSync('git', ['fetch', '--no-tags', 'origin', `${base}:refs/remotes/origin/${base}`], { stdio: 'pipe' });
+}
+
+// Importable for tests; only the direct invocation runs the gates.
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (!isMain) { /* imported — expose the helpers above without running anything */ }
+else main();
+
+function main() {
 console.log(`preflight: running the ${GATES.length} gates that block a PR (base: origin/${BASE})\n`);
 
 if (!refreshBase()) process.exit(1);
@@ -93,3 +119,4 @@ for (const [i, gate] of GATES.entries()) {
 }
 
 console.log(`✔ preflight: all ${GATES.length} PR-blocking gates passed in ${Math.round((Date.now() - started) / 1000)}s`);
+}

--- a/scripts/test/preflight.test.mjs
+++ b/scripts/test/preflight.test.mjs
@@ -12,11 +12,13 @@ import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildGates, parseBase, refreshBase } from '../preflight.mjs';
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const SCRIPT = resolve(REPO, 'scripts/preflight.mjs');
 const src = readFileSync(SCRIPT, 'utf8');
 const ci = readFileSync(resolve(REPO, '.github/workflows/ci.yml'), 'utf8');
+const flat = (g) => [g.argv[0], ...g.argv[1]].join(' ');
 
 // gate -> (how CI invokes it, what preflight must run). Kept as a pair so the
 // assertion fails loudly if CI stops running a gate OR preflight stops matching.
@@ -43,6 +45,42 @@ test('CONTRIBUTING points contributors at preflight, not just npm test', async (
   const doc = readFileSync(resolve(REPO, 'CONTRIBUTING.md'), 'utf8');
 
   assert.match(doc, /npm run preflight/, 'the PR process must name the command that matches CI');
+});
+
+test('every gate is invoked EXACTLY as ci.yml invokes it', async () => {
+  // The failure this pins: mutation-gate reads its base as the first NON-FLAG
+  // positional and defaults to origin/main, so `--base main` silently diffs
+  // against a different ref than CI. A grep for the script name cannot see that.
+  const [tests, rail, mutation] = buildGates('main');
+
+  assert.deepEqual(tests.argv[1], ['scripts/run-tests.mjs']);
+  assert.deepEqual(rail.argv[1], ['scripts/rails-guard-ci.mjs', 'origin/main']);
+  assert.deepEqual(mutation.argv[1], ['scripts/mutation-gate.mjs', 'origin/main', '--max', '12']);
+
+  // ...and CI really does use the positional + --max form.
+  assert.match(ci, /mutation-gate\.mjs "origin\/\$BASE_REF" --max 12/);
+  assert.match(ci, /rails-guard-ci\.mjs "origin\/\$BASE_REF"/);
+});
+
+test('--base selects the ref every diff-based gate compares against', async () => {
+  assert.equal(parseBase(['node', 'preflight.mjs', '--base', 'release-2']), 'release-2');
+  assert.equal(parseBase(['node', 'preflight.mjs']), 'main', 'defaults to main');
+  assert.equal(parseBase(['node', 'preflight.mjs', '--base']), 'main', 'a dangling --base is not a ref');
+
+  for (const g of buildGates('release-2').filter((x) => x.name !== 'tests')) {
+    assert.ok(flat(g).includes('origin/release-2'), `${g.name} must honor --base`);
+  }
+});
+
+test('refreshBase reports success only when the fetch actually succeeded', async () => {
+  // Both diff gates compare against origin/<base>. Reporting success on a failed
+  // fetch would let them run against a stale ref and pass for the wrong reason —
+  // the "green locally, red in CI" gap this script exists to close.
+  const calls = [];
+  assert.equal(refreshBase('main', (b) => calls.push(b)), true);
+  assert.deepEqual(calls, ['main'], 'the requested base is what gets fetched');
+
+  assert.equal(refreshBase('main', () => { throw new Error('no such ref'); }), false);
 });
 
 test('preflight refreshes the base ref before diffing against it', async () => {

--- a/scripts/test/preflight.test.mjs
+++ b/scripts/test/preflight.test.mjs
@@ -1,0 +1,69 @@
+// preflight — the single local entry point for the gates that block a PR.
+//
+// The bug this defends against is documentation drift: CONTRIBUTING said to run
+// `npm test`, CI enforced three gates, and nothing connected the two. So the
+// load-bearing property is not "the script runs" — it is that the gate LIST
+// stays identical to what CI actually requires. A preflight that silently drops
+// a gate is worse than none, because it reads as full clearance.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = resolve(REPO, 'scripts/preflight.mjs');
+const src = readFileSync(SCRIPT, 'utf8');
+const ci = readFileSync(resolve(REPO, '.github/workflows/ci.yml'), 'utf8');
+
+// gate -> (how CI invokes it, what preflight must run). Kept as a pair so the
+// assertion fails loudly if CI stops running a gate OR preflight stops matching.
+const GATES = [
+  { gate: 'tests',         ci: 'npm test',                     preflight: 'scripts/run-tests.mjs' },
+  { gate: 'rail-freeze',   ci: 'scripts/rails-guard-ci.mjs',   preflight: 'scripts/rails-guard-ci.mjs' },
+  { gate: 'mutation-gate', ci: 'scripts/mutation-gate.mjs',    preflight: 'scripts/mutation-gate.mjs' },
+];
+
+test('preflight runs every gate CI blocks a PR on', async () => {
+  for (const { gate, ci: marker, preflight } of GATES) {
+    assert.ok(ci.includes(marker), `precondition: CI must still run ${gate} via "${marker}"`);
+    assert.ok(src.includes(preflight), `preflight must run ${gate} — CI blocks the PR on it`);
+  }
+});
+
+test('preflight is registered as an npm script', async () => {
+  const pkg = JSON.parse(readFileSync(resolve(REPO, 'package.json'), 'utf8'));
+
+  assert.equal(pkg.scripts.preflight, 'node scripts/preflight.mjs');
+});
+
+test('CONTRIBUTING points contributors at preflight, not just npm test', async () => {
+  const doc = readFileSync(resolve(REPO, 'CONTRIBUTING.md'), 'utf8');
+
+  assert.match(doc, /npm run preflight/, 'the PR process must name the command that matches CI');
+});
+
+test('preflight refreshes the base ref before diffing against it', async () => {
+  // Both diff-based gates compare against origin/<base>. A stale remote ref
+  // makes them compare against the wrong tree and pass for the wrong reason —
+  // the same "green locally, red in CI" gap preflight exists to close.
+  assert.match(src, /git['"],\s*\[['"]fetch['"]/, 'preflight must fetch the base ref');
+});
+
+test('preflight stops at the first failing gate with a non-zero exit', async () => {
+  // Drive the real script with a base ref that cannot resolve: the fetch guard
+  // must refuse rather than silently proceeding to compare against nothing.
+  const r = spawnSync(process.execPath, [SCRIPT, '--base', 'no-such-branch-xyz'], { cwd: REPO, encoding: 'utf8' });
+
+  assert.notEqual(r.status, 0, 'an unresolvable base must fail, not pass vacuously');
+  assert.match(`${r.stderr}${r.stdout}`, /stale base|could not fetch/i);
+});
+
+test('preflight names the rail-freeze/adlc rails-guard distinction on failure', async () => {
+  // The near-miss that motivated this: `adlc rails-guard` reported "all checks
+  // passed" while the stricter CI gate rejected the branch. If preflight ever
+  // fails that gate, it must say why the friendlier command disagreed.
+  assert.match(src, /STRICTER than `adlc rails-guard`/);
+});


### PR DESCRIPTION
ADLC P7 (distill) for the #284 / #309 sessions. Ticket **T71**.

## Problem

CONTRIBUTING step 2 told contributors to run `npm test` before pushing. CI blocks a PR on **three** required gates:

| gate | command | documented? |
| --- | --- | --- |
| tests | `npm test` | yes |
| rail-freeze | `node scripts/rails-guard-ci.mjs origin/main` | **no** |
| mutation coverage | `node scripts/mutation-gate.mjs origin/main --max 12` | **no** |

Two of the three had no local entry point, so following CONTRIBUTING exactly still left you surprised by CI.

Worse, there is an active trap: **`adlc rails-guard` is not the CI check.** The names are near-identical; the CI script additionally forbids changing an *existing* ticket's contract in `.adlc/tickets.json` — the rail trust root.

That is not hypothetical. During #309 a branch reused a ticket id a concurrent session had already claimed, silently rewriting that ticket's contract. `adlc rails-guard` reported `all checks passed` throughout, and the branch was reported as merge-ready; CI rejected it. The gate did its job — the local workflow was the defect. **The weaker check was the more discoverable one.**

## Deterministic defenses (preferred over prose)

- **`scripts/preflight.mjs` + `npm run preflight`** — runs all three PR-blocking gates in CI's order, cheapest first, stopping at the first failure, after fetching the base ref. A stale `origin/<base>` makes both diff gates compare against the wrong tree and pass for the wrong reason, so the fetch is part of the gate, not a convenience.
- **CONTRIBUTING** step 2 now points at it and names the three gates.
- **`adlc rails-guard`'s clean pass emits a stderr advisory** naming the stricter CI gate, the `.adlc/tickets.json` rule that differs, and `npm run preflight`. Output-only: stdout stays pipeable and the `--json` document is untouched, asserted by test.

## Prose defense, only for what a script cannot encode

**`AGENTS.md`** at the repo root — harness-agnostic rather than `CLAUDE.md`, because this repo ships seven harness plugins and a tool-specific file would contradict its own thesis. Restricted to non-derivable, *session-proven* lessons:

- `npm run preflight`, not `npm test` — and why `adlc rails-guard` is not the same check
- ticket ids must be re-read after a fetch **and** checked against open PRs (an id added by an open PR is invisible on `main`)
- `.adlc/tickets.json` conflicts during a **rebase**: `--ours`/`--theirs` are inverted, so `--theirs` keeps your stale store and drops tickets that landed on the base
- never `git checkout -- <file>` to undo a mutation experiment — it discards uncommitted work
- never pair a bare `git stash push`/`pop` around a checkout: a push on a clean tree saves nothing, so the pop takes *someone else's* entry (this repo carries long-lived stashes from other branches). Includes the `git fsck` + `git stash store` recovery
- check for a concurrent agent session mutating the checkout before trusting `git status`
- PRs are squash-merged, so rebuilding on a merged base is a cherry-pick, not a rebase

## The gate caught a bug in its own fix

Worth calling out, because it is the strongest evidence the gate earns its keep. `mutation-gate.mjs` reads its base as the first **non-flag positional** (`args.find(a => !a.startsWith('--'))`, defaulting to `origin/main`). preflight originally passed `--base main`, so `find()` returned the bare branch name and the gate diffed against a **different ref than CI**. That is exactly the "green locally, red in CI" class preflight exists to close — reproduced inside the fix for it, and caught by the mutation gate rather than by review.

The fix also made the script testable by construction: `buildGates()` / `parseBase()` / `refreshBase()` are exported and the gate loop only runs on direct invocation, so tests assert the **exact argv per gate** instead of grepping the source for a script name. A grep cannot see a wrong flag form — five mutants survived the grep-based tests; none survive these.

## Verification

- `npm run preflight` — **all 3 gates pass** (`✔ preflight: all 3 PR-blocking gates passed in 207s`)
- `adlc hollow-test` via the mutation gate — **11/11 killed, 0 survived**
- `scripts/rails-guard-ci.mjs origin/main` — clean
- The preflight test reads `.github/workflows/ci.yml` and asserts every CI gate marker has a matching preflight command, so **CI growing a gate reds the test** instead of silently outdating the script.

## Review notes

1. **`packages/rails-guard` is trust-root tier.** Per ADLC P5, a same-model prosecution is not sufficient for this package and a cross-model review should be recorded before merge. The change there is deliberately output-only — no effect on exit codes, violation detection, the `--json` document, or the manifest record — but the tier rule is path-based, so flagging rather than self-approving.
2. **The full suite is flaky on some machines.** Repeated local runs fail a *varying* 2–4 segments (`scripts`, `ticket-sync`, `ticket-prune`, `gate-fuzzing`, `model-ratchet`, `review-calibration`), and this reproduces on clean `main` with no changes, so it predates this PR. It is not reproducing in CI. preflight will surface it locally — that is the gate being honest, but it is worth a separate look since a flaky gate trains people to ignore it.

## What P7's own mining found

`adlc lesson-foundry --prompt-only` reported `(no clusters to refine)` and `rejection-mining` emitted only its placeholder. Both were honest: `.adlc/findings.jsonl` is empty, and there were no human PR rejections to mine.

That is itself a finding worth recording: a P5 prosecution run through the subagent path produces no durable record. `/adlc:adlc-prosecute` records via `gate-manifest record prosecution`, which captures that prosecution *happened*, not *what it found* — so roughly twenty real findings across two rounds of #284 left nothing for lesson-foundry to cluster. **P7 cannot compound from P5 today.** Not fixed here; flagged as worth its own issue.
