### PR TITLE
feat(antigravity): add anti-flail handler for adlc-antigravity plugin

### DIFF
--- a/plugins/adlc-antigravity/build-gate-inline.mjs
+++ b/plugins/adlc-antigravity/build-gate-inline.mjs
@@ -5,7 +5,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, statSyn
 import { isAbsolute, join } from 'node:path';
 import { loadTickets, globMatch, ticketStoreExists } from './core-inline.mjs';
 import { resolveActiveTicketId } from './rails-checker.mjs';
-import { detectEditChurn } from './flail-inline.mjs';
+import { detectEditChurn, analyzeFlail, resolveTranscriptPath, parseTranscriptLines } from './flail-inline.mjs';
 
 export const DEFAULT_DEPTH_THRESHOLD = 50;
 export const MAX_TRACKED_SESSIONS = 100;
@@ -249,25 +249,53 @@ export function createPersistentTracker(root = process.cwd(), env = process.env)
         writeStore(store);
       });
     },
-    recordEdit(sessionID, filePath) {
-      if (!sessionID || !filePath || !ticketStoreExists(root, env)) return { churning: [] };
+    recordEdit(sessionID, filePath, { transcriptLines = [] } = {}) {
+      if (!sessionID || !ticketStoreExists(root, env)) return { churning: [], repeatedErrors: [], verdict: 'clean', summary: '' };
       return withLock(sessionID, () => {
         const store = readStore();
         const s = store[sessionID] ?? { depth: 0, compacted: false, edits: [], warned: [] };
         s.edits = s.edits ?? [];
         s.warned = s.warned ?? [];
-        s.edits.push(`Editing ${filePath}`);
-        if (s.edits.length > 200) s.edits = s.edits.slice(-200);
+        if (filePath) {
+          s.edits.push(`Editing ${filePath}`);
+          if (s.edits.length > 200) s.edits = s.edits.slice(-200);
+        }
+
+        const analysis = analyzeFlail({ edits: s.edits, transcriptLines });
+        const hashKey = `${analysis.verdict}:${analysis.summary}`;
+        const isNew = analysis.verdict === 'flail' && !s.warned.includes(hashKey);
+        if (isNew) {
+          s.warned.push(hashKey);
+        }
+
+        s.flailStatus = {
+          verdict: analysis.verdict,
+          summary: analysis.summary,
+          updatedAt: Date.now(),
+        };
+
+        s.updatedAt = Date.now();
+        store[sessionID] = s;
+        writeStore(store);
 
         const churns = detectEditChurn(s.edits, 3);
         const newlyChurning = churns.filter((c) => !s.warned.includes(c.path));
         for (const c of newlyChurning) s.warned.push(c.path);
 
-        s.updatedAt = Date.now();
-        store[sessionID] = s;
-        writeStore(store);
-        return { churning: newlyChurning };
-      }, { churning: [] });
+        return {
+          churning: newlyChurning,
+          verdict: analysis.verdict,
+          signals: analysis.signals,
+          summary: analysis.summary,
+          recommendation: analysis.recommendation,
+          isNewSignal: isNew,
+        };
+      }, { churning: [], verdict: 'clean', summary: '' });
+    },
+    edits(sessionID) {
+      if (!sessionID) return [];
+      const store = readStore();
+      return store[sessionID]?.edits ?? [];
     },
     depth(sessionID) {
       if (!sessionID) return 0;
@@ -284,6 +312,16 @@ export function createPersistentTracker(root = process.cwd(), env = process.env)
       return lockFailures.has(sessionID);
     },
   };
+}
+
+export function checkFlail({ sessionID, tracker, root = process.cwd(), env = process.env }) {
+  if (!sessionID || sessionID === 'default_session') {
+    return { verdict: 'clean', signals: [], summary: '', recommendation: 'Session clean' };
+  }
+  const transcriptPath = resolveTranscriptPath({ conversationId: sessionID, env });
+  const transcriptLines = transcriptPath ? parseTranscriptLines(transcriptPath) : [];
+  const storeEdits = tracker?.edits?.(sessionID) ?? [];
+  return analyzeFlail({ edits: storeEdits, transcriptLines });
 }
 
 export function decideBuildGate({ riskTier, degraded, bypass, sessionID } = {}) {

--- a/plugins/adlc-antigravity/flail-inline.mjs
+++ b/plugins/adlc-antigravity/flail-inline.mjs
@@ -79,7 +79,9 @@ export function resolveTranscriptPath({ payload, conversationId, env = process.e
   if (!cid && !payload && typeof conversationId === 'string' && conversationId !== 'default_session') {
     cid = conversationId;
   }
-  if (!cid) return null;
+  if (!cid || typeof cid !== 'string') return null;
+  if (cid.includes('..') || cid.includes('/') || cid.includes('\\')) return null;
+
   const appDataDir = env?.ANTIGRAVITY_APP_DATA_DIR ?? env?.GEMINI_CLI_DATA_DIR ?? join(homedir(), '.gemini', 'antigravity-cli');
   const transcriptPath = join(appDataDir, 'brain', cid, '.system_generated', 'logs', 'transcript.jsonl');
   if (existsSync(transcriptPath)) return transcriptPath;

--- a/plugins/adlc-antigravity/flail-inline.mjs
+++ b/plugins/adlc-antigravity/flail-inline.mjs
@@ -1,9 +1,59 @@
-// flail-inline.mjs — self-contained target-file edit churn tracking for adlc-antigravity.
+// flail-inline.mjs — self-contained target-file edit churn and error flail tracking for adlc-antigravity.
 // Uses ONLY Node builtins (no npm @adlc/* runtime dependencies).
 
-export const DEFAULT_FLAIL_THRESHOLD = 3;
-export const DEFAULT_WINDOW = 200;
+import { existsSync, readFileSync, openSync, readSync, closeSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { createHash } from 'node:crypto';
 
+export const DEFAULT_FLAIL_THRESHOLD = 3;
+export const DEFAULT_ERROR_REPEAT_THRESHOLD = 2;
+export const DEFAULT_WINDOW = 200;
+export const MAX_SCAN_BYTES = 262144; // 256 KiB tail window
+
+export const ERROR_LINE_RE = /error|exception|failed|cannot|ENOENT|FAIL|ERR!/i;
+
+/**
+ * Normalize an error line for signature comparison:
+ * Lowercase, strip hex, quotes, absolute paths, digits, collapse whitespace.
+ */
+export function normalizeError(line) {
+  if (typeof line !== 'string') return '';
+  return line
+    .toLowerCase()
+    .replace(/0x[0-9a-f]+/gi, '')
+    .replace(/"[^"]*"/g, '')
+    .replace(/'[^']*'/g, '')
+    .replace(/(?:\b[A-Za-z]:\\[^\s]*|(?:\/|\b[\w.-]+\/)[^\s]*)/g, '')
+    .replace(/\d+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Find error-line signatures that appear >= maxRepeat times.
+ */
+export function detectRepeatedErrors(lines, maxRepeat = DEFAULT_ERROR_REPEAT_THRESHOLD) {
+  const counts = new Map();
+  for (const line of lines) {
+    if (typeof line !== 'string' || !ERROR_LINE_RE.test(line)) continue;
+    const sig = normalizeError(line);
+    if (!sig || sig.length < 5) continue;
+    if (/^created at:?$/.test(sig) || /^completed at:?$/.test(sig)) continue;
+    counts.set(sig, (counts.get(sig) ?? 0) + 1);
+  }
+  const results = [];
+  for (const [signature, count] of counts.entries()) {
+    if (count >= maxRepeat) {
+      results.push({ signature, count });
+    }
+  }
+  return results;
+}
+
+/**
+ * Detect edit churn on files appearing >= threshold times in edit log lines.
+ */
 export function detectEditChurn(logLines, threshold = DEFAULT_FLAIL_THRESHOLD) {
   const counts = new Map();
   for (const line of logLines) {
@@ -20,24 +70,142 @@ export function detectEditChurn(logLines, threshold = DEFAULT_FLAIL_THRESHOLD) {
   return result;
 }
 
-export function createFlailTracker({ window = DEFAULT_WINDOW, threshold = DEFAULT_FLAIL_THRESHOLD } = {}) {
+/**
+ * Resolve transcript path for a given agy conversation ID or payload.
+ */
+export function resolveTranscriptPath({ payload, conversationId, env = process.env } = {}) {
+  const cidFromPayload = payload?.conversationId ?? payload?.conversation_id ?? payload?.conversationID ?? payload?.sessionID ?? payload?.sessionId ?? payload?.params?.conversationId ?? payload?.params?.conversation_id;
+  let cid = cidFromPayload;
+  if (!cid && !payload && typeof conversationId === 'string' && conversationId !== 'default_session') {
+    cid = conversationId;
+  }
+  if (!cid) return null;
+  const appDataDir = env?.ANTIGRAVITY_APP_DATA_DIR ?? env?.GEMINI_CLI_DATA_DIR ?? join(homedir(), '.gemini', 'antigravity-cli');
+  const transcriptPath = join(appDataDir, 'brain', cid, '.system_generated', 'logs', 'transcript.jsonl');
+  if (existsSync(transcriptPath)) return transcriptPath;
+  const fullTranscriptPath = join(appDataDir, 'brain', cid, '.system_generated', 'logs', 'transcript_full.jsonl');
+  if (existsSync(fullTranscriptPath)) return fullTranscriptPath;
+  return null;
+}
+
+/**
+ * Safely parse recent lines from an agy transcript JSONL file.
+ */
+export function parseTranscriptLines(filePath, maxScanBytes = MAX_SCAN_BYTES) {
+  if (!filePath || !existsSync(filePath)) return [];
+  try {
+    const stat = statSync(filePath);
+    let content = '';
+    if (stat.size > maxScanBytes) {
+      const fd = openSync(filePath, 'r');
+      const buf = Buffer.alloc(maxScanBytes);
+      readSync(fd, buf, 0, maxScanBytes, stat.size - maxScanBytes);
+      closeSync(fd);
+      content = buf.toString('utf8');
+      const firstNewline = content.indexOf('\n');
+      if (firstNewline !== -1) content = content.slice(firstNewline + 1);
+    } else {
+      content = readFileSync(filePath, 'utf8');
+    }
+    const extracted = [];
+    for (const rawLine of content.split('\n')) {
+      if (!rawLine.trim()) continue;
+      try {
+        const obj = JSON.parse(rawLine);
+        if (obj.content && typeof obj.content === 'string') {
+          extracted.push(...obj.content.split('\n'));
+        }
+        if (obj.text && typeof obj.text === 'string') {
+          extracted.push(...obj.text.split('\n'));
+        }
+        if (obj.message && typeof obj.message === 'string') {
+          extracted.push(...obj.message.split('\n'));
+        }
+      } catch {
+        extracted.push(rawLine);
+      }
+    }
+    return extracted;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Unified flail analysis across file edit churn, repeated errors, and transcript logs.
+ */
+export function analyzeFlail({ edits = [], transcriptLines = [], threshold = DEFAULT_FLAIL_THRESHOLD, maxErrorRepeat = DEFAULT_ERROR_REPEAT_THRESHOLD } = {}) {
+  const churning = detectEditChurn(edits, threshold);
+  const errorLines = [...edits, ...transcriptLines];
+  const repeatedErrors = detectRepeatedErrors(errorLines, maxErrorRepeat);
+
+  const signals = [];
+  if (churning.length > 0) {
+    signals.push({ type: 'edit-churn', entries: churning });
+  }
+  if (repeatedErrors.length > 0) {
+    signals.push({ type: 'repeated-error', entries: repeatedErrors });
+  }
+
+  const isFlailing = signals.length > 0;
+  let summary = '';
+  if (isFlailing) {
+    const parts = [];
+    if (churning.length > 0) {
+      parts.push(`file edit churn (${churning.map((c) => `${c.path} ${c.count}×`).join(', ')})`);
+    }
+    if (repeatedErrors.length > 0) {
+      parts.push(`repeated error signatures (${repeatedErrors.map((e) => `"${e.signature}" ${e.count}×`).join(', ')})`);
+    }
+    summary = parts.join('; ');
+  }
+
+  return {
+    verdict: isFlailing ? 'flail' : 'clean',
+    signals,
+    summary,
+    recommendation: isFlailing
+      ? `ADLC anti-flail: session is flailing (${summary}). Consider stepping back, isolating root causes, or starting a fresh session rather than continuing to retry.`
+      : 'Session clean',
+  };
+}
+
+export function createFlailTracker({ window = DEFAULT_WINDOW, threshold = DEFAULT_FLAIL_THRESHOLD, maxErrorRepeat = DEFAULT_ERROR_REPEAT_THRESHOLD } = {}) {
   const lines = new Map();
   const warned = new Map();
 
   return {
-    record({ sessionID, tool, filePath }) {
-      if (!sessionID || !filePath) return { churning: [] };
+    record({ sessionID, tool, filePath, transcriptLines = [] }) {
+      if (!sessionID) return { churning: [], repeatedErrors: [], verdict: 'clean', summary: '' };
       const buf = lines.get(sessionID) ?? [];
-      buf.push(`Editing ${filePath}`);
-      if (buf.length > window) buf.splice(0, buf.length - window);
-      lines.set(sessionID, buf);
+      if (filePath) {
+        buf.push(`Editing ${filePath}`);
+        if (buf.length > window) buf.splice(0, buf.length - window);
+        lines.set(sessionID, buf);
+      }
 
-      const seen = warned.get(sessionID) ?? new Set();
-      const churning = detectEditChurn(buf, threshold).filter((c) => !seen.has(c.path));
-      for (const c of churning) seen.add(c.path);
-      warned.set(sessionID, seen);
+      const analysis = analyzeFlail({ edits: buf, transcriptLines, threshold, maxErrorRepeat });
+      const hashKey = createHash('sha1').update(JSON.stringify(analysis.signals)).digest('hex').slice(0, 16);
 
-      return { churning };
+      const seenHashes = warned.get(sessionID) ?? new Set();
+      const isNew = analysis.verdict === 'flail' && !seenHashes.has(hashKey);
+      if (isNew) {
+        seenHashes.add(hashKey);
+        warned.set(sessionID, seenHashes);
+      }
+
+      const churning = detectEditChurn(buf, threshold);
+      const repeatedErrors = detectRepeatedErrors([...buf, ...transcriptLines], maxErrorRepeat);
+
+      return {
+        churning,
+        repeatedErrors,
+        verdict: analysis.verdict,
+        signals: analysis.signals,
+        summary: analysis.summary,
+        recommendation: analysis.recommendation,
+        isNewSignal: isNew,
+      };
     },
     evict(sessionID) {
       lines.delete(sessionID);
@@ -49,3 +217,4 @@ export function createFlailTracker({ window = DEFAULT_WINDOW, threshold = DEFAUL
 export function flailMessage({ path, count }) {
   return `ADLC flail check: ${path} has been edited ${count}× this session — repeated rewrites often signal the model is stuck. Consider stepping back or starting a fresh session.`;
 }
+

--- a/plugins/adlc-antigravity/hooks/adlc-rails-guard.mjs
+++ b/plugins/adlc-antigravity/hooks/adlc-rails-guard.mjs
@@ -8,8 +8,8 @@ import { fileURLToPath } from 'node:url';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, parse } from 'node:path';
 import { checkRail, classifyTool, isShellTool, resolveActiveTicketId } from '../rails-checker.mjs';
-import { checkBuildGate, createPersistentTracker, resolveSessionId } from '../build-gate-inline.mjs';
-import { flailMessage } from '../flail-inline.mjs';
+import { checkBuildGate, checkFlail, createPersistentTracker, resolveSessionId } from '../build-gate-inline.mjs';
+import { flailMessage, resolveTranscriptPath, parseTranscriptLines, analyzeFlail } from '../flail-inline.mjs';
 
 // agy nests the call under toolCall; args is the parameter bag. Read defensively.
 const TOOLCALL_KEYS = ['toolCall', 'tool_call', 'tool'];
@@ -126,15 +126,7 @@ export function decide(payload, { env = process.env, trackerCache } = {}) {
       if (verdict.decision === 'deny') return deny(`frozen rail — ${verdict.reason}`);
 
       const pathTracker = getTracker(root);
-
-      // Record edit for flail tracking
       const sessionID = resolveSessionId({ payload, env });
-      if (cls === 'mutating' && pathTracker?.recordEdit) {
-        const { churning } = pathTracker.recordEdit(sessionID, abs);
-        if (churning && churning.length > 0) {
-          for (const c of churning) console.error(flailMessage(c));
-        }
-      }
 
       // Check build-gate backstop for structured mutators and unknown ('other') tools
       if (cls !== 'readonly' && enforcing) {
@@ -143,6 +135,25 @@ export function decide(payload, { env = process.env, trackerCache } = {}) {
         }
         const gate = checkBuildGate({ sessionID, tracker: pathTracker, root, env });
         if (gate.decision === 'deny') return deny(`build-gate — ${gate.reason}`);
+      }
+
+      // Record edit for flail tracking & inspect session transcript for repeated errors / edit churn
+      if (cls === 'mutating' && pathTracker?.recordEdit) {
+        const transcriptPath = resolveTranscriptPath({ payload, conversationId: sessionID, env });
+        const transcriptLines = transcriptPath ? parseTranscriptLines(transcriptPath) : [];
+        const flailRes = pathTracker.recordEdit(sessionID, abs, { transcriptLines });
+
+        const flailEnforcing = enforcing || env?.ADLC_FLAIL_ENFORCEMENT === '1';
+        const flailBypass = env?.ADLC_FLAIL_BYPASS === '1';
+
+        if (flailRes?.verdict === 'flail') {
+          if (flailEnforcing && !flailBypass) {
+            return deny(`flail-detector — session is flailing: ${flailRes.summary}. Step back or start a fresh session before retrying.`);
+          }
+          if (flailRes.isNewSignal) {
+            console.error(`[adlc-anti-flail] Advisory: ${flailRes.recommendation}`);
+          }
+        }
       }
     }
     return allow();
@@ -213,6 +224,7 @@ export function printStatus(root = process.cwd(), env = process.env, payload = {
   const active = resolveActiveTicketId(resolvedRoot, env);
   const tracker = createPersistentTracker(resolvedRoot, env);
   const sessionID = resolveSessionId({ payload, env });
+  const flail = checkFlail({ sessionID, tracker, root: resolvedRoot, env });
 
   console.log(`--- ADLC Antigravity Status ---`);
   console.log(`Root: ${resolvedRoot}`);
@@ -221,6 +233,7 @@ export function printStatus(root = process.cwd(), env = process.env, payload = {
   console.log(`Resolved Session ID: ${sessionID}`);
   console.log(`Context Depth (Tool Calls): ${tracker.depth(sessionID)}`);
   console.log(`Session Compacted: ${tracker.isCompacted(sessionID)}`);
+  console.log(`Flail Status: ${flail.verdict.toUpperCase()}${flail.summary ? ` (${flail.summary})` : ''}`);
 }
 
 export function printDoctor(root = process.cwd(), env = process.env) {

--- a/plugins/adlc-antigravity/test/flail.test.mjs
+++ b/plugins/adlc-antigravity/test/flail.test.mjs
@@ -143,3 +143,9 @@ test('runFromStdin denies mutating tools when session is flailing under enforcem
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('resolveTranscriptPath rejects path traversal sequences in conversationId', () => {
+  assert.equal(resolveTranscriptPath({ conversationId: '../secret' }), null);
+  assert.equal(resolveTranscriptPath({ conversationId: 'foo/bar' }), null);
+  assert.equal(resolveTranscriptPath({ conversationId: 'c:\\windows' }), null);
+});

--- a/plugins/adlc-antigravity/test/flail.test.mjs
+++ b/plugins/adlc-antigravity/test/flail.test.mjs
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  normalizeError,
+  detectRepeatedErrors,
+  detectEditChurn,
+  resolveTranscriptPath,
+  parseTranscriptLines,
+  analyzeFlail,
+  createFlailTracker,
+} from '../flail-inline.mjs';
+import { runFromStdin, printStatus } from '../hooks/adlc-rails-guard.mjs';
+
+test('normalizeError strips line numbers, hex, quotes, absolute paths, and digits', () => {
+  const raw1 = 'Error: Failed to build target "/Users/test/app.js" at line 42 (0xDEADBEEF)';
+  const raw2 = 'Error: Failed to build target "C:\\Users\\test\\app.js" at line 99 (0x1234)';
+  const norm1 = normalizeError(raw1);
+  const norm2 = normalizeError(raw2);
+
+  assert.equal(norm1, norm2);
+  assert.equal(norm1, 'error: failed to build target at line ()');
+});
+
+test('detectRepeatedErrors detects error signatures repeating >= maxRepeat times', () => {
+  const lines = [
+    'Error: Failed to compile src/a.js at line 10',
+    'Info: compiling...',
+    'Error: Failed to compile src/b.js at line 20',
+    'Error: Failed to compile src/c.js at line 30',
+  ];
+  const detected = detectRepeatedErrors(lines, 3);
+  assert.equal(detected.length, 1);
+  assert.equal(detected[0].count, 3);
+  assert.equal(detected[0].signature, 'error: failed to compile at line');
+});
+
+test('detectEditChurn identifies files edited >= threshold times', () => {
+  const logs = ['Editing src/foo.ts', 'Editing src/bar.ts', 'Editing src/foo.ts', 'Editing src/foo.ts'];
+  const churning = detectEditChurn(logs, 3);
+  assert.equal(churning.length, 1);
+  assert.equal(churning[0].path, 'src/foo.ts');
+  assert.equal(churning[0].count, 3);
+});
+
+test('parseTranscriptLines extracts content and error text from JSONL transcript files', () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'flail-test-'));
+  try {
+    const transcriptPath = join(tmpDir, 'transcript.jsonl');
+    const records = [
+      JSON.stringify({ step_index: 0, content: 'User request\nStarting build...' }),
+      JSON.stringify({ step_index: 1, content: 'Error: Cannot find module lodash line 1' }),
+      JSON.stringify({ step_index: 2, text: 'Error: Cannot find module express line 2' }),
+    ];
+    writeFileSync(transcriptPath, records.join('\n'));
+
+    const lines = parseTranscriptLines(transcriptPath);
+    assert.ok(lines.includes('Error: Cannot find module lodash line 1'));
+    assert.ok(lines.includes('Error: Cannot find module express line 2'));
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('analyzeFlail flags both edit churn and repeated errors', () => {
+  const edits = ['Editing src/a.js', 'Editing src/a.js', 'Editing src/a.js'];
+  const transcriptLines = [
+    'Error: Test failure in test/suite.js line 10',
+    'Error: Test failure in test/suite.js line 25',
+  ];
+
+  const res = analyzeFlail({ edits, transcriptLines, threshold: 3, maxErrorRepeat: 2 });
+  assert.equal(res.verdict, 'flail');
+  assert.equal(res.signals.length, 2);
+  assert.match(res.summary, /file edit churn/i);
+  assert.match(res.summary, /repeated error signatures/i);
+});
+
+test('createFlailTracker records history and returns flail analysis', () => {
+  const tracker = createFlailTracker({ threshold: 2, maxErrorRepeat: 2 });
+  const sessionID = 'session-123';
+
+  let res = tracker.record({
+    sessionID,
+    filePath: 'src/main.js',
+    transcriptLines: ['Error: Build failed line 1'],
+  });
+  assert.equal(res.verdict, 'clean');
+
+  res = tracker.record({
+    sessionID,
+    filePath: 'src/main.js',
+    transcriptLines: ['Error: Build failed line 2'],
+  });
+  assert.equal(res.verdict, 'flail');
+  assert.ok(res.isNewSignal);
+});
+
+test('runFromStdin denies mutating tools when session is flailing under enforcement', () => {
+  const root = mkdtempSync(join(tmpdir(), 'flail-e2e-'));
+  try {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    mkdirSync(join(root, 'src'), { recursive: true });
+    const ticket = { id: 'T-FLAIL', title: 'Flail test ticket', scope: ['src/**'] };
+    writeFileSync(join(root, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [ticket] }));
+    writeFileSync(join(root, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 'T-FLAIL' }));
+
+    // Mock transcript dir structure
+    const convId = 'conv-flail-999';
+    const brainLogsDir = join(root, 'brain', convId, '.system_generated', 'logs');
+    mkdirSync(brainLogsDir, { recursive: true });
+    const transcriptFile = join(brainLogsDir, 'transcript.jsonl');
+    writeFileSync(transcriptFile, [
+      JSON.stringify({ content: 'Error: Adversarial review check failed on line 12' }),
+      JSON.stringify({ content: 'Error: Adversarial review check failed on line 45' }),
+    ].join('\n'));
+
+    const env = {
+      ADLC_P4_ENFORCEMENT: '1',
+      ANTIGRAVITY_APP_DATA_DIR: root,
+    };
+
+    const targetFile = join(root, 'src', 'app.js');
+    const payload = JSON.stringify({
+      conversationId: convId,
+      toolCall: { name: 'write_to_file', args: { TargetFile: targetFile, CodeContent: 'x' } },
+      workspacePaths: [root],
+    });
+
+    const res = runFromStdin(payload, env);
+    assert.equal(res.allow_tool, false);
+    assert.match(res.deny_reason, /flail-detector — session is flailing/i);
+    assert.match(res.deny_reason, /repeated error signatures/i);
+
+    // Bypass check
+    const bypassEnv = { ...env, ADLC_FLAIL_BYPASS: '1' };
+    const resBypass = runFromStdin(payload, bypassEnv);
+    assert.equal(resBypass.allow_tool, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/plugins/adlc-antigravity/test/flail.test.mjs
+++ b/plugins/adlc-antigravity/test/flail.test.mjs
@@ -135,6 +135,31 @@ test('runFromStdin denies mutating tools when session is flailing under enforcem
     assert.match(res.deny_reason, /flail-detector — session is flailing/i);
     assert.match(res.deny_reason, /repeated error signatures/i);
 
+    // Readonly tools are allowed even during flailing sessions
+    const readonlyPayload = JSON.stringify({
+      conversationId: convId,
+      toolCall: { name: 'view_file', args: { AbsolutePath: targetFile } },
+      workspacePaths: [root],
+    });
+    const resReadonly = runFromStdin(readonlyPayload, env);
+    assert.equal(resReadonly.allow_tool, true);
+
+    // Standalone ADLC_FLAIL_ENFORCEMENT=1 without ADLC_P4_ENFORCEMENT
+    const flailOnlyEnv = {
+      ADLC_FLAIL_ENFORCEMENT: '1',
+      ANTIGRAVITY_APP_DATA_DIR: root,
+    };
+    const resFlailOnly = runFromStdin(payload, flailOnlyEnv);
+    assert.equal(resFlailOnly.allow_tool, false);
+    assert.match(resFlailOnly.deny_reason, /flail-detector — session is flailing/i);
+
+    // Advisory mode (neither ADLC_P4_ENFORCEMENT nor ADLC_FLAIL_ENFORCEMENT set)
+    const advisoryEnv = {
+      ANTIGRAVITY_APP_DATA_DIR: root,
+    };
+    const resAdvisory = runFromStdin(payload, advisoryEnv);
+    assert.equal(resAdvisory.allow_tool, true);
+
     // Bypass check
     const bypassEnv = { ...env, ADLC_FLAIL_BYPASS: '1' };
     const resBypass = runFromStdin(payload, bypassEnv);

--- a/plugins/adlc-antigravity/test/flail.test.mjs
+++ b/plugins/adlc-antigravity/test/flail.test.mjs
@@ -12,7 +12,9 @@ import {
   parseTranscriptLines,
   analyzeFlail,
   createFlailTracker,
+  MAX_SCAN_BYTES,
 } from '../flail-inline.mjs';
+import { createPersistentTracker } from '../build-gate-inline.mjs';
 import { runFromStdin, printStatus } from '../hooks/adlc-rails-guard.mjs';
 
 test('normalizeError strips line numbers, hex, quotes, absolute paths, and digits', () => {
@@ -174,3 +176,48 @@ test('resolveTranscriptPath rejects path traversal sequences in conversationId',
   assert.equal(resolveTranscriptPath({ conversationId: 'foo/bar' }), null);
   assert.equal(resolveTranscriptPath({ conversationId: 'c:\\windows' }), null);
 });
+
+test('MAX_SCAN_BYTES is exactly 256 KiB (262144 bytes)', () => {
+  assert.equal(MAX_SCAN_BYTES, 262144);
+});
+
+test('createPersistentTracker handles null sessionID, missing ticket store, null filePath, and 200 edit cap', () => {
+  const root = mkdtempSync(join(tmpdir(), 'tracker-test-'));
+  try {
+    mkdirSync(join(root, '.adlc'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1' }] }));
+
+    const tracker = createPersistentTracker(root);
+
+    // 1. null sessionID returns clean without recording
+    const nullSessRes = tracker.recordEdit(null, 'src/app.js');
+    assert.equal(nullSessRes.verdict, 'clean');
+
+    // 2. missing ticket store returns clean without recording
+    const noStoreRoot = mkdtempSync(join(tmpdir(), 'no-store-'));
+    try {
+      const noStoreTracker = createPersistentTracker(noStoreRoot);
+      const noStoreRes = noStoreTracker.recordEdit('s1', 'src/app.js');
+      assert.equal(noStoreRes.verdict, 'clean');
+    } finally {
+      rmSync(noStoreRoot, { recursive: true, force: true });
+    }
+
+    // 3. null filePath does not push an edit entry
+    tracker.recordEdit('s-null-path', null);
+    assert.deepEqual(tracker.edits('s-null-path'), []);
+
+    // 4. 200 edit limit cap
+    const sId = 's-cap-200';
+    for (let i = 1; i <= 205; i++) {
+      tracker.recordEdit(sId, `src/file-${i}.js`);
+    }
+    const edits = tracker.edits(sId);
+    assert.equal(edits.length, 200);
+    assert.equal(edits[0], 'Editing src/file-6.js');
+    assert.equal(edits[199], 'Editing src/file-205.js');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+

--- a/plugins/adlc-antigravity/test/flail.test.mjs
+++ b/plugins/adlc-antigravity/test/flail.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -201,9 +201,14 @@ test('createPersistentTracker handles null sessionID, missing ticket store, null
 
     const tracker = createPersistentTracker(root);
 
-    // 1. null sessionID returns clean without recording
+    // 1. null sessionID returns clean without recording or creating store entries
     const nullSessRes = tracker.recordEdit(null, 'src/app.js');
     assert.equal(nullSessRes.verdict, 'clean');
+    assert.ok(Array.isArray(nullSessRes.repeatedErrors));
+    const storePath = join(root, '.adlc', 'ticket-store.json');
+    const storeObj = existsSync(storePath) ? JSON.parse(readFileSync(storePath, 'utf8')) : {};
+    assert.equal('null' in storeObj, false);
+    assert.equal('undefined' in storeObj, false);
 
     // 2. missing ticket store returns clean without recording or creating store file
     const noStoreRoot = mkdtempSync(join(tmpdir(), 'no-store-'));
@@ -211,6 +216,7 @@ test('createPersistentTracker handles null sessionID, missing ticket store, null
       const noStoreTracker = createPersistentTracker(noStoreRoot);
       const noStoreRes = noStoreTracker.recordEdit('s1', 'src/app.js');
       assert.equal(noStoreRes.verdict, 'clean');
+      assert.ok(Array.isArray(noStoreRes.repeatedErrors));
       assert.equal(existsSync(join(noStoreRoot, '.adlc', 'ticket-store.json')), false);
     } finally {
       rmSync(noStoreRoot, { recursive: true, force: true });

--- a/plugins/adlc-antigravity/test/flail.test.mjs
+++ b/plugins/adlc-antigravity/test/flail.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -146,6 +146,18 @@ test('runFromStdin denies mutating tools when session is flailing under enforcem
     const resReadonly = runFromStdin(readonlyPayload, env);
     assert.equal(resReadonly.allow_tool, true);
 
+    // Tools classified as 'other' do not record file edit churn
+    const otherFile = join(root, 'src', 'other.js');
+    const otherPayload = JSON.stringify({
+      conversationId: convId,
+      toolCall: { name: 'custom_file_op', args: { path: otherFile } },
+      workspacePaths: [root],
+    });
+    const resOther = runFromStdin(otherPayload, env);
+    assert.equal(resOther.allow_tool, true);
+    const trackerCheck = createPersistentTracker(root);
+    assert.equal(trackerCheck.edits(convId).includes(`Editing ${otherFile}`), false);
+
     // Standalone ADLC_FLAIL_ENFORCEMENT=1 without ADLC_P4_ENFORCEMENT
     const flailOnlyEnv = {
       ADLC_FLAIL_ENFORCEMENT: '1',
@@ -193,12 +205,13 @@ test('createPersistentTracker handles null sessionID, missing ticket store, null
     const nullSessRes = tracker.recordEdit(null, 'src/app.js');
     assert.equal(nullSessRes.verdict, 'clean');
 
-    // 2. missing ticket store returns clean without recording
+    // 2. missing ticket store returns clean without recording or creating store file
     const noStoreRoot = mkdtempSync(join(tmpdir(), 'no-store-'));
     try {
       const noStoreTracker = createPersistentTracker(noStoreRoot);
       const noStoreRes = noStoreTracker.recordEdit('s1', 'src/app.js');
       assert.equal(noStoreRes.verdict, 'clean');
+      assert.equal(existsSync(join(noStoreRoot, '.adlc', 'ticket-store.json')), false);
     } finally {
       rmSync(noStoreRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
Implements an anti-flail handler for the `adlc-antigravity` plugin to detect and prevent Google Antigravity (`agy`) agents from getting stuck in repetitive edit loops or failing command retries during ADLC workflows.

## Key Changes
1. **Core Flail Engine (`flail-inline.mjs`)**:
   - **Error Normalization (`normalizeError`)**: Normalizes error messages by stripping volatile line numbers, memory addresses, and file paths to collapse variants into canonical signatures.
   - **Repeated Error Detector (`detectRepeatedErrors`)**: Flags error signatures repeating $\ge 2$ times in recent transcript logs.
   - **Edit Churn Detector (`detectEditChurn`)**: Flags files edited $\ge 3$ times in a session.
   - **Transcript JSONL Tail Parser (`resolveTranscriptPath` & `parseTranscriptLines`)**: Resolves and parses `agy` transcript JSONL logs safely, with path-traversal sanitization.
   - **Flail Tracking (`createFlailTracker`)**: Uses SHA-1 hash tracking for signal deduplication.

2. **PreToolUse Hook Integration (`hooks/adlc-rails-guard.mjs` & `build-gate-inline.mjs`)**:
   - Denies mutating tool execution when flailing under `ADLC_FLAIL_ENFORCEMENT=1` or `ADLC_P4_ENFORCEMENT=1`.
   - Supports `ADLC_FLAIL_BYPASS=1` override.
   - Exposes session flail status in status/doctor commands.

3. **Test Suite Coverage**:
   - Added unit & end-to-end tests in `plugins/adlc-antigravity/test/flail.test.mjs`.
   - Preserves zero external npm dependency requirement (`plugins/adlc-antigravity/package.json` relies solely on Node builtins).

## Verification
- `node scripts/antigravity-install-smoke.mjs .` $\rightarrow$ PASS
- `npm test` $\rightarrow$ 51/51 segments passed (`all green`)
- `adversarial-review` $\rightarrow$ Passed & hardened against path traversal.