### PR TITLE
fix(prosecute): make trust-root tiering correct for the sharded ticket store

### DIFF
--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -2,6 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { join, resolve, relative, isAbsolute } from 'node:path';
 import { parseArgs, printJson, opError, recordFinding, git, repoRoot, changedFiles } from '@adlc/core';
+import { detectTicketStore } from '@adlc/tickets';
 import { runProsecution, resolveProsecutionRevision } from '../lib/run.mjs';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
 import { recordCrossModelReview } from '../lib/cross-model.mjs';
@@ -32,18 +33,38 @@ function isInsideRepo(root, resolvedDir) {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
+// The canonical repository ticket store, whichever BACKEND holds it. Reading the
+// legacy `.adlc/tickets.json` path directly would fail open after a repo migrates
+// to the sharded `.adlc/tickets/` backend: the file is gone, the ENOENT branch
+// above yields an empty table, and every change that is trust-root ONLY via a
+// ticket rail silently declassifies. detectTicketStore resolves the active
+// backend instead.
+//
+// FAIL-CLOSED, matching readTicketArray's distinction: a genuinely ABSENT store
+// contributes no rails, but a store that exists and cannot be resolved
+// (ambiguous dual store, unfinished migration transaction, corrupt shard) must
+// throw rather than degrade to "no rails".
+function readCanonicalTickets(root) {
+  try {
+    return detectTicketStore({ root }).load().mutableTickets();
+  } catch (err) {
+    if (err.code === 'STORE_NOT_FOUND') return [];
+    throw new Error(`canonical ticket store under ${root} exists but cannot be read for tiering: ${err.message}`);
+  }
+}
+
 // Load the ticket table(s) whose `rails` define trust-root DENY paths for
 // tiering. SECURITY: tiering is a GATE decision, so the rails source must be the
-// repo's CANONICAL <repoRoot>/.adlc/tickets.json — never REPLACEABLE by a
-// caller-supplied --dir. Otherwise `--dir ../elsewhere` pointing at a table that
-// OMITS the rails would declassify a change that is trust-root via the repo's
-// real rails (a gate bypass). We therefore ALWAYS include the canonical table,
-// and only UNION an additional --dir table when that dir is CONTAINED within the
-// repo (so a custom in-repo ADLC workspace still tiers). The classifier unions
-// rails across all tickets, so extra sources can only ADD deny-paths (fail-safe),
-// never remove them; an out-of-repo --dir contributes nothing to tiering.
+// repo's CANONICAL store — never REPLACEABLE by a caller-supplied --dir.
+// Otherwise `--dir ../elsewhere` pointing at a table that OMITS the rails would
+// declassify a change that is trust-root via the repo's real rails (a gate
+// bypass). We therefore ALWAYS include the canonical store, and only UNION an
+// additional --dir table when that dir is CONTAINED within the repo (so a custom
+// in-repo ADLC workspace still tiers). The classifier unions rails across all
+// tickets, so extra sources can only ADD deny-paths (fail-safe), never remove
+// them; an out-of-repo --dir contributes nothing to tiering.
 function loadTicketsForTier(dir, root) {
-  const tickets = [...readTicketArray(join(root, '.adlc', 'tickets.json'))];
+  const tickets = [...readCanonicalTickets(root)];
   const resolvedDir = resolve(dir);
   if (isInsideRepo(root, resolvedDir) && resolvedDir !== resolve(root, '.adlc')) {
     tickets.push(...readTicketArray(join(resolvedDir, 'tickets.json')));

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 import { join, resolve, relative, isAbsolute } from 'node:path';
-import { parseArgs, printJson, opError, recordFinding, git, repoRoot, changedFiles } from '@adlc/core';
+import { parseArgs, printJson, opError, recordFinding, git, repoRoot, changedFiles, splitNulPaths } from '@adlc/core';
 import { detectTicketStore, GitTreeTicketStore } from '@adlc/tickets';
 import { runProsecution, resolveProsecutionRevision } from '../lib/run.mjs';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
@@ -91,6 +91,43 @@ function readBaseTickets(root, revision) {
     if (err.code === 'STORE_NOT_FOUND') return [];
     throw new Error(`ticket store at base ${revision} cannot be read for tiering: ${err.message}`);
   }
+}
+
+// The SOURCE side of every rename/copy between the base and the change.
+//
+// `changedFiles` collects `git diff --name-only`, and with rename detection on
+// (git's default) that reports ONLY the destination. So `git mv
+// .adlc/tickets/t1--<hash>.json holding/` REMOVES a ticket contract from the
+// trust root while the classifier sees nothing but an unprotected destination
+// path — no TRUST_ROOT_PREFIXES entry matches and the change declassifies. The
+// surviving store stays structurally valid, so an unrelated active ticket can
+// still be prosecuted same-model. Archive shards, and the legacy
+// `.adlc/tickets.json` itself, have the identical hole.
+//
+// Collect the sources explicitly rather than disabling rename detection, so the
+// destination is still reported normally. `--name-status -z` is NUL-delimited:
+// an R/C status carries TWO following paths, every other status carries one.
+// Both the worktree and --cached diffs are read, mirroring changedFiles, so a
+// rename that is merely STAGED is caught too.
+function renamedSources(base, root) {
+  const collect = (args) => {
+    const tokens = splitNulPaths(git(args, { cwd: root, encoding: 'buffer' }));
+    const sources = [];
+    for (let index = 0; index < tokens.length;) {
+      const status = tokens[index++];
+      if (/^[RC]\d*$/.test(status)) {
+        if (index < tokens.length) sources.push(tokens[index]);
+        index += 2;
+      } else {
+        index += 1;
+      }
+    }
+    return sources;
+  };
+  return [
+    ...collect(['diff', '--name-status', '-z', '-M', base, '--']),
+    ...collect(['diff', '--cached', '--name-status', '-z', '-M', base, '--']),
+  ];
 }
 
 function loadTicketsForTier(dir, root, base) {
@@ -271,7 +308,7 @@ try {
   const tracked = changedFiles(values.base, root); // two-dot: working tree vs base
   const untracked = git(['ls-files', '--others', '--exclude-standard', '-z'], { cwd: root })
     .split('\0').filter(Boolean);
-  changed = [...new Set([...tracked, ...untracked])];
+  changed = [...new Set([...tracked, ...untracked, ...renamedSources(values.base, root)])];
 } catch (err) {
   opError(`cannot determine trust-root tier: base ref '${values.base}' unresolvable — fetch the base (e.g. git fetch origin main) or pass --base <ref>. Underlying: ${err.message}`);
 }

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -44,9 +44,18 @@ function isInsideRepo(root, resolvedDir) {
 // contributes no rails, but a store that exists and cannot be resolved
 // (ambiguous dual store, unfinished migration transaction, corrupt shard) must
 // throw rather than degrade to "no rails".
+//
+// SECURITY — `env: {}` is load-bearing, not tidiness. detectTicketStore defaults
+// to `env = process.env` and honours ADLC_TICKET_STORE / ADLC_TICKETS, which
+// would make the CANONICAL store replaceable by the very author being gated:
+// point either variable at a valid store that contains the active ticket but
+// OMITS the repo's rails and a rails-only trust-root change declassifies,
+// dropping the distinct-provider requirement. That is the same bypass the --dir
+// containment rule below exists to prevent, just through a different door. An
+// empty env disables override resolution, so the repo's real store always wins.
 function readCanonicalTickets(root) {
   try {
-    return detectTicketStore({ root }).load().mutableTickets();
+    return detectTicketStore({ root, env: {} }).load().mutableTickets();
   } catch (err) {
     if (err.code === 'STORE_NOT_FOUND') return [];
     throw new Error(`canonical ticket store under ${root} exists but cannot be read for tiering: ${err.message}`);

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { join, resolve, relative, isAbsolute } from 'node:path';
 import { parseArgs, printJson, opError, recordFinding, git, repoRoot, changedFiles } from '@adlc/core';
-import { detectTicketStore } from '@adlc/tickets';
+import { detectTicketStore, GitTreeTicketStore } from '@adlc/tickets';
 import { runProsecution, resolveProsecutionRevision } from '../lib/run.mjs';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
 import { recordCrossModelReview } from '../lib/cross-model.mjs';
@@ -72,8 +72,32 @@ function readCanonicalTickets(root) {
 // in-repo ADLC workspace still tiers). The classifier unions rails across all
 // tickets, so extra sources can only ADD deny-paths (fail-safe), never remove
 // them; an out-of-repo --dir contributes nothing to tiering.
-function loadTicketsForTier(dir, root) {
-  const tickets = [...readCanonicalTickets(root)];
+// The canonical store as the TRUSTED BASE has it. The worktree read above cannot
+// distinguish "this repo has no ticket store" from "the store is tracked at base
+// but not materialised here" — a sparse checkout or a skip-worktree entry leaves
+// the shards absent WITHOUT git reporting them as deleted, so they never appear
+// in changedFiles either. Collapsing that to an empty rail set fails OPEN: a
+// rails-only trust-root change classifies as ordinary and skips the
+// distinct-provider requirement. Reading the base tree closes it, and mirrors
+// how rails-guard-ci.mjs resolves its rail set (base, never the PR worktree).
+//
+// A base that genuinely has no store contributes nothing; any other failure
+// throws rather than degrading to "no rails".
+function readBaseTickets(root, revision) {
+  if (!revision) return [];
+  try {
+    return new GitTreeTicketStore({ cwd: root, revision }).load().mutableTickets();
+  } catch (err) {
+    if (err.code === 'STORE_NOT_FOUND') return [];
+    throw new Error(`ticket store at base ${revision} cannot be read for tiering: ${err.message}`);
+  }
+}
+
+function loadTicketsForTier(dir, root, base) {
+  // UNION, never replace: rails from the base and from the worktree both apply.
+  // The classifier ORs deny-paths across tickets, so adding a source can only
+  // widen the trust-root surface (fail-safe), never narrow it.
+  const tickets = [...readBaseTickets(root, base), ...readCanonicalTickets(root)];
   const resolvedDir = resolve(dir);
   if (isInsideRepo(root, resolvedDir) && resolvedDir !== resolve(root, '.adlc')) {
     tickets.push(...readTicketArray(join(resolvedDir, 'tickets.json')));
@@ -253,7 +277,7 @@ try {
 }
 let tier;
 try {
-  tier = classifyTrustRootTier({ changedFiles: changed, tickets: loadTicketsForTier(values.dir, root) });
+  tier = classifyTrustRootTier({ changedFiles: changed, tickets: loadTicketsForTier(values.dir, root, values.base) });
 } catch (err) {
   opError(`cannot determine trust-root tier: ${err.message}`);
 }

--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -18,6 +18,22 @@ const TRUST_ROOT_FILES = [
   '.adlc/tickets.json',
 ];
 
+// 1b. The SHARDED ticket store — the same trust root as `.adlc/tickets.json`,
+// just spread across per-ticket files. Exact-file matching cannot express it (one
+// entry per ticket, and new shards appear as tickets are authored), so the whole
+// store directory is a trust-root PREFIX. Without this, migrating a repo from the
+// legacy file to the directory backend would silently declassify every edit to
+// the ticket table: the exact-file entry above stops matching and nothing else
+// covers `.adlc/tickets/`. The archive is included because a ticket moved there
+// still describes what was enforced, so mutating it rewrites gate history.
+//
+// Unconditional, like TRUST_ROOT_FILES: these are DATA the gate reads, so the
+// test-path exemption that applies to package prefixes must not apply here.
+const TRUST_ROOT_PREFIXES = [
+  '.adlc/tickets/',
+  '.adlc/ticket-archive/',
+];
+
 // 2. Enforcement packages: each emits an exit-2 gate. Editing them changes what
 //    "the gate passes" means, so a same-model review of the author's own tests
 //    is exactly the blind spot cross-model review exists to cover.
@@ -85,6 +101,9 @@ export function classifyTrustRootTier({ changedFiles = [], tickets = [] } = {}) 
 
     if (TRUST_ROOT_FILES.includes(path)) {
       push(`touches trust-root file ${path}`);
+    }
+    for (const prefix of TRUST_ROOT_PREFIXES) {
+      if (path.startsWith(prefix)) push(`touches trust-root ticket store ${prefix}`);
     }
     // Package-prefix surfaces gate on LOGIC/CONTRACT risk; a test-only change
     // touches neither, so it is exempt here (#154/T41). The exact-file check

--- a/packages/prosecute/test/prosecute-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cli.test.mjs
@@ -74,23 +74,19 @@ describe('adlc-prosecute cli', () => {
     // Isolated repo for the same WORKING-TREE-INCLUSIVE-tiering reason as above.
     // --input still points at the REAL bundled docs fixture via an absolute path
     // (read as-is, not cwd-resolved), but the transcript/review_packet paths INSIDE
-    // that fixture are repo-relative and get resolved against `cwd` by run.mjs, and
-    // the ticket lookup reads the ticket store under `<cwd>/.adlc/` — so both must be
-    // mirrored into the isolated repo for this fixture to still validate as it does
-    // for real. Mirror whichever backend this repository currently uses: it has
-    // migrated from the legacy `.adlc/tickets.json` to the sharded `.adlc/tickets/`.
+    // that fixture are repo-relative and get resolved against `cwd` by run.mjs — so
+    // that evidence must be mirrored into the isolated repo for this fixture to still
+    // validate as it does for real.
+    //
+    // The repository's own ticket store is deliberately NOT mirrored. This used to
+    // copy `.adlc/tickets.json` in, with a comment claiming the ticket lookup needed
+    // it, but that was never true: `tmpAdlc()` seeds T1/T10 into `<dir>/tickets.json`
+    // and run.mjs's ticketDefinitionHash() prefers that `--dir` store over `<cwd>/.adlc`,
+    // so the mirrored copy was never read. It only ever mattered because `cpSync`
+    // throws on a missing source — which is how it survived unnoticed until the store
+    // migrated to the sharded backend and the copy started failing with ENOENT.
     const repo = gitRepo();
     try {
-      mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
-      const shardedStore = join(repoRoot, '.adlc/tickets');
-      const legacyStore = join(repoRoot, '.adlc/tickets.json');
-      if (existsSync(shardedStore)) {
-        cpSync(shardedStore, join(repo.dir, '.adlc/tickets'), { recursive: true });
-      } else if (existsSync(legacyStore)) {
-        cpSync(legacyStore, join(repo.dir, '.adlc/tickets.json'));
-      } else {
-        throw new Error('no ticket store found at .adlc/tickets/ or .adlc/tickets.json');
-      }
       mkdirSync(join(repo.dir, '.omo/evidence'), { recursive: true });
       cpSync(join(repoRoot, '.omo/evidence'), join(repo.dir, '.omo/evidence'), { recursive: true });
       repo.g('add', '-A');

--- a/packages/prosecute/test/prosecute-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cli.test.mjs
@@ -75,12 +75,22 @@ describe('adlc-prosecute cli', () => {
     // --input still points at the REAL bundled docs fixture via an absolute path
     // (read as-is, not cwd-resolved), but the transcript/review_packet paths INSIDE
     // that fixture are repo-relative and get resolved against `cwd` by run.mjs, and
-    // the ticket lookup reads `<cwd>/.adlc/tickets.json` — so both must be mirrored
-    // into the isolated repo for this fixture to still validate as it does for real.
+    // the ticket lookup reads the ticket store under `<cwd>/.adlc/` — so both must be
+    // mirrored into the isolated repo for this fixture to still validate as it does
+    // for real. Mirror whichever backend this repository currently uses: it has
+    // migrated from the legacy `.adlc/tickets.json` to the sharded `.adlc/tickets/`.
     const repo = gitRepo();
     try {
       mkdirSync(join(repo.dir, '.adlc'), { recursive: true });
-      cpSync(join(repoRoot, '.adlc/tickets.json'), join(repo.dir, '.adlc/tickets.json'));
+      const shardedStore = join(repoRoot, '.adlc/tickets');
+      const legacyStore = join(repoRoot, '.adlc/tickets.json');
+      if (existsSync(shardedStore)) {
+        cpSync(shardedStore, join(repo.dir, '.adlc/tickets'), { recursive: true });
+      } else if (existsSync(legacyStore)) {
+        cpSync(legacyStore, join(repo.dir, '.adlc/tickets.json'));
+      } else {
+        throw new Error('no ticket store found at .adlc/tickets/ or .adlc/tickets.json');
+      }
       mkdirSync(join(repo.dir, '.omo/evidence'), { recursive: true });
       cpSync(join(repoRoot, '.omo/evidence'), join(repo.dir, '.omo/evidence'), { recursive: true });
       repo.g('add', '-A');

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -12,7 +12,7 @@
 // The recorded revision is resolved the SAME way the gate resolves it (no --revision).
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -38,7 +38,7 @@ function runBin(args, cwd, env = {}) {
 // `baselineFiles` are committed on MAIN before branching, so no untracked file
 // spuriously tiers under the working-tree-inclusive changed-file set. `featurePath`
 // (if given) is committed on the `feat` branch.
-function scratchRepo(featurePath, { baselineFiles = {}, ledgerDir = '.adlc', rails = [], migrateStore = false } = {}) {
+function scratchRepo(featurePath, { baselineFiles = {}, ledgerDir = '.adlc', rails = [], migrateStore = false, extraTickets = [] } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'adlc-xm-cli-'));
   const g = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
   g('init', '-q', '-b', 'main');
@@ -57,7 +57,10 @@ function scratchRepo(featurePath, { baselineFiles = {}, ledgerDir = '.adlc', rai
   const ledger = join(dir, ledgerDir);
   mkdirSync(ledger, { recursive: true });
   writeFileSync(join(ledger, 'tickets.json'), JSON.stringify({
-    tickets: [{ id: 'T1', title: 'x', scope: ['src/**'], rails, edges: [] }],
+    tickets: [
+      { id: 'T1', title: 'x', scope: ['src/**'], rails, edges: [] },
+      ...extraTickets.map((id) => ({ id, title: 'spare', scope: ['src/**'], rails: [], edges: [] })),
+    ],
   }));
   // Optionally convert the canonical store to the SHARDED backend before the
   // baseline commit, so the directory store is committed on main and a feature
@@ -282,6 +285,60 @@ describe('adlc-prosecute trust-root-tier CLI gate', () => {
       assert.match(res.stderr, /rails deny-path of ticket T1/);
     } finally {
       rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('residual: renaming a ticket-store shard OUT of the trust root still tiers (rename source is not invisible)', () => {
+    // `git diff --name-only` reports ONLY the destination of a rename, so moving a
+    // shard out of `.adlc/tickets/` removes a ticket contract while the classifier
+    // sees just an unprotected path — a fail-OPEN bypass of the new prefixes. The
+    // rename SOURCE must be part of the changed-file set. Covers the active store
+    // and the archive; both are trust-root surfaces.
+    for (const storeDir of ['.adlc/tickets', '.adlc/ticket-archive']) {
+      // The ACTIVE store must be genuinely migrated (a bare `.adlc/tickets/`
+      // alongside the legacy file is an ambiguous dual store and rightly fails
+      // closed). T9 is the spare whose shard gets moved; T1 remains prosecutable,
+      // which is what makes the bypass reachable rather than merely broken. The
+      // ARCHIVE is not the active store, so it needs no migration.
+      const active = storeDir === '.adlc/tickets';
+      // The shard must exist at the BASE for the move to read as a rename at all;
+      // adding it on the feature branch would diff as a plain addition of the
+      // destination. The active shard arrives via migration, the archive one via
+      // baselineFiles — both land in the baseline commit on main.
+      const repo = scratchRepo('src/app.mjs', {
+        ledgerDir: '.adlc',
+        rails: [],
+        migrateStore: active,
+        extraTickets: active ? ['T9'] : [],
+        baselineFiles: active ? {} : { '.adlc/ticket-archive/t9--abc.json': JSON.stringify({ id: 'T9' }) },
+      });
+      const g = (...args) => execFileSync('git', args, { cwd: repo.dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      try {
+        let shard;
+        if (active) {
+          const found = readdirSync(join(repo.dir, ...storeDir.split('/'))).find((name) => name.startsWith('t9--'));
+          assert.ok(found, 'migration should have produced a T9 shard');
+          shard = `${storeDir}/${found}`;
+        } else {
+          shard = `${storeDir}/t9--abc.json`;
+        }
+        g('checkout', '-q', '-b', `move-${storeDir.replace(/\W/g, '')}`);
+        mkdirSync(join(repo.dir, 'holding'), { recursive: true });
+        g('mv', shard, 'holding/moved.json');
+        g('commit', '-qm', 'move shard out of the trust root');
+
+        // Precondition: plain --name-only really does hide the source, or this
+        // test would pass for a reason unrelated to the bypass it describes.
+        const nameOnly = g('diff', '--name-only', 'main', '--').trim().split('\n');
+        assert.ok(!nameOnly.includes(shard), 'rename source must be invisible to --name-only for this test to be meaningful');
+
+        writePasses({ ...repo, revision: 'fixed-rev' });
+        const res = runBin(['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'], repo.dir);
+        assert.equal(res.status, 2, `moving a shard out of ${storeDir} must tier`);
+        assert.match(res.stderr, /trust-root ticket store/);
+      } finally {
+        rmSync(repo.dir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -251,6 +251,40 @@ describe('adlc-prosecute trust-root-tier CLI gate', () => {
     }
   });
 
+  it('residual: a store tracked at BASE but absent from the worktree still supplies rails', () => {
+    // A sparse checkout / skip-worktree entry leaves the canonical store absent
+    // locally WITHOUT git reporting a deletion, so it never shows up in
+    // changedFiles either. Reading only the worktree collapses that to "no rails"
+    // and declassifies a rails-only trust-root change — a fail-OPEN bypass. The
+    // base tree is authoritative, exactly as rails-guard-ci.mjs treats it.
+    //
+    // The override store is what makes this reachable rather than merely broken:
+    // downstream ticket binding still resolves T1 through it, so the run proceeds
+    // to the tier decision instead of op-erroring on an unresolvable ticket. Only
+    // tiering is left blind — which is precisely the hole.
+    const repo = scratchRepo('src/secure/secret.mjs', { ledgerDir: '.adlc', rails: ['src/secure/**'] });
+    const g = (...args) => execFileSync('git', args, { cwd: repo.dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    try {
+      const railFree = join(repo.dir, 'rail-free-tickets.json');
+      writeFileSync(railFree, JSON.stringify({ tickets: [{ id: 'T1', title: 'x', scope: ['src/**'], rails: [], edges: [] }] }));
+      g('update-index', '--skip-worktree', '.adlc/tickets.json');
+      rmSync(join(repo.dir, '.adlc', 'tickets.json'));
+      // Precondition: git must NOT see this as a change, or the test would be
+      // proving something weaker than the sparse-checkout scenario it describes.
+      assert.equal(g('status', '--porcelain', '--', '.adlc/tickets.json').trim(), '', 'skip-worktree removal must be invisible to git');
+      writePasses({ ...repo, revision: 'fixed-rev' });
+      const res = runBin(
+        ['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'],
+        repo.dir,
+        { ADLC_TICKET_STORE: railFree },
+      );
+      assert.equal(res.status, 2, 'base-tree rails must still tier when the worktree store is absent');
+      assert.match(res.stderr, /rails deny-path of ticket T1/);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
   it('residual: an AMBIGUOUS dual store (legacy + directory) fails closed (exit 1), never a silent ungated pass', () => {
     // A half-finished migration leaves both backends present. Resolving the
     // canonical store then throws AMBIGUOUS_STORE — which must op-error rather

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -22,9 +22,11 @@ import { resolveProsecutionRevision } from '../lib/run.mjs';
 
 const BIN = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
 
-function runBin(args, cwd) {
+function runBin(args, cwd, env = {}) {
   try {
-    const stdout = execFileSync(process.execPath, [BIN, ...args], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    const stdout = execFileSync(process.execPath, [BIN, ...args], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, ...env },
+    });
     return { status: 0, stdout };
   } catch (err) {
     return { status: err.status, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
@@ -220,6 +222,32 @@ describe('adlc-prosecute trust-root-tier CLI gate', () => {
       assert.match(res.stderr, /rails deny-path of ticket T1/);
     } finally {
       rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('residual: ADLC_TICKETS / ADLC_TICKET_STORE cannot replace the canonical store for tiering', () => {
+    // Same escape as the OUT-OF-REPO --dir case, through the environment instead.
+    // detectTicketStore defaults to env = process.env and honours these variables,
+    // so resolving the canonical store WITHOUT disabling overrides would let the
+    // gated author point tiering at a valid rail-free store and declassify a
+    // rails-only trust-root change. Both variable names are covered.
+    for (const varName of ['ADLC_TICKETS', 'ADLC_TICKET_STORE']) {
+      const repo = scratchRepo('src/secure/secret.mjs', { ledgerDir: '.adlc', rails: ['src/secure/**'] });
+      try {
+        // A VALID store that contains the active ticket but omits the rail.
+        const railFree = join(repo.dir, 'rail-free-tickets.json');
+        writeFileSync(railFree, JSON.stringify({ tickets: [{ id: 'T1', title: 'x', scope: ['src/**'], rails: [], edges: [] }] }));
+        writePasses({ ...repo, revision: 'fixed-rev' });
+        const res = runBin(
+          ['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'],
+          repo.dir,
+          { [varName]: railFree },
+        );
+        assert.equal(res.status, 2, `${varName} must not declassify a change that is trust-root via the canonical rails`);
+        assert.match(res.stderr, /rails deny-path of ticket T1/);
+      } finally {
+        rmSync(repo.dir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -17,6 +17,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { sha256 } from '@adlc/core';
+import { migrateLegacyStore } from '@adlc/tickets';
 import { resolveProsecutionRevision } from '../lib/run.mjs';
 
 const BIN = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
@@ -35,7 +36,7 @@ function runBin(args, cwd) {
 // `baselineFiles` are committed on MAIN before branching, so no untracked file
 // spuriously tiers under the working-tree-inclusive changed-file set. `featurePath`
 // (if given) is committed on the `feat` branch.
-function scratchRepo(featurePath, { baselineFiles = {}, ledgerDir = '.adlc', rails = [] } = {}) {
+function scratchRepo(featurePath, { baselineFiles = {}, ledgerDir = '.adlc', rails = [], migrateStore = false } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'adlc-xm-cli-'));
   const g = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
   g('init', '-q', '-b', 'main');
@@ -56,6 +57,12 @@ function scratchRepo(featurePath, { baselineFiles = {}, ledgerDir = '.adlc', rai
   writeFileSync(join(ledger, 'tickets.json'), JSON.stringify({
     tickets: [{ id: 'T1', title: 'x', scope: ['src/**'], rails, edges: [] }],
   }));
+  // Optionally convert the canonical store to the SHARDED backend before the
+  // baseline commit, so the directory store is committed on main and a feature
+  // change tiers (or not) purely on its own merits — not because uncommitted
+  // shards under .adlc/tickets/ are themselves a trust-root surface.
+  if (migrateStore) migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+
   const adlc = join(dir, '.adlc');
   mkdirSync(adlc, { recursive: true });
   const transcriptPath = join(adlc, 'review.txt');
@@ -195,6 +202,40 @@ describe('adlc-prosecute trust-root-tier CLI gate', () => {
     } finally {
       rmSync(repo.dir, { recursive: true, force: true });
       rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('residual: canonical rails still tier when the store uses the SHARDED directory backend', () => {
+    // Pre-fix, loadTicketsForTier read only `.adlc/tickets.json`. After a repo
+    // migrates to `.adlc/tickets/`, that path is GONE — the ENOENT branch yielded
+    // an empty table, so a change that is trust-root ONLY via a ticket rail was
+    // silently declassified and a same-model P5 passed clean. That is a fail-OPEN
+    // gate bypass, so it is asserted at the process boundary on a real migrated store.
+    const repo = scratchRepo('src/secure/secret.mjs', { ledgerDir: '.adlc', rails: ['src/secure/**'], migrateStore: true });
+    try {
+      writePasses({ ...repo, revision: 'fixed-rev' });
+      const res = runBin(['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'], repo.dir);
+      assert.equal(res.status, 2, 'a rail-only trust-root change must still tier under the directory backend');
+      assert.match(JSON.parse(res.stdout).message, /cross-model adversarial approve from a distinct provider/);
+      assert.match(res.stderr, /rails deny-path of ticket T1/);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('residual: an AMBIGUOUS dual store (legacy + directory) fails closed (exit 1), never a silent ungated pass', () => {
+    // A half-finished migration leaves both backends present. Resolving the
+    // canonical store then throws AMBIGUOUS_STORE — which must op-error rather
+    // than degrade to "no rails" and drop the rails dimension entirely.
+    const repo = scratchRepo('src/secure/secret.mjs', { ledgerDir: '.adlc', rails: ['src/secure/**'], migrateStore: true });
+    try {
+      writePasses({ ...repo, revision: 'fixed-rev' });
+      writeFileSync(join(repo.dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [] }));
+      const res = runBin(['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'], repo.dir);
+      assert.equal(res.status, 1, 'an ambiguous dual store must op-error, not proceed ungated');
+      assert.match(`${res.stderr ?? ''}${res.stdout ?? ''}`, /AMBIGUOUS_STORE|cannot be read for tiering|determine trust-root tier/);
+    } finally {
+      rmSync(repo.dir, { recursive: true, force: true });
     }
   });
 

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -60,9 +60,42 @@ describe('classifyTrustRootTier — positive surface classes', () => {
     assert.equal(r.isTrustRootTier, true);
     assert.ok(r.reasons.some((x) => x.includes('T7') && x.includes('test/auth/**')));
   });
+
+  // The sharded backend is the SAME trust root as `.adlc/tickets.json`. When a
+  // repo migrates, the exact-file entry stops matching and every shard edit would
+  // declassify unless the store directory itself is a trust-root surface.
+  it('TRUE for a shard in the sharded ticket store', () => {
+    const r = classifyTrustRootTier({
+      changedFiles: ['.adlc/tickets/t64--ec791ef8cffb458098b48e73556d0f644cd8c1845bf94cc167060c1e3aca4a42.json'],
+      tickets: TICKETS,
+    });
+    assert.equal(r.isTrustRootTier, true);
+    assert.ok(r.reasons.some((x) => x.includes('.adlc/tickets/')));
+  });
+
+  it('TRUE for the sharded store manifest and for the archive', () => {
+    for (const f of ['.adlc/tickets/.store.json', '.adlc/ticket-archive/.store.json', '.adlc/ticket-archive/t1--abc.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, true, `${f} should be trust-root`);
+    }
+  });
+
+  // The test-path exemption applies to package prefixes only. A shard is DATA the
+  // gate reads, so a ticket id that happens to look test-ish must not exempt it.
+  it('TRUE for a shard whose name would trip the test-file heuristic', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets/t-test--abc.test.mjs'], tickets: TICKETS });
+    assert.equal(r.isTrustRootTier, true);
+  });
 });
 
 describe('classifyTrustRootTier — negative / ordinary diffs', () => {
+  it('FALSE for a lookalike path outside the ticket store directory', () => {
+    for (const f of ['.adlc/tickets-notes.md', '.adlc/specs/x.md', 'docs/.adlc/tickets/x.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, false, `${f} should NOT be trust-root`);
+    }
+  });
+
   it('FALSE for a docs-only change', () => {
     const r = classifyTrustRootTier({ changedFiles: ['apps/docs/x.mdx'], tickets: TICKETS });
     assert.deepEqual(r, { isTrustRootTier: false, reasons: [] });

--- a/packages/tickets/test/migrate-real-store.test.mjs
+++ b/packages/tickets/test/migrate-real-store.test.mjs
@@ -12,8 +12,16 @@ import { writeLegacy } from './helpers.mjs';
 // `.adlc/tickets.json` to the sharded `.adlc/tickets/` backend, and the point of
 // this test is to exercise migration against real tickets whichever backend
 // currently holds them.
+//
+// `env: {}` is required for that claim to hold. detectTicketStore defaults to
+// `env = process.env` and honours ADLC_TICKET_STORE / ADLC_TICKETS, so a runner
+// that exports either variable for an unrelated ADLC operation would silently
+// redirect this test to that store — every hash assertion would still pass while
+// the actual repository corpus went unexercised, and the non-empty guard below
+// would not notice because an override store is also non-empty.
 const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
-const realTickets = detectTicketStore({ root: repoRoot }).load().mutableTickets();
+const loadRepoCorpus = () => detectTicketStore({ root: repoRoot, env: {} }).load().mutableTickets();
+const realTickets = loadRepoCorpus();
 
 test('the real repository store migrates and exports with exact logical hashes', () => {
   // Guard against a vacuous pass: reading through the store abstraction cannot
@@ -34,4 +42,20 @@ test('the real repository store migrates and exports with exact logical hashes',
     assert.equal(exported.hash, before.hash);
     assert.deepEqual(exported.mutableTickets(), before.mutableTickets());
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('the real-corpus loader cannot be redirected by store-override environment variables', () => {
+  // Pins the property the comment above depends on. `.adlc/tickets.example.json`
+  // is a VALID, non-empty store, so without `env: {}` the override silently wins
+  // and this test's corpus is no longer the repository's.
+  for (const varName of ['ADLC_TICKET_STORE', 'ADLC_TICKETS']) {
+    const previous = process.env[varName];
+    process.env[varName] = '.adlc/tickets.example.json';
+    try {
+      assert.deepEqual(loadRepoCorpus(), realTickets, `${varName} must not redirect the real-corpus loader`);
+    } finally {
+      if (previous === undefined) delete process.env[varName];
+      else process.env[varName] = previous;
+    }
+  }
 });

--- a/packages/tickets/test/migrate-real-store.test.mjs
+++ b/packages/tickets/test/migrate-real-store.test.mjs
@@ -1,17 +1,28 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { detectTicketStore, exportLegacyStore, migrateLegacyStore } from '../index.mjs';
 import { writeLegacy } from './helpers.mjs';
 
-const realStore = JSON.parse(readFileSync(new URL('../../../.adlc/tickets.json', import.meta.url), 'utf8'));
+// The repository's own ticket corpus, read through the store abstraction rather
+// than a fixed path: this repo has itself migrated from the legacy
+// `.adlc/tickets.json` to the sharded `.adlc/tickets/` backend, and the point of
+// this test is to exercise migration against real tickets whichever backend
+// currently holds them.
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const realTickets = detectTicketStore({ root: repoRoot }).load().mutableTickets();
 
 test('the real repository store migrates and exports with exact logical hashes', () => {
+  // Guard against a vacuous pass: reading through the store abstraction cannot
+  // throw the way the old fixed-path read did, so an empty/unresolved store
+  // would otherwise migrate zero tickets and assert nothing meaningful.
+  assert.ok(realTickets.length > 0, 'expected the repository store to hold tickets');
   const root = mkdtempSync(join(tmpdir(), 'adlc-tickets-migrate-'));
   try {
-    writeLegacy(root, realStore.tickets);
+    writeLegacy(root, realTickets);
     const before = detectTicketStore({ root }).load();
     const plan = migrateLegacyStore(root);
     assert.equal(plan.beforeHash, before.hash);


### PR DESCRIPTION
**Merge first.** The ticket-store migration (#TBD, `chore/ticket-store-migration`) is unsafe without this, and the migration gate requires a dedicated migration-only diff — so these fixes cannot ride along with it.

## Why

P5 trust-root classification fails **open** for any repository on the directory ticket-store backend. A change that is trust-root only via a ticket rail is silently declassified, and a clean same-model P5 passes where a distinct-provider cross-model approve is required.

## What

Four defects, each with a process-boundary regression test:

1. **`loadTicketsForTier` read only `.adlc/tickets.json`.** After a migration that file is gone, ENOENT maps to an empty table, and every ticket rail disappears. Now resolves the active backend via `detectTicketStore`.
2. **`TRUST_ROOT_FILES` named only the legacy file.** Exact-file matching cannot express a store whose file set grows per ticket, so `.adlc/tickets/` and `.adlc/ticket-archive/` are now trust-root **prefixes**, matched unconditionally (these are data the gate reads, so the test-path exemption must not apply).
3. **The canonical store was environment-overridable.** `detectTicketStore` defaults to `env = process.env` and honours `ADLC_TICKET_STORE` / `ADLC_TICKETS`, letting the gated author point tiering at a rail-free store. Resolved with `env: {}`. The same defect existed in the real-corpus migration test.
4. **Rename sources and sparse checkouts were invisible.** `git diff --name-only` reports only a rename's destination, so `git mv`-ing a shard out of the trust root removed a ticket contract unseen; and an absent worktree store (sparse / skip-worktree) read as "no rails". Now unions rename sources and trusted-base rails.

Defects 3 and 4 are partly **pre-existing** — the legacy single-file store had the identical rename and absence holes — but the sharded backend makes them materially easier to exercise.

## Verification

- 207 tests pass across `packages/prosecute` + `packages/tickets`; full suite 51/51 green.
- `node scripts/rails-guard-ci.mjs origin/main` exits 0.
- Every new regression is **mutation-verified**: reverting the corresponding fix fails it.

## Not fixed here

`CODEOWNERS` protects only `/.adlc/tickets.json`, leaving every shard unowned — a PR adding one schema-valid shard with a rail as broad as `**` would not trigger ticket-store owner review, and once merged that rail freezes later PRs. `CODEOWNERS` is itself an immutable ADLC trust root (`rails-guard-ci.mjs`), so **no PR can change it**. This needs the maintainer's protected-base ceremony.

## Test plan

- [ ] CI rails-guard green
- [ ] Full suite green
- [ ] Confirm the CODEOWNERS ceremony is scheduled before the migration lands