### PR TITLE
fix(tickets): make the migration write a .gitignore that actually works

### DIFF
--- a/packages/tickets/lib/migrate.mjs
+++ b/packages/tickets/lib/migrate.mjs
@@ -13,6 +13,12 @@ import { recordTicketEvidence } from './evidence.mjs';
 import { validateTickets } from './schema.mjs';
 import { durableCopy, durableMkdir, durableRemove, durableRename, durableWrite } from './durability.mjs';
 
+// The tracked surface of `.adlc/` after a migration. `!.adlc/manifest.jsonl` is
+// NOT optional: the rails-guard CI migration gate requires hash-bound
+// ticket-migrate/apply evidence to exist in a fresh checkout, and without this
+// negation the ledger stays ignored, `git add -A` silently omits it, and the
+// migration PR the documented command sequence produces is REJECTED for missing
+// evidence.
 const GITIGNORE_STANZA = [
   '.adlc/*',
   '!.adlc/tickets.json',
@@ -21,7 +27,13 @@ const GITIGNORE_STANZA = [
   '!.adlc/ticket-archive/',
   '!.adlc/ticket-archive/**',
   '!.adlc/specs/',
+  '!.adlc/manifest.jsonl',
 ];
+
+// The blanket rule whose position decides whether any `.adlc/` negation works at
+// all: in gitignore, the LAST matching pattern wins, so every negation must sit
+// below it.
+const ADLC_BLANKET = '.adlc/*';
 const TRANSACTION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 function safeJournalPath(root, value, label) {
   if (typeof value !== 'string' || !value) throw operational('INVALID_JOURNAL', `${label} must be a non-empty relative path`);
@@ -33,12 +45,46 @@ function safeJournalPath(root, value, label) {
   return absolute;
 }
 
+// Ensure the migrated store is tracked, WITHOUT stranding negations the repo
+// already declares.
+//
+// The previous implementation stripped its own stanza lines and re-appended the
+// whole block at the end of the file. That silently broke any `.adlc/` negation
+// it does not itself know about — `!.adlc/tickets.example.json`, `!.adlc/lessons/`,
+// a user's own — because relocating `.adlc/*` to the end left those negations
+// ABOVE the blanket rule, where the later pattern wins and they become dead. The
+// failure is invisible: the file still reads as if the path were tracked.
+//
+// So: when the blanket rule is already present, leave it where it is and insert
+// only the MISSING stanza lines directly after the existing run of `.adlc/`
+// negations that follows it. Nothing moves, so no negation can be orphaned by
+// construction, and repos that already track extra `.adlc/` paths keep them.
+// Only a file with no blanket rule at all gets the whole stanza appended.
 function migrationGitignoreText(original) {
-  let lines = original.split(/\r?\n/);
+  const lines = original.split(/\r?\n/);
   while (lines.at(-1) === '') lines.pop();
-  lines = lines.filter((line) => !GITIGNORE_STANZA.includes(line));
-  if (lines.length && lines.at(-1) !== '') lines.push('');
-  lines.push(...GITIGNORE_STANZA);
+
+  const blanketIndex = lines.lastIndexOf(ADLC_BLANKET);
+  if (blanketIndex === -1) {
+    // Separate the appended stanza from existing rules. The trailing-blank pop
+    // above already guarantees the last line is non-empty, so testing it again
+    // would be dead logic.
+    if (lines.length) lines.push('');
+    lines.push(...GITIGNORE_STANZA);
+    return `${lines.join('\n')}\n`;
+  }
+
+  // Anything below the blanket rule is already effective; only those count as
+  // present. A stanza line sitting above it is dead and must be re-added below.
+  const effective = new Set(lines.slice(blanketIndex + 1));
+  const missing = GITIGNORE_STANZA.filter((line) => line !== ADLC_BLANKET && !effective.has(line));
+  if (missing.length === 0) return original;
+
+  // Append after the contiguous run of `.adlc/` rules following the blanket, so
+  // the block stays together instead of splitting around unrelated entries.
+  let insertAt = blanketIndex + 1;
+  while (insertAt < lines.length && /^!?\.adlc\//.test(lines[insertAt])) insertAt++;
+  lines.splice(insertAt, 0, ...missing);
   return `${lines.join('\n')}\n`;
 }
 

--- a/packages/tickets/test/migrate-gitignore.test.mjs
+++ b/packages/tickets/test/migrate-gitignore.test.mjs
@@ -1,0 +1,183 @@
+// Concern: the .gitignore the migration writes must make the migrated store —
+// AND its mandatory CI evidence — actually trackable, without breaking negations
+// the repository already declares.
+//
+// Both properties are asserted through `git check-ignore`, not by reading the
+// file: gitignore semantics are last-match-wins, so a negation can be present in
+// the text and still be dead. Only git can answer whether a path is tracked.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { migrateLegacyStore } from '../index.mjs';
+
+const TICKET = { id: 'T1', title: 'x', scope: ['src/**'], rails: [], edges: [] };
+
+function legacyRepo(gitignore) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-migrate-ignore-'));
+  const g = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  g('init', '-q', '-b', 'main');
+  g('config', 'user.email', 't@t.co');
+  g('config', 'user.name', 'tester');
+  // Never inherit the developer's signing config: a fixture that depends on an
+  // external signing agent turns an unrelated agent hiccup into a test failure.
+  g('config', 'commit.gpgsign', 'false');
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [TICKET] }));
+  if (gitignore !== undefined) writeFileSync(join(dir, '.gitignore'), gitignore);
+  writeFileSync(join(dir, 'README.md'), 'base\n');
+  g('add', '-A'); g('commit', '-qm', 'base');
+  return { dir, g };
+}
+
+// `git check-ignore` exits 0 when a path IS ignored, 1 when it is not.
+function isIgnored(dir, path) {
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--no-index', '--', path], { cwd: dir, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('migration tracks the manifest the CI evidence gate requires', () => {
+  const { dir } = legacyRepo('.adlc/*\n!.adlc/tickets.json\n');
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    assert.equal(isIgnored(dir, '.adlc/manifest.jsonl'), false,
+      'the ticket-migrate/apply evidence must be trackable or the migration PR fails CI for missing evidence');
+    assert.equal(isIgnored(dir, '.adlc/tickets/.store.json'), false);
+    // Runtime state stays ignored — tracking the manifest must not track everything.
+    assert.equal(isIgnored(dir, '.adlc/findings.jsonl'), true);
+    assert.equal(isIgnored(dir, '.adlc/tickets.lock'), true);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('migration does not strand pre-existing .adlc negations', () => {
+  // Negations the stanza knows nothing about, already effective (below the
+  // blanket rule). Relocating the blanket to the end of the file would leave
+  // these above it, where the later pattern wins and they silently die.
+  const { dir } = legacyRepo([
+    '.adlc/*',
+    '!.adlc/tickets.json',
+    '!.adlc/tickets.example.json',
+    '!.adlc/lessons/',
+    '!.adlc/lessons/**',
+    '',
+  ].join('\n'));
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    for (const path of ['.adlc/tickets.example.json', '.adlc/lessons/interrogation-template.md']) {
+      assert.equal(isIgnored(dir, path), false, `${path} was tracked before the migration and must stay tracked`);
+    }
+    assert.equal(isIgnored(dir, '.adlc/manifest.jsonl'), false, 'and the new evidence negation still applies');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('migration adds the whole stanza when no .adlc rule exists yet', () => {
+  const { dir } = legacyRepo('node_modules/\n');
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    assert.equal(isIgnored(dir, '.adlc/manifest.jsonl'), false);
+    assert.equal(isIgnored(dir, '.adlc/tickets/t1--abc.json'), false);
+    assert.equal(isIgnored(dir, '.adlc/findings.jsonl'), true);
+    assert.match(readFileSync(join(dir, '.gitignore'), 'utf8'), /node_modules\//, 'existing rules are preserved');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// The stanza is a SET of required rules, so "already complete" must be a no-op.
+// Without this, a rule that is present but miscounted as missing gets appended
+// again — harmless to `check-ignore` (a duplicate negation still negates) and
+// therefore invisible to every assertion above, but it grows the file on each
+// migration and misrepresents what changed.
+test('a .gitignore that already satisfies the stanza is left byte-identical', () => {
+  const complete = [
+    '.adlc/*',
+    '!.adlc/tickets.json',
+    '!.adlc/tickets/',
+    '!.adlc/tickets/**',
+    '!.adlc/ticket-archive/',
+    '!.adlc/ticket-archive/**',
+    '!.adlc/specs/',
+    '!.adlc/manifest.jsonl',
+    '',
+  ].join('\n');
+  const { dir } = legacyRepo(complete);
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    assert.equal(readFileSync(join(dir, '.gitignore'), 'utf8'), complete,
+      'a complete stanza must not be rewritten, duplicated or reordered');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// The realistic upgrade path: a repo migrated by the PREVIOUS version already
+// has every rule except the evidence negation. Exactly one line is missing, so
+// an off-by-one in the "nothing to do" short-circuit silently skips the only
+// repair that matters.
+test('a stanza missing exactly one rule still gets that rule', () => {
+  const { dir } = legacyRepo([
+    '.adlc/*',
+    '!.adlc/tickets.json',
+    '!.adlc/tickets/',
+    '!.adlc/tickets/**',
+    '!.adlc/ticket-archive/',
+    '!.adlc/ticket-archive/**',
+    '!.adlc/specs/',
+    '',
+  ].join('\n'));
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    assert.equal(isIgnored(dir, '.adlc/manifest.jsonl'), false,
+      'the single missing rule is the evidence negation — skipping it fails CI for missing evidence');
+
+    // APPENDED to the existing block, not spliced in front of it. Both orderings
+    // are equally effective (all below the blanket), so only position pins this —
+    // and a stable position is what keeps the diff reviewable across upgrades.
+    const lines = readFileSync(join(dir, '.gitignore'), 'utf8').split('\n');
+    assert.ok(lines.indexOf('!.adlc/manifest.jsonl') > lines.indexOf('!.adlc/specs/'),
+      `new rules must be appended after existing .adlc rules, got:\n${lines.join('\n')}`);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// Inserted rules belong with the block they extend. Placement below the blanket
+// is what makes them EFFECTIVE (asserted elsewhere); placement immediately after
+// it is what keeps the file readable, and nothing else pins that.
+test('inserted rules land directly after the blanket rule, not after unrelated entries', () => {
+  const { dir } = legacyRepo(['.adlc/*', 'node_modules/', 'dist/', ''].join('\n'));
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    const lines = readFileSync(join(dir, '.gitignore'), 'utf8').split('\n');
+    const blanketAt = lines.indexOf('.adlc/*');
+    assert.ok(blanketAt >= 0, 'blanket rule must survive');
+    assert.match(lines[blanketAt + 1] ?? '', /^!\.adlc\//,
+      `expected an .adlc negation directly after the blanket rule, got ${JSON.stringify(lines[blanketAt + 1])}`);
+    assert.equal(lines.filter((l) => l === 'node_modules/').length, 1, 'unrelated rules are neither moved nor duplicated');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('an ordinary `git add -A` stages everything the migration evidence gate needs', () => {
+  // The end-to-end property that matters: a user runs the documented command,
+  // stages normally, and the commit CONTAINS the store, the archive and the
+  // evidence. No force-add, no manual .gitignore repair.
+  const { dir, g } = legacyRepo('.adlc/*\n!.adlc/tickets.json\n');
+  try {
+    migrateLegacyStore(dir, { write: true, yes: true, requireClean: false });
+    g('add', '-A');
+    const staged = g('diff', '--cached', '--name-only', 'HEAD').trim().split('\n').filter(Boolean);
+    assert.ok(staged.includes('.adlc/manifest.jsonl'), `evidence not staged; staged: ${staged.join(', ')}`);
+    assert.ok(staged.includes('.adlc/tickets/.store.json'), 'store manifest not staged');
+    assert.ok(staged.some((p) => p.startsWith('.adlc/tickets/') && p.endsWith('.json')), 'no ticket shard staged');
+    assert.ok(staged.includes('.adlc/tickets.json'), 'legacy store deletion not staged');
+
+    // And the staged evidence is the real thing, bound to the migrated store.
+    const manifest = readFileSync(join(dir, '.adlc', 'manifest.jsonl'), 'utf8').trim().split('\n').filter(Boolean);
+    assert.equal(manifest.length, 1, 'a fresh ledger holds exactly the migration entry');
+    const entry = JSON.parse(manifest[0]);
+    assert.equal(entry.gate, 'ticket-migrate');
+    assert.equal(entry.data.action, 'apply');
+    assert.equal(entry.seq, 1, 'a fresh chain starts at seq 1');
+    assert.equal(entry.prev, null, 'with no predecessor');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/scripts/test/gitignore-negations-effective.test.mjs
+++ b/scripts/test/gitignore-negations-effective.test.mjs
@@ -1,0 +1,87 @@
+// Concern: every negation this repository declares in .gitignore must actually
+// take effect.
+//
+// gitignore is LAST-MATCH-WINS, so a negation placed above a blanket rule that
+// re-matches it is dead — the file still READS as though the path were tracked,
+// but git ignores it and `git add -A` silently omits it. That has bitten this
+// repo repeatedly: `adlc ticket store migrate` used to relocate the `.adlc/*`
+// blanket to the end of the file, stranding every negation above it, and the
+// symptom only surfaced later as a CI gate rejecting a PR for missing files.
+//
+// This asserts BEHAVIOUR via `git check-ignore` rather than inspecting the text,
+// because only git can settle precedence. It is deliberately generic: it covers
+// negations that do not exist yet, so a future stranding fails here rather than
+// in CI on an unrelated PR.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+
+// A concrete path the negation is meant to un-ignore. --no-index means it need
+// not exist on disk.
+//
+// A trailing-slash negation probes the DIRECTORY ITSELF, not a member: `!dir/`
+// exists so git will descend into the directory, and it is idiomatic to pair it
+// with a `dir/*` rule that re-ignores the contents so only specific members are
+// then negated (this repo does exactly that for `.omo/evidence/`). Probing a
+// member would flag that correct, intentional pattern as dead.
+function samplePath(pattern) {
+  const body = pattern.slice(1);
+  if (body.endsWith('/**')) return `${body.slice(0, -3)}/sample-probe.json`;
+  if (body.endsWith('/')) return body.slice(0, -1);
+  if (body.endsWith('*')) return `${body.slice(0, -1)}sample-probe`;
+  return body;
+}
+
+function isIgnoredIn(cwd, path) {
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--no-index', '--', path], { cwd, stdio: 'ignore' });
+    return true;
+  } catch (err) {
+    // Exit 1 means "not ignored"; anything else is an operational failure and
+    // must not be mistaken for a pass.
+    if (err.status === 1) return false;
+    throw new Error(`git check-ignore failed for ${path}: ${err.message}`);
+  }
+}
+
+const isIgnored = (path) => isIgnoredIn(REPO_ROOT, path);
+
+const negations = readFileSync(join(REPO_ROOT, '.gitignore'), 'utf8')
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter((line) => line.startsWith('!') && line.length > 1);
+
+test('every .gitignore negation is effective, not shadowed by a later blanket rule', () => {
+  assert.ok(negations.length > 0, 'expected .gitignore to declare negations — otherwise this guard is vacuous');
+  const dead = negations.filter((pattern) => isIgnored(samplePath(pattern)));
+  assert.deepEqual(
+    dead,
+    [],
+    'these negations are dead — a later pattern re-ignores the paths they name, so git will silently omit them from commits. '
+    + 'Move them BELOW the blanket rule that shadows them.',
+  );
+});
+
+test('the guard itself detects a stranded negation (self-test)', () => {
+  // Pins the mechanism the assertion above depends on. Without this, a bug that
+  // made isIgnored() always return false would leave the real test green while
+  // detecting nothing. A negation ABOVE a blanket rule that re-matches it must
+  // be reported dead; the same negation BELOW it must be reported live.
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-ignore-selftest-'));
+  try {
+    // check-ignore requires a repository; outside one it exits 128, which
+    // isIgnoredIn correctly refuses to read as "not ignored".
+    execFileSync('git', ['init', '-q'], { cwd: dir, stdio: 'ignore' });
+    writeFileSync(join(dir, '.gitignore'), ['!.adlc/keep.json', '.adlc/*', ''].join('\n'));
+    assert.equal(isIgnoredIn(dir, '.adlc/keep.json'), true, 'a negation above the blanket rule is dead');
+
+    writeFileSync(join(dir, '.gitignore'), ['.adlc/*', '!.adlc/keep.json', ''].join('\n'));
+    assert.equal(isIgnoredIn(dir, '.adlc/keep.json'), false, 'the same negation below the blanket rule is live');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge before #321.** The migration PR should be regenerated *after* this lands, so it needs no hand-edited `.gitignore` or manifest — which is the only real proof the documented command sequence works.

## Why

The documented migration path produced a commit that CI rejects, and silently broke unrelated ignore rules on the way. Two defects in `migrationGitignoreText`, both invisible in the resulting file.

**1. The stanza omitted `!.adlc/manifest.jsonl`.** The rails-guard CI migration gate requires hash-bound `ticket-migrate`/`apply` evidence to exist in a fresh checkout. With the ledger still ignored, an ordinary `git add -A` omits it and the migration-only PR is denied for missing evidence. This hits **every consumer** following the documented commands, not just this repo.

**2. It relocated the whole block to the end of the file.** It stripped its own stanza lines and re-appended them, so `.adlc/*` moved below any negation it doesn't know about. gitignore is last-match-wins, so those negations — `!.adlc/tickets.example.json`, `!.adlc/lessons/`, a user's own — became **dead**. The file still reads as though the paths were tracked; the failure surfaces much later as a gate rejecting a PR for missing files.

This stranded a negation three separate times while preparing #321. With **#320 now merged**, `main` declares `!.adlc/lessons/` — so without this fix, regenerating #321 would silently untrack the lessons file and undo #320 the moment the migration lands.

## What

Insert missing stanza lines **in place** after the existing blanket rule instead of moving anything. No negation can be orphaned by construction, and repos that already track extra `.adlc/` paths keep them. Only a file with no `.adlc/*` rule at all gets the whole stanza appended.

## Tests

`packages/tickets/test/migrate-gitignore.test.mjs` asserts through **`git check-ignore`**, not by reading the file — text cannot settle last-match-wins precedence, which is exactly why this stayed invisible. Includes the end-to-end property that matters: migrate a legacy fixture, stage with an ordinary `git add -A`, and confirm the store, archive, shards, legacy deletion **and evidence** are all staged, with no force-add and no manual repair.

`scripts/test/gitignore-negations-effective.test.mjs` is a generic guard that every negation this repo declares is actually effective — covering negations that don't exist yet, so a future stranding fails there rather than as a confusing CI rejection on an unrelated PR. It carries a self-test proving it detects a stranded negation rather than passing vacuously. Directory-form negations probe the directory itself, since `!dir/` paired with a deliberate `dir/*` re-ignore is a correct idiom this repo uses for `.omo/evidence/`.

## Verification

- `packages/tickets` **110/110**, exit 0 (rebased on `0da039e`).
- `scripts/test` 473 (472 pass, 1 pre-existing skip), exit 0.
- `node scripts/rails-guard-ci.mjs origin/main` exits **0**.
- The negation guard passes against `main`'s current `.gitignore`, including #320's new `!.adlc/lessons/` entries.
- **Both halves mutation-verified independently:** dropping the manifest negation fails the evidence test; restoring the relocating writer fails the stranding test with the real symptom.

## Test plan

- [ ] CI green on all matrix legs
- [ ] Regenerate #321 on top of this and confirm it needs **zero** manual `.gitignore` or manifest edits