### PR TITLE
Ticket-completion lifecycle close-step (T144–T148 + 35 adversarial-review rounds)

### DIFF
--- a/.adlc/tickets/t144--973c990aa0aefa3545163f20f58e51b73984524ab6764ef472360441d00d0b03.json
+++ b/.adlc/tickets/t144--973c990aa0aefa3545163f20f58e51b73984524ab6764ef472360441d00d0b03.json
@@ -1,0 +1,16 @@
+{
+  "body": "Root problem: fleet computes the merged-ticket set (packages/fleet/lib/run.mjs:122) and discards it; nothing in the ADLC lifecycle ever sets completed:true automatically, so shipped tickets accumulate open. In runFleet's merge effect (packages/fleet/lib/run.mjs:29-37), after postMergeGate PASSES for a ticket, invoke TicketService.planComplete(ticket.id) + apply() in the integration-branch worktree and commit the add-only completed:true diff onto the fleet run branch, so completion rides the single PR fleet already opens. Constraints: idempotent (an already-completed ticket is a no-op, never an error); a ticket whose merge/postMergeGate FAILED must NOT be completed; completion must go through the existing planComplete path so manifest evidence is recorded; rails-less tickets merge under rails-guard-ci's existing isCompletionAnnotationOnly exemption. Verification: `node --test packages/fleet/test/*.test.mjs` with a NEW test proving (a) a merged+gate-passed ticket ends completed:true on the run branch, (b) a gate-failed ticket stays open, (c) re-running over an already-completed ticket is a no-op. allow-suppression: none",
+  "budget": "frontier",
+  "category": "feature",
+  "duration": 3,
+  "edges": [],
+  "id": "T144",
+  "rails": [],
+  "scope": [
+    "packages/fleet/lib/run.mjs",
+    "packages/fleet/lib/**",
+    "packages/fleet/test/**",
+    "packages/fleet/README.md"
+  ],
+  "title": "fleet: auto-complete tickets on the integration branch after a passing merge gate"
+}

--- a/.adlc/tickets/t145--ec3c610eb10b9b5d571a19b8ee5dbd5680ee553a005be19ee3188c95ec0fc0fd.json
+++ b/.adlc/tickets/t145--ec3c610eb10b9b5d571a19b8ee5dbd5680ee553a005be19ee3188c95ec0fc0fd.json
@@ -1,0 +1,19 @@
+{
+  "body": "The documented lifecycle has no completion step: ADLC.md's P6 section (~lines 352-373) ends at 'human behavioral acceptance' and the word 'completed' never appears; the adlc skill P6 block (plugins/adlc-claude-code/skills/adlc/SKILL.md:125-128) says only 'record gate-manifest'. Add the missing close step in the process docs: (1) ADLC.md P6 section and (2) the adlc skill P6 block must state that acceptance concludes with `adlc gate-manifest record p6-accept --ticket <id>` then `adlc ticket complete <id> --write` (plus --authorize/ceremony when the ticket is railed). (3) Thin optional convenience: when `gate-manifest record` is given --ticket for a p6-accept gate, print a one-line reminder of the `ticket complete` command (no change to recording semantics, no auto-mutation). Verification: a docs-lint/grep test asserting ADLC.md P6 and SKILL.md P6 both mention `ticket complete`; if the gate-manifest reminder is added, `node --test packages/gate-manifest/test/*.test.mjs` stays green and covers the reminder line. allow-suppression: none",
+  "budget": "mid",
+  "category": "docs",
+  "duration": 2,
+  "edges": [],
+  "id": "T145",
+  "rails": [],
+  "scope": [
+    "ADLC.md",
+    "plugins/adlc-claude-code/skills/adlc/SKILL.md",
+    "plugins/adlc-claude-code/commands/**",
+    "packages/gate-manifest/lib/**",
+    "packages/gate-manifest/test/**",
+    "docs/**",
+    "scripts/test/**"
+  ],
+  "title": "P6: make acceptance conclude with ticket completion (docs + gate-manifest bridge)"
+}

--- a/.adlc/tickets/t146--1c488f09ade1e5acaee25410cef743ddba63db39849ae5a6d5ecbe9e54588622.json
+++ b/.adlc/tickets/t146--1c488f09ade1e5acaee25410cef743ddba63db39849ae5a6d5ecbe9e54588622.json
@@ -1,0 +1,15 @@
+{
+  "body": "`adlc ticket-prune --write` returns on the first archive error (packages/ticket-prune/lib/run.mjs:155-161), so a completed tombstone that retains inbound edges (e.g. T9, T46/T47) fails closed with ARCHIVE_INBOUND_EDGE and wedges the whole sweep, leaving the store half-processed. Fix: (1) order archive candidates topologically so edge SOURCES are archived before their targets; (2) on a per-ticket archive failure, collect it into the report and CONTINUE the batch instead of returning, surfacing the failed/blocked set the way needsCeremony already is. Invariants: never archive a ticket before a dependency it points to is handled; a run with some blocked tickets still archives every eligible one and exits with a report rather than a hard failure; dry-run output must list what WOULD archive vs what is blocked. Verification: `node --test packages/ticket-prune/test/*.test.mjs` with NEW tests proving (a) a batch containing one inbound-edge-blocked ticket still archives the rest and names the blocked one, (b) archive order is topological. allow-suppression: none",
+  "budget": "frontier",
+  "category": "bug",
+  "duration": 3,
+  "edges": [],
+  "id": "T146",
+  "rails": [],
+  "scope": [
+    "packages/ticket-prune/lib/run.mjs",
+    "packages/ticket-prune/lib/**",
+    "packages/ticket-prune/test/**"
+  ],
+  "title": "ticket-prune: skip-and-continue on ARCHIVE_INBOUND_EDGE + topological archive order (no mid-batch wedge)"
+}

--- a/.adlc/tickets/t147--f3085cc4683ff614fc16638185f5ea4d2d8e3b52fe7eb01ed0ad6e1f20419dba.json
+++ b/.adlc/tickets/t147--f3085cc4683ff614fc16638185f5ea4d2d8e3b52fe7eb01ed0ad6e1f20419dba.json
@@ -1,0 +1,15 @@
+{
+  "body": "The pi plugin enumerates ALL tickets for argument completions (plugins/adlc-pi/lib/commands.mjs:166-168) and the interactive picker (line 204) with no completed!==true filter, and ticketLabel (line 55) doesn't even mark completed tickets, so 40 of 80 entries are closed tickets offered as activation candidates. Invariant #104 requires backlog ENUMERATIONS to filter completed:true. Fix: filter t.completed !== true in getArgumentCompletions and in the interactive picker options. Named-id activation of a completed ticket stays allowed (that is a lookup, not an enumeration) — only the offered lists are filtered. Verification: `node --test plugins/adlc-pi/test/*.test.mjs` with a NEW test proving the picker and completions exclude a completed ticket, still include an open one, and named activation of a completed id still resolves. allow-suppression: none",
+  "budget": "mid",
+  "category": "bug",
+  "duration": 1,
+  "edges": [],
+  "id": "T147",
+  "rails": [],
+  "scope": [
+    "plugins/adlc-pi/lib/commands.mjs",
+    "plugins/adlc-pi/lib/**",
+    "plugins/adlc-pi/test/**"
+  ],
+  "title": "pi plugin: filter completed tickets out of the /adlc-ticket picker and completions (#104 invariant)"
+}

--- a/.adlc/tickets/t148--2a0a8d8b893689b637913166bd59c3fbb812fb177f49974216202267f8e6bc06.json
+++ b/.adlc/tickets/t148--2a0a8d8b893689b637913166bd59c3fbb812fb177f49974216202267f8e6bc06.json
@@ -1,0 +1,15 @@
+{
+  "body": "doctorTicketStore (packages/tickets/lib/doctor.mjs:39-65) reports the current storeHash but never compares it to the most recent ticket-op entry in .adlc/manifest.jsonl, so a silent local shard edit between transactions (hand-editing a ticket file) goes undetected — .store.json is a format marker, not a content bind. Add a READ-ONLY doctor check: the live storeHash equals the storeHash bound in the last evidence-required manifest entry, OR report N unevidenced non-sensitive ops since (a legitimate state, reported not failed). A genuine mismatch (tamper) is flagged. Verification: `node --test packages/tickets/test/doctor*.test.mjs` (or the tickets doctor test file) with a NEW test proving (a) a tampered shard makes doctor flag a storeHash/manifest mismatch, (b) a clean store passes, (c) legitimate unevidenced non-sensitive ops are reported, not failed. allow-suppression: none",
+  "budget": "frontier",
+  "category": "feature",
+  "duration": 2,
+  "edges": [],
+  "id": "T148",
+  "rails": [],
+  "scope": [
+    "packages/tickets/lib/doctor.mjs",
+    "packages/tickets/lib/**",
+    "packages/tickets/test/**"
+  ],
+  "title": "ticket doctor: bind the live storeHash to the last recorded manifest evidence entry"
+}

--- a/ADLC.md
+++ b/ADLC.md
@@ -370,7 +370,16 @@ Merge sequentially. Worktree branches integrate one at a time with rebases
 between (squash-merge recovery per the worktree conventions). No parallel
 builds across worktrees.
 
-**Gate:** human behavioral acceptance. Second of the two human gates.
+**Close the ticket.** Acceptance is not finished until it is recorded *and* the
+ticket is marked done: `adlc gate-manifest record p6-accept --ticket <id>` to log
+the human verdict, then `adlc ticket complete <id> --write` to set
+`completed:true` (add `--authorize` — the railed-ticket completion ceremony —
+when the ticket declares rails). Fleet does this automatically on a passing
+post-merge gate; do it by hand for a solo merge. A ticket left un-completed keeps
+resurfacing in every backlog enumeration.
+
+**Gate:** human behavioral acceptance, concluded by `adlc ticket complete`.
+Second of the two human gates.
 
 ### P7 — Distill
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ pre-squash commits and conflicts throughout.
 
 This repo is the toolkit, and it uses it: author a ticket (P0), check
 executability (`adlc coldstart <id> --prompt-only`, P2), and prosecute before
-merge (`/adlc:adlc-prosecute`, P5). Two rules that carry real weight:
+merge (`/adlc:adlc-prosecute`, P5). Three rules that carry real weight:
 
 - **Fail-open vs fail-closed is a deliberate choice, never an accident.** Several
   gates fail open on purpose so an unverifiable signal cannot kill real work.
@@ -119,6 +119,14 @@ merge (`/adlc:adlc-prosecute`, P5). Two rules that carry real weight:
   every fixture mocked a tool's output in a shape that tool has never produced.
   For contract tests, drive the real binary, and export the production adapter
   so tests use *it* rather than a copy of it.
+- **An unused parameter that every caller passes is a missing check, not dead
+  code.** `completeTicketOnIntegration` accepted `integrationBranch`, ignored it,
+  and committed to whatever happened to be checked out. A lint cleanup read
+  "declared but never read" and deleted the parameter; review later found the
+  real defect underneath — a concurrent checkout switch could land a lifecycle
+  commit on the wrong branch. When every call site faithfully supplies a value
+  the callee ignores, the fix is to make it load-bearing (verify against it),
+  not to delete it. Deleting it removes the evidence of the missing guard.
 
 Changes under `packages/rails-guard`, `prosecute`, `gate-manifest`, or
 `build-gate` are trust-root tier: a same-model P5 is not sufficient, and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -768,7 +768,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -9742,7 +9742,8 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@adlc/core": "1.6.0"
+        "@adlc/core": "1.6.0",
+        "@adlc/tickets": "1.6.0"
       },
       "bin": {
         "adlc-fleet": "bin/fleet.mjs"

--- a/packages/fleet/README.md
+++ b/packages/fleet/README.md
@@ -29,6 +29,12 @@ Design contract: [`docs/specs/fleet-orchestration.md`](../../docs/specs/fleet-or
   reachable.
 - **Integration branch, never base** — finished tickets merge sequentially into
   `fleet/run-<runId>`; the fleet opens at most one PR to base and never pushes.
+- **Auto-completes on a passing merge gate** — once a ticket's post-merge gate
+  passes, the fleet marks it `completed:true` on the integration branch via the
+  same `adlc ticket complete` (`planComplete` + apply) path a human would use, so
+  the add-only annotation and its manifest evidence ride the single PR. Idempotent
+  (an already-completed ticket is a no-op) and gated (a gate-failed ticket stays
+  open).
 - **Two-strike failure policy** informed by `flail-detector` (fails open).
 
 ## Usage

--- a/packages/fleet/bin/fleet.mjs
+++ b/packages/fleet/bin/fleet.mjs
@@ -15,7 +15,7 @@ import { readLockOwner, forceUnlock, releaseLock } from '../lib/lock.mjs';
 import { runPreflight } from '../lib/preflight.mjs';
 import { reconcileRun } from '../lib/resume.mjs';
 import { buildLiveDeps, defaultIo } from '../lib/live-deps.mjs';
-import { runFleet } from '../lib/run.mjs';
+import { runFleet, runExitCode } from '../lib/run.mjs';
 import { selfIdentity, lockProbes } from '../lib/proc.mjs';
 import { Sandbox } from '../lib/sandbox.mjs';
 import { repoCommandEnv } from '../lib/env-scrub.mjs';
@@ -199,11 +199,17 @@ async function runLive({ repo, dir, all, config, onlyIds }) {
       deps,
     });
 
-    const states = Object.values(summary.results);
-    const failed = states.filter((s) => s === 'failed' || s === 'blocked').length;
-    console.log(`\nfleet run ${runId}: ${summary.merged} merged, ${failed} failed/blocked → ${summary.integrationBranch}` +
-      `${summary.prCount ? ' (PR opened)' : ''}`);
-    return failed > 0 ? 2 : 0;
+    if (summary.contaminated) {
+      console.error(`\nfleet run ${runId}: QUARANTINED — ${summary.contaminationReason}.` +
+        ` Branch ${summary.integrationBranch} carries an ungated change and needs manual cleanup; no PR was opened.`);
+    } else {
+      const failed = Object.values(summary.results).filter((s) => s === 'failed' || s === 'blocked').length;
+      console.log(`\nfleet run ${runId}: ${summary.merged} merged, ${failed} failed/blocked → ${summary.integrationBranch}` +
+        `${summary.prCount ? ' (PR opened)' : ''}`);
+    }
+    // Exit code keys on quarantine FIRST — see runExitCode. A quarantined-no-work resume
+    // must not report success just because no ticket reached a failed/blocked state.
+    return runExitCode(summary);
   } finally {
     releaseLock(dir); // always release the preflight-held lock
   }

--- a/packages/fleet/bin/fleet.mjs
+++ b/packages/fleet/bin/fleet.mjs
@@ -30,6 +30,7 @@ Usage:
 
 Exit codes: 0 ok · 1 operational error · 2 a ticket failed/blocked.`;
 
+function runCli() {
 const raw = process.argv.slice(2);
 const sub = raw[0];
 
@@ -139,9 +140,24 @@ if (sub === 'run') {
 if (!['run', 'status', 'unlock'].includes(sub)) {
   gateFail(`unknown subcommand: ${sub}\n\n${USAGE}`);
 }
+}
 
-async function runLive({ repo, dir, all, config, onlyIds }) {
-  const io = defaultIo();
+// Dispatch the CLI ONLY when run as the entry point. Importing this module (e.g. a unit
+// test importing runLive) must not parse argv, hit process.exit, or gateFail.
+if (import.meta.url === `file://${process.argv[1]}`) runCli();
+
+// Collaborators are injectable (defaulting to the real implementations) purely for
+// testability: the production call site passes no overrides, so behavior is unchanged, but a
+// unit test can drive the preflight / run / exit-code path without a real sandbox.
+export async function runLive({ repo, dir, all, config, onlyIds }, {
+  io = defaultIo(),
+  preflight = runPreflight,
+  build = buildLiveDeps,
+  run = runFleet,
+  loadPrior = loadStatus,
+  reconcile = reconcileRun,
+  release = releaseLock,
+} = {}) {
   const repoGit = io.git(repo);
 
   // Preflight (spec §8.0): resolve+require sandbox, lock, clean tree, rail-hook
@@ -168,7 +184,7 @@ async function runLive({ repo, dir, all, config, onlyIds }) {
     finally { if (tmp) try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } }
   };
 
-  const pre = await runPreflight({
+  const pre = await preflight({
     repo, config, statusDir: dir, io,
     self: selfIdentity(), probes: lockProbes(),
     railHookInstalled,
@@ -182,18 +198,18 @@ async function runLive({ repo, dir, all, config, onlyIds }) {
     // work by integration-branch ancestry; refuse on missing/moved anchors; and
     // CONTINUE that run (reuse its runId/integration branch/reconciled status)
     // rather than starting fresh (adversarial-review L3).
-    const prior = loadStatus(dir);
+    const prior = loadPrior(dir);
     let resume;
     if (prior) {
-      const rec = reconcileRun({ all, status: prior, repo, io });
+      const rec = reconcile({ all, status: prior, repo, io });
       if (rec.refused) { console.error(`cannot resume: ${rec.reason}`); return 1; }
       if (rec.resume) { resume = { status: rec.status, integrationBranch: rec.status.integrationBranch }; console.error(`resuming run ${rec.status.runId} on ${rec.status.integrationBranch}`); }
     }
 
     const runId = resume ? resume.status.runId : `${new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 14)}`;
     const baseSha = resume ? resume.status.baseSha : repoGit('rev-parse', config.base);
-    const deps = buildLiveDeps({ repo, config, statusDir: dir, sandboxSpec: pre.sandboxSpec, io });
-    const summary = await runFleet({
+    const deps = build({ repo, config, statusDir: dir, sandboxSpec: pre.sandboxSpec, io });
+    const summary = await run({
       all, runId, resume,
       config: { ...config, baseSha, sandboxMode: pre.sandboxSpec.mode, onlyIds, startedAt: new Date().toISOString() },
       deps,
@@ -211,6 +227,6 @@ async function runLive({ repo, dir, all, config, onlyIds }) {
     // must not report success just because no ticket reached a failed/blocked state.
     return runExitCode(summary);
   } finally {
-    releaseLock(dir); // always release the preflight-held lock
+    release(dir); // always release the preflight-held lock
   }
 }

--- a/packages/fleet/bin/fleet.mjs
+++ b/packages/fleet/bin/fleet.mjs
@@ -15,7 +15,7 @@ import { readLockOwner, forceUnlock, releaseLock } from '../lib/lock.mjs';
 import { runPreflight } from '../lib/preflight.mjs';
 import { reconcileRun } from '../lib/resume.mjs';
 import { buildLiveDeps, defaultIo } from '../lib/live-deps.mjs';
-import { runFleet, runExitCode } from '../lib/run.mjs';
+import { runFleet, runExitCode, failedBlockedCount } from '../lib/run.mjs';
 import { selfIdentity, lockProbes } from '../lib/proc.mjs';
 import { Sandbox } from '../lib/sandbox.mjs';
 import { repoCommandEnv } from '../lib/env-scrub.mjs';
@@ -203,7 +203,7 @@ async function runLive({ repo, dir, all, config, onlyIds }) {
       console.error(`\nfleet run ${runId}: QUARANTINED — ${summary.contaminationReason}.` +
         ` Branch ${summary.integrationBranch} carries an ungated change and needs manual cleanup; no PR was opened.`);
     } else {
-      const failed = Object.values(summary.results).filter((s) => s === 'failed' || s === 'blocked').length;
+      const failed = failedBlockedCount(summary.results);
       console.log(`\nfleet run ${runId}: ${summary.merged} merged, ${failed} failed/blocked → ${summary.integrationBranch}` +
         `${summary.prCount ? ' (PR opened)' : ''}`);
     }

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -33,7 +33,7 @@ function completionStorePath(store, id) {
  *
  * @returns {{completed: boolean, alreadyComplete?: boolean, reason?: string}}
  */
-export function completeTicketOnIntegration({ repo, ticketId, integrationBranch, git = defaultGit(repo), detectStore = detectTicketStore } = {}) {
+export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(repo), detectStore = detectTicketStore } = {}) {
   const store = detectStore({ root: repo });
   const snapshot = store.load();
   const existing = snapshot.get(ticketId);

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -192,6 +192,7 @@ export function completeTicketOnIntegration({ repo, ticketId, integrationBranch,
 
     // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
     // ledger). A path-scoped add + commit never sweeps in unrelated build output.
+    let committed = false;
     try {
       // Re-verify immediately before staging/committing: an external checkout switch
       // between entry and here would otherwise land this lifecycle commit on whatever
@@ -199,11 +200,24 @@ export function completeTicketOnIntegration({ repo, ticketId, integrationBranch,
       assertOnBranch(git, integrationBranch, 'before committing');
       git('add', '--', storePath, MANIFEST_FILE);
       git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
-      // And DETECT the switch we cannot prevent: if the checkout moved mid-commit, the
-      // commit landed somewhere we do not own. Surface it as a hard, quarantining
-      // failure rather than reporting a completion that is not on the run's branch.
+      committed = true;
+      // DETECT the switch we cannot prevent. Note this can only fail AFTER the commit
+      // landed, which is a materially different situation from a failed commit.
       assertOnBranch(git, integrationBranch, 'after committing');
     } catch (error) {
+      if (committed) {
+        // The commit LANDED and then the checkout moved under us. Two consequences, and
+        // neither is a "degrade quietly" case:
+        //   - We must NOT restore any path: we no longer know which branch is checked
+        //     out, so writing files here would corrupt an unrelated checkout.
+        //   - The caller's post-completion re-gate never runs (we are throwing), so an
+        //     UNGATED completion commit is sitting on the integration branch. Left as a
+        //     plain error it would be logged and swallowed, and the run could still open
+        //     a PR carrying it.
+        // Flag contamination so the run quarantines the branch instead of publishing it.
+        error.branchContaminated = true;
+        throw error;
+      }
       // A failed commit (e.g. a rejecting hook) must NOT leave the shared integration
       // checkout dirty. Restore the two owned paths to their exact pre-completion
       // bytes and unstage them, then re-throw so the caller degrades to "merged, not

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -89,7 +89,21 @@ export function revertCompletionCommit({ repo, toSha, shardPath = null, completi
  *
  * @returns {{completed: boolean, alreadyComplete?: boolean, reason?: string}}
  */
-export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(repo), detectStore = detectTicketStore } = {}) {
+export function completeTicketOnIntegration({ repo, ticketId, integrationBranch, git = defaultGit(repo), detectStore = detectTicketStore } = {}) {
+  // Every git operation below targets the SHARED checkout's current HEAD. The merge
+  // mutex serializes only this fleet process — another local process can change the
+  // checkout between the post-merge gate and here — so verify we are actually on the
+  // integration branch BEFORE any mutation, rather than trusting the caller's
+  // choreography. Without this a lifecycle commit can land on the wrong branch.
+  if (!integrationBranch) throw new Error('completeTicketOnIntegration requires integrationBranch to verify the checkout before mutating');
+  const currentBranch = git('symbolic-ref', '--short', 'HEAD'); // throws on detached HEAD — fail closed
+  if (currentBranch !== integrationBranch) {
+    throw new Error(`refusing to complete: checkout is on "${currentBranch}", not the integration branch "${integrationBranch}"`);
+  }
+  if (git('rev-parse', 'HEAD') !== git('rev-parse', integrationBranch)) {
+    throw new Error(`refusing to complete: HEAD does not point at "${integrationBranch}"`);
+  }
+
   const store = detectStore({ root: repo });
   const storePath = completionStorePath(store, ticketId);
   const storeAbs = join(repo, storePath);

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -79,6 +79,13 @@ export function revertCompletionCommit({ repo, toSha, shardPath = null, completi
   //      ledger falsely attest a completion that was withdrawn.
   // Failing either, we refuse. The caller escalates a refusal to a branch quarantine,
   // which is the honest outcome: this branch needs a human, not more blind surgery.
+  // Reacquire the TICKET lock for the withdrawal. completeTicketOnIntegration released
+  // it when it returned, and the caller then ran a potentially long post-completion
+  // gate — during which a legal non-sensitive ticket update can land (such updates
+  // record no manifest evidence, so the ledger check below cannot see them). Restoring
+  // the shard without this lock would silently erase that update.
+  const lock = acquireTicketLock(repo, { command: 'fleet:withdraw-completion' });
+  try {
   const head = git('rev-parse', 'HEAD');
   if (completionSha && head !== completionSha) {
     throw new Error(`refusing to withdraw: HEAD is ${head}, no longer the completion commit ${completionSha} — another process committed on this branch`);
@@ -97,14 +104,28 @@ export function revertCompletionCommit({ repo, toSha, shardPath = null, completi
     if (liveManifest !== committedManifest.trimEnd()) {
       throw new Error('refusing to withdraw: the evidence ledger changed since the completion commit (concurrent append) — cannot remove our entry without disturbing another writer');
     }
-    // Preconditions hold AND no recorder can interleave while we hold the lock, so
-    // restore both owned paths exactly. Still path-scoped — never a checkout-wide
-    // reset --hard.
+    // Same exactness rule for the SHARD: it must still be byte-for-byte what the
+    // completion commit recorded. A concurrent non-sensitive update leaves no evidence
+    // trail, so this content check is the only thing standing between a withdrawal and
+    // silently reverting someone else's legitimate edit.
+    if (shardPath) {
+      const committedShard = git('show', `${head}:${shardPath}`);
+      const shardAbs = join(repo, shardPath);
+      const liveShard = existsSync(shardAbs) ? readFileSync(shardAbs, 'utf8').trimEnd() : '';
+      if (liveShard !== committedShard.trimEnd()) {
+        throw new Error('refusing to withdraw: the ticket shard changed since the completion commit (concurrent update) — restoring would erase it');
+      }
+    }
+
+    // Preconditions hold AND neither a recorder nor a ticket writer can interleave
+    // while we hold both locks, so restore both owned paths exactly. Still
+    // path-scoped — never a checkout-wide reset --hard.
     git('reset', '-q', '--soft', toSha);
     const paths = shardPath ? [shardPath, MANIFEST_FILE] : [MANIFEST_FILE];
     git('restore', '--staged', '--worktree', '--', ...paths);
     return { reverted: true, toSha };
   });
+  } finally { releaseTicketLock(lock); }
 }
 
 /**

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -31,6 +31,16 @@ function restoreFile(absPath, priorBytes) {
 }
 
 /**
+ * Discard the completion commit, returning the integration branch to `toSha`.
+ * Used when the gate re-run over the completion commit fails: the shipped merge
+ * below it stays intact, only the completion annotation is withdrawn.
+ */
+export function revertCompletionCommit({ repo, toSha, git = defaultGit(repo) } = {}) {
+  git('reset', '--hard', toSha);
+  return { reverted: true, toSha };
+}
+
+/**
  * Complete `ticketId` in the ticket store rooted at `repo` and commit the
  * add-only diff onto the currently checked-out (integration) branch.
  *
@@ -74,6 +84,10 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
     // auto-completion in that case and degrade to "merged, not yet completed".
     if (priorManifest === null) return { completed: false, reason: 'no-manifest-baseline' };
 
+    // The tip BEFORE the completion commit — the caller re-gates the new commit and
+    // rolls back to exactly here if that gate fails.
+    const preCompletionSha = git('rev-parse', 'HEAD');
+
     const service = new TicketService(store, { root: repo });
     service.apply(service.planComplete(ticketId), { lock });
 
@@ -94,7 +108,7 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
       throw error;
     }
 
-    return { completed: true };
+    return { completed: true, preCompletionSha };
   } finally {
     releaseTicketLock(lock);
   }

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -60,6 +60,14 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
   const priorStore = existsSync(storeAbs) ? readFileSync(storeAbs) : null;
   const priorManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
 
+  // rails-guard-ci DENIES a PR that CREATES .adlc/manifest.jsonl with evidence
+  // (only a verified migration may); appending to an existing one is allowed. On a
+  // repo whose ADLC manifest is not yet bootstrapped, recording completion evidence
+  // here would create the ledger and get the whole fleet PR rejected. Skip
+  // auto-completion in that case and degrade to "merged, not yet completed" rather
+  // than open a PR the CI gate is guaranteed to reject.
+  if (priorManifest === null) return { completed: false, reason: 'no-manifest-baseline' };
+
   const service = new TicketService(store, { root: repo });
   service.apply(service.planComplete(ticketId));
 

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -31,12 +31,25 @@ function restoreFile(absPath, priorBytes) {
 }
 
 /**
- * Discard the completion commit, returning the integration branch to `toSha`.
+ * Withdraw the completion commit, returning the integration branch to `toSha`.
  * Used when the gate re-run over the completion commit fails: the shipped merge
  * below it stays intact, only the completion annotation is withdrawn.
+ *
+ * Deliberately NOT a checkout-wide `reset --hard`: this runs in the SHARED
+ * integration checkout, so a hard reset would destroy unrelated tracked work. HEAD
+ * moves back with --soft and only this completion's own paths are discarded.
+ *
+ * The manifest is treated differently from the shard: it is a shared, append-only
+ * evidence ledger whose appends are serialized by the LEDGER lock, not the ticket
+ * lock — a concurrent recorder may have appended since. So the manifest is only
+ * UNSTAGED (its bytes are left on disk); restoring it to `toSha` would erase that
+ * concurrent evidence. An extra append-only evidence line is harmless; losing
+ * another writer's evidence is not.
  */
-export function revertCompletionCommit({ repo, toSha, git = defaultGit(repo) } = {}) {
-  git('reset', '--hard', toSha);
+export function revertCompletionCommit({ repo, toSha, shardPath = null, git = defaultGit(repo) } = {}) {
+  git('reset', '-q', '--soft', toSha);
+  if (shardPath) git('restore', '--staged', '--worktree', '--', shardPath);
+  git('restore', '--staged', '--', MANIFEST_FILE);
   return { reverted: true, toSha };
 }
 
@@ -90,6 +103,9 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
 
     const service = new TicketService(store, { root: repo });
     service.apply(service.planComplete(ticketId), { lock });
+    // What the manifest looks like immediately after OUR append — the baseline for
+    // detecting a concurrent evidence append before any rollback.
+    const afterManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
 
     // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
     // ledger). A path-scoped add + commit never sweeps in unrelated build output.
@@ -102,13 +118,22 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
       // bytes and unstage them, then re-throw so the caller degrades to "merged, not
       // yet completed". Safe under the held lock — no other writer can have touched
       // these paths since we captured them.
+      // The shard is covered by the ticket lock we hold, so restoring it is safe.
       restoreFile(storeAbs, priorStore);
-      restoreFile(manifestAbs, priorManifest);
+      // The manifest is NOT: its appends are serialized by the ledger lock, and other
+      // pipeline steps record gate evidence concurrently. Only roll it back when it is
+      // byte-identical to what THIS completion left — i.e. nothing appended since.
+      // Otherwise leave it: an extra append-only evidence line is harmless, erasing a
+      // concurrent writer's evidence is data loss.
+      const manifestNow = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
+      const untouchedSinceOurAppend = manifestNow !== null && afterManifest !== null
+        && manifestNow.equals(afterManifest);
+      if (untouchedSinceOurAppend) restoreFile(manifestAbs, priorManifest);
       try { git('reset', '-q', '--', storePath, MANIFEST_FILE); } catch { /* best-effort unstage */ }
       throw error;
     }
 
-    return { completed: true, preCompletionSha };
+    return { completed: true, preCompletionSha, shardPath: storePath };
   } finally {
     releaseTicketLock(lock);
   }

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -35,7 +35,7 @@ function completionStorePath(store, id) {
  * DETECT a switch we could not prevent. The complete fix is not to share the checkout
  * at all — give the integration branch a dedicated worktree. Tracked as follow-up.
  */
-function assertOnBranch(git, branch, when, action = 'complete') {
+export function assertOnBranch(git, branch, when, action = 'complete') {
   const current = git('symbolic-ref', '--short', 'HEAD'); // throws on detached HEAD — fail closed
   if (current !== branch) {
     throw new Error(`refusing to ${action} (${when}): checkout is on "${current}", not the integration branch "${branch}"`);

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -46,10 +46,34 @@ function restoreFile(absPath, priorBytes) {
  * concurrent evidence. An extra append-only evidence line is harmless; losing
  * another writer's evidence is not.
  */
-export function revertCompletionCommit({ repo, toSha, shardPath = null, git = defaultGit(repo) } = {}) {
+export function revertCompletionCommit({ repo, toSha, shardPath = null, completionSha = null, git = defaultGit(repo) } = {}) {
+  // Withdrawal is EXACT or it does not happen. Two preconditions, both checked against
+  // the shared checkout as it is RIGHT NOW:
+  //   1. HEAD is still our completion commit. Otherwise a --soft reset would silently
+  //      uncommit whatever another process committed on this shared branch.
+  //   2. The evidence ledger has not been appended to since our commit. Otherwise we
+  //      would have to choose between erasing a concurrent writer's evidence and
+  //      leaving a REJECTED completion's attestation on disk — where a later
+  //      completion's `git add` would sweep it into an unrelated commit, making the
+  //      ledger falsely attest a completion that was withdrawn.
+  // Failing either, we refuse. The caller escalates a refusal to a branch quarantine,
+  // which is the honest outcome: this branch needs a human, not more blind surgery.
+  const head = git('rev-parse', 'HEAD');
+  if (completionSha && head !== completionSha) {
+    throw new Error(`refusing to withdraw: HEAD is ${head}, no longer the completion commit ${completionSha} — another process committed on this branch`);
+  }
+  const committedManifest = git('show', `${head}:${MANIFEST_FILE}`);
+  const manifestAbs = join(repo, MANIFEST_FILE);
+  const liveManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs, 'utf8').trimEnd() : '';
+  if (liveManifest !== committedManifest.trimEnd()) {
+    throw new Error('refusing to withdraw: the evidence ledger changed since the completion commit (concurrent append) — cannot remove our entry without disturbing another writer');
+  }
+
+  // Preconditions hold: nothing concurrent to lose, so restore BOTH owned paths
+  // exactly. Still path-scoped — never a checkout-wide reset --hard.
   git('reset', '-q', '--soft', toSha);
-  if (shardPath) git('restore', '--staged', '--worktree', '--', shardPath);
-  git('restore', '--staged', '--', MANIFEST_FILE);
+  const paths = shardPath ? [shardPath, MANIFEST_FILE] : [MANIFEST_FILE];
+  git('restore', '--staged', '--worktree', '--', ...paths);
   return { reverted: true, toSha };
 }
 
@@ -133,7 +157,10 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
       throw error;
     }
 
-    return { completed: true, preCompletionSha, shardPath: storePath };
+    // The exact commit we created — the withdrawal path requires HEAD to still be
+    // this, so it can never uncommit someone else's work.
+    const completionSha = git('rev-parse', 'HEAD');
+    return { completed: true, preCompletionSha, completionSha, shardPath: storePath };
   } finally {
     releaseTicketLock(lock);
   }

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -14,7 +14,7 @@
 
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { ACTIVE_DIRECTORY, DirectoryTicketStore, LEGACY_FILE, detectTicketStore, TicketService, ticketFilename } from '@adlc/tickets';
+import { ACTIVE_DIRECTORY, DirectoryTicketStore, LEGACY_FILE, detectTicketStore, TicketService, ticketFilename, acquireTicketLock, releaseTicketLock } from '@adlc/tickets';
 import { defaultGit } from './worktrees.mjs';
 
 const MANIFEST_FILE = '.adlc/manifest.jsonl';
@@ -43,53 +43,59 @@ function restoreFile(absPath, priorBytes) {
  */
 export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(repo), detectStore = detectTicketStore } = {}) {
   const store = detectStore({ root: repo });
-  const snapshot = store.load();
-  const existing = snapshot.get(ticketId);
-  if (!existing) return { completed: false, reason: 'ticket-not-found' };
-  // Idempotency: guard BEFORE planComplete. A no-change complete transaction
-  // still records evidence (evidenceRequired) and would leave an empty commit —
-  // so an already-completed ticket must short-circuit here.
-  if (existing.completed === true) return { completed: false, alreadyComplete: true };
-
-  // Capture the exact pre-completion bytes of the two paths this touches, BEFORE
-  // the transaction writes them, so a failed commit can be rolled back precisely
-  // whether or not the manifest already existed.
   const storePath = completionStorePath(store, ticketId);
   const storeAbs = join(repo, storePath);
   const manifestAbs = join(repo, MANIFEST_FILE);
-  const priorStore = existsSync(storeAbs) ? readFileSync(storeAbs) : null;
-  const priorManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
 
-  // rails-guard-ci DENIES a PR that CREATES .adlc/manifest.jsonl with evidence
-  // (only a verified migration may); appending to an existing one is allowed. On a
-  // repo whose ADLC manifest is not yet bootstrapped, recording completion evidence
-  // here would create the ledger and get the whole fleet PR rejected. Skip
-  // auto-completion in that case and degrade to "merged, not yet completed" rather
-  // than open a PR the CI gate is guaranteed to reject.
-  if (priorManifest === null) return { completed: false, reason: 'no-manifest-baseline' };
-
-  const service = new TicketService(store, { root: repo });
-  service.apply(service.planComplete(ticketId));
-
-  // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
-  // ledger). A path-scoped add + commit never sweeps in unrelated build output
-  // the post-merge gate may have left in the working tree.
+  // Hold the ticket writer lock across the ENTIRE completion — the read, the
+  // transaction, the commit, and any rollback. The transaction alone releases the
+  // lock as soon as it returns, which would let another ticket/manifest writer
+  // interleave before the commit; a failed-commit rollback (which rewrites the whole
+  // shard + manifest back to pre-completion bytes) could then clobber that writer's
+  // committed state. Holding one lock over the whole unit makes it atomic. `apply`
+  // reuses this lock and does NOT release it (we release in finally).
+  const lock = acquireTicketLock(repo, { command: `fleet:complete:${ticketId}` });
   try {
-    git('add', '--', storePath, MANIFEST_FILE);
-    git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
-  } catch (error) {
-    // planComplete already wrote the shard + manifest to disk and `git add` may
-    // have staged them. A failed commit (e.g. a rejecting commit hook) must NOT
-    // leave the shared integration checkout dirty — a later fleet step could sweep
-    // the orphaned staged change into an unrelated commit, and the pushed branch
-    // would be inconsistent. Restore the two owned paths to their exact
-    // pre-completion bytes, unstage them, then re-throw so the caller degrades to
-    // "merged, not yet completed" exactly as before.
-    restoreFile(storeAbs, priorStore);
-    restoreFile(manifestAbs, priorManifest);
-    try { git('reset', '-q', '--', storePath, MANIFEST_FILE); } catch { /* best-effort unstage */ }
-    throw error;
-  }
+    const existing = store.load().get(ticketId);
+    if (!existing) return { completed: false, reason: 'ticket-not-found' };
+    // Idempotency: an already-completed ticket short-circuits — a no-change complete
+    // still records evidence and would leave an empty commit.
+    if (existing.completed === true) return { completed: false, alreadyComplete: true };
 
-  return { completed: true };
+    // Capture pre-completion bytes (BEFORE the transaction writes them) so a failed
+    // commit rolls back precisely.
+    const priorStore = existsSync(storeAbs) ? readFileSync(storeAbs) : null;
+    const priorManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
+
+    // rails-guard-ci DENIES a PR that CREATES .adlc/manifest.jsonl with evidence
+    // (only a verified migration may); appending to an existing one is allowed. On a
+    // repo whose ADLC manifest is not yet bootstrapped, recording completion evidence
+    // here would create the ledger and get the whole fleet PR rejected. Skip
+    // auto-completion in that case and degrade to "merged, not yet completed".
+    if (priorManifest === null) return { completed: false, reason: 'no-manifest-baseline' };
+
+    const service = new TicketService(store, { root: repo });
+    service.apply(service.planComplete(ticketId), { lock });
+
+    // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
+    // ledger). A path-scoped add + commit never sweeps in unrelated build output.
+    try {
+      git('add', '--', storePath, MANIFEST_FILE);
+      git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
+    } catch (error) {
+      // A failed commit (e.g. a rejecting hook) must NOT leave the shared integration
+      // checkout dirty. Restore the two owned paths to their exact pre-completion
+      // bytes and unstage them, then re-throw so the caller degrades to "merged, not
+      // yet completed". Safe under the held lock — no other writer can have touched
+      // these paths since we captured them.
+      restoreFile(storeAbs, priorStore);
+      restoreFile(manifestAbs, priorManifest);
+      try { git('reset', '-q', '--', storePath, MANIFEST_FILE); } catch { /* best-effort unstage */ }
+      throw error;
+    }
+
+    return { completed: true };
+  } finally {
+    releaseTicketLock(lock);
+  }
 }

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -35,13 +35,13 @@ function completionStorePath(store, id) {
  * DETECT a switch we could not prevent. The complete fix is not to share the checkout
  * at all — give the integration branch a dedicated worktree. Tracked as follow-up.
  */
-function assertOnBranch(git, branch, when) {
+function assertOnBranch(git, branch, when, action = 'complete') {
   const current = git('symbolic-ref', '--short', 'HEAD'); // throws on detached HEAD — fail closed
   if (current !== branch) {
-    throw new Error(`refusing to complete (${when}): checkout is on "${current}", not the integration branch "${branch}"`);
+    throw new Error(`refusing to ${action} (${when}): checkout is on "${current}", not the integration branch "${branch}"`);
   }
   if (git('rev-parse', 'HEAD') !== git('rev-parse', branch)) {
-    throw new Error(`refusing to complete (${when}): HEAD does not point at "${branch}"`);
+    throw new Error(`refusing to ${action} (${when}): HEAD does not point at "${branch}"`);
   }
 }
 
@@ -67,7 +67,13 @@ function restoreFile(absPath, priorBytes) {
  * concurrent evidence. An extra append-only evidence line is harmless; losing
  * another writer's evidence is not.
  */
-export function revertCompletionCommit({ repo, toSha, shardPath = null, completionSha = null, git = defaultGit(repo) } = {}) {
+export function revertCompletionCommit({ repo, toSha, shardPath = null, completionSha = null, integrationBranch, git = defaultGit(repo) } = {}) {
+  // Branch IDENTITY, not just commit identity. A SHA match alone is insufficient:
+  // another branch can legitimately point at the completion commit, so if the shared
+  // checkout switched to one of those, every SHA precondition below would pass and the
+  // `reset --soft` would rewind THAT branch — leaving the rejected completion sitting
+  // on the integration branch. Same guard completeTicketOnIntegration uses.
+  if (!integrationBranch) throw new Error('revertCompletionCommit requires integrationBranch to verify the checkout before rewinding');
   // Withdrawal is EXACT or it does not happen. Two preconditions, both checked against
   // the shared checkout as it is RIGHT NOW:
   //   1. HEAD is still our completion commit. Otherwise a --soft reset would silently
@@ -86,9 +92,13 @@ export function revertCompletionCommit({ repo, toSha, shardPath = null, completi
   // the shard without this lock would silently erase that update.
   const lock = acquireTicketLock(repo, { command: 'fleet:withdraw-completion' });
   try {
+  assertOnBranch(git, integrationBranch, 'before rewinding', 'withdraw');
   const head = git('rev-parse', 'HEAD');
   if (completionSha && head !== completionSha) {
     throw new Error(`refusing to withdraw: HEAD is ${head}, no longer the completion commit ${completionSha} — another process committed on this branch`);
+  }
+  if (completionSha && git('rev-parse', integrationBranch) !== completionSha) {
+    throw new Error(`refusing to withdraw: "${integrationBranch}" no longer points at the completion commit ${completionSha}`);
   }
   const committedManifest = git('show', `${head}:${MANIFEST_FILE}`);
   const manifestAbs = join(repo, MANIFEST_FILE);

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -1,0 +1,57 @@
+// T73 — mark a ticket completed on the integration branch after its post-merge
+// gate passes, so the single PR the fleet already opens carries the add-only
+// `completed:true` annotation (nothing in the ADLC lifecycle set it before, so
+// shipped tickets accumulated open).
+//
+// Completion goes through the SAME TicketService.planComplete + apply path the
+// `adlc ticket complete` CLI uses, so it records manifest evidence exactly like a
+// human completion (spec: "go through the existing planComplete path"). The git
+// runner is injected (like worktrees.mjs) so the whole thing is unit-testable.
+//
+// The integration branch is expected to be checked out at `repo` (the merge
+// choreography checks it out for the post-merge gate immediately before this
+// runs, all under the merge mutex), so a commit here lands on that branch.
+
+import { ACTIVE_DIRECTORY, DirectoryTicketStore, LEGACY_FILE, detectTicketStore, TicketService, ticketFilename } from '@adlc/tickets';
+import { defaultGit } from './worktrees.mjs';
+
+const MANIFEST_FILE = '.adlc/manifest.jsonl';
+
+/** Repo-relative path of the store artifact a completion of `id` rewrites. */
+function completionStorePath(store, id) {
+  return store instanceof DirectoryTicketStore ? `${ACTIVE_DIRECTORY}/${ticketFilename(id)}` : LEGACY_FILE;
+}
+
+/**
+ * Complete `ticketId` in the ticket store rooted at `repo` and commit the
+ * add-only diff onto the currently checked-out (integration) branch.
+ *
+ * Idempotent: an already-completed ticket is a no-op — no planComplete, no
+ * apply, no commit, no spurious evidence entry, and never an error. A ticket
+ * that is not in the store is likewise a no-op (reported, not thrown), so the
+ * caller — a best-effort post-merge step — never reverts a good, shipped merge.
+ *
+ * @returns {{completed: boolean, alreadyComplete?: boolean, reason?: string}}
+ */
+export function completeTicketOnIntegration({ repo, ticketId, integrationBranch, git = defaultGit(repo), detectStore = detectTicketStore } = {}) {
+  const store = detectStore({ root: repo });
+  const snapshot = store.load();
+  const existing = snapshot.get(ticketId);
+  if (!existing) return { completed: false, reason: 'ticket-not-found' };
+  // Idempotency: guard BEFORE planComplete. A no-change complete transaction
+  // still records evidence (evidenceRequired) and would leave an empty commit —
+  // so an already-completed ticket must short-circuit here.
+  if (existing.completed === true) return { completed: false, alreadyComplete: true };
+
+  const service = new TicketService(store, { root: repo });
+  service.apply(service.planComplete(ticketId));
+
+  // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
+  // ledger). A path-scoped add + commit never sweeps in unrelated build output
+  // the post-merge gate may have left in the working tree.
+  const storePath = completionStorePath(store, ticketId);
+  git('add', '--', storePath, MANIFEST_FILE);
+  git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
+
+  return { completed: true };
+}

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -25,6 +25,26 @@ function completionStorePath(store, id) {
   return store instanceof DirectoryTicketStore ? `${ACTIVE_DIRECTORY}/${ticketFilename(id)}` : LEGACY_FILE;
 }
 
+/**
+ * Assert the shared checkout is on `branch` and HEAD points at it.
+ *
+ * NOTE ON THE RESIDUAL RACE: nothing we can lock stops an external process from
+ * running `git checkout` in a shared checkout — the ticket and manifest locks do not
+ * serialize git's own refs. So this is checked at entry AND again immediately before
+ * the commit (narrowing the window to that call), with a post-commit verification to
+ * DETECT a switch we could not prevent. The complete fix is not to share the checkout
+ * at all — give the integration branch a dedicated worktree. Tracked as follow-up.
+ */
+function assertOnBranch(git, branch, when) {
+  const current = git('symbolic-ref', '--short', 'HEAD'); // throws on detached HEAD — fail closed
+  if (current !== branch) {
+    throw new Error(`refusing to complete (${when}): checkout is on "${current}", not the integration branch "${branch}"`);
+  }
+  if (git('rev-parse', 'HEAD') !== git('rev-parse', branch)) {
+    throw new Error(`refusing to complete (${when}): HEAD does not point at "${branch}"`);
+  }
+}
+
 /** Restore a file to captured bytes (or delete it if it did not exist before). */
 function restoreFile(absPath, priorBytes) {
   if (priorBytes === null) { if (existsSync(absPath)) rmSync(absPath); }
@@ -65,17 +85,26 @@ export function revertCompletionCommit({ repo, toSha, shardPath = null, completi
   }
   const committedManifest = git('show', `${head}:${MANIFEST_FILE}`);
   const manifestAbs = join(repo, MANIFEST_FILE);
-  const liveManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs, 'utf8').trimEnd() : '';
-  if (liveManifest !== committedManifest.trimEnd()) {
-    throw new Error('refusing to withdraw: the evidence ledger changed since the completion commit (concurrent append) — cannot remove our entry without disturbing another writer');
-  }
 
-  // Preconditions hold: nothing concurrent to lose, so restore BOTH owned paths
-  // exactly. Still path-scoped — never a checkout-wide reset --hard.
-  git('reset', '-q', '--soft', toSha);
-  const paths = shardPath ? [shardPath, MANIFEST_FILE] : [MANIFEST_FILE];
-  git('restore', '--staged', '--worktree', '--', ...paths);
-  return { reverted: true, toSha };
+  // The ledger comparison and the restore that acts on it MUST be one critical
+  // section. Checking first and restoring after leaves a window in which a recorder
+  // appends between the two — the restore then rewrites the ledger to the
+  // pre-completion version and silently destroys that evidence. Hold the manifest
+  // lock across BOTH. Lock order is ticket → manifest everywhere, matching the
+  // transaction layer, so this cannot deadlock against a concurrent recorder.
+  return withLedgerLock(manifestAbs, () => {
+    const liveManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs, 'utf8').trimEnd() : '';
+    if (liveManifest !== committedManifest.trimEnd()) {
+      throw new Error('refusing to withdraw: the evidence ledger changed since the completion commit (concurrent append) — cannot remove our entry without disturbing another writer');
+    }
+    // Preconditions hold AND no recorder can interleave while we hold the lock, so
+    // restore both owned paths exactly. Still path-scoped — never a checkout-wide
+    // reset --hard.
+    git('reset', '-q', '--soft', toSha);
+    const paths = shardPath ? [shardPath, MANIFEST_FILE] : [MANIFEST_FILE];
+    git('restore', '--staged', '--worktree', '--', ...paths);
+    return { reverted: true, toSha };
+  });
 }
 
 /**
@@ -96,13 +125,7 @@ export function completeTicketOnIntegration({ repo, ticketId, integrationBranch,
   // integration branch BEFORE any mutation, rather than trusting the caller's
   // choreography. Without this a lifecycle commit can land on the wrong branch.
   if (!integrationBranch) throw new Error('completeTicketOnIntegration requires integrationBranch to verify the checkout before mutating');
-  const currentBranch = git('symbolic-ref', '--short', 'HEAD'); // throws on detached HEAD — fail closed
-  if (currentBranch !== integrationBranch) {
-    throw new Error(`refusing to complete: checkout is on "${currentBranch}", not the integration branch "${integrationBranch}"`);
-  }
-  if (git('rev-parse', 'HEAD') !== git('rev-parse', integrationBranch)) {
-    throw new Error(`refusing to complete: HEAD does not point at "${integrationBranch}"`);
-  }
+  assertOnBranch(git, integrationBranch, 'before mutating');
 
   const store = detectStore({ root: repo });
   const storePath = completionStorePath(store, ticketId);
@@ -149,8 +172,16 @@ export function completeTicketOnIntegration({ repo, ticketId, integrationBranch,
     // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
     // ledger). A path-scoped add + commit never sweeps in unrelated build output.
     try {
+      // Re-verify immediately before staging/committing: an external checkout switch
+      // between entry and here would otherwise land this lifecycle commit on whatever
+      // branch is now current. This narrows the unpreventable window to these calls.
+      assertOnBranch(git, integrationBranch, 'before committing');
       git('add', '--', storePath, MANIFEST_FILE);
       git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
+      // And DETECT the switch we cannot prevent: if the checkout moved mid-commit, the
+      // commit landed somewhere we do not own. Surface it as a hard, quarantining
+      // failure rather than reporting a completion that is not on the run's branch.
+      assertOnBranch(git, integrationBranch, 'after committing');
     } catch (error) {
       // A failed commit (e.g. a rejecting hook) must NOT leave the shared integration
       // checkout dirty. Restore the two owned paths to their exact pre-completion

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -12,6 +12,8 @@
 // choreography checks it out for the post-merge gate immediately before this
 // runs, all under the merge mutex), so a commit here lands on that branch.
 
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { ACTIVE_DIRECTORY, DirectoryTicketStore, LEGACY_FILE, detectTicketStore, TicketService, ticketFilename } from '@adlc/tickets';
 import { defaultGit } from './worktrees.mjs';
 
@@ -20,6 +22,12 @@ const MANIFEST_FILE = '.adlc/manifest.jsonl';
 /** Repo-relative path of the store artifact a completion of `id` rewrites. */
 function completionStorePath(store, id) {
   return store instanceof DirectoryTicketStore ? `${ACTIVE_DIRECTORY}/${ticketFilename(id)}` : LEGACY_FILE;
+}
+
+/** Restore a file to captured bytes (or delete it if it did not exist before). */
+function restoreFile(absPath, priorBytes) {
+  if (priorBytes === null) { if (existsSync(absPath)) rmSync(absPath); }
+  else writeFileSync(absPath, priorBytes);
 }
 
 /**
@@ -43,15 +51,37 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
   // so an already-completed ticket must short-circuit here.
   if (existing.completed === true) return { completed: false, alreadyComplete: true };
 
+  // Capture the exact pre-completion bytes of the two paths this touches, BEFORE
+  // the transaction writes them, so a failed commit can be rolled back precisely
+  // whether or not the manifest already existed.
+  const storePath = completionStorePath(store, ticketId);
+  const storeAbs = join(repo, storePath);
+  const manifestAbs = join(repo, MANIFEST_FILE);
+  const priorStore = existsSync(storeAbs) ? readFileSync(storeAbs) : null;
+  const priorManifest = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
+
   const service = new TicketService(store, { root: repo });
   service.apply(service.planComplete(ticketId));
 
   // Commit ONLY the completion artifacts (the shard/legacy file + the evidence
   // ledger). A path-scoped add + commit never sweeps in unrelated build output
   // the post-merge gate may have left in the working tree.
-  const storePath = completionStorePath(store, ticketId);
-  git('add', '--', storePath, MANIFEST_FILE);
-  git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
+  try {
+    git('add', '--', storePath, MANIFEST_FILE);
+    git('commit', '-q', '-m', `chore(${ticketId}): mark completed after passing merge gate`, '--', storePath, MANIFEST_FILE);
+  } catch (error) {
+    // planComplete already wrote the shard + manifest to disk and `git add` may
+    // have staged them. A failed commit (e.g. a rejecting commit hook) must NOT
+    // leave the shared integration checkout dirty — a later fleet step could sweep
+    // the orphaned staged change into an unrelated commit, and the pushed branch
+    // would be inconsistent. Restore the two owned paths to their exact
+    // pre-completion bytes, unstage them, then re-throw so the caller degrades to
+    // "merged, not yet completed" exactly as before.
+    restoreFile(storeAbs, priorStore);
+    restoreFile(manifestAbs, priorManifest);
+    try { git('reset', '-q', '--', storePath, MANIFEST_FILE); } catch { /* best-effort unstage */ }
+    throw error;
+  }
 
   return { completed: true };
 }

--- a/packages/fleet/lib/complete.mjs
+++ b/packages/fleet/lib/complete.mjs
@@ -14,6 +14,7 @@
 
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { withLedgerLock } from '@adlc/core';
 import { ACTIVE_DIRECTORY, DirectoryTicketStore, LEGACY_FILE, detectTicketStore, TicketService, ticketFilename, acquireTicketLock, releaseTicketLock } from '@adlc/tickets';
 import { defaultGit } from './worktrees.mjs';
 
@@ -142,18 +143,26 @@ export function completeTicketOnIntegration({ repo, ticketId, git = defaultGit(r
       // bytes and unstage them, then re-throw so the caller degrades to "merged, not
       // yet completed". Safe under the held lock — no other writer can have touched
       // these paths since we captured them.
-      // The shard is covered by the ticket lock we hold, so restoring it is safe.
+      // The shard is covered by the ticket lock we hold, so restoring it is exact.
       restoreFile(storeAbs, priorStore);
-      // The manifest is NOT: its appends are serialized by the ledger lock, and other
-      // pipeline steps record gate evidence concurrently. Only roll it back when it is
-      // byte-identical to what THIS completion left — i.e. nothing appended since.
-      // Otherwise leave it: an extra append-only evidence line is harmless, erasing a
-      // concurrent writer's evidence is data loss.
-      const manifestNow = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
-      const untouchedSinceOurAppend = manifestNow !== null && afterManifest !== null
-        && manifestNow.equals(afterManifest);
-      if (untouchedSinceOurAppend) restoreFile(manifestAbs, priorManifest);
+      // The ledger is NOT: its appends are serialized by the MANIFEST lock, which the
+      // ticket lock does not cover. Take that lock and undo our append only if it is
+      // still the tail. If a concurrent recorder appended meanwhile we cannot remove
+      // ours without disturbing theirs — and leaving it would let a later completion's
+      // `git add` commit an attestation that THIS ticket completed, when we just
+      // restored it to open. Undo is exact or we refuse: flag the ledger dirty and let
+      // the caller quarantine the branch (same rule as revertCompletionCommit).
+      // Lock order is ticket → manifest here, matching the transaction layer, so this
+      // cannot deadlock against a concurrent recorder.
+      let ledgerDirty = false;
+      withLedgerLock(manifestAbs, () => {
+        const now = existsSync(manifestAbs) ? readFileSync(manifestAbs) : null;
+        const stillOurTail = now !== null && afterManifest !== null && now.equals(afterManifest);
+        if (stillOurTail) restoreFile(manifestAbs, priorManifest);
+        else ledgerDirty = true;
+      });
       try { git('reset', '-q', '--', storePath, MANIFEST_FILE); } catch { /* best-effort unstage */ }
+      if (ledgerDirty) error.ledgerDirty = true;
       throw error;
     }
 

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -141,6 +141,11 @@ function parseStatusPaths(out) {
  */
 export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunner, io = defaultIo() }) {
   const repoGit = io.git(repo);
+  // EVERY integration-branch operation runs in the run's dedicated worktree, never in
+  // the shared main checkout. The path is deterministic so it resolves identically on
+  // a resume, before createIntegrationBranch has run.
+  const integrationPath = join(repo, worktrees.INTEGRATION_WORKTREE);
+  const integrationGit = io.git(integrationPath);
   // Resolve the configured worker harness (T44). Fails closed on an unknown name.
   const adapter = getAdapter(config.adapter ?? 'claude-code');
   const review = reviewRunner ?? makeReviewRunner({
@@ -181,7 +186,11 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
 
     createIntegrationBranch: ({ integrationBranch, baseSha }) => {
       io.ensureGitignore(repo, repoGit);
-      worktrees.createIntegrationBranch(repo, integrationBranch, baseSha, repoGit);
+      // Create the branch AND its dedicated worktree in one step. From here on the
+      // integration branch is checked out ONLY there — git will refuse to check it out
+      // in the shared main checkout, so the whole class of "another process moved HEAD
+      // under us" becomes impossible instead of merely detectable.
+      worktrees.ensureIntegrationWorktree(repo, integrationBranch, { baseSha, git: repoGit, gitAt: io.git });
     },
 
     createWorktree: async ({ ticket, integrationBranch }) => {
@@ -284,28 +293,32 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       { adlcBin, exec: flailExec(io) },
     ),
 
-    mergeToIntegration: ({ branch, integrationBranch }) => worktrees.mergeToIntegration(repo, branch, integrationBranch, repoGit),
+    // Rebase inside the ticket's own worktree, merge inside the integration worktree —
+    // no checkout switching anywhere, and the shared checkout is never involved.
+    mergeToIntegration: ({ branch, integrationBranch, worktree }) => worktrees.mergeToIntegration({
+      branch,
+      integrationBranch,
+      ticketGit: io.git(worktree),
+      integrationGit,
+    }),
 
     postMergeGate: ({ integrationBranch }) => {
-      // Run the configured gate on the integration branch in the repo, sandboxed.
-      repoGit('checkout', integrationBranch);
-      // A gate verdict is only meaningful for the exact branch and commit it inspected.
-      // In a SHARED checkout an external switch between the checkout above and the gate
-      // below would have it examine a different branch entirely, and that pass would
-      // then be credited to the completion commit — admitting an ungated commit to the
-      // PR. Pin branch identity AND the SHA either side of the run, and fail closed on
-      // any drift rather than trusting a verdict we cannot attribute.
+      // Gate inside the integration worktree — no checkout, nothing shared. The branch
+      // identity and SHA are still pinned either side: the worktree removes the
+      // external-interference class, and these assertions keep the verdict provably
+      // attributable to the commit being approved (defence in depth, and they cost
+      // two git calls).
       let gatedSha;
       try {
-        assertOnBranch(repoGit, integrationBranch, 'before gating', 'trust the gate');
-        gatedSha = repoGit('rev-parse', 'HEAD');
+        assertOnBranch(integrationGit, integrationBranch, 'before gating', 'trust the gate');
+        gatedSha = integrationGit('rev-parse', 'HEAD');
       } catch (error) {
         return { ok: false, output: `${error.message}; refusing to gate` };
       }
-      const result = runGates(sandboxFor(repo), config.gate, repoCmdEnv(repo));
+      const result = runGates(sandboxFor(integrationPath), config.gate, repoCmdEnv(integrationPath));
       try {
-        assertOnBranch(repoGit, integrationBranch, 'after gating', 'trust the gate');
-        if (repoGit('rev-parse', 'HEAD') !== gatedSha) {
+        assertOnBranch(integrationGit, integrationBranch, 'after gating', 'trust the gate');
+        if (integrationGit('rev-parse', 'HEAD') !== gatedSha) {
           throw new Error(`refusing to trust the gate: HEAD moved from ${gatedSha} while the gate ran`);
         }
       } catch (error) {
@@ -315,19 +328,19 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
     },
 
     revertMerge: ({ integrationBranch, mergeSha, preMergeSha }) =>
-      worktrees.revertMerge(repo, integrationBranch, { mergeSha, preMergeSha }, repoGit),
+      worktrees.revertMerge(integrationPath, integrationBranch, { mergeSha, preMergeSha }, integrationGit),
 
     // T73: after the post-merge gate passes, complete the ticket ON the integration
     // branch (checked out at `repo` by postMergeGate) via the same planComplete +
     // apply path the CLI uses, committing the add-only completed:true diff so it
     // rides the single PR. Idempotent and best-effort at the call site (§run.mjs).
     completeTicket: ({ ticket, integrationBranch }) =>
-      completeTicketOnIntegration({ repo, ticketId: ticket.id, integrationBranch, git: repoGit }),
+      completeTicketOnIntegration({ repo: integrationPath, ticketId: ticket.id, integrationBranch, git: integrationGit }),
 
     // Withdraw ONLY the completion commit when the gate re-run over it fails; the
     // shipped merge underneath is never touched.
     revertCompletion: ({ toSha, shardPath, completionSha, integrationBranch }) =>
-      revertCompletionCommit({ repo, toSha, shardPath, completionSha, integrationBranch, git: repoGit }),
+      revertCompletionCommit({ repo: integrationPath, toSha, shardPath, completionSha, integrationBranch, git: integrationGit }),
 
     cleanup: ({ worktree, state }) => {
       // Keep failed worktrees for inspection; remove merged ones.
@@ -344,7 +357,7 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
     openPR: ({ integrationBranch, base }) => {
       if (!io.hasGh()) return { opened: false, reason: 'gh CLI not available' };
       try {
-        repoGit('push', '-u', 'origin', integrationBranch);
+        integrationGit('push', '-u', 'origin', integrationBranch);
         io.spawnWorker('gh', ['pr', 'create', '--base', base, '--head', integrationBranch, '--fill'], { cwd: repo });
         return { opened: true };
       } catch (e) { return { opened: false, reason: e.message }; }

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -191,14 +191,13 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       // in the shared main checkout, so the whole class of "another process moved HEAD
       // under us" becomes impossible instead of merely detectable.
       worktrees.ensureIntegrationWorktree(repo, integrationBranch, { baseSha, git: repoGit, gitAt: io.git });
-      return integrationBranch;
     },
 
     // Resume counterpart: re-attach the dedicated worktree to an EXISTING integration
     // branch (no baseSha — the branch and its history must be preserved).
     ensureIntegrationWorktree: ({ integrationBranch }) => {
       io.ensureGitignore(repo, repoGit);
-      return worktrees.ensureIntegrationWorktree(repo, integrationBranch, { git: repoGit, gitAt: io.git });
+      worktrees.ensureIntegrationWorktree(repo, integrationBranch, { git: repoGit, gitAt: io.git });
     },
 
     createWorktree: async ({ ticket, integrationBranch }) => {

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -304,7 +304,7 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
 
     // Withdraw ONLY the completion commit when the gate re-run over it fails; the
     // shipped merge underneath is never touched.
-    revertCompletion: ({ toSha, shardPath }) => revertCompletionCommit({ repo, toSha, shardPath, git: repoGit }),
+    revertCompletion: ({ toSha, shardPath, completionSha }) => revertCompletionCommit({ repo, toSha, shardPath, completionSha, git: repoGit }),
 
     cleanup: ({ worktree, state }) => {
       // Keep failed worktrees for inspection; remove merged ones.

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -23,7 +23,7 @@ import { spawnSync, execFileSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
 import { spawnAsync } from './spawn-async.mjs';
-import { completeTicketOnIntegration } from './complete.mjs';
+import { completeTicketOnIntegration, revertCompletionCommit } from './complete.mjs';
 
 // Ignore fleet working state WITHOUT committing to the base checkout
 // (adversarial-review L2). `.git/info/exclude` is a local, per-repo, UNcommitted
@@ -301,6 +301,10 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
     // rides the single PR. Idempotent and best-effort at the call site (§run.mjs).
     completeTicket: ({ ticket, integrationBranch }) =>
       completeTicketOnIntegration({ repo, ticketId: ticket.id, integrationBranch, git: repoGit }),
+
+    // Withdraw ONLY the completion commit when the gate re-run over it fails; the
+    // shipped merge underneath is never touched.
+    revertCompletion: ({ toSha }) => revertCompletionCommit({ repo, toSha, git: repoGit }),
 
     cleanup: ({ worktree, state }) => {
       // Keep failed worktrees for inspection; remove merged ones.

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -304,7 +304,7 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
 
     // Withdraw ONLY the completion commit when the gate re-run over it fails; the
     // shipped merge underneath is never touched.
-    revertCompletion: ({ toSha }) => revertCompletionCommit({ repo, toSha, git: repoGit }),
+    revertCompletion: ({ toSha, shardPath }) => revertCompletionCommit({ repo, toSha, shardPath, git: repoGit }),
 
     cleanup: ({ worktree, state }) => {
       // Keep failed worktrees for inspection; remove merged ones.

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -191,6 +191,14 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       // in the shared main checkout, so the whole class of "another process moved HEAD
       // under us" becomes impossible instead of merely detectable.
       worktrees.ensureIntegrationWorktree(repo, integrationBranch, { baseSha, git: repoGit, gitAt: io.git });
+      return integrationBranch;
+    },
+
+    // Resume counterpart: re-attach the dedicated worktree to an EXISTING integration
+    // branch (no baseSha — the branch and its history must be preserved).
+    ensureIntegrationWorktree: ({ integrationBranch }) => {
+      io.ensureGitignore(repo, repoGit);
+      return worktrees.ensureIntegrationWorktree(repo, integrationBranch, { git: repoGit, gitAt: io.git });
     },
 
     createWorktree: async ({ ticket, integrationBranch }) => {

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -23,6 +23,7 @@ import { spawnSync, execFileSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
 import { spawnAsync } from './spawn-async.mjs';
+import { completeTicketOnIntegration } from './complete.mjs';
 
 // Ignore fleet working state WITHOUT committing to the base checkout
 // (adversarial-review L2). `.git/info/exclude` is a local, per-repo, UNcommitted
@@ -293,6 +294,13 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
 
     revertMerge: ({ integrationBranch, mergeSha, preMergeSha }) =>
       worktrees.revertMerge(repo, integrationBranch, { mergeSha, preMergeSha }, repoGit),
+
+    // T73: after the post-merge gate passes, complete the ticket ON the integration
+    // branch (checked out at `repo` by postMergeGate) via the same planComplete +
+    // apply path the CLI uses, committing the add-only completed:true diff so it
+    // rides the single PR. Idempotent and best-effort at the call site (§run.mjs).
+    completeTicket: ({ ticket, integrationBranch }) =>
+      completeTicketOnIntegration({ repo, ticketId: ticket.id, integrationBranch, git: repoGit }),
 
     cleanup: ({ worktree, state }) => {
       // Keep failed worktrees for inspection; remove merged ones.

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -367,11 +367,17 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       catch { /* evidence is best-effort */ }
     },
 
-    openPR: ({ integrationBranch, base }) => {
+    openPR: async ({ integrationBranch, base }) => {
       if (!io.hasGh()) return { opened: false, reason: 'gh CLI not available' };
       try {
         integrationGit('push', '-u', 'origin', integrationBranch);
-        io.spawnWorker('gh', ['pr', 'create', '--base', base, '--head', integrationBranch, '--fill'], { cwd: repo });
+        // AWAIT the creation: spawnWorker is async, so a fire-and-forget call would
+        // report success before `gh pr create` ran and could miss its failure entirely.
+        const res = await io.spawnWorker('gh', ['pr', 'create', '--base', base, '--head', integrationBranch, '--fill'], { cwd: repo });
+        if (res?.error) throw res.error;
+        if (typeof res?.status === 'number' && res.status !== 0) {
+          return { opened: false, reason: `gh pr create exited ${res.status}: ${(res.stderr ?? '').trim()}`.trim() };
+        }
         return { opened: true };
       } catch (e) { return { opened: false, reason: e.message }; }
     },

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -310,9 +310,9 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       integrationGit,
     }),
 
-    postMergeGate: ({ integrationBranch }) => {
+    postMergeGate: async ({ integrationBranch }) => {
       // Gate inside the integration worktree — no checkout, nothing shared. The branch
-      // identity and SHA are still pinned either side: the worktree removes the
+      // identity and SHA are pinned either side: the worktree removes the
       // external-interference class, and these assertions keep the verdict provably
       // attributable to the commit being approved (defence in depth, and they cost
       // two git calls).
@@ -323,7 +323,12 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
       } catch (error) {
         return { ok: false, output: `${error.message}; refusing to gate` };
       }
-      const result = runGates(sandboxFor(integrationPath), config.gate, repoCmdEnv(integrationPath));
+      // MUST await: runGates is async (it runs build/test to completion). Reading HEAD
+      // before awaiting would pin it BEFORE the gate's commands ever ran, so a commit or
+      // ref movement DURING the build/test would be invisible and a stale passing verdict
+      // would be trusted (adversarial-review round-30). The whole point of the after-gate
+      // pin is to observe the branch tip AS IT WAS while the gate executed.
+      const result = await runGates(sandboxFor(integrationPath), config.gate, repoCmdEnv(integrationPath));
       try {
         assertOnBranch(integrationGit, integrationBranch, 'after gating', 'trust the gate');
         if (integrationGit('rev-parse', 'HEAD') !== gatedSha) {

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -304,7 +304,8 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
 
     // Withdraw ONLY the completion commit when the gate re-run over it fails; the
     // shipped merge underneath is never touched.
-    revertCompletion: ({ toSha, shardPath, completionSha }) => revertCompletionCommit({ repo, toSha, shardPath, completionSha, git: repoGit }),
+    revertCompletion: ({ toSha, shardPath, completionSha, integrationBranch }) =>
+      revertCompletionCommit({ repo, toSha, shardPath, completionSha, integrationBranch, git: repoGit }),
 
     cleanup: ({ worktree, state }) => {
       // Keep failed worktrees for inspection; remove merged ones.

--- a/packages/fleet/lib/live-deps.mjs
+++ b/packages/fleet/lib/live-deps.mjs
@@ -23,7 +23,7 @@ import { spawnSync, execFileSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, mkdirSync, appendFileSync } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
 import { spawnAsync } from './spawn-async.mjs';
-import { completeTicketOnIntegration, revertCompletionCommit } from './complete.mjs';
+import { completeTicketOnIntegration, revertCompletionCommit, assertOnBranch } from './complete.mjs';
 
 // Ignore fleet working state WITHOUT committing to the base checkout
 // (adversarial-review L2). `.git/info/exclude` is a local, per-repo, UNcommitted
@@ -289,7 +289,29 @@ export function buildLiveDeps({ repo, config, statusDir, sandboxSpec, reviewRunn
     postMergeGate: ({ integrationBranch }) => {
       // Run the configured gate on the integration branch in the repo, sandboxed.
       repoGit('checkout', integrationBranch);
-      return runGates(sandboxFor(repo), config.gate, repoCmdEnv(repo));
+      // A gate verdict is only meaningful for the exact branch and commit it inspected.
+      // In a SHARED checkout an external switch between the checkout above and the gate
+      // below would have it examine a different branch entirely, and that pass would
+      // then be credited to the completion commit — admitting an ungated commit to the
+      // PR. Pin branch identity AND the SHA either side of the run, and fail closed on
+      // any drift rather than trusting a verdict we cannot attribute.
+      let gatedSha;
+      try {
+        assertOnBranch(repoGit, integrationBranch, 'before gating', 'trust the gate');
+        gatedSha = repoGit('rev-parse', 'HEAD');
+      } catch (error) {
+        return { ok: false, output: `${error.message}; refusing to gate` };
+      }
+      const result = runGates(sandboxFor(repo), config.gate, repoCmdEnv(repo));
+      try {
+        assertOnBranch(repoGit, integrationBranch, 'after gating', 'trust the gate');
+        if (repoGit('rev-parse', 'HEAD') !== gatedSha) {
+          throw new Error(`refusing to trust the gate: HEAD moved from ${gatedSha} while the gate ran`);
+        }
+      } catch (error) {
+        return { ok: false, output: `${error.message}; the gate result cannot be attributed to ${integrationBranch}` };
+      }
+      return result;
     },
 
     revertMerge: ({ integrationBranch, mergeSha, preMergeSha }) =>

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -49,7 +49,18 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
         if (completion?.completed && completion.preCompletionSha) {
           const recheck = await deps.postMergeGate({ ticket, integrationBranch });
           if (!recheck.ok) {
-            await deps.revertCompletion?.({ ticket, integrationBranch, toSha: completion.preCompletionSha });
+            // The completion commit FAILED the gate, so it must come off the branch.
+            // Withdrawal failing is NOT a degradation we may swallow: the branch would
+            // carry a gate-rejected commit into the fleet PR. Both a missing withdrawal
+            // path and a throwing one fail the ticket loudly instead.
+            if (!deps.revertCompletion) {
+              return { ok: false, output: 'completion commit failed its gate and no withdrawal path is wired; integration branch would carry an ungated commit' };
+            }
+            try {
+              await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha });
+            } catch (revertError) {
+              return { ok: false, output: `completion commit failed its gate and could NOT be withdrawn (${revertError.message}); integration branch carries an ungated commit` };
+            }
             deps.log?.(`${ticket.id} WARNING: gate over the completion commit failed; completion withdrawn (merged, not marked completed)`);
           }
         }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -238,3 +238,20 @@ export async function runFleet({ all, runId, config, deps, resume }) {
 
   return { integrationBranch, results, merged, prCount, status, contaminated: runState.contaminated, contaminationReason: runState.contaminationReason };
 }
+
+/**
+ * Derive the process exit code from a fleet run summary.
+ *
+ * A QUARANTINED run is a failure no matter what the per-ticket states say. Quarantine
+ * is persisted the instant it occurs, but a crash between that write and a ticket's own
+ * state update can leave the ticket nonterminal ('merging'); a resume then fails closed
+ * without touching it. Keying the exit code on failed/blocked states alone would report
+ * 0 for that quarantined-no-work run — so `contaminated` is checked first.
+ *
+ * @returns {0|2} 2 = quarantined OR some ticket failed/blocked; 0 = clean.
+ */
+export function runExitCode(summary) {
+  if (summary?.contaminated) return 2;
+  const failed = Object.values(summary?.results ?? {}).filter((s) => s === 'failed' || s === 'blocked').length;
+  return failed > 0 ? 2 : 0;
+}

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -231,6 +231,11 @@ export async function runFleet({ all, runId, config, deps, resume }) {
   // Run end: open exactly ONE PR from the integration branch to base (§9), only
   // if something merged and the deps provide it. The fleet never pushes base.
   let prCount = 0;
+  // Set ONLY when a PR was attempted (merged, not quarantined, opener wired) and openPR
+  // REPORTED it did not open. It drives a non-zero exit so automation never treats a run
+  // whose merged work was never published as complete (adversarial-review round-33). It is
+  // deliberately NOT set when no opener is wired — that is a missing attempt, not a failure.
+  let prOpenFailed = false;
   // A quarantined branch is NEVER opened as a PR, however many other tickets merged
   // cleanly — the branch itself carries a commit that failed its gate.
   if (runState.contaminated) {
@@ -245,11 +250,12 @@ export async function runFleet({ all, runId, config, deps, resume }) {
     if (pr && pr.opened) {
       prCount = 1;
     } else {
+      prOpenFailed = true;
       log(`FLEET: ${integrationBranch} merged ${merged} ticket(s) but the PR was NOT opened${pr?.reason ? ` — ${pr.reason}` : ''}. Push the branch and open the PR manually.`);
     }
   }
 
-  return { integrationBranch, results, merged, prCount, status, contaminated: runState.contaminated, contaminationReason: runState.contaminationReason };
+  return { integrationBranch, results, merged, prCount, prOpenFailed, status, contaminated: runState.contaminated, contaminationReason: runState.contaminationReason };
 }
 
 /**
@@ -261,10 +267,17 @@ export async function runFleet({ all, runId, config, deps, resume }) {
  * without touching it. Keying the exit code on failed/blocked states alone would report
  * 0 for that quarantined-no-work run — so `contaminated` is checked first.
  *
- * @returns {0|2} 2 = quarantined OR some ticket failed/blocked; 0 = clean.
+ * A PR-open failure is ALSO a non-zero exit: if every ticket merged but the PR could not be
+ * opened (gh unavailable, push or `gh pr create` failed), the merged work was never
+ * published. Exiting 0 there would let CI or an operator script mark the fleet operation
+ * complete when nothing is on a PR (adversarial-review round-33).
+ *
+ * @returns {0|2} 2 = quarantined, some ticket failed/blocked, OR the PR failed to open;
+ *   0 = clean.
  */
 export function runExitCode(summary) {
   if (summary?.contaminated) return 2;
+  if (summary?.prOpenFailed) return 2;
   const failed = Object.values(summary?.results ?? {}).filter((s) => s === 'failed' || s === 'blocked').length;
   return failed > 0 ? 2 : 0;
 }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -18,7 +18,7 @@ export function integrationBranchName(runId) {
  * concurrently across tickets; the MERGE runs under `mergeMutex` so merges are
  * strictly sequential (spec §9; adversarial-review C4).
  */
-function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
+function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState) {
   return {
     dispatch: ({ strike, deadEnds }) => deps.dispatch({ ticket, worktree: wt.path, startSha: wt.startSha, strike, deadEnds }),
     gate: () => deps.gate({ ticket, worktree: wt.path, startSha: wt.startSha }),
@@ -27,6 +27,12 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
     // Best-effort evidence (spec §8.5): a recorder error must never abort the run.
     record: (phase, ok) => { try { deps.recordGate?.({ ticket, phase, ok }); } catch { /* evidence is best-effort */ } },
     merge: () => mergeMutex.runExclusive(async () => {
+      // QUARANTINE: once a gate-rejected completion could not be withdrawn, the shared
+      // integration branch carries an ungated commit. Nothing further may land on it —
+      // no merges, no retries — and the run must not open a PR from it.
+      if (runState?.contaminated) {
+        return { ok: false, output: `integration branch quarantined: ${runState.contaminationReason}` };
+      }
       const { mergeSha, preMergeSha } = await deps.mergeToIntegration({ ticket, branch: wt.branch, integrationBranch });
       const post = await deps.postMergeGate({ ticket, integrationBranch });
       if (!post.ok) {
@@ -54,12 +60,16 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
             // carry a gate-rejected commit into the fleet PR. Both a missing withdrawal
             // path and a throwing one fail the ticket loudly instead.
             if (!deps.revertCompletion) {
-              return { ok: false, output: 'completion commit failed its gate and no withdrawal path is wired; integration branch would carry an ungated commit' };
+              const reason = 'a gate-rejected completion commit could not be withdrawn (no withdrawal path wired)';
+              if (runState) { runState.contaminated = true; runState.contaminationReason = reason; }
+              return { ok: false, output: `${reason}; integration branch quarantined` };
             }
             try {
               await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha });
             } catch (revertError) {
-              return { ok: false, output: `completion commit failed its gate and could NOT be withdrawn (${revertError.message}); integration branch carries an ungated commit` };
+              const reason = `a gate-rejected completion commit could not be withdrawn (${revertError.message})`;
+              if (runState) { runState.contaminated = true; runState.contaminationReason = reason; }
+              return { ok: false, output: `${reason}; integration branch quarantined` };
             }
             deps.log?.(`${ticket.id} WARNING: gate over the completion commit failed; completion withdrawn (merged, not marked completed)`);
           }
@@ -86,6 +96,10 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
  */
 export async function runFleet({ all, runId, config, deps, resume }) {
   const log = deps.log ?? (() => {});
+  // Run-scoped quarantine flag. Set when a gate-rejected completion commit could not
+  // be withdrawn: the shared integration branch then carries an ungated commit, so no
+  // further merge may land on it and the run must never open a PR from it.
+  const runState = { contaminated: false, contaminationReason: null };
   // Resume (adversarial-review L3): reuse the recorded run — its integration
   // branch, runId, and reconciled status — instead of starting fresh, so merged
   // tickets are not re-dispatched and the prior integration branch is continued.
@@ -126,7 +140,7 @@ export async function runFleet({ all, runId, config, deps, resume }) {
     status = withTicket(status, ticket.id, { state: 'building', branch: wt.branch, startSha: wt.startSha, strikes: 0 });
     persist();
     await deps.provision?.({ ticket, worktree: wt.path });
-    const outcome = await advanceTicket(ticket, buildEffects(ticket, wt, deps, integrationBranch, mergeMutex), { log });
+    const outcome = await advanceTicket(ticket, buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState), { log });
     status = withTicket(status, ticket.id, { state: outcome.state, strikes: outcome.strikes, reason: outcome.reason, prosecution: outcome.prosecution ?? null });
     persist();
     await deps.cleanup?.({ ticket, worktree: wt.path, state: outcome.state });
@@ -159,7 +173,13 @@ export async function runFleet({ all, runId, config, deps, resume }) {
   // Run end: open exactly ONE PR from the integration branch to base (§9), only
   // if something merged and the deps provide it. The fleet never pushes base.
   let prCount = 0;
-  if (merged > 0 && deps.openPR) { deps.openPR({ integrationBranch, base: config.base }); prCount = 1; }
+  // A quarantined branch is NEVER opened as a PR, however many other tickets merged
+  // cleanly — the branch itself carries a commit that failed its gate.
+  if (runState.contaminated) {
+    log(`FLEET QUARANTINE: ${integrationBranch} not opened as a PR — ${runState.contaminationReason}. Inspect and clean the branch manually.`);
+  } else if (merged > 0 && deps.openPR) {
+    deps.openPR({ integrationBranch, base: config.base }); prCount = 1;
+  }
 
-  return { integrationBranch, results, merged, prCount, status };
+  return { integrationBranch, results, merged, prCount, status, contaminated: runState.contaminated, contaminationReason: runState.contaminationReason };
 }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -78,8 +78,10 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
         // A completion that failed but left its evidence append behind is NOT a
         // degradation we can shrug off: the ledger now attests a completion that never
         // landed, and a later completion's `git add` would commit it. Quarantine.
-        if (error?.ledgerDirty) {
-          const reason = `completion evidence could not be withdrawn after a failed commit (${error.message})`;
+        if (error?.ledgerDirty || error?.branchContaminated) {
+          const reason = error.branchContaminated
+            ? `the checkout switched during the completion commit — an UNGATED completion commit may be on ${integrationBranch} (${error.message})`
+            : `completion evidence could not be withdrawn after a failed commit (${error.message})`;
           markContaminated(reason);
           return { ok: false, output: `${reason}; integration branch quarantined` };
         }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -18,7 +18,7 @@ export function integrationBranchName(runId) {
  * concurrently across tickets; the MERGE runs under `mergeMutex` so merges are
  * strictly sequential (spec §9; adversarial-review C4).
  */
-function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState) {
+function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState, markContaminated = () => {}) {
   return {
     dispatch: ({ strike, deadEnds }) => deps.dispatch({ ticket, worktree: wt.path, startSha: wt.startSha, strike, deadEnds }),
     gate: () => deps.gate({ ticket, worktree: wt.path, startSha: wt.startSha }),
@@ -61,14 +61,14 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState)
             // path and a throwing one fail the ticket loudly instead.
             if (!deps.revertCompletion) {
               const reason = 'a gate-rejected completion commit could not be withdrawn (no withdrawal path wired)';
-              if (runState) { runState.contaminated = true; runState.contaminationReason = reason; }
+              markContaminated(reason);
               return { ok: false, output: `${reason}; integration branch quarantined` };
             }
             try {
               await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha });
             } catch (revertError) {
               const reason = `a gate-rejected completion commit could not be withdrawn (${revertError.message})`;
-              if (runState) { runState.contaminated = true; runState.contaminationReason = reason; }
+              markContaminated(reason);
               return { ok: false, output: `${reason}; integration branch quarantined` };
             }
             deps.log?.(`${ticket.id} WARNING: gate over the completion commit failed; completion withdrawn (merged, not marked completed)`);
@@ -120,6 +120,34 @@ export async function runFleet({ all, runId, config, deps, resume }) {
   });
   const persist = () => { if (deps.statusDir) saveStatus(deps.statusDir, status); };
 
+  // Quarantine is a property of the BRANCH, not of this process, so it is restored
+  // from the persisted status on resume — otherwise a resume would start "clean" and
+  // happily open a PR from a branch still carrying a gate-rejected commit.
+  runState.contaminated = Boolean(status.contaminated);
+  runState.contaminationReason = status.contaminationReason ?? null;
+  const markContaminated = (reason) => {
+    runState.contaminated = true;
+    runState.contaminationReason = reason;
+    status = { ...status, contaminated: true, contaminationReason: reason };
+    persist(); // persist IMMEDIATELY — a crash after this must not forget the quarantine
+  };
+
+  // Fail closed before doing any work: a quarantined branch cannot accept merges, so
+  // dispatching would only burn agents on work that can never land.
+  if (runState.contaminated) {
+    log(`FLEET QUARANTINE: ${integrationBranch} is quarantined (${runState.contaminationReason}); refusing to resume. Clean the branch, then start a new run.`);
+    const quarantinedResults = Object.fromEntries(Object.entries(status.tickets).map(([id, r]) => [id, r.state]));
+    return {
+      integrationBranch,
+      results: quarantinedResults,
+      merged: Object.values(quarantinedResults).filter((s) => s === 'merged').length,
+      prCount: 0,
+      status,
+      contaminated: true,
+      contaminationReason: runState.contaminationReason,
+    };
+  }
+
   const cap = config.concurrency;
   const onlyIds = config.onlyIds;
   const mergeMutex = createMutex();
@@ -140,7 +168,7 @@ export async function runFleet({ all, runId, config, deps, resume }) {
     status = withTicket(status, ticket.id, { state: 'building', branch: wt.branch, startSha: wt.startSha, strikes: 0 });
     persist();
     await deps.provision?.({ ticket, worktree: wt.path });
-    const outcome = await advanceTicket(ticket, buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState), { log });
+    const outcome = await advanceTicket(ticket, buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState, markContaminated), { log });
     status = withTicket(status, ticket.id, { state: outcome.state, strikes: outcome.strikes, reason: outcome.reason, prosecution: outcome.prosecution ?? null });
     persist();
     await deps.cleanup?.({ ticket, worktree: wt.path, state: outcome.state });

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -75,6 +75,14 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
           }
         }
       } catch (error) {
+        // A completion that failed but left its evidence append behind is NOT a
+        // degradation we can shrug off: the ledger now attests a completion that never
+        // landed, and a later completion's `git add` would commit it. Quarantine.
+        if (error?.ledgerDirty) {
+          const reason = `completion evidence could not be withdrawn after a failed commit (${error.message})`;
+          markContaminated(reason);
+          return { ok: false, output: `${reason}; integration branch quarantined` };
+        }
         deps.log?.(`${ticket.id} WARNING: post-merge completion failed (${error.message}); ticket merged but not marked completed`);
       }
       return { ok: true };

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -65,7 +65,7 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
               return { ok: false, output: `${reason}; integration branch quarantined` };
             }
             try {
-              await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha, shardPath: completion.shardPath });
+              await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha, shardPath: completion.shardPath, completionSha: completion.completionSha });
             } catch (revertError) {
               const reason = `a gate-rejected completion commit could not be withdrawn (${revertError.message})`;
               markContaminated(reason);

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -33,6 +33,18 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
         const rev = await deps.revertMerge({ integrationBranch, mergeSha, preMergeSha });
         return { ok: false, reverted: true, output: `post-merge gate failed; recovery=${rev.method}` };
       }
+      // Post-merge gate PASSED (T73): mark the ticket completed on the integration
+      // branch so the single PR the fleet opens carries the add-only completed:true
+      // annotation. Runs here — inside the merge mutex, right after the gate that
+      // just checked the integration branch out — so exactly one completion touches
+      // that branch at a time. Best-effort: the merge already landed and passed its
+      // gate, so a completion failure must NOT revert good, shipped work; it degrades
+      // to the pre-T73 status quo (merged, not yet marked completed) and is logged.
+      try {
+        await deps.completeTicket?.({ ticket, integrationBranch });
+      } catch (error) {
+        deps.log?.(`${ticket.id} WARNING: post-merge completion failed (${error.message}); ticket merged but not marked completed`);
+      }
       return { ok: true };
     }),
   };

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -65,7 +65,7 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
               return { ok: false, output: `${reason}; integration branch quarantined` };
             }
             try {
-              await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha });
+              await deps.revertCompletion({ ticket, integrationBranch, toSha: completion.preCompletionSha, shardPath: completion.shardPath });
             } catch (revertError) {
               const reason = `a gate-rejected completion commit could not be withdrawn (${revertError.message})`;
               markContaminated(reason);

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -275,9 +275,14 @@ export async function runFleet({ all, runId, config, deps, resume }) {
  * @returns {0|2} 2 = quarantined, some ticket failed/blocked, OR the PR failed to open;
  *   0 = clean.
  */
+/** Count the tickets in a terminal non-success state. Shared by the exit code AND the CLI's
+ *  end-of-run summary line so the two can never disagree on what "failed/blocked" means. */
+export function failedBlockedCount(results) {
+  return Object.values(results ?? {}).filter((s) => s === 'failed' || s === 'blocked').length;
+}
+
 export function runExitCode(summary) {
   if (summary?.contaminated) return 2;
   if (summary?.prOpenFailed) return 2;
-  const failed = Object.values(summary?.results ?? {}).filter((s) => s === 'failed' || s === 'blocked').length;
-  return failed > 0 ? 2 : 0;
+  return failedBlockedCount(summary?.results) > 0 ? 2 : 0;
 }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -117,6 +117,12 @@ export async function runFleet({ all, runId, config, deps, resume }) {
   const integrationBranch = resuming ? resume.integrationBranch : integrationBranchName(runId);
   if (!resuming) {
     await deps.createIntegrationBranch?.({ integrationBranch, baseSha: config.baseSha });
+  } else {
+    // Resume: the branch survives in the repo, but its dedicated worktree may not —
+    // cleanup, a crash, or manual tidying can remove it, and EVERY integration step now
+    // requires it. Re-attach before dispatching anything, so a recoverable run fails
+    // fast here instead of after burning worker time on tickets that cannot merge.
+    await deps.ensureIntegrationWorktree?.({ integrationBranch });
   }
 
   let status = resuming ? resume.status : newStatus({

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -33,7 +33,7 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
       if (runState?.contaminated) {
         return { ok: false, output: `integration branch quarantined: ${runState.contaminationReason}` };
       }
-      const { mergeSha, preMergeSha } = await deps.mergeToIntegration({ ticket, branch: wt.branch, integrationBranch });
+      const { mergeSha, preMergeSha } = await deps.mergeToIntegration({ ticket, branch: wt.branch, integrationBranch, worktree: wt.path });
       const post = await deps.postMergeGate({ ticket, integrationBranch });
       if (!post.ok) {
         const rev = await deps.revertMerge({ integrationBranch, mergeSha, preMergeSha });

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -41,7 +41,18 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex) {
       // gate, so a completion failure must NOT revert good, shipped work; it degrades
       // to the pre-T73 status quo (merged, not yet marked completed) and is logged.
       try {
-        await deps.completeTicket?.({ ticket, integrationBranch });
+        const completion = await deps.completeTicket?.({ ticket, integrationBranch });
+        // The completion adds a commit AFTER the gate that just passed, so re-run the
+        // gate over it — no unvalidated commit reaches the PR. If that re-gate fails,
+        // withdraw ONLY the completion commit (the shipped merge below it stays) and
+        // degrade to the pre-T73 status quo: merged, not marked completed.
+        if (completion?.completed && completion.preCompletionSha) {
+          const recheck = await deps.postMergeGate({ ticket, integrationBranch });
+          if (!recheck.ok) {
+            await deps.revertCompletion?.({ ticket, integrationBranch, toSha: completion.preCompletionSha });
+            deps.log?.(`${ticket.id} WARNING: gate over the completion commit failed; completion withdrawn (merged, not marked completed)`);
+          }
+        }
       } catch (error) {
         deps.log?.(`${ticket.id} WARNING: post-merge completion failed (${error.message}); ticket merged but not marked completed`);
       }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -44,7 +44,10 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
         // further merge lands and no PR opens from the contaminated branch. Reporting
         // `reverted: true` here (ignoring rev.ok) let that merge ride into the PR.
         if (!rev.ok) {
-          const reason = `post-merge gate failed and its merge could NOT be withdrawn (${rev.reason ?? rev.method}) — ${integrationBranch} carries a gate-rejected merge`;
+          // revertMerge returns ok:false both when it could not withdraw the merge AND
+          // when it withdrew ours but an UNGATED intervening commit remains. Its reason
+          // is accurate for either; surface it verbatim rather than assuming which.
+          const reason = rev.reason ?? `post-merge gate failed and the merge could not be safely withdrawn (${rev.method}) on ${integrationBranch}`;
           markContaminated(reason);
           return { ok: false, output: `${reason}; integration branch quarantined` };
         }

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -37,6 +37,17 @@ function buildEffects(ticket, wt, deps, integrationBranch, mergeMutex, runState,
       const post = await deps.postMergeGate({ ticket, integrationBranch });
       if (!post.ok) {
         const rev = await deps.revertMerge({ integrationBranch, mergeSha, preMergeSha });
+        // revertMerge returns { ok: false, method: 'refused' } when it cannot safely
+        // undo the merge (HEAD moved and `git revert` also failed). That leaves the
+        // GATE-REJECTED merge on the shared branch — the same hazard a failed completion
+        // withdrawal creates, and it must get the same treatment: quarantine, so no
+        // further merge lands and no PR opens from the contaminated branch. Reporting
+        // `reverted: true` here (ignoring rev.ok) let that merge ride into the PR.
+        if (!rev.ok) {
+          const reason = `post-merge gate failed and its merge could NOT be withdrawn (${rev.reason ?? rev.method}) — ${integrationBranch} carries a gate-rejected merge`;
+          markContaminated(reason);
+          return { ok: false, output: `${reason}; integration branch quarantined` };
+        }
         return { ok: false, reverted: true, output: `post-merge gate failed; recovery=${rev.method}` };
       }
       // Post-merge gate PASSED (T73): mark the ticket completed on the integration

--- a/packages/fleet/lib/run.mjs
+++ b/packages/fleet/lib/run.mjs
@@ -236,7 +236,17 @@ export async function runFleet({ all, runId, config, deps, resume }) {
   if (runState.contaminated) {
     log(`FLEET QUARANTINE: ${integrationBranch} not opened as a PR — ${runState.contaminationReason}. Inspect and clean the branch manually.`);
   } else if (merged > 0 && deps.openPR) {
-    deps.openPR({ integrationBranch, base: config.base }); prCount = 1;
+    // Trust openPR's REPORTED outcome — never fabricate success. It returns
+    // { opened:false, reason } when gh is unavailable or the push / PR creation fails,
+    // and counting that as an opened PR would tell the operator a PR exists when none
+    // does (adversarial-review round-31). await it: the real openPR runs `gh pr create`
+    // asynchronously, so an un-awaited call could miss a creation failure entirely.
+    const pr = await deps.openPR({ integrationBranch, base: config.base });
+    if (pr && pr.opened) {
+      prCount = 1;
+    } else {
+      log(`FLEET: ${integrationBranch} merged ${merged} ticket(s) but the PR was NOT opened${pr?.reason ? ` — ${pr.reason}` : ''}. Push the branch and open the PR manually.`);
+    }
   }
 
   return { integrationBranch, results, merged, prCount, status, contaminated: runState.contaminated, contaminationReason: runState.contaminationReason };

--- a/packages/fleet/lib/status.mjs
+++ b/packages/fleet/lib/status.mjs
@@ -29,6 +29,10 @@ export function newStatus({ runId, base, baseSha, integrationBranch, concurrency
     sandboxMode,
     concurrency,
     startedAt,
+    // Branch-level quarantine: survives across resumes, so a run that could not
+    // withdraw a gate-rejected completion never publishes that branch later.
+    contaminated: false,
+    contaminationReason: null,
     tickets: {},
   };
 }

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -10,6 +10,19 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, appendFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { ACTIVE_DIRECTORY, LEGACY_FILE } from '@adlc/tickets';
+
+// The evidence ledger the completion appends to (mirrors complete.mjs's MANIFEST_FILE).
+const MANIFEST_FILE = '.adlc/manifest.jsonl';
+
+/**
+ * The ONLY paths a crashed completion can leave dirty in the integration worktree:
+ * the ticket store (sharded dir OR legacy file, whichever this repo uses) and the
+ * evidence ledger. Imported from @adlc/tickets so the store layout stays authoritative
+ * and cannot drift out from under the resume-cleanup scope. Used to bound the resume
+ * cleanup so it never touches untracked diagnostics or unrelated work.
+ */
+export const INTEGRATION_OWNED_PATHS = [ACTIVE_DIRECTORY, LEGACY_FILE, MANIFEST_FILE];
 
 export function defaultGit(repo) {
   return (...args) =>
@@ -61,15 +74,25 @@ export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = n
   // completion commit, leaves the worktree DIRTY with orphaned completion artifacts.
   // Reusing that as-is would let a later ticket's completion stage and commit the
   // orphan alongside its own — a false attestation that the crashed ticket completed.
-  // Everything legitimately merged lives in the branch's COMMITTED history, and the
-  // uncommitted delta here is only ever a crash orphan, so hard-reset to HEAD and drop
-  // untracked leftovers before reusing.
+  // Everything legitimately merged lives in the branch's COMMITTED history, so we revert
+  // the orphan before reusing — but scoped to the completion-owned paths only, never a
+  // repo-wide reset that would also erase a human's untracked diagnostics or in-progress
+  // recovery work in this shared worktree.
   try {
     const wtGit = gitAt(abs);
     if (wtGit('symbolic-ref', '--short', 'HEAD') === integrationBranch) {
-      if (wtGit('status', '--porcelain').trim()) {
-        wtGit('reset', '--hard', 'HEAD');
-        wtGit('clean', '-fd');
+      // Restore ONLY the completion-owned paths a crashed completion could have left
+      // dirty — the ticket store and the evidence ledger. A repo-wide `reset --hard` +
+      // `clean -fd` (the earlier fix) was too broad: it would also destroy untracked
+      // diagnostic files or manual recovery work a human may have left in this shared
+      // worktree while investigating a quarantined branch. `git checkout HEAD -- <path>`
+      // reverts only tracked changes under that path; untracked and unrelated work is
+      // untouched. Each path is restored independently so one absent from HEAD (e.g. the
+      // legacy store file in a sharded repo) does not skip the others.
+      if (wtGit('status', '--porcelain', '--', ...INTEGRATION_OWNED_PATHS).trim()) {
+        for (const p of INTEGRATION_OWNED_PATHS) {
+          try { wtGit('checkout', 'HEAD', '--', p); } catch { /* path may not exist in HEAD */ }
+        }
       }
       return { path: abs, created: false };
     }

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -156,11 +156,17 @@ export function revertMerge(repo, integrationBranch, { mergeSha, preMergeSha }, 
     git('reset', '--hard', preMergeSha);
     return { method: 'reset', ok: true };
   }
-  // HEAD moved: a blind reset would discard the intervening commit. Revert the
-  // known merge commit instead (creates a new commit; loses nothing).
+  // HEAD moved: an intervening commit landed on top of our merge. Two truths hold at
+  // once. (1) A blind reset would DISCARD that commit, so we revert our known merge
+  // instead — the intervening commit is preserved (AC9/F4/N2). (2) But that intervening
+  // commit was never covered by a passing gate, and reverting our merge does not remove
+  // it. Treating this as clean recovery (ok:true) would carry an UNGATED commit into the
+  // fleet PR. So the revert succeeds AND the branch is quarantined: ok:false, which the
+  // caller routes to quarantine — no further merge lands, no PR opens. A human decides
+  // what to do with the preserved-but-ungated commit.
   try {
     git('revert', '--no-edit', '-m', '1', mergeSha);
-    return { method: 'revert', ok: true, reason: 'integration HEAD moved during gate; used git revert to avoid dropping unrelated work' };
+    return { method: 'revert', ok: false, reason: `integration HEAD moved to ${head} during the gate; our merge was reverted but the intervening commit is UNGATED — quarantined so it cannot reach the PR` };
   } catch (e) {
     return { method: 'refused', ok: false, reason: `integration HEAD moved and git revert failed (${e.message}); manual recovery required` };
   }

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -8,21 +8,28 @@
 // unit-testable without a real repository.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, appendFileSync } from 'node:fs';
+import { existsSync, readFileSync, appendFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { ACTIVE_DIRECTORY, LEGACY_FILE } from '@adlc/tickets';
+import { LEGACY_FILE } from '@adlc/tickets';
 
-// The evidence ledger the completion appends to (mirrors complete.mjs's MANIFEST_FILE).
+// The evidence ledger every completion appends to (mirrors complete.mjs's MANIFEST_FILE).
 const MANIFEST_FILE = '.adlc/manifest.jsonl';
 
 /**
- * The ONLY paths a crashed completion can leave dirty in the integration worktree:
- * the ticket store (sharded dir OR legacy file, whichever this repo uses) and the
- * evidence ledger. Imported from @adlc/tickets so the store layout stays authoritative
- * and cannot drift out from under the resume-cleanup scope. Used to bound the resume
- * cleanup so it never touches untracked diagnostics or unrelated work.
+ * The completion commits path-scoped: `git commit -- <its-shard> .adlc/manifest.jsonl`.
+ * That means the ONLY completion-owned files another ticket's commit can accidentally
+ * capture are the ones EVERY completion names and that ACCUMULATE across tickets — the
+ * SHARED files. A per-ticket shard is private to its own completion's pathspec, so a
+ * dirty orphan shard can never ride onto another ticket's commit and must be left alone
+ * on resume (reverting the whole shard directory would destroy an operator's unrelated
+ * in-flight edit). The shared, contamination-prone files are:
+ *   - the manifest ledger — always in the pathspec; a crash orphan appends to it, and
+ *     that append is a provable, disposable shape we can safely revert; and
+ *   - the legacy single-file store — every ticket lives in this one file, so in a
+ *     pre-shard repo it is shared too; its orphan shape is NOT distinguishable from a
+ *     legitimate edit, so a dirty one is refused (never auto-destroyed).
  */
-export const INTEGRATION_OWNED_PATHS = [ACTIVE_DIRECTORY, LEGACY_FILE, MANIFEST_FILE];
+const SHARED_COMPLETION_FILES = { manifest: MANIFEST_FILE, legacyStore: LEGACY_FILE };
 
 export function defaultGit(repo) {
   return (...args) =>
@@ -71,32 +78,25 @@ export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = n
   const abs = join(repo, INTEGRATION_WORKTREE);
   // Resume: a live worktree already on the right branch is reused — but NOT blindly.
   // A crash after planComplete wrote the shard + manifest, yet before the path-scoped
-  // completion commit, leaves the worktree DIRTY with orphaned completion artifacts.
-  // Reusing that as-is would let a later ticket's completion stage and commit the
-  // orphan alongside its own — a false attestation that the crashed ticket completed.
-  // Everything legitimately merged lives in the branch's COMMITTED history, so we revert
-  // the orphan before reusing — but scoped to the completion-owned paths only, never a
-  // repo-wide reset that would also erase a human's untracked diagnostics or in-progress
-  // recovery work in this shared worktree.
+  // completion commit, leaves the worktree DIRTY with an orphaned completion. Reusing
+  // that as-is could let a later ticket's completion stage and commit the orphaned SHARED
+  // ledger append alongside its own — a false attestation that the crashed ticket
+  // completed. We reconcile that ONE contamination vector and nothing else (see
+  // reconcileResumeOrphan): shards and unrelated work are never touched.
+  //
+  // Determine "on the right branch" inside a guarded probe, but run the reconciliation
+  // OUTSIDE it — a reconcile that refuses (throws) must ABORT the resume, not fall through
+  // to the recreate path below, which would `--force`-remove the worktree and destroy the
+  // very dirty state a human needs for recovery.
+  let wtGit = null;
   try {
-    const wtGit = gitAt(abs);
-    if (wtGit('symbolic-ref', '--short', 'HEAD') === integrationBranch) {
-      // Restore ONLY the completion-owned paths a crashed completion could have left
-      // dirty — the ticket store and the evidence ledger. A repo-wide `reset --hard` +
-      // `clean -fd` (the earlier fix) was too broad: it would also destroy untracked
-      // diagnostic files or manual recovery work a human may have left in this shared
-      // worktree while investigating a quarantined branch. `git checkout HEAD -- <path>`
-      // reverts only tracked changes under that path; untracked and unrelated work is
-      // untouched. Each path is restored independently so one absent from HEAD (e.g. the
-      // legacy store file in a sharded repo) does not skip the others.
-      if (wtGit('status', '--porcelain', '--', ...INTEGRATION_OWNED_PATHS).trim()) {
-        for (const p of INTEGRATION_OWNED_PATHS) {
-          try { wtGit('checkout', 'HEAD', '--', p); } catch { /* path may not exist in HEAD */ }
-        }
-      }
-      return { path: abs, created: false };
-    }
+    const probe = gitAt(abs);
+    if (probe('symbolic-ref', '--short', 'HEAD') === integrationBranch) wtGit = probe;
   } catch { /* not a usable worktree — fall through and (re)create */ }
+  if (wtGit) {
+    reconcileResumeOrphan(abs, wtGit);
+    return { path: abs, created: false };
+  }
 
   try { git('worktree', 'remove', '--force', INTEGRATION_WORKTREE); } catch { /* none */ }
   try { git('worktree', 'prune'); } catch { /* best effort */ }
@@ -107,6 +107,73 @@ export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = n
     git('worktree', 'add', INTEGRATION_WORKTREE, integrationBranch);
   }
   return { path: abs, created: true };
+}
+
+/**
+ * Neutralize a crash orphan in the resumed integration worktree WITHOUT destroying any
+ * work we cannot prove is a disposable orphan.
+ *
+ * Scope is deliberately minimal (see SHARED_COMPLETION_FILES): the manifest ledger is the
+ * only file a later ticket's path-scoped completion commit can accidentally capture, so it
+ * is the only file we ever revert — and only when its dirty delta has the provable shape of
+ * a crash orphan. Everything else (per-ticket shards, untracked diagnostics, an operator's
+ * unrelated edits) is left exactly as found.
+ *
+ *  - Manifest UNTRACKED (never committed): the whole file is an uncommitted orphan; remove
+ *    it (no committed evidence exists to lose).
+ *  - Manifest TRACKED and dirty as a pure APPEND on top of HEAD: the crash-orphan shape;
+ *    revert to HEAD, dropping the orphaned append.
+ *  - Manifest dirty any OTHER way, or the legacy single-file store dirty at all: we cannot
+ *    prove a benign orphan, so REFUSE — throw to abort the resume for manual recovery
+ *    rather than silently destroy state. (The caller does NOT swallow this into recreate.)
+ */
+export function reconcileResumeOrphan(worktreeAbs, wtGit) {
+  const { manifest, legacyStore } = SHARED_COMPLETION_FILES;
+
+  const manifestStatus = wtGit('status', '--porcelain', '--', manifest).trim();
+  if (manifestStatus) {
+    if (manifestStatus[0] === '?') {
+      // Untracked: entirely uncommitted → removing it drops the orphan and only the orphan.
+      rmSync(join(worktreeAbs, manifest), { force: true });
+    } else if (manifestIsAppendOrphan(worktreeAbs, wtGit, manifest)) {
+      wtGit('checkout', 'HEAD', '--', manifest);
+    } else {
+      throw new Error(
+        `integration worktree ${manifest} diverged from HEAD in a non-append shape on ` +
+        `resume; cannot prove a benign crash orphan — refusing to reuse (manual recovery ` +
+        `required so no committed evidence is silently discarded)`,
+      );
+    }
+  }
+
+  // The legacy single-file store is shared across every ticket, so an orphan and a
+  // legitimate edit are indistinguishable in it. Never auto-destroy — refuse.
+  if (wtGit('status', '--porcelain', '--', legacyStore).trim()) {
+    throw new Error(
+      `integration worktree ${legacyStore} is dirty on resume; the legacy single-file ` +
+      `store cannot be proven a crash orphan (all tickets share the file) — refusing to ` +
+      `reuse (manual recovery required)`,
+    );
+  }
+}
+
+/**
+ * True iff the working manifest is exactly the committed ledger plus zero-or-more appended
+ * lines — the shape a crash between append and commit leaves. Compared line-by-line so a
+ * trailing-newline difference does not matter. A working copy that is NOT a superset-prefix
+ * of HEAD (rewritten or truncated lines) is NOT an append orphan.
+ */
+function manifestIsAppendOrphan(worktreeAbs, wtGit, manifest) {
+  let committed;
+  try { committed = wtGit('show', `HEAD:${manifest}`); }
+  catch { return false; } // not in HEAD → no committed baseline to append onto
+  const working = readFileSync(join(worktreeAbs, manifest), 'utf8');
+  const committedLines = committed.split('\n').filter((l) => l !== '');
+  const workingLines = working.split('\n').filter((l) => l !== '');
+  return (
+    workingLines.length >= committedLines.length &&
+    committedLines.every((line, i) => workingLines[i] === line)
+  );
 }
 
 /**

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -56,9 +56,23 @@ export const INTEGRATION_WORKTREE = join('.worktrees', 'fleet-integration');
  */
 export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = null, git = defaultGit(repo), gitAt = defaultGit } = {}) {
   const abs = join(repo, INTEGRATION_WORKTREE);
-  // Resume: a live worktree already on the right branch is reused as-is.
+  // Resume: a live worktree already on the right branch is reused — but NOT blindly.
+  // A crash after planComplete wrote the shard + manifest, yet before the path-scoped
+  // completion commit, leaves the worktree DIRTY with orphaned completion artifacts.
+  // Reusing that as-is would let a later ticket's completion stage and commit the
+  // orphan alongside its own — a false attestation that the crashed ticket completed.
+  // Everything legitimately merged lives in the branch's COMMITTED history, and the
+  // uncommitted delta here is only ever a crash orphan, so hard-reset to HEAD and drop
+  // untracked leftovers before reusing.
   try {
-    if (gitAt(abs)('symbolic-ref', '--short', 'HEAD') === integrationBranch) return { path: abs, created: false };
+    const wtGit = gitAt(abs);
+    if (wtGit('symbolic-ref', '--short', 'HEAD') === integrationBranch) {
+      if (wtGit('status', '--porcelain').trim()) {
+        wtGit('reset', '--hard', 'HEAD');
+        wtGit('clean', '-fd');
+      }
+      return { path: abs, created: false };
+    }
   } catch { /* not a usable worktree — fall through and (re)create */ }
 
   try { git('worktree', 'remove', '--force', INTEGRATION_WORKTREE); } catch { /* none */ }

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -80,10 +80,25 @@ export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = n
 
   // Recreate: the fixed path is on another run's branch, detached, or unusable, so it must be
   // rebuilt. The integration worktree survives across runs and may hold a human's in-progress
-  // recovery work, so before force-removing it we refuse if it holds uncommitted changes.
-  // Only a clean — or already-gone — worktree is safe to force-remove.
-  if (existsSync(abs) && probe) {
-    assertIntegrationWorktreeClean(abs, probe, `the existing integration worktree at ${INTEGRATION_WORKTREE}`);
+  // recovery work, so a force-remove is only safe once we have PROVEN the path holds nothing
+  // uncommitted. Fail closed on uncertainty:
+  //   - absent path (nothing on disk)     → nothing to lose; fall through to prune + recreate.
+  //   - readable worktree (probe worked)  → require a clean status (refuse if dirty), then remove.
+  //   - EXISTS but UNREADABLE (probe null) → its git state can't be read (damaged .git, a
+  //     permissions change, an interrupted git op), so we CANNOT prove it is empty of
+  //     uncommitted work → REFUSE rather than blindly force-remove it.
+  if (existsSync(abs)) {
+    if (probe) {
+      assertIntegrationWorktreeClean(abs, probe, `the existing integration worktree at ${INTEGRATION_WORKTREE}`);
+    } else {
+      throw new Error(
+        `the integration worktree path ${abs} exists but its git state could not be read ` +
+        `(damaged .git metadata, a permissions change, or an interrupted git operation). ` +
+        `Refusing to force-remove it: it may hold uncommitted recovery work that cannot be ` +
+        `recovered once deleted. Inspect it and remove it deliberately, then re-run (manual ` +
+        `recovery required).`,
+      );
+    }
   }
 
   try { git('worktree', 'remove', '--force', INTEGRATION_WORKTREE); } catch { /* none */ }
@@ -104,13 +119,22 @@ export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = n
  * point of view, so we never auto-clean, revert, or force-remove a dirty worktree. The
  * caller must NOT swallow this — a throw here aborts the run so a human resolves the state.
  *
- * A worktree that cannot be stat'd (stale/removed directory) is treated as nothing-to-lose:
- * the status probe throws, we return, and the caller's remove/recreate handles it.
+ * Callers only invoke this once they have established the worktree is readable (a resume on
+ * the right branch, or a recreate whose probe succeeded). If `git status` nonetheless fails
+ * here, the worktree's state is UNKNOWN — we fail closed and refuse, never assume it is safe
+ * to reuse or delete (a fail-open assumption there could discard uncommitted recovery work).
  */
 export function assertIntegrationWorktreeClean(worktreeAbs, wtGit, label) {
   let dirty;
   try { dirty = wtGit('status', '--porcelain').trim(); }
-  catch { return; /* not a live worktree — no committed state to protect */ }
+  catch (e) {
+    throw new Error(
+      `${label} could not be read (${e.message.trim()}). Refusing to reuse or force-remove ` +
+      `it while its state is unknown — it may hold uncommitted recovery work. Inspect the ` +
+      `worktree at ${worktreeAbs} and resolve it deliberately, then re-run (manual recovery ` +
+      `required).`,
+    );
+  }
   if (dirty) {
     throw new Error(
       `${label} has uncommitted changes:\n${dirty}\n\n` +

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -38,6 +38,40 @@ export function createIntegrationBranch(repo, integrationBranch, baseSha, git = 
   return integrationBranch;
 }
 
+/** Repo-relative path of the run's dedicated integration worktree. */
+export const INTEGRATION_WORKTREE = join('.worktrees', 'fleet-integration');
+
+/**
+ * Give the integration branch its OWN worktree, so no integration-branch operation
+ * ever runs in the shared main checkout.
+ *
+ * This is a correctness boundary, not a convenience. Every integration step used to
+ * `git checkout <integrationBranch>` in the shared repo and then act on ambient HEAD,
+ * which an external process could move at any moment — merges, gates, completions and
+ * withdrawals could all be attributed to the wrong branch. A worktree has its own HEAD
+ * and index, and git REFUSES to check out a branch that is already checked out in
+ * another worktree, so the collision becomes impossible rather than merely detected.
+ *
+ * `baseSha` creates the branch fresh; omit it to attach to an existing branch (resume).
+ */
+export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = null, git = defaultGit(repo), gitAt = defaultGit } = {}) {
+  const abs = join(repo, INTEGRATION_WORKTREE);
+  // Resume: a live worktree already on the right branch is reused as-is.
+  try {
+    if (gitAt(abs)('symbolic-ref', '--short', 'HEAD') === integrationBranch) return { path: abs, created: false };
+  } catch { /* not a usable worktree — fall through and (re)create */ }
+
+  try { git('worktree', 'remove', '--force', INTEGRATION_WORKTREE); } catch { /* none */ }
+  try { git('worktree', 'prune'); } catch { /* best effort */ }
+  if (baseSha !== null) {
+    try { git('branch', '-D', integrationBranch); } catch { /* none */ }
+    git('worktree', 'add', '-b', integrationBranch, INTEGRATION_WORKTREE, baseSha);
+  } else {
+    git('worktree', 'add', INTEGRATION_WORKTREE, integrationBranch);
+  }
+  return { path: abs, created: true };
+}
+
 /**
  * Create a worktree + branch for a ticket, cut from the current integration tip.
  * Returns { path, branch, startSha } — startSha is the integration tip the
@@ -77,12 +111,19 @@ export function commitWorker(worktreePath, ticketId, git = defaultGit(worktreePa
  * as a strike — conflicts were scheduled away by scope serialization; one
  * appearing means the plan lied, not something to auto-resolve).
  */
-export function mergeToIntegration(repo, branch, integrationBranch, git = defaultGit(repo)) {
-  const preMergeSha = git('rev-parse', integrationBranch);
-  git('rebase', integrationBranch, branch);
-  git('checkout', integrationBranch);
-  git('merge', '--no-ff', '--no-edit', branch);
-  const mergeSha = git('rev-parse', integrationBranch);
+/**
+ * Merge a ticket branch into the integration branch WITHOUT any checkout switching.
+ *
+ * Each branch is operated on in the worktree that already has it checked out: the
+ * ticket branch rebases inside its own worktree, and the merge runs inside the
+ * integration worktree. Nothing touches the shared main checkout, and no step depends
+ * on ambient HEAD being what we last set it to.
+ */
+export function mergeToIntegration({ branch, integrationBranch, ticketGit, integrationGit }) {
+  const preMergeSha = integrationGit('rev-parse', integrationBranch);
+  ticketGit('rebase', integrationBranch); // the ticket branch is checked out here
+  integrationGit('merge', '--no-ff', '--no-edit', branch);
+  const mergeSha = integrationGit('rev-parse', integrationBranch);
   return { mergeSha, preMergeSha };
 }
 

--- a/packages/fleet/lib/worktrees.mjs
+++ b/packages/fleet/lib/worktrees.mjs
@@ -8,28 +8,8 @@
 // unit-testable without a real repository.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, appendFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, appendFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { LEGACY_FILE } from '@adlc/tickets';
-
-// The evidence ledger every completion appends to (mirrors complete.mjs's MANIFEST_FILE).
-const MANIFEST_FILE = '.adlc/manifest.jsonl';
-
-/**
- * The completion commits path-scoped: `git commit -- <its-shard> .adlc/manifest.jsonl`.
- * That means the ONLY completion-owned files another ticket's commit can accidentally
- * capture are the ones EVERY completion names and that ACCUMULATE across tickets — the
- * SHARED files. A per-ticket shard is private to its own completion's pathspec, so a
- * dirty orphan shard can never ride onto another ticket's commit and must be left alone
- * on resume (reverting the whole shard directory would destroy an operator's unrelated
- * in-flight edit). The shared, contamination-prone files are:
- *   - the manifest ledger — always in the pathspec; a crash orphan appends to it, and
- *     that append is a provable, disposable shape we can safely revert; and
- *   - the legacy single-file store — every ticket lives in this one file, so in a
- *     pre-shard repo it is shared too; its orphan shape is NOT distinguishable from a
- *     legitimate edit, so a dirty one is refused (never auto-destroyed).
- */
-const SHARED_COMPLETION_FILES = { manifest: MANIFEST_FILE, legacyStore: LEGACY_FILE };
 
 export function defaultGit(repo) {
   return (...args) =>
@@ -76,26 +56,34 @@ export const INTEGRATION_WORKTREE = join('.worktrees', 'fleet-integration');
  */
 export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = null, git = defaultGit(repo), gitAt = defaultGit } = {}) {
   const abs = join(repo, INTEGRATION_WORKTREE);
-  // Resume: a live worktree already on the right branch is reused — but NOT blindly.
-  // A crash after planComplete wrote the shard + manifest, yet before the path-scoped
-  // completion commit, leaves the worktree DIRTY with an orphaned completion. Reusing
-  // that as-is could let a later ticket's completion stage and commit the orphaned SHARED
-  // ledger append alongside its own — a false attestation that the crashed ticket
-  // completed. We reconcile that ONE contamination vector and nothing else (see
-  // reconcileResumeOrphan): shards and unrelated work are never touched.
-  //
-  // Determine "on the right branch" inside a guarded probe, but run the reconciliation
-  // OUTSIDE it — a reconcile that refuses (throws) must ABORT the resume, not fall through
-  // to the recreate path below, which would `--force`-remove the worktree and destroy the
-  // very dirty state a human needs for recovery.
-  let wtGit = null;
+
+  // Probe an existing worktree at the fixed path: is it usable, and is it on our branch?
+  let onRightBranch = false;
+  let probe = null;
   try {
-    const probe = gitAt(abs);
-    if (probe('symbolic-ref', '--short', 'HEAD') === integrationBranch) wtGit = probe;
-  } catch { /* not a usable worktree — fall through and (re)create */ }
-  if (wtGit) {
-    reconcileResumeOrphan(abs, wtGit);
+    probe = gitAt(abs);
+    onRightBranch = probe('symbolic-ref', '--short', 'HEAD') === integrationBranch;
+  } catch { probe = null; /* not a usable worktree */ }
+
+  // Resume: reuse a worktree already on the right branch — but NEVER a DIRTY one. A crash
+  // between a completion's manifest append and its path-scoped commit can leave the worktree
+  // dirty with an orphaned completion; reusing it could let a later completion sweep that
+  // orphan into its own commit (a false attestation). We deliberately do NOT try to
+  // classify orphan-vs-legitimate and auto-clean: every shape heuristic risks reverting real
+  // recovery evidence or deleting a file that was never a disposable orphan. Instead we FAIL
+  // CLOSED — refuse and let a human inspect. A dirty worktree is never reused, so an orphan
+  // can never reach a commit; a clean worktree is reused directly.
+  if (onRightBranch) {
+    assertIntegrationWorktreeClean(abs, probe, `the resumed integration worktree (${integrationBranch})`);
     return { path: abs, created: false };
+  }
+
+  // Recreate: the fixed path is on another run's branch, detached, or unusable, so it must be
+  // rebuilt. The integration worktree survives across runs and may hold a human's in-progress
+  // recovery work, so before force-removing it we refuse if it holds uncommitted changes.
+  // Only a clean — or already-gone — worktree is safe to force-remove.
+  if (existsSync(abs) && probe) {
+    assertIntegrationWorktreeClean(abs, probe, `the existing integration worktree at ${INTEGRATION_WORKTREE}`);
   }
 
   try { git('worktree', 'remove', '--force', INTEGRATION_WORKTREE); } catch { /* none */ }
@@ -110,70 +98,29 @@ export function ensureIntegrationWorktree(repo, integrationBranch, { baseSha = n
 }
 
 /**
- * Neutralize a crash orphan in the resumed integration worktree WITHOUT destroying any
- * work we cannot prove is a disposable orphan.
+ * Refuse (throw) if the integration worktree has ANY uncommitted change — tracked or
+ * untracked. This is the fleet's fail-closed guard against silently destroying state: a
+ * crash orphan and a human's manual recovery work are indistinguishable from a heuristic's
+ * point of view, so we never auto-clean, revert, or force-remove a dirty worktree. The
+ * caller must NOT swallow this — a throw here aborts the run so a human resolves the state.
  *
- * Scope is deliberately minimal (see SHARED_COMPLETION_FILES): the manifest ledger is the
- * only file a later ticket's path-scoped completion commit can accidentally capture, so it
- * is the only file we ever revert — and only when its dirty delta has the provable shape of
- * a crash orphan. Everything else (per-ticket shards, untracked diagnostics, an operator's
- * unrelated edits) is left exactly as found.
- *
- *  - Manifest UNTRACKED (never committed): the whole file is an uncommitted orphan; remove
- *    it (no committed evidence exists to lose).
- *  - Manifest TRACKED and dirty as a pure APPEND on top of HEAD: the crash-orphan shape;
- *    revert to HEAD, dropping the orphaned append.
- *  - Manifest dirty any OTHER way, or the legacy single-file store dirty at all: we cannot
- *    prove a benign orphan, so REFUSE — throw to abort the resume for manual recovery
- *    rather than silently destroy state. (The caller does NOT swallow this into recreate.)
+ * A worktree that cannot be stat'd (stale/removed directory) is treated as nothing-to-lose:
+ * the status probe throws, we return, and the caller's remove/recreate handles it.
  */
-export function reconcileResumeOrphan(worktreeAbs, wtGit) {
-  const { manifest, legacyStore } = SHARED_COMPLETION_FILES;
-
-  const manifestStatus = wtGit('status', '--porcelain', '--', manifest).trim();
-  if (manifestStatus) {
-    if (manifestStatus[0] === '?') {
-      // Untracked: entirely uncommitted → removing it drops the orphan and only the orphan.
-      rmSync(join(worktreeAbs, manifest), { force: true });
-    } else if (manifestIsAppendOrphan(worktreeAbs, wtGit, manifest)) {
-      wtGit('checkout', 'HEAD', '--', manifest);
-    } else {
-      throw new Error(
-        `integration worktree ${manifest} diverged from HEAD in a non-append shape on ` +
-        `resume; cannot prove a benign crash orphan — refusing to reuse (manual recovery ` +
-        `required so no committed evidence is silently discarded)`,
-      );
-    }
-  }
-
-  // The legacy single-file store is shared across every ticket, so an orphan and a
-  // legitimate edit are indistinguishable in it. Never auto-destroy — refuse.
-  if (wtGit('status', '--porcelain', '--', legacyStore).trim()) {
+export function assertIntegrationWorktreeClean(worktreeAbs, wtGit, label) {
+  let dirty;
+  try { dirty = wtGit('status', '--porcelain').trim(); }
+  catch { return; /* not a live worktree — no committed state to protect */ }
+  if (dirty) {
     throw new Error(
-      `integration worktree ${legacyStore} is dirty on resume; the legacy single-file ` +
-      `store cannot be proven a crash orphan (all tickets share the file) — refusing to ` +
-      `reuse (manual recovery required)`,
+      `${label} has uncommitted changes:\n${dirty}\n\n` +
+      `Refusing to reuse or force-remove it. A fleet crash can leave an orphaned completion ` +
+      `here, and this shared worktree may also hold manual recovery work — the two are not ` +
+      `distinguishable automatically, so nothing is auto-cleaned. Inspect the worktree at ` +
+      `${worktreeAbs}, commit or discard the changes deliberately, then re-run (manual ` +
+      `recovery required).`,
     );
   }
-}
-
-/**
- * True iff the working manifest is exactly the committed ledger plus zero-or-more appended
- * lines — the shape a crash between append and commit leaves. Compared line-by-line so a
- * trailing-newline difference does not matter. A working copy that is NOT a superset-prefix
- * of HEAD (rewritten or truncated lines) is NOT an append orphan.
- */
-function manifestIsAppendOrphan(worktreeAbs, wtGit, manifest) {
-  let committed;
-  try { committed = wtGit('show', `HEAD:${manifest}`); }
-  catch { return false; } // not in HEAD → no committed baseline to append onto
-  const working = readFileSync(join(worktreeAbs, manifest), 'utf8');
-  const committedLines = committed.split('\n').filter((l) => l !== '');
-  const workingLines = working.split('\n').filter((l) => l !== '');
-  return (
-    workingLines.length >= committedLines.length &&
-    committedLines.every((line, i) => workingLines[i] === line)
-  );
 }
 
 /**

--- a/packages/fleet/package.json
+++ b/packages/fleet/package.json
@@ -28,7 +28,8 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@adlc/core": "1.6.0"
+    "@adlc/core": "1.6.0",
+    "@adlc/tickets": "1.6.0"
   },
   "scripts": {
     "test": "node --test test/*.test.mjs"

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -377,6 +377,28 @@ test('withdrawal REFUSES when HEAD moved — it never uncommits another process 
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('withdrawal REFUSES when the shard gained a concurrent update — it never erases another writer edit', () => {
+  // The gap this closes: the ticket lock is released when completion returns, and the
+  // caller then runs a potentially long post-completion gate. A legal non-sensitive
+  // ticket update during that window records NO manifest evidence, so the ledger check
+  // cannot see it — only a shard content check can.
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+
+    const shardAbs = join(root, res.shardPath);
+    const edited = { ...JSON.parse(readFileSync(shardAbs, 'utf8')), title: 'legitimately retitled during the gate' };
+    writeFileSync(shardAbs, `${JSON.stringify(edited, null, 2)}\n`);
+
+    assert.throws(
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, git }),
+      /ticket shard changed since the completion commit/,
+      'it refuses rather than reverting the concurrent edit away',
+    );
+    assert.match(readFileSync(shardAbs, 'utf8'), /legitimately retitled during the gate/, 'the concurrent edit survives');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('withdrawal REFUSES when the ledger gained a concurrent append — no false attestation left behind', () => {
   const { root, git, integrationBranch } = makeRepo();
   try {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -215,6 +215,50 @@ test('runFleet completes a merged+gate-passed ticket via the completeTicket effe
   assert.deepEqual(rec.completed, [{ id: 'T1', integrationBranch: integrationBranchName('r') }]);
 });
 
+// The completion adds a commit AFTER the post-merge gate, so the gate is re-run over
+// it. A failing re-gate withdraws ONLY the completion — never the shipped merge.
+function regateHarness({ regatePasses }) {
+  const rec = { completed: [], reverted: [], gateCalls: 0 };
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: () => ({ mergeSha: 'M', preMergeSha: 'P' }),
+    // 1st call = post-merge gate (passes); 2nd = the re-gate over the completion commit.
+    postMergeGate: () => { rec.gateCalls += 1; return { ok: rec.gateCalls === 1 ? true : regatePasses }; },
+    revertMerge: () => ({ method: 'reset', ok: true }),
+    completeTicket: ({ ticket }) => { rec.completed.push(ticket.id); return { completed: true, preCompletionSha: 'PRE' }; },
+    revertCompletion: ({ toSha }) => { rec.reverted.push(toSha); },
+    openPR: () => {},
+  };
+  return { deps, rec };
+}
+
+test('runFleet re-gates the completion commit and withdraws it when that gate fails (T73)', async () => {
+  const { deps, rec } = regateHarness({ regatePasses: false });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+
+  assert.equal(summary.results.T1, 'merged', 'the shipped merge is NOT reverted by a completion re-gate failure');
+  assert.deepEqual(rec.completed, ['T1']);
+  assert.equal(rec.gateCalls, 2, 'the gate ran again over the new completion commit');
+  assert.deepEqual(rec.reverted, ['PRE'], 'the completion commit is withdrawn to the pre-completion sha');
+});
+
+test('runFleet keeps the completion when the re-gate over it passes (T73)', async () => {
+  const { deps, rec } = regateHarness({ regatePasses: true });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+
+  assert.equal(summary.results.T1, 'merged');
+  assert.equal(rec.gateCalls, 2, 'the completion commit is still validated');
+  assert.deepEqual(rec.reverted, [], 'nothing is withdrawn when the completion commit gates clean');
+});
+
 test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {
   const { deps, rec } = harness({ postMerge: () => ({ ok: false }) });
   const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -13,7 +13,7 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
-import { initializeTicketStores, TicketService, detectTicketStore, ticketFilename } from '@adlc/tickets';
+import { initializeTicketStores, TicketService, detectTicketStore, ticketFilename, readTicketLock } from '@adlc/tickets';
 import { runFleet, integrationBranchName } from '../lib/run.mjs';
 import { resolveRunConfig } from '../lib/config.mjs';
 import { completeTicketOnIntegration } from '../lib/complete.mjs';
@@ -163,6 +163,24 @@ test('on a repo with NO manifest baseline, completion is skipped — it never cr
     assert.equal(isCompleted(root, 'T1'), false, 'the ticket stays open');
     assert.ok(!existsSync(join(root, '.adlc', 'manifest.jsonl')), 'no manifest was created');
     assert.equal(git('status', '--porcelain'), '', 'the checkout is untouched');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('the completion holds the ticket writer lock across the transaction AND the commit, then releases it (T73)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    // Observe the lock state at commit time: the transaction, the commit, and any
+    // rollback must run under ONE held lock so a concurrent writer cannot interleave
+    // and be clobbered by the rollback.
+    let lockHeldDuringCommit = null;
+    const observingGit = (...args) => {
+      if (args[0] === 'commit') lockHeldDuringCommit = readTicketLock(root);
+      return git(...args);
+    };
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: observingGit });
+    assert.equal(res.completed, true);
+    assert.ok(lockHeldDuringCommit, 'the writer lock is held during the commit — transaction+commit are atomic');
+    assert.ok(!readTicketLock(root), 'and the lock is released afterward (no stale lock left behind)');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -221,6 +221,71 @@ test('a failed commit does NOT erase a concurrent manifest evidence append (data
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('a failed commit whose evidence CANNOT be withdrawn flags the ledger dirty (so the caller quarantines)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const manifestPath = join(root, '.adlc', 'manifest.jsonl');
+    const failingGit = (...args) => {
+      if (args[0] === 'commit') {
+        // Concurrent recorder appends AFTER our evidence — ours is no longer the tail,
+        // so it cannot be removed without disturbing theirs.
+        writeFileSync(manifestPath, `${readFileSync(manifestPath, 'utf8')}{"seq":97,"gate":"concurrent","ts":"2026-01-04T00:00:00.000Z","data":{},"prev":null}\n`);
+        throw new Error('commit rejected by hook');
+      }
+      return git(...args);
+    };
+
+    let caught = null;
+    try { completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: failingGit }); }
+    catch (error) { caught = error; }
+
+    assert.ok(caught, 'the completion still fails');
+    assert.equal(caught.ledgerDirty, true, 'and marks the ledger dirty so the branch gets quarantined');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a clean failed commit does NOT flag the ledger dirty (evidence withdrawn exactly)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const failingGit = (...args) => {
+      if (args[0] === 'commit') throw new Error('commit rejected by hook');
+      return git(...args);
+    };
+    let caught = null;
+    try { completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: failingGit }); }
+    catch (error) { caught = error; }
+
+    assert.ok(caught);
+    assert.notEqual(caught.ledgerDirty, true, 'no concurrent append ⇒ our entry was removed exactly ⇒ no quarantine');
+    assert.equal(git('status', '--porcelain'), '', 'and the checkout is clean');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('runFleet QUARANTINES the branch when completion evidence could not be withdrawn', async () => {
+  const rec = { prs: [] };
+  const dirty = Object.assign(new Error('commit rejected by hook'), { ledgerDirty: true });
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: () => ({ mergeSha: 'M', preMergeSha: 'P' }),
+    postMergeGate: () => ({ ok: true }),
+    revertMerge: () => ({ method: 'reset', ok: true }),
+    completeTicket: () => { throw dirty; },
+    openPR: ({ integrationBranch }) => { rec.prs.push(integrationBranch); },
+  };
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+
+  assert.equal(summary.contaminated, true, 'a dirty ledger quarantines the branch');
+  assert.deepEqual(rec.prs, [], 'and no PR is opened from it');
+  assert.notEqual(summary.results.T1, 'merged');
+});
+
 test('withdrawing the completion commit does NOT destroy unrelated tracked work in the shared checkout', () => {
   const { root, git, integrationBranch } = makeRepo();
   try {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -175,12 +175,44 @@ test('a checkout switch DURING the commit is detected, not silently accepted', (
       if (args[0] === 'commit' && !switched) { switched = true; git('checkout', '-q', 'main'); }
       return out;
     };
-    assert.throws(
-      () => completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: switchingGit }),
-      /after committing/,
-      'the post-commit verification catches the switch',
-    );
+    let caught = null;
+    try { completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: switchingGit }); }
+    catch (error) { caught = error; }
+
+    assert.ok(caught, 'the post-commit verification catches the switch');
+    assert.match(caught.message, /after committing/);
+    // Detection alone is not enough: the commit LANDED, the caller's re-gate never
+    // runs, so this must quarantine rather than be logged and swallowed.
+    assert.equal(caught.branchContaminated, true, 'it is flagged as branch contamination');
+    // And it must NOT have written files into whatever checkout we ended up on.
+    assert.equal(git('symbolic-ref', '--short', 'HEAD'), 'main', 'we ended up on the other branch');
+    assert.equal(git('status', '--porcelain'), '', 'no paths were restored into the unknown checkout');
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('runFleet QUARANTINES when the checkout switched during the completion commit', async () => {
+  const rec = { prs: [] };
+  const contaminating = Object.assign(new Error('refusing to complete (after committing): checkout is on "main"'), { branchContaminated: true });
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: () => ({ mergeSha: 'M', preMergeSha: 'P' }),
+    postMergeGate: () => ({ ok: true }),
+    revertMerge: () => ({ method: 'reset', ok: true }),
+    completeTicket: () => { throw contaminating; },
+    openPR: ({ integrationBranch }) => { rec.prs.push(integrationBranch); },
+  };
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+
+  assert.equal(summary.contaminated, true, 'an ungated commit on the branch quarantines the run');
+  assert.match(summary.contaminationReason ?? '', /UNGATED completion commit/);
+  assert.deepEqual(rec.prs, [], 'no PR is opened carrying the ungated commit');
 });
 
 test('completion REFUSES without an integrationBranch to verify against', () => {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -163,6 +163,26 @@ test('completion REFUSES when the shared checkout is not on the integration bran
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('a checkout switch DURING the commit is detected, not silently accepted', () => {
+  // The race we cannot prevent (no lock we hold serializes `git checkout`) must at
+  // least be detected: a completion that landed somewhere we do not own is never
+  // reported as success.
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    let switched = false;
+    const switchingGit = (...args) => {
+      const out = git(...args);
+      if (args[0] === 'commit' && !switched) { switched = true; git('checkout', '-q', 'main'); }
+      return out;
+    };
+    assert.throws(
+      () => completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: switchingGit }),
+      /after committing/,
+      'the post-commit verification catches the switch',
+    );
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('completion REFUSES without an integrationBranch to verify against', () => {
   const { root, git } = makeRepo();
   try {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -243,6 +243,42 @@ test('withdrawing the completion commit does NOT destroy unrelated tracked work 
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('withdrawal REFUSES when HEAD moved — it never uncommits another process work', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    // Another process commits on the shared integration branch after our completion.
+    writeFileSync(join(root, 'other.txt'), 'concurrent work\n');
+    git('add', '--', 'other.txt');
+    git('commit', '-q', '-m', 'concurrent commit by another process');
+    const headBefore = git('rev-parse', 'HEAD');
+
+    assert.throws(
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, git }),
+      /HEAD is .*no longer the completion commit/,
+      'it refuses rather than rewinding past a concurrent commit',
+    );
+    assert.equal(git('rev-parse', 'HEAD'), headBefore, 'the concurrent commit is still on the branch');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('withdrawal REFUSES when the ledger gained a concurrent append — no false attestation left behind', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    // A concurrent recorder appends gate evidence after our completion commit.
+    const manifestPath = join(root, '.adlc', 'manifest.jsonl');
+    writeFileSync(manifestPath, `${readFileSync(manifestPath, 'utf8')}{"seq":98,"gate":"concurrent","ts":"2026-01-03T00:00:00.000Z","data":{},"prev":null}\n`);
+
+    assert.throws(
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, git }),
+      /evidence ledger changed since the completion commit/,
+      'it refuses rather than erasing their evidence or leaving ours to be swept into a later commit',
+    );
+    assert.ok(readFileSync(manifestPath, 'utf8').includes('concurrent'), 'the concurrent evidence is untouched');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 // ---- runFleet wiring: completion is gated on a passing post-merge gate --------
 
 const T = (id) => ({ id, title: id, scope: [`src/${id}/**`], edges: [] });

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -654,10 +654,36 @@ test('a REFUSED merge-revert quarantines the branch — the gate-rejected merge 
   const summary = await runFleet({ all: [T('T1'), T('T2')], runId: 'r', config, deps });
 
   assert.equal(summary.contaminated, true, 'a refused merge-revert quarantines the run');
-  assert.match(summary.contaminationReason ?? '', /could NOT be withdrawn/);
+  // The quarantine reason is surfaced verbatim from revertMerge.
+  assert.match(summary.contaminationReason ?? '', /git revert failed|HEAD moved/);
   assert.deepEqual(rec.prs, [], 'no PR is opened carrying the gate-rejected merge');
   assert.equal(rec.merges.length, 1, 'no further merge lands on the quarantined branch');
   assert.notEqual(summary.results.T1, 'merged');
+});
+
+test('a moved-HEAD revert (ungated intervening commit) QUARANTINES the run — no PR', async () => {
+  // revertMerge returns ok:false when it reverted our merge but an UNGATED intervening
+  // commit remains on the branch. That must quarantine, exactly like a refused revert.
+  const rec = { prs: [] };
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: () => ({ mergeSha: 'M', preMergeSha: 'P' }),
+    postMergeGate: () => ({ ok: false }),
+    revertMerge: () => ({ method: 'revert', ok: false, reason: 'HEAD moved; merge reverted but the intervening commit is UNGATED' }),
+    openPR: ({ integrationBranch }) => { rec.prs.push(integrationBranch); },
+  };
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1'), T('T2')], runId: 'r', config, deps });
+
+  assert.equal(summary.contaminated, true, 'the ungated intervening commit quarantines the run');
+  assert.match(summary.contaminationReason ?? '', /UNGATED/);
+  assert.deepEqual(rec.prs, [], 'no PR carrying the ungated commit');
 });
 
 test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -217,7 +217,7 @@ test('runFleet completes a merged+gate-passed ticket via the completeTicket effe
 
 // The completion adds a commit AFTER the post-merge gate, so the gate is re-run over
 // it. A failing re-gate withdraws ONLY the completion — never the shipped merge.
-function regateHarness({ regatePasses }) {
+function regateHarness({ regatePasses, revert = 'ok' }) {
   const rec = { completed: [], reverted: [], gateCalls: 0 };
   const deps = {
     baseSha: 'BASE',
@@ -235,6 +235,8 @@ function regateHarness({ regatePasses }) {
     revertCompletion: ({ toSha }) => { rec.reverted.push(toSha); },
     openPR: () => {},
   };
+  if (revert === 'throw') deps.revertCompletion = () => { throw new Error('reset failed: index.lock held'); };
+  if (revert === 'missing') delete deps.revertCompletion;
   return { deps, rec };
 }
 
@@ -257,6 +259,27 @@ test('runFleet keeps the completion when the re-gate over it passes (T73)', asyn
   assert.equal(summary.results.T1, 'merged');
   assert.equal(rec.gateCalls, 2, 'the completion commit is still validated');
   assert.deepEqual(rec.reverted, [], 'nothing is withdrawn when the completion commit gates clean');
+});
+
+test('runFleet FAILS the ticket when a gate-rejected completion cannot be withdrawn (throwing revert)', async () => {
+  // A swallowed rollback failure would leave a gate-rejected commit on the branch and
+  // let it ride into the fleet PR — the ticket must fail loudly instead.
+  const { deps } = regateHarness({ regatePasses: false, revert: 'throw' });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+
+  assert.notEqual(summary.results.T1, 'merged', 'a branch carrying an ungated commit is never reported merged');
+  assert.equal(summary.merged, 0, 'and it does not count toward opening the PR');
+});
+
+test('runFleet FAILS the ticket when a gate-rejected completion has no withdrawal path wired', async () => {
+  // Optional-chaining on a missing dep must not read as "successfully withdrawn".
+  const { deps } = regateHarness({ regatePasses: false, revert: 'missing' });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+
+  assert.notEqual(summary.results.T1, 'merged', 'a missing withdrawal path is a failure, not a silent success');
+  assert.equal(summary.merged, 0);
 });
 
 test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -1,0 +1,126 @@
+// T73 — fleet auto-completes a ticket on the integration branch after a passing
+// merge gate. Two levels of proof:
+//   1. completeTicketOnIntegration against a REAL directory store + REAL git repo,
+//      proving (a) a merged+gate-passed ticket ends completed:true ON THE BRANCH
+//      (a commit lands) and (c) a re-run over an already-completed ticket is a
+//      no-op (no second commit, no error).
+//   2. runFleet wiring, proving completion is GATED — invoked after a passing
+//      post-merge gate, and (b) NEVER invoked when the post-merge gate fails.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { initializeTicketStores, TicketService, detectTicketStore } from '@adlc/tickets';
+import { runFleet, integrationBranchName } from '../lib/run.mjs';
+import { resolveRunConfig } from '../lib/config.mjs';
+import { completeTicketOnIntegration } from '../lib/complete.mjs';
+
+function gitRunner(cwd) {
+  return (...args) =>
+    execFileSync('git', ['-c', 'commit.gpgsign=false', '-c', 'user.email=fleet@test', '-c', 'user.name=fleet', ...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+}
+
+/** A temp git repo carrying a directory ticket store with one open ticket on an integration branch. */
+function makeRepo(ticket = { id: 'T1', title: 'first' }) {
+  const root = mkdtempSync(join(tmpdir(), 'fleet-complete-'));
+  const git = gitRunner(root);
+  git('init', '-b', 'main');
+  git('commit', '--allow-empty', '-q', '-m', 'root');
+  initializeTicketStores(root);
+  const service = new TicketService(detectTicketStore({ root }), { root });
+  service.apply(service.planCreate(ticket));
+  git('add', '-A');
+  git('commit', '-q', '-m', 'author ticket');
+  const integrationBranch = integrationBranchName('t73');
+  git('branch', integrationBranch);
+  git('checkout', '-q', integrationBranch);
+  return { root, git, integrationBranch };
+}
+
+const commitCount = (git) => Number(git('rev-list', '--count', 'HEAD'));
+const isCompleted = (root, id) => detectTicketStore({ root }).load().get(id)?.completed === true;
+
+test('completeTicketOnIntegration marks completed:true and commits it onto the run branch (T73 a)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    assert.equal(isCompleted(root, 'T1'), false, 'precondition: ticket starts open');
+    const before = commitCount(git);
+
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+
+    assert.equal(res.completed, true);
+    assert.equal(isCompleted(root, 'T1'), true, 'store now records completed:true');
+    assert.equal(commitCount(git), before + 1, 'a single completion commit landed on the run branch');
+
+    // The commit is the add-only annotation: it touches the ticket shard and the
+    // evidence ledger, nothing else.
+    const touched = git('show', '--name-only', '--format=', 'HEAD').split('\n').filter(Boolean);
+    assert.ok(touched.some((p) => p.startsWith('.adlc/tickets/')), `commit touches a ticket shard: ${touched.join(', ')}`);
+    assert.ok(touched.includes('.adlc/manifest.jsonl'), 'completion records manifest evidence in the same commit');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('completeTicketOnIntegration is idempotent — a re-run over an already-completed ticket is a no-op (T73 c)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    const after = commitCount(git);
+
+    const again = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+
+    assert.equal(again.completed, false, 'no completion performed the second time');
+    assert.equal(again.alreadyComplete, true, 'and it says so, rather than erroring');
+    assert.equal(commitCount(git), after, 'no second commit is created');
+    assert.equal(isCompleted(root, 'T1'), true, 'ticket stays completed');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ---- runFleet wiring: completion is gated on a passing post-merge gate --------
+
+const T = (id) => ({ id, title: id, scope: [`src/${id}/**`], edges: [] });
+
+function harness({ postMerge = () => ({ ok: true }) } = {}) {
+  const rec = { completed: [] };
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: () => ({ mergeSha: 'M', preMergeSha: 'P' }),
+    postMergeGate: postMerge,
+    revertMerge: () => ({ method: 'reset', ok: true }),
+    completeTicket: ({ ticket, integrationBranch }) => { rec.completed.push({ id: ticket.id, integrationBranch }); },
+    openPR: () => {},
+  };
+  return { deps, rec };
+}
+
+test('runFleet completes a merged+gate-passed ticket via the completeTicket effect', async () => {
+  const { deps, rec } = harness();
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+  assert.equal(summary.results.T1, 'merged');
+  assert.deepEqual(rec.completed, [{ id: 'T1', integrationBranch: integrationBranchName('r') }]);
+});
+
+test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {
+  const { deps, rec } = harness({ postMerge: () => ({ ok: false }) });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+  assert.notEqual(summary.results.T1, 'merged', 'a gate-failed ticket must not be reported merged');
+  assert.equal(rec.completed.length, 0, 'a gate-failed ticket is never completed');
+});

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -629,6 +629,37 @@ test('quarantine is persisted and survives RESUME — a resumed run refuses to w
   assert.deepEqual(rec2.merges, [], 'nothing merges onto the quarantined branch');
 });
 
+test('a REFUSED merge-revert quarantines the branch — the gate-rejected merge never reaches a PR', async () => {
+  // The post-merge gate FAILURE path (older than T73) must honor rev.ok: revertMerge
+  // returns { ok:false, method:'refused' } when it cannot undo the merge, leaving a
+  // gate-rejected merge on the shared branch. That is the same hazard the completion
+  // withdrawal path quarantines for, and it must be treated identically.
+  const rec = { prs: [], merges: [] };
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: ({ ticket }) => { rec.merges.push(ticket.id); return { mergeSha: 'M', preMergeSha: 'P' }; },
+    // T1's post-merge gate fails; T2's would pass — but the branch is already quarantined.
+    postMergeGate: ({ ticket }) => ({ ok: ticket.id !== 'T1' }),
+    revertMerge: () => ({ method: 'refused', ok: false, reason: 'integration HEAD moved and git revert failed' }),
+    completeTicket: () => ({ completed: true, preCompletionSha: 'PRE' }),
+    openPR: ({ integrationBranch }) => { rec.prs.push(integrationBranch); },
+  };
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1'), T('T2')], runId: 'r', config, deps });
+
+  assert.equal(summary.contaminated, true, 'a refused merge-revert quarantines the run');
+  assert.match(summary.contaminationReason ?? '', /could NOT be withdrawn/);
+  assert.deepEqual(rec.prs, [], 'no PR is opened carrying the gate-rejected merge');
+  assert.equal(rec.merges.length, 1, 'no further merge lands on the quarantined branch');
+  assert.notEqual(summary.results.T1, 'merged');
+});
+
 test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {
   const { deps, rec } = harness({ postMerge: () => ({ ok: false }) });
   const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -9,7 +9,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -53,6 +53,12 @@ test('completeTicketOnIntegration marks completed:true and commits it onto the r
     assert.equal(isCompleted(root, 'T1'), false, 'precondition: ticket starts open');
     const before = commitCount(git);
 
+    // The post-merge gate runs a build on the integration branch immediately
+    // before completion and can leave untracked output in the tree. The
+    // completion commit MUST be path-scoped and never sweep such files into the
+    // PR-riding commit (an `git add -A` would).
+    writeFileSync(join(root, 'dist-leaked-build-artifact.js'), '// build output the gate left behind\n');
+
     const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
 
     assert.equal(res.completed, true);
@@ -60,10 +66,17 @@ test('completeTicketOnIntegration marks completed:true and commits it onto the r
     assert.equal(commitCount(git), before + 1, 'a single completion commit landed on the run branch');
 
     // The commit is the add-only annotation: it touches the ticket shard and the
-    // evidence ledger, nothing else.
+    // evidence ledger — and NOTHING else.
     const touched = git('show', '--name-only', '--format=', 'HEAD').split('\n').filter(Boolean);
     assert.ok(touched.some((p) => p.startsWith('.adlc/tickets/')), `commit touches a ticket shard: ${touched.join(', ')}`);
     assert.ok(touched.includes('.adlc/manifest.jsonl'), 'completion records manifest evidence in the same commit');
+    assert.deepEqual(
+      touched.filter((p) => !p.startsWith('.adlc/')),
+      [],
+      `completion commit is scoped to .adlc/ — it must not sweep in unrelated tree state, but committed: ${touched.join(', ')}`,
+    );
+    // The stray build output stays untracked (never staged by the scoped commit).
+    assert.match(git('status', '--porcelain'), /\?\? dist-leaked-build-artifact\.js/, 'the build artifact remains untracked');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -99,6 +99,32 @@ test('completeTicketOnIntegration is idempotent — a re-run over an already-com
   }
 });
 
+test('a failed completion commit is rolled back — the shared integration checkout stays clean (T73)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    // A git that behaves normally except it refuses to COMMIT (e.g. a rejecting
+    // commit hook). add/reset delegate to real git so staging is real.
+    const failingGit = (...args) => {
+      if (args[0] === 'commit') throw new Error('commit rejected by hook');
+      return git(...args);
+    };
+
+    assert.throws(
+      () => completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: failingGit }),
+      /commit rejected/,
+      'the completion surfaces the commit failure',
+    );
+
+    // The on-disk transaction was undone: the ticket is open again...
+    assert.equal(isCompleted(root, 'T1'), false, 'the completion write is rolled back');
+    // ...and NOTHING is left staged or modified in the shared checkout — a later
+    // fleet step must not find orphaned completion state to sweep into a commit.
+    assert.equal(git('status', '--porcelain'), '', 'the integration checkout is clean after the failed completion');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 // ---- runFleet wiring: completion is gated on a passing post-merge gate --------
 
 const T = (id) => ({ id, title: id, scope: [`src/${id}/**`], edges: [] });

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -9,14 +9,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { initializeTicketStores, TicketService, detectTicketStore, ticketFilename, readTicketLock } from '@adlc/tickets';
 import { runFleet, integrationBranchName } from '../lib/run.mjs';
 import { resolveRunConfig } from '../lib/config.mjs';
-import { completeTicketOnIntegration } from '../lib/complete.mjs';
+import { completeTicketOnIntegration, revertCompletionCommit } from '../lib/complete.mjs';
 
 function gitRunner(cwd) {
   return (...args) =>
@@ -195,6 +195,51 @@ test('the completion holds the ticket writer lock across the transaction AND the
     assert.equal(res.completed, true);
     assert.ok(lockHeldDuringCommit, 'the writer lock is held during the commit — transaction+commit are atomic');
     assert.ok(!readTicketLock(root), 'and the lock is released afterward (no stale lock left behind)');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a failed commit does NOT erase a concurrent manifest evidence append (data loss)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const manifestPath = join(root, '.adlc', 'manifest.jsonl');
+    // A concurrent recorder appends gate evidence between our transaction and the
+    // commit — it holds the LEDGER lock, which our ticket lock does not cover.
+    const concurrentLine = '{"seq":99,"gate":"concurrent-recorder","ts":"2026-01-02T00:00:00.000Z","data":{},"prev":null}';
+    const failingGit = (...args) => {
+      if (args[0] === 'commit') {
+        writeFileSync(manifestPath, `${readFileSync(manifestPath, 'utf8')}${concurrentLine}\n`);
+        throw new Error('commit rejected by hook');
+      }
+      return git(...args);
+    };
+
+    assert.throws(() => completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git: failingGit }), /commit rejected/);
+
+    const manifestAfter = readFileSync(manifestPath, 'utf8');
+    assert.ok(manifestAfter.includes('concurrent-recorder'), 'the concurrent evidence append survives the rollback');
+    assert.equal(isCompleted(root, 'T1'), false, 'while the shard is still rolled back');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('withdrawing the completion commit does NOT destroy unrelated tracked work in the shared checkout', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    assert.equal(res.completed, true);
+
+    // Unrelated tracked work present in the shared integration checkout, as another
+    // step may legitimately have staged/modified. A checkout-wide reset --hard would
+    // destroy it.
+    const unrelated = join(root, 'unrelated.txt');
+    writeFileSync(unrelated, 'work in progress\n');
+    git('add', '--', 'unrelated.txt');
+
+    revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, git });
+
+    assert.equal(isCompleted(root, 'T1'), false, 'the completion annotation is withdrawn');
+    assert.equal(git('rev-parse', 'HEAD'), res.preCompletionSha, 'HEAD is back at the pre-completion commit');
+    assert.ok(existsSync(unrelated), 'unrelated tracked work is NOT destroyed');
+    assert.equal(readFileSync(unrelated, 'utf8'), 'work in progress\n');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -9,11 +9,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
-import { initializeTicketStores, TicketService, detectTicketStore } from '@adlc/tickets';
+import { initializeTicketStores, TicketService, detectTicketStore, ticketFilename } from '@adlc/tickets';
 import { runFleet, integrationBranchName } from '../lib/run.mjs';
 import { resolveRunConfig } from '../lib/config.mjs';
 import { completeTicketOnIntegration } from '../lib/complete.mjs';
@@ -28,12 +28,18 @@ function gitRunner(cwd) {
 }
 
 /** A temp git repo carrying a directory ticket store with one open ticket on an integration branch. */
-function makeRepo(ticket = { id: 'T1', title: 'first' }) {
+function makeRepo(ticket = { id: 'T1', title: 'first' }, { bootstrapManifest = true } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'fleet-complete-'));
   const git = gitRunner(root);
   git('init', '-b', 'main');
   git('commit', '--allow-empty', '-q', '-m', 'root');
   initializeTicketStores(root);
+  // Bootstrap a manifest ledger so completion evidence APPENDS — the supported case
+  // (rails-guard-ci allows append, denies create). Tests that want the un-bootstrapped
+  // repo pass { bootstrapManifest: false }.
+  if (bootstrapManifest) {
+    writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1,"gate":"bootstrap","ts":"2026-01-01T00:00:00.000Z","data":{"note":"test-bootstrap"},"prev":null}\n');
+  }
   const service = new TicketService(detectTicketStore({ root }), { root });
   service.apply(service.planCreate(ticket));
   git('add', '-A');
@@ -123,6 +129,41 @@ test('a failed completion commit is rolled back — the shared integration check
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('the completion commit is CI-shaped — completed:true-only shard + append-only manifest (rails-guard-ci)', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const shardRel = `.adlc/tickets/${ticketFilename('T1')}`;
+    const baseShard = JSON.parse(git('show', `HEAD:${shardRel}`));
+    const baseManifest = git('show', 'HEAD:.adlc/manifest.jsonl');
+    assert.ok(!('completed' in baseShard), 'precondition: base shard has no completed field');
+
+    completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+
+    // Shard diff is EXACTLY `completed: true` added — what rails-guard-ci's
+    // isCompletionAnnotationOnly exempts (add-only on a pristine field).
+    const headShard = JSON.parse(git('show', `HEAD:${shardRel}`));
+    assert.equal(headShard.completed, true);
+    const { completed, ...headWithoutCompleted } = headShard;
+    assert.deepEqual(headWithoutCompleted, baseShard, 'the only shard change is the completed:true annotation');
+
+    // Manifest diff is append-only — what rails-guard-ci requires (HEAD starts with base).
+    const headManifest = git('show', 'HEAD:.adlc/manifest.jsonl');
+    assert.ok(headManifest.startsWith(baseManifest), 'the manifest is append-only');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('on a repo with NO manifest baseline, completion is skipped — it never creates a manifest CI would reject', () => {
+  const { root, git, integrationBranch } = makeRepo({ id: 'T1', title: 'first' }, { bootstrapManifest: false });
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    assert.equal(res.completed, false);
+    assert.equal(res.reason, 'no-manifest-baseline', 'it degrades to merged-not-completed with a clear reason');
+    assert.equal(isCompleted(root, 'T1'), false, 'the ticket stays open');
+    assert.ok(!existsSync(join(root, '.adlc', 'manifest.jsonl')), 'no manifest was created');
+    assert.equal(git('status', '--porcelain'), '', 'the checkout is untouched');
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
 // ---- runFleet wiring: completion is gated on a passing post-merge gate --------

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -326,6 +326,36 @@ test('a failed withdrawal QUARANTINES the branch — no PR even when another tic
   assert.equal(rec.merges.length, 1, 'no further merge lands on the quarantined branch');
 });
 
+test('quarantine is persisted and survives RESUME — a resumed run refuses to work or open a PR', async () => {
+  // Quarantine is a property of the branch, not the process. A resume that started
+  // "clean" would happily merge onto — and publish — a branch still carrying the
+  // gate-rejected commit.
+  const { deps } = regateHarness({ regatePasses: false, revert: 'throw' });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const first = await runFleet({ all: [T('T1')], runId: 'r', config, deps });
+  assert.equal(first.contaminated, true);
+  assert.equal(first.status.contaminated, true, 'the quarantine is recorded IN the persisted status');
+
+  // Resume with that persisted status: the branch is still contaminated.
+  const rec2 = { dispatched: [], prs: [], merges: [] };
+  const resumeDeps = {
+    ...deps,
+    dispatch: ({ ticket }) => { rec2.dispatched.push(ticket.id); return { exitCode: 0, output: 'TICKET-DONE' }; },
+    mergeToIntegration: ({ ticket }) => { rec2.merges.push(ticket.id); return { mergeSha: 'M', preMergeSha: 'P' }; },
+    openPR: ({ integrationBranch }) => { rec2.prs.push(integrationBranch); },
+  };
+  const resumed = await runFleet({
+    all: [T('T1'), T('T2')], runId: 'r', config, deps: resumeDeps,
+    resume: { status: first.status, integrationBranch: first.integrationBranch },
+  });
+
+  assert.equal(resumed.contaminated, true, 'the resumed run restores the quarantine');
+  assert.deepEqual(rec2.prs, [], 'no PR is opened from the quarantined branch on resume');
+  assert.equal(resumed.prCount, 0);
+  assert.deepEqual(rec2.dispatched, [], 'and it fails closed BEFORE dispatching work that can never land');
+  assert.deepEqual(rec2.merges, [], 'nothing merges onto the quarantined branch');
+});
+
 test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {
   const { deps, rec } = harness({ postMerge: () => ({ ok: false }) });
   const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -145,6 +145,36 @@ test('a RAILED ticket completes normally — rails are enforced by rails-guard-c
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('completion REFUSES when the shared checkout is not on the integration branch', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    // Another local process switched the shared checkout away between the post-merge
+    // gate and completion. Every git op here targets current HEAD, so without a check
+    // the lifecycle commit would land on the wrong branch.
+    git('checkout', '-q', 'main');
+
+    assert.throws(
+      () => completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git }),
+      /checkout is on "main", not the integration branch/,
+      'it fails closed instead of committing to whatever is checked out',
+    );
+    assert.equal(isCompleted(root, 'T1'), false, 'and mutates nothing');
+    assert.equal(git('status', '--porcelain'), '', 'leaving the checkout clean');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('completion REFUSES without an integrationBranch to verify against', () => {
+  const { root, git } = makeRepo();
+  try {
+    assert.throws(
+      () => completeTicketOnIntegration({ repo: root, ticketId: 'T1', git }),
+      /requires integrationBranch/,
+      'the verification target is mandatory — it cannot be silently skipped',
+    );
+    assert.equal(isCompleted(root, 'T1'), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('the completion commit is CI-shaped — completed:true-only shard + append-only manifest (rails-guard-ci)', () => {
   const { root, git, integrationBranch } = makeRepo();
   try {

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -11,8 +11,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { execFileSync } from 'node:child_process';
-import { join } from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { initializeTicketStores, TicketService, detectTicketStore, ticketFilename, readTicketLock } from '@adlc/tickets';
 import { runFleet, integrationBranchName } from '../lib/run.mjs';
 import { resolveRunConfig } from '../lib/config.mjs';
@@ -247,6 +248,29 @@ test('the completion commit is CI-shaped — completed:true-only shard + append-
     // Manifest diff is append-only — what rails-guard-ci requires (HEAD starts with base).
     const headManifest = git('show', 'HEAD:.adlc/manifest.jsonl');
     assert.ok(headManifest.startsWith(baseManifest), 'the manifest is append-only');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// The assertion above independently RE-IMPLEMENTS what rails-guard-ci accepts. A model of
+// the consumer cannot catch drift in the real consumer (AGENTS.md), so this test round-trips
+// an actual fleet completion commit through the REAL scripts/rails-guard-ci.mjs gate that CI
+// runs on the PR — the producer→consumer contract, not a fleet-side approximation of it
+// (adversarial-review round-32).
+const RAILS_GUARD_CI = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'scripts', 'rails-guard-ci.mjs');
+
+test('PRODUCER→CONSUMER: a fleet completion commit is ACCEPTED by the real rails-guard-ci gate', () => {
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const base = git('rev-parse', 'HEAD'); // the pre-completion tip; the diff base CI uses
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    assert.equal(res.completed, true, 'precondition: a real completion commit was produced');
+
+    // Run the ACTUAL gate against the ACTUAL commit, in the repo, exactly as CI would.
+    const r = spawnSync(process.execPath, [RAILS_GUARD_CI, base], { cwd: root, encoding: 'utf8' });
+    assert.equal(
+      r.status, 0,
+      `the real rails-guard-ci must accept the fleet completion commit (exit ${r.status}):\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -282,6 +282,36 @@ test('runFleet FAILS the ticket when a gate-rejected completion has no withdrawa
   assert.equal(summary.merged, 0);
 });
 
+test('a failed withdrawal QUARANTINES the branch — no PR even when another ticket merges cleanly', async () => {
+  // The hole this closes: failing only the affected ticket still left the rejected
+  // commit on the SHARED branch, so a second clean ticket made merged>0 and openPR
+  // fired with the contaminated branch.
+  const rec = { prs: [], gateCalls: 0, merges: [] };
+  const deps = {
+    baseSha: 'BASE',
+    createIntegrationBranch: () => {},
+    createWorktree: ({ ticket }) => ({ path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }),
+    dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+    gate: () => ({ ok: true }),
+    prosecute: () => ({ verdict: 'pass' }),
+    flail: () => ({ flail: false }),
+    mergeToIntegration: ({ ticket }) => { rec.merges.push(ticket.id); return { mergeSha: 'M', preMergeSha: 'P' }; },
+    // Every merge-gate passes; every completion RE-gate fails (calls 2,4,...).
+    postMergeGate: () => { rec.gateCalls += 1; return { ok: rec.gateCalls % 2 === 1 }; },
+    revertMerge: () => ({ method: 'reset', ok: true }),
+    completeTicket: () => ({ completed: true, preCompletionSha: 'PRE' }),
+    revertCompletion: () => { throw new Error('reset failed: index.lock held'); },
+    openPR: ({ integrationBranch }) => { rec.prs.push(integrationBranch); },
+  };
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all: [T('T1'), T('T2')], runId: 'r', config, deps });
+
+  assert.equal(summary.contaminated, true, 'the run is marked contaminated');
+  assert.deepEqual(rec.prs, [], 'NO PR is opened from a quarantined branch');
+  assert.equal(summary.prCount, 0);
+  assert.equal(rec.merges.length, 1, 'no further merge lands on the quarantined branch');
+});
+
 test('runFleet does NOT complete a ticket whose post-merge gate failed (T73 b)', async () => {
   const { deps, rec } = harness({ postMerge: () => ({ ok: false }) });
   const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -381,7 +381,7 @@ test('withdrawing the completion commit does NOT destroy unrelated tracked work 
     writeFileSync(unrelated, 'work in progress\n');
     git('add', '--', 'unrelated.txt');
 
-    revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, git });
+    revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, integrationBranch, git });
 
     assert.equal(isCompleted(root, 'T1'), false, 'the completion annotation is withdrawn');
     assert.equal(git('rev-parse', 'HEAD'), res.preCompletionSha, 'HEAD is back at the pre-completion commit');
@@ -401,11 +401,34 @@ test('withdrawal REFUSES when HEAD moved — it never uncommits another process 
     const headBefore = git('rev-parse', 'HEAD');
 
     assert.throws(
-      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, git }),
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, integrationBranch, git }),
       /HEAD is .*no longer the completion commit/,
       'it refuses rather than rewinding past a concurrent commit',
     );
     assert.equal(git('rev-parse', 'HEAD'), headBefore, 'the concurrent commit is still on the branch');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('withdrawal REFUSES on a DIFFERENT branch pointing at the same commit — it never rewinds the wrong branch', () => {
+  // SHA identity is not branch identity. Another branch can legitimately point at the
+  // completion commit; if the shared checkout switched to it, every SHA precondition
+  // would pass and `reset --soft` would rewind THAT branch, leaving the rejected
+  // completion on the integration branch.
+  const { root, git, integrationBranch } = makeRepo();
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    // A sibling branch at the very same commit, and an external switch onto it.
+    git('branch', 'sibling-at-same-commit');
+    git('checkout', '-q', 'sibling-at-same-commit');
+    assert.equal(git('rev-parse', 'HEAD'), res.completionSha, 'precondition: SHA checks would all pass');
+
+    assert.throws(
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, integrationBranch, git }),
+      /refusing to withdraw \(before rewinding\).*sibling-at-same-commit/s,
+      'branch identity is verified, not just the commit SHA',
+    );
+    assert.equal(git('rev-parse', 'sibling-at-same-commit'), res.completionSha, 'the sibling branch was not rewound');
+    assert.equal(git('rev-parse', integrationBranch), res.completionSha, 'and the integration branch is untouched');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -423,7 +446,7 @@ test('withdrawal REFUSES when the shard gained a concurrent update — it never 
     writeFileSync(shardAbs, `${JSON.stringify(edited, null, 2)}\n`);
 
     assert.throws(
-      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, git }),
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, integrationBranch, git }),
       /ticket shard changed since the completion commit/,
       'it refuses rather than reverting the concurrent edit away',
     );
@@ -440,7 +463,7 @@ test('withdrawal REFUSES when the ledger gained a concurrent append — no false
     writeFileSync(manifestPath, `${readFileSync(manifestPath, 'utf8')}{"seq":98,"gate":"concurrent","ts":"2026-01-03T00:00:00.000Z","data":{},"prev":null}\n`);
 
     assert.throws(
-      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, git }),
+      () => revertCompletionCommit({ repo: root, toSha: res.preCompletionSha, shardPath: res.shardPath, completionSha: res.completionSha, integrationBranch, git }),
       /evidence ledger changed since the completion commit/,
       'it refuses rather than erasing their evidence or leaving ours to be swept into a later commit',
     );

--- a/packages/fleet/test/complete.test.mjs
+++ b/packages/fleet/test/complete.test.mjs
@@ -131,6 +131,20 @@ test('a failed completion commit is rolled back — the shared integration check
   }
 });
 
+test('a RAILED ticket completes normally — rails are enforced by rails-guard-ci on the diff, not by TicketService', () => {
+  // Guards against a plausible-but-wrong belief that fleet cannot complete railed
+  // tickets. TicketService only refuses completion for ids passed as `protectedIds`
+  // to its constructor, and NO production path (CLI included) populates that — it
+  // defaults to empty. The real rails protection is rails-guard-ci over the PR diff,
+  // which exempts a completed:true-only annotation. So railed tickets DO auto-complete.
+  const { root, git, integrationBranch } = makeRepo({ id: 'T1', title: 'railed', rails: ['test/contract.test.mjs'], scope: ['src/**'] });
+  try {
+    const res = completeTicketOnIntegration({ repo: root, ticketId: 'T1', integrationBranch, git });
+    assert.equal(res.completed, true, 'a railed ticket is not silently left open');
+    assert.equal(isCompleted(root, 'T1'), true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('the completion commit is CI-shaped — completed:true-only shard + append-only manifest (rails-guard-ci)', () => {
   const { root, git, integrationBranch } = makeRepo();
   try {

--- a/packages/fleet/test/exit-code.test.mjs
+++ b/packages/fleet/test/exit-code.test.mjs
@@ -1,0 +1,30 @@
+// The process exit code derived from a run summary. A QUARANTINED run must fail even
+// when no ticket reached a terminal failed/blocked state — the crash-resume case where
+// quarantine was persisted but the affected ticket is still 'merging'.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runExitCode } from '../lib/run.mjs';
+
+test('a clean run (all merged) exits 0', () => {
+  assert.equal(runExitCode({ results: { T1: 'merged', T2: 'merged' }, contaminated: false }), 0);
+});
+
+test('a failed or blocked ticket exits 2', () => {
+  assert.equal(runExitCode({ results: { T1: 'merged', T2: 'failed' } }), 2);
+  assert.equal(runExitCode({ results: { T1: 'blocked' } }), 2);
+});
+
+test('a QUARANTINED run exits 2 even with only NONTERMINAL ticket states', () => {
+  // The crash-resume gap: quarantine persisted, then the process died before the
+  // ticket left 'merging'. Keying only on failed/blocked would report success.
+  assert.equal(
+    runExitCode({ results: { T1: 'merging' }, contaminated: true, contaminationReason: 'ungated merge on the branch' }),
+    2,
+    'a quarantined-no-work run is never a success',
+  );
+});
+
+test('a QUARANTINED run exits 2 even if every ticket looks merged', () => {
+  assert.equal(runExitCode({ results: { T1: 'merged' }, contaminated: true }), 2);
+});

--- a/packages/fleet/test/exit-code.test.mjs
+++ b/packages/fleet/test/exit-code.test.mjs
@@ -28,3 +28,15 @@ test('a QUARANTINED run exits 2 even with only NONTERMINAL ticket states', () =>
 test('a QUARANTINED run exits 2 even if every ticket looks merged', () => {
   assert.equal(runExitCode({ results: { T1: 'merged' }, contaminated: true }), 2);
 });
+
+test('a run whose PR FAILED to open exits 2 even though every ticket merged', () => {
+  // The merged work was never published (gh unavailable, push or gh pr create failed).
+  // Exiting 0 would let automation mark the operation complete with nothing on a PR.
+  assert.equal(
+    runExitCode({ results: { T1: 'merged', T2: 'merged' }, contaminated: false, prOpenFailed: true }),
+    2,
+    'merged-but-unpublished is not a success',
+  );
+  // A successfully opened PR (or no PR attempt) stays 0.
+  assert.equal(runExitCode({ results: { T1: 'merged' }, contaminated: false, prOpenFailed: false }), 0);
+});

--- a/packages/fleet/test/exit-code.test.mjs
+++ b/packages/fleet/test/exit-code.test.mjs
@@ -4,7 +4,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { runExitCode } from '../lib/run.mjs';
+import { runExitCode, failedBlockedCount } from '../lib/run.mjs';
+
+test('failedBlockedCount counts ONLY failed/blocked states (shared by exit code + CLI summary)', () => {
+  assert.equal(failedBlockedCount({ A: 'merged', B: 'failed', C: 'blocked', D: 'merging' }), 2);
+  assert.equal(failedBlockedCount({ A: 'merged', B: 'merged' }), 0);
+  assert.equal(failedBlockedCount({}), 0);
+  assert.equal(failedBlockedCount(undefined), 0);
+});
 
 test('a clean run (all merged) exits 0', () => {
   assert.equal(runExitCode({ results: { T1: 'merged', T2: 'merged' }, contaminated: false }), 0);

--- a/packages/fleet/test/fleet-entry.test.mjs
+++ b/packages/fleet/test/fleet-entry.test.mjs
@@ -1,0 +1,24 @@
+// The fleet bin dispatches its CLI ONLY when run as the entry point, so importing it (e.g.
+// run-live.test.mjs importing runLive) does not parse argv or exit.
+//
+// This file deliberately does NOT import ../bin/fleet.mjs: under an inverted guard the import
+// itself would dispatch (and process.exit), which would let this test's worker exit cleanly
+// before ever asserting. Driving the bin as a SUBPROCESS is the only way to observe the guard
+// from the direct-execution side.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const BIN = join(dirname(fileURLToPath(import.meta.url)), '..', 'bin', 'fleet.mjs');
+
+test('running fleet.mjs directly DISPATCHES the CLI (--help prints usage)', () => {
+  // Original guard (import.meta.url === argv[1]): fleet IS the entry → runCli → usage printed.
+  // Inverted guard: fleet is the entry → guard false → runCli NOT called → no usage. So this
+  // pins the entry-point dispatch that an import-based test cannot.
+  const r = spawnSync(process.execPath, [BIN, '--help'], { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /fleet — parallel ADLC ticket orchestration/, 'the entry-point guard dispatches when run directly');
+});

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -1,0 +1,89 @@
+// The integration branch lives in its OWN worktree, never in the shared main checkout.
+//
+// This is the structural close-out for a whole class of defects: every integration step
+// used to `git checkout <integrationBranch>` in the shared repo and then act on ambient
+// HEAD, so an external process could move it mid-operation and merges, gates,
+// completions and withdrawals could all be attributed to the wrong branch. Detection
+// could only ever narrow that window. A dedicated worktree removes it: git REFUSES to
+// check out a branch that is already checked out elsewhere, so the collision cannot
+// occur in the first place.
+//
+// Driven against REAL git — a stub cannot demonstrate git's own refusal.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { ensureIntegrationWorktree, INTEGRATION_WORKTREE, defaultGit } from '../lib/worktrees.mjs';
+
+function makeRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'fleet-integ-wt-'));
+  const git = (...args) =>
+    execFileSync('git', ['-c', 'commit.gpgsign=false', '-c', 'user.email=f@t', '-c', 'user.name=f', ...args], {
+      cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  git('init', '-b', 'main');
+  git('commit', '--allow-empty', '-q', '-m', 'root');
+  return { root, git, baseSha: git('rev-parse', 'HEAD') };
+}
+
+test('the integration branch is checked out in its own worktree, not the main checkout', () => {
+  const { root, git, baseSha } = makeRepo();
+  try {
+    const { path, created } = ensureIntegrationWorktree(root, 'fleet/run-x', { baseSha, git });
+
+    assert.equal(created, true);
+    assert.equal(path, join(root, INTEGRATION_WORKTREE));
+    assert.ok(existsSync(path), 'the worktree exists on disk');
+    assert.equal(defaultGit(path)('symbolic-ref', '--short', 'HEAD'), 'fleet/run-x', 'and has the integration branch checked out');
+    // The shared checkout is untouched.
+    assert.equal(git('symbolic-ref', '--short', 'HEAD'), 'main', 'the main checkout stays on its own branch');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('git REFUSES to check out the integration branch in the shared checkout — the race becomes impossible', () => {
+  const { root, git, baseSha } = makeRepo();
+  try {
+    ensureIntegrationWorktree(root, 'fleet/run-x', { baseSha, git });
+
+    // This is the exact hostile action the previous design could not defend against:
+    // an external process switching the shared checkout onto the integration branch
+    // mid-run. Git itself now rejects it.
+    assert.throws(
+      () => git('checkout', 'fleet/run-x'),
+      /already (used by|checked out)/i,
+      'the shared checkout cannot take the integration branch while the worktree holds it',
+    );
+    assert.equal(git('symbolic-ref', '--short', 'HEAD'), 'main', 'so the main checkout never moved');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a second call reuses the existing worktree (resume) instead of recreating it', () => {
+  const { root, git, baseSha } = makeRepo();
+  try {
+    const first = ensureIntegrationWorktree(root, 'fleet/run-x', { baseSha, git });
+    // Resume: no baseSha — attach to the branch that already exists.
+    const again = ensureIntegrationWorktree(root, 'fleet/run-x', { git });
+
+    assert.equal(again.created, false, 'the live worktree is reused, not rebuilt');
+    assert.equal(again.path, first.path);
+    assert.equal(defaultGit(again.path)('symbolic-ref', '--short', 'HEAD'), 'fleet/run-x');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a stale worktree directory is rebuilt rather than inherited', () => {
+  const { root, git, baseSha } = makeRepo();
+  try {
+    ensureIntegrationWorktree(root, 'fleet/run-x', { baseSha, git });
+    // Simulate a prior run's leftovers: the worktree is gone from disk but git may
+    // still have it registered.
+    rmSync(join(root, INTEGRATION_WORKTREE), { recursive: true, force: true });
+
+    const rebuilt = ensureIntegrationWorktree(root, 'fleet/run-y', { baseSha, git });
+
+    assert.equal(rebuilt.created, true, 'it rebuilds rather than trusting a stale directory');
+    assert.equal(defaultGit(rebuilt.path)('symbolic-ref', '--short', 'HEAD'), 'fleet/run-y');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -12,7 +12,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -120,6 +120,34 @@ test('RESUME re-attaches a missing integration worktree before any work is dispa
     assert.equal(defaultGit(join(root, INTEGRATION_WORKTREE))('symbolic-ref', '--short', 'HEAD'), 'fleet/run-r');
     assert.equal(git('rev-parse', 'fleet/run-r'), priorSha, 'and the branch history is preserved, not reset to base');
     assert.equal(order[0], 'ensure', 'the re-attach happens BEFORE any ticket work is set up');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('RESUME resets a DIRTY integration worktree — orphaned completion artifacts never survive', () => {
+  // A crash after planComplete wrote the shard + manifest but before the completion
+  // commit leaves the worktree dirty. Resume must NOT reuse that as-is: a later
+  // completion would stage and commit the orphan alongside its own (false attestation).
+  const { root, git, baseSha } = makeRepo();
+  try {
+    const { path } = ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
+    const wtGit = defaultGit(path);
+    const headBefore = wtGit('rev-parse', 'HEAD');
+
+    // Simulate the crash orphan: an uncommitted tracked change AND an untracked file
+    // in the integration worktree.
+    writeFileSync(join(path, 'orphan-shard.json'), '{"completed":true}\n');
+    wtGit('add', 'orphan-shard.json');
+    writeFileSync(join(path, 'untracked-manifest-append.txt'), 'orphan\n');
+    assert.notEqual(wtGit('status', '--porcelain').trim(), '', 'precondition: worktree is dirty');
+
+    // Resume (no baseSha — attach to the existing branch).
+    const again = ensureIntegrationWorktree(root, 'fleet/run-r', { git });
+
+    assert.equal(again.created, false, 'the worktree is reused, not rebuilt');
+    assert.equal(wtGit('status', '--porcelain').trim(), '', 'but reset CLEAN before reuse — no orphan survives');
+    assert.equal(wtGit('rev-parse', 'HEAD'), headBefore, 'the committed history is preserved');
+    assert.ok(!existsSync(join(path, 'orphan-shard.json')), 'the staged orphan is gone');
+    assert.ok(!existsSync(join(path, 'untracked-manifest-append.txt')), 'the untracked orphan is gone');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -12,7 +12,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -123,31 +123,52 @@ test('RESUME re-attaches a missing integration worktree before any work is dispa
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('RESUME resets a DIRTY integration worktree — orphaned completion artifacts never survive', () => {
-  // A crash after planComplete wrote the shard + manifest but before the completion
-  // commit leaves the worktree dirty. Resume must NOT reuse that as-is: a later
-  // completion would stage and commit the orphan alongside its own (false attestation).
-  const { root, git, baseSha } = makeRepo();
+test('RESUME reverts orphaned completion artifacts but PRESERVES unrelated work in the shared worktree', () => {
+  // Two truths must hold at once on resume of a dirty integration worktree:
+  //  (1) A crash after planComplete wrote the shard + manifest but before the completion
+  //      commit leaves those COMPLETION-OWNED paths dirty. Reusing them as-is would let a
+  //      later completion stage and commit the orphan alongside its own (false attestation),
+  //      so the orphan MUST be reverted.
+  //  (2) The integration worktree is a shared checkout a human may be using to investigate
+  //      a quarantined run — untracked diagnostics, an in-progress recovery edit. A
+  //      repo-wide `reset --hard`/`clean -fd` would destroy that. So cleanup MUST be scoped
+  //      to the completion-owned paths and leave everything else untouched.
+  const { root, git } = makeRepo();
   try {
+    // Seed HEAD with the completion-owned files (so there is a clean state to revert to)
+    // plus an unrelated tracked file.
+    mkdirSync(join(root, '.adlc', 'tickets'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'tickets', 'T1--abc.json'), '{"id":"T1","completed":false}\n');
+    writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
+    writeFileSync(join(root, 'README.md'), 'project\n');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'seed store + ledger + readme');
+    const baseSha = git('rev-parse', 'HEAD');
+
     const { path } = ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
     const wtGit = defaultGit(path);
     const headBefore = wtGit('rev-parse', 'HEAD');
 
-    // Simulate the crash orphan: an uncommitted tracked change AND an untracked file
-    // in the integration worktree.
-    writeFileSync(join(path, 'orphan-shard.json'), '{"completed":true}\n');
-    wtGit('add', 'orphan-shard.json');
-    writeFileSync(join(path, 'untracked-manifest-append.txt'), 'orphan\n');
+    // (1) Crash orphan in COMPLETION-OWNED paths: a modified shard + an appended manifest.
+    writeFileSync(join(path, '.adlc', 'tickets', 'T1--abc.json'), '{"id":"T1","completed":true}\n');
+    writeFileSync(join(path, '.adlc', 'manifest.jsonl'), '{"seq":1}\n{"seq":2,"orphan":true}\n');
+    // (2) Unrelated work a human left: a tracked edit OUTSIDE the owned paths, plus an
+    //     untracked diagnostic. Neither is a completion orphan; both must survive.
+    writeFileSync(join(path, 'README.md'), 'HUMAN RECOVERY EDIT\n');
+    writeFileSync(join(path, 'diagnostic.txt'), 'why did the run wedge?\n');
     assert.notEqual(wtGit('status', '--porcelain').trim(), '', 'precondition: worktree is dirty');
 
     // Resume (no baseSha — attach to the existing branch).
     const again = ensureIntegrationWorktree(root, 'fleet/run-r', { git });
 
     assert.equal(again.created, false, 'the worktree is reused, not rebuilt');
-    assert.equal(wtGit('status', '--porcelain').trim(), '', 'but reset CLEAN before reuse — no orphan survives');
+    // The orphan is reverted...
+    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T1--abc.json'), 'utf8'), '{"id":"T1","completed":false}\n', 'the orphaned shard is reverted to HEAD');
+    assert.equal(readFileSync(join(path, '.adlc', 'manifest.jsonl'), 'utf8'), '{"seq":1}\n', 'the orphaned manifest append is reverted to HEAD');
+    // ...but unrelated work is untouched.
+    assert.equal(readFileSync(join(path, 'README.md'), 'utf8'), 'HUMAN RECOVERY EDIT\n', 'an unrelated tracked edit is PRESERVED — not a completion orphan');
+    assert.ok(existsSync(join(path, 'diagnostic.txt')), 'an untracked diagnostic file is PRESERVED');
     assert.equal(wtGit('rev-parse', 'HEAD'), headBefore, 'the committed history is preserved');
-    assert.ok(!existsSync(join(path, 'orphan-shard.json')), 'the staged orphan is gone');
-    assert.ok(!existsSync(join(path, 'untracked-manifest-append.txt')), 'the untracked orphan is gone');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -185,6 +185,29 @@ test('a NEW run REFUSES to force-remove a DIRTY integration worktree left on ano
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('a NEW run REFUSES to force-remove an integration worktree whose git state is UNREADABLE', () => {
+  // The path exists but its git metadata cannot be read (damaged .git, a permissions change,
+  // an interrupted git op), so the branch/status probe throws. That is precisely the state
+  // where we cannot prove the worktree is empty of uncommitted work — force-removing it would
+  // destroy recovery edits we simply could not read (adversarial-review round-29, high/0.88).
+  // Fail closed: refuse, do not force-remove.
+  const { root, git, baseSha } = makeRepo();
+  try {
+    const { path } = ensureIntegrationWorktree(root, 'fleet/run-1', { baseSha, git });
+    writeFileSync(join(path, 'unreadable-recovery.txt'), 'precious and unreadable\n');
+
+    // Simulate unreadable git metadata: every git command in the worktree throws.
+    const throwingGitAt = () => () => { throw new Error('fatal: not a git repository (damaged .git)'); };
+
+    assert.throws(
+      () => ensureIntegrationWorktree(root, 'fleet/run-2', { baseSha, git, gitAt: throwingGitAt }),
+      /could not be read|manual recovery required/i,
+      'an existing-but-unreadable worktree is refused, not force-removed',
+    );
+    assert.ok(existsSync(join(path, 'unreadable-recovery.txt')), 'uncommitted recovery work survives — the unreadable worktree was not force-deleted');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('a stale worktree directory is rebuilt rather than inherited', () => {
   const { root, git, baseSha } = makeRepo();
   try {

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -123,82 +123,65 @@ test('RESUME re-attaches a missing integration worktree before any work is dispa
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('RESUME reverts ONLY the orphaned manifest append — shards and unrelated work survive', () => {
-  // The contamination vector is narrow: a completion commits path-scoped
-  // (`git commit -- <its-shard> .adlc/manifest.jsonl`), so the ONLY completion-owned file
-  // a LATER ticket's commit can accidentally capture is the shared manifest ledger. A
-  // per-ticket shard is private to its own completion's pathspec, so an orphan shard can
-  // never ride onto another ticket's commit. Therefore resume must revert exactly the
-  // orphaned manifest append and leave everything else — including a SECOND ticket's shard
-  // an operator was mid-edit — untouched. Reverting the whole shard directory (the earlier
-  // over-broad fix) would silently destroy that operator's unrelated work.
+test('RESUME REFUSES a DIRTY integration worktree instead of auto-cleaning — nothing is destroyed', () => {
+  // A crash between a completion's manifest append and its commit leaves the worktree dirty
+  // with an orphaned completion. But a human investigating a wedged run leaves dirty state
+  // too — recovery edits, diagnostics. The two are NOT distinguishable by any shape heuristic,
+  // so the fleet does not guess: it refuses to reuse a dirty worktree and destroys nothing.
+  // (This is the fail-closed guarantee: a dirty worktree is never reused, so an orphaned
+  // completion can never be swept into a later ticket's commit — without ever auto-reverting
+  // or deleting a file that might be real evidence.)
   const { root, git } = makeRepo();
   try {
-    // Seed HEAD: two committed shards, the ledger, and an unrelated tracked file.
     mkdirSync(join(root, '.adlc', 'tickets'), { recursive: true });
     writeFileSync(join(root, '.adlc', 'tickets', 'T1--aaa.json'), '{"id":"T1","completed":false}\n');
-    writeFileSync(join(root, '.adlc', 'tickets', 'T2--bbb.json'), '{"id":"T2","completed":false}\n');
     writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
-    writeFileSync(join(root, 'README.md'), 'project\n');
     git('add', '-A');
-    git('commit', '-q', '-m', 'seed two shards + ledger + readme');
+    git('commit', '-q', '-m', 'seed shard + ledger');
     const baseSha = git('rev-parse', 'HEAD');
 
     const { path } = ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
     const wtGit = defaultGit(path);
     const headBefore = wtGit('rev-parse', 'HEAD');
 
-    // The crash orphan: T1's completion wrote its shard AND appended to the shared ledger.
-    writeFileSync(join(path, '.adlc', 'tickets', 'T1--aaa.json'), '{"id":"T1","completed":true}\n');
+    // Dirty the worktree: an orphaned manifest append, a shard edit, and an untracked file.
     writeFileSync(join(path, '.adlc', 'manifest.jsonl'), '{"seq":1}\n{"seq":2,"orphan":true}\n');
-    // Unrelated in-flight work in the SHARED worktree: an operator's edit to a DIFFERENT
-    // ticket's shard, an unrelated tracked file edit, and an untracked diagnostic. None of
-    // these is a completion orphan; all must survive resume.
-    writeFileSync(join(path, '.adlc', 'tickets', 'T2--bbb.json'), '{"id":"T2","completed":false,"operatorNote":"under review"}\n');
-    writeFileSync(join(path, 'README.md'), 'HUMAN RECOVERY EDIT\n');
-    writeFileSync(join(path, 'diagnostic.txt'), 'why did the run wedge?\n');
+    writeFileSync(join(path, '.adlc', 'tickets', 'T1--aaa.json'), '{"id":"T1","completed":true}\n');
+    writeFileSync(join(path, 'recovery-notes.txt'), 'operator was here\n');
 
-    // Resume (no baseSha — attach to the existing branch).
-    const again = ensureIntegrationWorktree(root, 'fleet/run-r', { git });
-
-    assert.equal(again.created, false, 'the worktree is reused, not rebuilt');
-    // The one contamination vector is reverted...
-    assert.equal(readFileSync(join(path, '.adlc', 'manifest.jsonl'), 'utf8'), '{"seq":1}\n', 'the orphaned manifest append is reverted to HEAD');
-    // ...and NOTHING else is touched — not the orphan's own shard, and crucially not the
-    // operator's unrelated second shard.
-    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T1--aaa.json'), 'utf8'), '{"id":"T1","completed":true}\n', "the orphan's own shard is left alone (never captured by another commit)");
-    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T2--bbb.json'), 'utf8'), '{"id":"T2","completed":false,"operatorNote":"under review"}\n', "the operator's UNRELATED second shard is PRESERVED — no directory-level overreach");
-    assert.equal(readFileSync(join(path, 'README.md'), 'utf8'), 'HUMAN RECOVERY EDIT\n', 'an unrelated tracked edit is PRESERVED');
-    assert.ok(existsSync(join(path, 'diagnostic.txt')), 'an untracked diagnostic file is PRESERVED');
+    // Resume (no baseSha — attach to the existing branch) MUST refuse, not auto-clean.
+    assert.throws(
+      () => ensureIntegrationWorktree(root, 'fleet/run-r', { git }),
+      /uncommitted changes|manual recovery required/i,
+      'a dirty integration worktree is refused on resume, not silently reconciled',
+    );
+    // Every dirty artifact is left EXACTLY as found — nothing reverted, nothing deleted.
+    assert.equal(readFileSync(join(path, '.adlc', 'manifest.jsonl'), 'utf8'), '{"seq":1}\n{"seq":2,"orphan":true}\n', 'the ledger is untouched (not auto-reverted)');
+    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T1--aaa.json'), 'utf8'), '{"id":"T1","completed":true}\n', 'the shard is untouched');
+    assert.ok(existsSync(join(path, 'recovery-notes.txt')), 'untracked recovery work is preserved');
     assert.equal(wtGit('rev-parse', 'HEAD'), headBefore, 'the committed history is preserved');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('RESUME REFUSES (does not destroy) when the manifest diverged in a non-append shape', () => {
-  // If the ledger is dirty in any way OTHER than a pure append, we cannot prove it is a
-  // disposable crash orphan — a rewritten or truncated line could be real evidence. Fail
-  // closed: throw to abort the resume, and critically do NOT fall through to recreate the
-  // worktree (which would --force-remove it and destroy the state a human needs).
-  const { root, git } = makeRepo();
+test('a NEW run REFUSES to force-remove a DIRTY integration worktree left on another run\'s branch', () => {
+  // The integration worktree survives across runs. A later run wants the path for its OWN
+  // integration branch, so the fixed path is on the wrong branch and the reuse guard does not
+  // apply. The old code fell straight through to `git worktree remove --force`, destroying any
+  // uncommitted work in it WITHOUT checking (adversarial-review round-28, high/0.98). The
+  // recreate path must therefore also refuse a dirty worktree rather than force-remove it.
+  const { root, git, baseSha } = makeRepo();
   try {
-    mkdirSync(join(root, '.adlc', 'tickets'), { recursive: true });
-    writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n{"seq":2}\n');
-    git('add', '-A');
-    git('commit', '-q', '-m', 'seed ledger with two entries');
-    const baseSha = git('rev-parse', 'HEAD');
+    const { path } = ensureIntegrationWorktree(root, 'fleet/run-1', { baseSha, git });
+    // A human left uncommitted recovery work in run-1's integration worktree.
+    writeFileSync(join(path, 'run-1-recovery.txt'), 'do not delete me\n');
 
-    const { path } = ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
-    // Rewrite an EXISTING committed line (not an append): committed line 1 is mutated.
-    writeFileSync(join(path, '.adlc', 'manifest.jsonl'), '{"seq":1,"TAMPERED":true}\n{"seq":2}\n');
-
+    // A NEW run (different integration branch) must NOT force-remove that dirty worktree.
     assert.throws(
-      () => ensureIntegrationWorktree(root, 'fleet/run-r', { git }),
-      /non-append shape|refusing to reuse/i,
-      'a non-append ledger divergence refuses rather than silently reverting',
+      () => ensureIntegrationWorktree(root, 'fleet/run-2', { baseSha, git }),
+      /uncommitted changes|manual recovery required/i,
+      'a dirty worktree on another branch is refused, not force-removed',
     );
-    // The worktree and its dirty state survive for manual recovery — NOT force-removed.
-    assert.ok(existsSync(join(path, '.adlc', 'manifest.jsonl')), 'the worktree is not destroyed by the refusal');
-    assert.equal(readFileSync(join(path, '.adlc', 'manifest.jsonl'), 'utf8'), '{"seq":1,"TAMPERED":true}\n{"seq":2}\n', 'the dirty state is left intact for a human to inspect');
+    assert.ok(existsSync(join(path, 'run-1-recovery.txt')), 'the prior run\'s uncommitted work survives — not force-deleted');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -123,52 +123,82 @@ test('RESUME re-attaches a missing integration worktree before any work is dispa
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('RESUME reverts orphaned completion artifacts but PRESERVES unrelated work in the shared worktree', () => {
-  // Two truths must hold at once on resume of a dirty integration worktree:
-  //  (1) A crash after planComplete wrote the shard + manifest but before the completion
-  //      commit leaves those COMPLETION-OWNED paths dirty. Reusing them as-is would let a
-  //      later completion stage and commit the orphan alongside its own (false attestation),
-  //      so the orphan MUST be reverted.
-  //  (2) The integration worktree is a shared checkout a human may be using to investigate
-  //      a quarantined run — untracked diagnostics, an in-progress recovery edit. A
-  //      repo-wide `reset --hard`/`clean -fd` would destroy that. So cleanup MUST be scoped
-  //      to the completion-owned paths and leave everything else untouched.
+test('RESUME reverts ONLY the orphaned manifest append — shards and unrelated work survive', () => {
+  // The contamination vector is narrow: a completion commits path-scoped
+  // (`git commit -- <its-shard> .adlc/manifest.jsonl`), so the ONLY completion-owned file
+  // a LATER ticket's commit can accidentally capture is the shared manifest ledger. A
+  // per-ticket shard is private to its own completion's pathspec, so an orphan shard can
+  // never ride onto another ticket's commit. Therefore resume must revert exactly the
+  // orphaned manifest append and leave everything else — including a SECOND ticket's shard
+  // an operator was mid-edit — untouched. Reverting the whole shard directory (the earlier
+  // over-broad fix) would silently destroy that operator's unrelated work.
   const { root, git } = makeRepo();
   try {
-    // Seed HEAD with the completion-owned files (so there is a clean state to revert to)
-    // plus an unrelated tracked file.
+    // Seed HEAD: two committed shards, the ledger, and an unrelated tracked file.
     mkdirSync(join(root, '.adlc', 'tickets'), { recursive: true });
-    writeFileSync(join(root, '.adlc', 'tickets', 'T1--abc.json'), '{"id":"T1","completed":false}\n');
+    writeFileSync(join(root, '.adlc', 'tickets', 'T1--aaa.json'), '{"id":"T1","completed":false}\n');
+    writeFileSync(join(root, '.adlc', 'tickets', 'T2--bbb.json'), '{"id":"T2","completed":false}\n');
     writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
     writeFileSync(join(root, 'README.md'), 'project\n');
     git('add', '-A');
-    git('commit', '-q', '-m', 'seed store + ledger + readme');
+    git('commit', '-q', '-m', 'seed two shards + ledger + readme');
     const baseSha = git('rev-parse', 'HEAD');
 
     const { path } = ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
     const wtGit = defaultGit(path);
     const headBefore = wtGit('rev-parse', 'HEAD');
 
-    // (1) Crash orphan in COMPLETION-OWNED paths: a modified shard + an appended manifest.
-    writeFileSync(join(path, '.adlc', 'tickets', 'T1--abc.json'), '{"id":"T1","completed":true}\n');
+    // The crash orphan: T1's completion wrote its shard AND appended to the shared ledger.
+    writeFileSync(join(path, '.adlc', 'tickets', 'T1--aaa.json'), '{"id":"T1","completed":true}\n');
     writeFileSync(join(path, '.adlc', 'manifest.jsonl'), '{"seq":1}\n{"seq":2,"orphan":true}\n');
-    // (2) Unrelated work a human left: a tracked edit OUTSIDE the owned paths, plus an
-    //     untracked diagnostic. Neither is a completion orphan; both must survive.
+    // Unrelated in-flight work in the SHARED worktree: an operator's edit to a DIFFERENT
+    // ticket's shard, an unrelated tracked file edit, and an untracked diagnostic. None of
+    // these is a completion orphan; all must survive resume.
+    writeFileSync(join(path, '.adlc', 'tickets', 'T2--bbb.json'), '{"id":"T2","completed":false,"operatorNote":"under review"}\n');
     writeFileSync(join(path, 'README.md'), 'HUMAN RECOVERY EDIT\n');
     writeFileSync(join(path, 'diagnostic.txt'), 'why did the run wedge?\n');
-    assert.notEqual(wtGit('status', '--porcelain').trim(), '', 'precondition: worktree is dirty');
 
     // Resume (no baseSha — attach to the existing branch).
     const again = ensureIntegrationWorktree(root, 'fleet/run-r', { git });
 
     assert.equal(again.created, false, 'the worktree is reused, not rebuilt');
-    // The orphan is reverted...
-    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T1--abc.json'), 'utf8'), '{"id":"T1","completed":false}\n', 'the orphaned shard is reverted to HEAD');
+    // The one contamination vector is reverted...
     assert.equal(readFileSync(join(path, '.adlc', 'manifest.jsonl'), 'utf8'), '{"seq":1}\n', 'the orphaned manifest append is reverted to HEAD');
-    // ...but unrelated work is untouched.
-    assert.equal(readFileSync(join(path, 'README.md'), 'utf8'), 'HUMAN RECOVERY EDIT\n', 'an unrelated tracked edit is PRESERVED — not a completion orphan');
+    // ...and NOTHING else is touched — not the orphan's own shard, and crucially not the
+    // operator's unrelated second shard.
+    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T1--aaa.json'), 'utf8'), '{"id":"T1","completed":true}\n', "the orphan's own shard is left alone (never captured by another commit)");
+    assert.equal(readFileSync(join(path, '.adlc', 'tickets', 'T2--bbb.json'), 'utf8'), '{"id":"T2","completed":false,"operatorNote":"under review"}\n', "the operator's UNRELATED second shard is PRESERVED — no directory-level overreach");
+    assert.equal(readFileSync(join(path, 'README.md'), 'utf8'), 'HUMAN RECOVERY EDIT\n', 'an unrelated tracked edit is PRESERVED');
     assert.ok(existsSync(join(path, 'diagnostic.txt')), 'an untracked diagnostic file is PRESERVED');
     assert.equal(wtGit('rev-parse', 'HEAD'), headBefore, 'the committed history is preserved');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('RESUME REFUSES (does not destroy) when the manifest diverged in a non-append shape', () => {
+  // If the ledger is dirty in any way OTHER than a pure append, we cannot prove it is a
+  // disposable crash orphan — a rewritten or truncated line could be real evidence. Fail
+  // closed: throw to abort the resume, and critically do NOT fall through to recreate the
+  // worktree (which would --force-remove it and destroy the state a human needs).
+  const { root, git } = makeRepo();
+  try {
+    mkdirSync(join(root, '.adlc', 'tickets'), { recursive: true });
+    writeFileSync(join(root, '.adlc', 'manifest.jsonl'), '{"seq":1}\n{"seq":2}\n');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'seed ledger with two entries');
+    const baseSha = git('rev-parse', 'HEAD');
+
+    const { path } = ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
+    // Rewrite an EXISTING committed line (not an append): committed line 1 is mutated.
+    writeFileSync(join(path, '.adlc', 'manifest.jsonl'), '{"seq":1,"TAMPERED":true}\n{"seq":2}\n');
+
+    assert.throws(
+      () => ensureIntegrationWorktree(root, 'fleet/run-r', { git }),
+      /non-append shape|refusing to reuse/i,
+      'a non-append ledger divergence refuses rather than silently reverting',
+    );
+    // The worktree and its dirty state survive for manual recovery — NOT force-removed.
+    assert.ok(existsSync(join(path, '.adlc', 'manifest.jsonl')), 'the worktree is not destroyed by the refusal');
+    assert.equal(readFileSync(join(path, '.adlc', 'manifest.jsonl'), 'utf8'), '{"seq":1,"TAMPERED":true}\n{"seq":2}\n', 'the dirty state is left intact for a human to inspect');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/integration-worktree.test.mjs
+++ b/packages/fleet/test/integration-worktree.test.mjs
@@ -17,6 +17,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { ensureIntegrationWorktree, INTEGRATION_WORKTREE, defaultGit } from '../lib/worktrees.mjs';
+import { runFleet } from '../lib/run.mjs';
+import { resolveRunConfig } from '../lib/config.mjs';
 
 function makeRepo() {
   const root = mkdtempSync(join(tmpdir(), 'fleet-integ-wt-'));
@@ -70,6 +72,54 @@ test('a second call reuses the existing worktree (resume) instead of recreating 
     assert.equal(again.created, false, 'the live worktree is reused, not rebuilt');
     assert.equal(again.path, first.path);
     assert.equal(defaultGit(again.path)('symbolic-ref', '--short', 'HEAD'), 'fleet/run-x');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('RESUME re-attaches a missing integration worktree before any work is dispatched', async () => {
+  // A resumed run continues an existing integration branch, but its worktree may have
+  // been removed by cleanup or a crash — and every integration step now needs it. The
+  // re-attach must happen BEFORE dispatch, or the run burns worker time on tickets that
+  // cannot possibly merge.
+  const { root, git, baseSha } = makeRepo();
+  try {
+    ensureIntegrationWorktree(root, 'fleet/run-r', { baseSha, git });
+    const priorSha = defaultGit(join(root, INTEGRATION_WORKTREE))('rev-parse', 'HEAD');
+    // The worktree vanishes; the BRANCH survives (this is what resume must cope with).
+    rmSync(join(root, INTEGRATION_WORKTREE), { recursive: true, force: true });
+    git('worktree', 'prune');
+    assert.ok(!existsSync(join(root, INTEGRATION_WORKTREE)), 'precondition: worktree gone');
+    assert.equal(git('rev-parse', 'fleet/run-r'), priorSha, 'precondition: branch survives');
+
+    const order = [];
+    const deps = {
+      baseSha: 'BASE',
+      ensureIntegrationWorktree: ({ integrationBranch }) => {
+        order.push('ensure');
+        return ensureIntegrationWorktree(root, integrationBranch, { git });
+      },
+      createWorktree: ({ ticket }) => { order.push('dispatch-setup'); return { path: `/wt/${ticket.id}`, branch: `fleet/${ticket.id.toLowerCase()}`, startSha: 'tip' }; },
+      dispatch: () => ({ exitCode: 0, output: 'TICKET-DONE' }),
+      gate: () => ({ ok: true }),
+      prosecute: () => ({ verdict: 'pass' }),
+      flail: () => ({ flail: false }),
+      mergeToIntegration: () => ({ mergeSha: 'M', preMergeSha: 'P' }),
+      postMergeGate: () => ({ ok: true }),
+      revertMerge: () => ({ method: 'reset', ok: true }),
+      openPR: () => {},
+    };
+    const status = { runId: 'r', base: 'main', baseSha: 'BASE', integrationBranch: 'fleet/run-r', concurrency: 1, tickets: {} };
+    await runFleet({
+      all: [{ id: 'T1', title: 'T1', scope: ['src/T1/**'], edges: [] }],
+      runId: 'r',
+      config: { ...resolveRunConfig({}, {}), baseSha: 'BASE' },
+      deps,
+      resume: { status, integrationBranch: 'fleet/run-r' },
+    });
+
+    assert.ok(existsSync(join(root, INTEGRATION_WORKTREE)), 'the worktree is restored on resume');
+    assert.equal(defaultGit(join(root, INTEGRATION_WORKTREE))('symbolic-ref', '--short', 'HEAD'), 'fleet/run-r');
+    assert.equal(git('rev-parse', 'fleet/run-r'), priorSha, 'and the branch history is preserved, not reset to base');
+    assert.equal(order[0], 'ensure', 'the re-attach happens BEFORE any ticket work is set up');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/fleet/test/live-concurrency.test.mjs
+++ b/packages/fleet/test/live-concurrency.test.mjs
@@ -9,19 +9,29 @@ import { runFleet } from '../lib/run.mjs';
 
 const T = (id, scope) => ({ id, title: id, scope, body: 'do', edges: [] });
 
+// Models git's PER-WORKTREE HEAD (see the note in live-deps.test.mjs): each worktree
+// carries its own branch, set by `worktree add -b`, and real git never returns '' from
+// symbolic-ref.
 function fakeGit() {
-  // Track the checked-out branch so `symbolic-ref` answers like real git does. A stub
-  // that returned '' there would make branch-identity checks look broken when they are
-  // in fact correct (AGENTS.md: a mock cannot catch drift in the thing it imitates).
-  let branch = 'main';
-  return () => (...args) => {
+  const headOf = new Map();
+  const branchFor = (dir) => {
+    for (const [p, b] of headOf) if (String(dir).endsWith(p)) return b;
+    return headOf.get(String(dir)) ?? 'main';
+  };
+  return (dir) => (...args) => {
     const verb = args[0];
-    if (verb === 'checkout') {
-      const target = args.slice(1).filter((a) => !String(a).startsWith('-')).pop();
-      if (target) branch = target;
+    if (verb === 'worktree' && args[1] === 'add') {
+      const i = args.indexOf('-b');
+      if (i >= 0) headOf.set(String(args[i + 2]), String(args[i + 1]));
+      else headOf.set(String(args[2]), String(args[3] ?? 'main'));
       return '';
     }
-    if (verb === 'symbolic-ref') return branch;
+    if (verb === 'checkout') {
+      const target = args.slice(1).filter((a) => !String(a).startsWith('-')).pop();
+      if (target) headOf.set(String(dir), String(target));
+      return '';
+    }
+    if (verb === 'symbolic-ref') return branchFor(dir);
     if (verb === 'diff') return ''; // no out-of-scope changes (this test targets concurrency, not the gate)
     if (verb === 'status') return '';
     if (verb === 'show') throw new Error('no template at rev');

--- a/packages/fleet/test/live-concurrency.test.mjs
+++ b/packages/fleet/test/live-concurrency.test.mjs
@@ -10,8 +10,18 @@ import { runFleet } from '../lib/run.mjs';
 const T = (id, scope) => ({ id, title: id, scope, body: 'do', edges: [] });
 
 function fakeGit() {
+  // Track the checked-out branch so `symbolic-ref` answers like real git does. A stub
+  // that returned '' there would make branch-identity checks look broken when they are
+  // in fact correct (AGENTS.md: a mock cannot catch drift in the thing it imitates).
+  let branch = 'main';
   return () => (...args) => {
     const verb = args[0];
+    if (verb === 'checkout') {
+      const target = args.slice(1).filter((a) => !String(a).startsWith('-')).pop();
+      if (target) branch = target;
+      return '';
+    }
+    if (verb === 'symbolic-ref') return branch;
     if (verb === 'diff') return ''; // no out-of-scope changes (this test targets concurrency, not the gate)
     if (verb === 'status') return '';
     if (verb === 'show') throw new Error('no template at rev');

--- a/packages/fleet/test/live-deps.test.mjs
+++ b/packages/fleet/test/live-deps.test.mjs
@@ -175,4 +175,7 @@ test('runFleet driven by live deps advances a ticket build→gate→prosecute→
   // The merge targeted the integration branch via rebase-first.
   assert.ok(rec.git.some((g) => g.args[0] === 'merge'), 'a merge occurred');
   assert.ok(rec.git.some((g) => g.args[0] === 'rebase'), 'rebase-first before merge');
+  // fakeIo.hasGh() is false, so the REAL openPR reports { opened:false } — the run must
+  // not fabricate a PR count from that (round-31).
+  assert.equal(summary.prCount, 0, 'no gh → openPR reports not-opened → prCount stays 0, not fabricated');
 });

--- a/packages/fleet/test/live-deps.test.mjs
+++ b/packages/fleet/test/live-deps.test.mjs
@@ -5,9 +5,19 @@ import { runFleet } from '../lib/run.mjs';
 
 // A permissive fake git: records calls, returns sensible defaults by verb.
 function fakeGit(rec) {
+  // Track the checked-out branch so `symbolic-ref` answers like real git does. Real git
+  // never returns '' there, and a stub that does makes correct branch-identity checks
+  // look broken (AGENTS.md: a mock cannot catch drift in the thing it imitates).
+  let branch = 'main';
   return (dir) => (...args) => {
     rec.git.push({ dir, args });
     const verb = args[0];
+    if (verb === 'checkout') {
+      const target = args.slice(1).filter((a) => !String(a).startsWith('-')).pop();
+      if (target) branch = target;
+      return '';
+    }
+    if (verb === 'symbolic-ref') return branch;
     if (verb === 'diff') return 'packages/fleet/lib/x.mjs'; // in-scope change
     if (verb === 'status') return ''; // no protected-path candidates
     if (verb === 'show') throw new Error('no such path at rev'); // no template

--- a/packages/fleet/test/live-deps.test.mjs
+++ b/packages/fleet/test/live-deps.test.mjs
@@ -4,20 +4,32 @@ import { buildLiveDeps } from '../lib/live-deps.mjs';
 import { runFleet } from '../lib/run.mjs';
 
 // A permissive fake git: records calls, returns sensible defaults by verb.
+// Model git's PER-WORKTREE HEAD. Each worktree has its own checked-out branch, which
+// `worktree add -b <branch> <path>` establishes — there is no `checkout` in the
+// integration flow at all any more. A stub that returned a single global branch (or
+// '', which real git never returns) would make correct branch-identity checks look
+// broken (AGENTS.md: a mock cannot catch drift in the thing it imitates).
 function fakeGit(rec) {
-  // Track the checked-out branch so `symbolic-ref` answers like real git does. Real git
-  // never returns '' there, and a stub that does makes correct branch-identity checks
-  // look broken (AGENTS.md: a mock cannot catch drift in the thing it imitates).
-  let branch = 'main';
+  const headOf = new Map(); // worktree path suffix → its checked-out branch
+  const branchFor = (dir) => {
+    for (const [p, b] of headOf) if (String(dir).endsWith(p)) return b;
+    return headOf.get(String(dir)) ?? 'main';
+  };
   return (dir) => (...args) => {
     rec.git.push({ dir, args });
     const verb = args[0];
-    if (verb === 'checkout') {
-      const target = args.slice(1).filter((a) => !String(a).startsWith('-')).pop();
-      if (target) branch = target;
+    if (verb === 'worktree' && args[1] === 'add') {
+      const i = args.indexOf('-b');
+      if (i >= 0) headOf.set(String(args[i + 2]), String(args[i + 1])); // add -b <branch> <path>
+      else headOf.set(String(args[2]), String(args[3] ?? 'main'));       // add <path> <branch>
       return '';
     }
-    if (verb === 'symbolic-ref') return branch;
+    if (verb === 'checkout') {
+      const target = args.slice(1).filter((a) => !String(a).startsWith('-')).pop();
+      if (target) headOf.set(String(dir), String(target));
+      return '';
+    }
+    if (verb === 'symbolic-ref') return branchFor(dir);
     if (verb === 'diff') return 'packages/fleet/lib/x.mjs'; // in-scope change
     if (verb === 'status') return ''; // no protected-path candidates
     if (verb === 'show') throw new Error('no such path at rev'); // no template

--- a/packages/fleet/test/live-deps.test.mjs
+++ b/packages/fleet/test/live-deps.test.mjs
@@ -165,6 +165,30 @@ test('postMergeGate AWAITS the gate before pinning HEAD — a commit landing DUR
   assert.match(r.output, /HEAD moved/);
 });
 
+test('postMergeGate REFUSES (ok:false) when the integration worktree is not on its branch BEFORE gating', async () => {
+  // The pre-gate assertOnBranch guard: if the integration worktree is not on the run branch
+  // when the gate is about to run, the gate must refuse rather than attribute a build to the
+  // wrong branch. Pins the `ok:false` refusal so a bool-flip to ok:true (a refused gate read
+  // as passing) is caught.
+  const io = {
+    git: () => (...args) => {
+      if (args[0] === 'symbolic-ref') return 'some-other-branch'; // NOT the run branch
+      if (args[0] === 'rev-parse') return 'SHA';
+      return '';
+    },
+    spawnWorker: async () => ({ status: 0, stdout: '', stderr: '' }),
+    mkdirp: () => {}, adlc: () => ({ status: 0, stdout: '' }), adlcAsync: async () => ({ status: 0, stdout: '' }),
+    appendLog: () => {}, readFile: () => undefined, exists: () => false, writeJson: () => {},
+    ensureGitignore: () => {}, hasGh: () => false, env,
+  };
+  const deps = buildLiveDeps({ repo: '/repo', config, statusDir: undefined, sandboxSpec, reviewRunner: () => ({ ok: true, findings: [] }), io });
+
+  const r = await deps.postMergeGate({ integrationBranch: 'fleet/run-z' });
+
+  assert.equal(r.ok, false, 'a wrong-branch worktree must make the gate refuse, not pass');
+  assert.match(r.output, /refusing to gate/);
+});
+
 test('runFleet driven by live deps advances a ticket build→gate→prosecute→merge (AC1)', async () => {
   const rec = newRec();
   const deps = makeDeps(rec);

--- a/packages/fleet/test/live-deps.test.mjs
+++ b/packages/fleet/test/live-deps.test.mjs
@@ -121,6 +121,50 @@ test('prosecute drives the review runner over the ticket startSha (AC1)', async 
   assert.equal(r.verdict, 'pass');
 });
 
+test('postMergeGate AWAITS the gate before pinning HEAD — a commit landing DURING the gate is caught (F4/N2)', async () => {
+  // runGates is async: it runs the build/test commands to completion. The post-gate branch
+  // and SHA assertions exist to reject a verdict whose commit moved WHILE the gate ran. If
+  // postMergeGate reads HEAD without awaiting runGates, those assertions fire BEFORE the
+  // gate's commands ever execute, so the HEAD move is invisible and a stale passing verdict
+  // is trusted (adversarial-review round-30, high/0.99).
+  //
+  // This test moves HEAD asynchronously, from inside the gate's spawn — the flip lands only
+  // after a microtask, i.e. AFTER the point where the un-awaited code already ran its
+  // assertions. So the buggy (sync) version pins the pre-gate SHA and returns ok; only the
+  // awaited version observes the moved HEAD and refuses.
+  let head = 'PRE';
+  const io = {
+    git: () => (...args) => {
+      if (args[0] === 'symbolic-ref') return 'fleet/run-z'; // still on the branch throughout
+      if (args[0] === 'rev-parse') return head;
+      return '';
+    },
+    // The gate's build/test run through here. Simulate an external commit landing mid-gate,
+    // but only AFTER a microtask so it cannot be observed by an assertion that skipped the await.
+    spawnWorker: async () => { await Promise.resolve(); head = 'POST'; return { status: 0, stdout: '', stderr: '' }; },
+    mkdirp: () => {},
+    adlc: () => ({ status: 0, stdout: '' }),
+    adlcAsync: async () => ({ status: 0, stdout: '' }),
+    appendLog: () => {},
+    readFile: () => undefined,
+    exists: () => false,
+    writeJson: () => {},
+    ensureGitignore: () => {},
+    hasGh: () => false,
+    env,
+  };
+  const deps = buildLiveDeps({
+    repo: '/repo', config, statusDir: undefined, sandboxSpec,
+    reviewRunner: () => ({ ok: true, findings: [] }),
+    io,
+  });
+
+  const r = await deps.postMergeGate({ integrationBranch: 'fleet/run-z' });
+
+  assert.equal(r.ok, false, 'a HEAD move DURING the gate must fail the post-merge gate, not pass');
+  assert.match(r.output, /HEAD moved/);
+});
+
 test('runFleet driven by live deps advances a ticket build→gate→prosecute→merge (AC1)', async () => {
   const rec = newRec();
   const deps = makeDeps(rec);

--- a/packages/fleet/test/merge-target.test.mjs
+++ b/packages/fleet/test/merge-target.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { runFleet, integrationBranchName } from '../lib/run.mjs';
+import { runFleet, integrationBranchName, runExitCode } from '../lib/run.mjs';
 import { resolveRunConfig } from '../lib/config.mjs';
 
 const T = (id, opts = {}) => ({ id, title: id, scope: opts.scope ?? [`src/${id}/**`], edges: opts.edges ?? [] });
@@ -70,6 +70,8 @@ test('a REPORTED PR-open failure is not fabricated as success (round-31)', async
   assert.equal(summary.merged, 2, 'precondition: tickets merged, so a PR was attempted');
   assert.equal(rec.prs.length, 1, 'openPR was invoked');
   assert.equal(summary.prCount, 0, 'a reported open-failure is NOT counted as an opened PR');
+  assert.equal(summary.prOpenFailed, true, 'the attempted-but-failed open is recorded');
+  assert.equal(runExitCode(summary), 2, 'merged-but-unpublished exits non-zero so automation is not told it is complete');
 });
 
 test('no PR is opened when nothing merged', async () => {

--- a/packages/fleet/test/merge-target.test.mjs
+++ b/packages/fleet/test/merge-target.test.mjs
@@ -7,7 +7,7 @@ const T = (id, opts = {}) => ({ id, title: id, scope: opts.scope ?? [`src/${id}/
 
 // A deps harness that records every git-ish interaction so we can assert base is
 // never written and merges land on the integration branch.
-function harness({ prosecuteVerdict = () => ({ verdict: 'pass' }), postMerge = () => ({ ok: true }) } = {}) {
+function harness({ prosecuteVerdict = () => ({ verdict: 'pass' }), postMerge = () => ({ ok: true }), openPR } = {}) {
   const rec = { merges: [], worktreeStartShas: [], prosecutedStartShas: [], gatedStartShas: [], prs: [], baseWrites: [] };
   const deps = {
     baseSha: 'BASE',
@@ -28,7 +28,9 @@ function harness({ prosecuteVerdict = () => ({ verdict: 'pass' }), postMerge = (
     },
     postMergeGate: postMerge,
     revertMerge: () => ({ method: 'reset', ok: true }),
-    openPR: ({ integrationBranch, base }) => { rec.prs.push({ integrationBranch, base }); },
+    // The real openPR reports { opened, reason }. Default models a successful open; a test
+    // can override to model gh being unavailable or a push/creation failure.
+    openPR: openPR ?? (({ integrationBranch, base }) => { rec.prs.push({ integrationBranch, base }); return { opened: true }; }),
   };
   return { deps, rec };
 }
@@ -46,13 +48,28 @@ test('merges land on fleet/run-<runId>, base is never written (AC13 i)', async (
   assert.deepEqual(Object.values(summary.results).sort(), ['merged', 'merged']);
 });
 
-test('run end opens at most ONE PR to base (AC13 i)', async () => {
+test('run end opens at most ONE PR to base and counts it only when opened (AC13 i)', async () => {
   const all = [T('T1'), T('T2'), T('T3')];
   const { deps, rec } = harness();
   const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
-  await runFleet({ all, runId: 'abc', config, deps });
+  const summary = await runFleet({ all, runId: 'abc', config, deps });
   assert.equal(rec.prs.length, 1, 'exactly one PR at run end');
   assert.equal(rec.prs[0].base, 'main');
+  assert.equal(summary.prCount, 1, 'the opened PR is counted');
+});
+
+test('a REPORTED PR-open failure is not fabricated as success (round-31)', async () => {
+  // merged > 0, but openPR reports { opened:false } (e.g. gh unavailable, or the push /
+  // gh pr create failed). The run must NOT claim a PR exists — prCount stays 0.
+  const all = [T('T1'), T('T2')];
+  const { deps, rec } = harness({
+    openPR: ({ integrationBranch, base }) => { rec.prs.push({ integrationBranch, base }); return { opened: false, reason: 'gh CLI not available' }; },
+  });
+  const config = { ...resolveRunConfig({}, {}), baseSha: 'BASE' };
+  const summary = await runFleet({ all, runId: 'abc', config, deps });
+  assert.equal(summary.merged, 2, 'precondition: tickets merged, so a PR was attempted');
+  assert.equal(rec.prs.length, 1, 'openPR was invoked');
+  assert.equal(summary.prCount, 0, 'a reported open-failure is NOT counted as an opened PR');
 });
 
 test('no PR is opened when nothing merged', async () => {

--- a/packages/fleet/test/revert-safety.test.mjs
+++ b/packages/fleet/test/revert-safety.test.mjs
@@ -23,13 +23,17 @@ test('resets to pre-merge SHA when integration HEAD is still the merge commit (A
   assert.ok(git.calls.some((c) => c === 'reset --hard PRE'), 'must reset to the recorded pre-merge SHA');
 });
 
-test('does NOT blind-reset when HEAD moved — uses git revert instead (AC9 / F4 / N2)', () => {
+test('HEAD moved: reverts our merge (preserving the intervening commit) but QUARANTINES it (AC9 / F4 / N2)', () => {
   const git = fakeGit({ head: 'SOMEONE_ELSES_COMMIT' });
   const r = revertMerge('/repo', 'fleet/run-1', { mergeSha: 'MERGE', preMergeSha: 'PRE' }, git);
-  assert.equal(r.method, 'revert', 'moved HEAD must take the revert path, not reset');
-  assert.equal(r.ok, true);
+  assert.equal(r.method, 'revert', 'moved HEAD takes the revert path, not a blind reset');
+  // Preserve the intervening commit — do NOT drop unrelated work.
   assert.ok(!git.calls.some((c) => c.startsWith('reset --hard')), 'must NOT reset and drop the moved-in commit');
-  assert.ok(git.calls.some((c) => c === 'revert --no-edit -m 1 MERGE'));
+  assert.ok(git.calls.some((c) => c === 'revert --no-edit -m 1 MERGE'), 'our merge is reverted');
+  // But the intervening commit was never gated, so recovery is NOT clean — the caller
+  // must quarantine, so the ungated commit cannot reach the PR.
+  assert.equal(r.ok, false, 'not clean recovery: an ungated intervening commit remains');
+  assert.match(r.reason, /UNGATED|quarantin/i);
 });
 
 test('refuses (manual recovery) when HEAD moved and revert fails', () => {

--- a/packages/fleet/test/run-live.test.mjs
+++ b/packages/fleet/test/run-live.test.mjs
@@ -1,0 +1,51 @@
+// runLive is the fleet CLI's live-run entry: preflight → resume-reconcile → runFleet →
+// exit code. Its collaborators are injectable purely so this can drive the exit-code path
+// without a real sandbox. The bin guards its top-level dispatch behind an entry-point check,
+// so importing runLive here does NOT parse argv or exit.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runLive } from '../bin/fleet.mjs';
+// NOTE: the entry-point-guard test lives in fleet-entry.test.mjs, NOT here — it must run in a
+// file that does NOT import the bin, since an inverted guard makes the import itself dispatch.
+
+const ARGS = { repo: '/repo', dir: '/repo/.adlc', all: [], config: { base: 'main' }, onlyIds: undefined };
+
+// All collaborators faked; `run` returns the summary under test, preflight passes by default.
+function overrides(summary, { preflightOk = true } = {}) {
+  return {
+    io: { git: () => () => 'SHA' },
+    preflight: async () =>
+      preflightOk
+        ? { ok: true, warnings: [], sandboxSpec: { mode: 'sandbox' } }
+        : { ok: false, warnings: [], reason: 'no sandbox', exitCode: 1 },
+    build: () => ({}),
+    run: async () => summary,
+    loadPrior: () => null,
+    reconcile: () => ({}),
+    release: () => {},
+  };
+}
+
+test('runLive returns 2 (quarantine) for a contaminated run', async () => {
+  const code = await runLive(ARGS, overrides({ contaminated: true, results: {}, integrationBranch: 'fleet/run-x', contaminationReason: 'ungated commit' }));
+  assert.equal(code, 2);
+});
+
+test('runLive returns 0 for a clean run (all merged, PR opened)', async () => {
+  const code = await runLive(ARGS, overrides({ contaminated: false, results: { A: 'merged' }, merged: 1, prCount: 1, integrationBranch: 'fleet/run-x' }));
+  assert.equal(code, 0);
+});
+
+test('runLive returns 2 when a ticket failed/blocked', async () => {
+  const code = await runLive(ARGS, overrides({ contaminated: false, results: { A: 'failed', B: 'merged' }, merged: 1, prCount: 1, integrationBranch: 'fleet/run-x' }));
+  assert.equal(code, 2);
+});
+
+test('runLive returns the preflight exit code when preflight fails (no run dispatched)', async () => {
+  let ran = false;
+  const ov = { ...overrides({}, { preflightOk: false }), run: async () => { ran = true; return {}; } };
+  const code = await runLive(ARGS, ov);
+  assert.equal(code, 1, 'a failed preflight returns its exit code');
+  assert.equal(ran, false, 'and never dispatches the run');
+});

--- a/packages/gate-manifest/bin/gate-manifest.mjs
+++ b/packages/gate-manifest/bin/gate-manifest.mjs
@@ -3,7 +3,7 @@
 // Verbs: record | verify | show | attest
 
 import { parseArgs, pass, gateFail, opError, printJson } from '@adlc/core';
-import { record, parseData } from '../lib/record.mjs';
+import { record, parseData, ticketCompletionReminder } from '../lib/record.mjs';
 import { verify } from '../lib/verify.mjs';
 import { loadFiltered, renderEntries } from '../lib/show.mjs';
 import { buildAttest } from '../lib/attest.mjs';
@@ -71,6 +71,12 @@ if (verb === 'record') {
     const signed = typeof entry.sig === 'string' ? ' (signed)' : ' (unsigned)';
     console.log(`recorded: seq=${entry.seq} gate=${entry.gate} ts=${entry.ts}${signed}`);
   }
+
+  // T74: a p6-accept verdict is not ticket completion. Print a one-line reminder
+  // of the command that IS — to stderr, so it never corrupts --json stdout, and
+  // WITHOUT touching what was recorded (no auto-mutation).
+  const reminder = ticketCompletionReminder(gate, flags.ticket);
+  if (reminder) console.error(reminder);
 
   pass();
 }

--- a/packages/gate-manifest/lib/record.mjs
+++ b/packages/gate-manifest/lib/record.mjs
@@ -4,7 +4,7 @@
 // while holding the ledger lock; parsed/re-serialized entries are never used.
 
 import { existsSync, readFileSync } from 'node:fs';
-import { sha256, hashFiles, appendEntries, ledgerPath, ADLC_DIR } from '@adlc/core';
+import { sha256, hashFiles, appendEntries, ADLC_DIR } from '@adlc/core';
 import { getKey, signEntry } from './sign.mjs';
 import { verify } from './verify.mjs';
 

--- a/packages/gate-manifest/lib/record.mjs
+++ b/packages/gate-manifest/lib/record.mjs
@@ -155,3 +155,22 @@ export function record({ gate, ticket, rawData, rawFiles, dir = ADLC_DIR }) {
   payload.files = filePaths.length > 0 ? hashFiles(filePaths) : {};
   return appendManifestEntry(payload, dir, { signatureVersion: 1 });
 }
+
+/**
+ * A one-line, side-effect-free reminder to conclude P6 by completing the ticket
+ * (T74). Recording a `p6-accept` verdict is evidence, NOT completion — this
+ * bridge never mutates a ticket, it only points the operator at the command that
+ * does. Returns null when the gate is not a P6 acceptance gate or no ticket was
+ * named, so there is nothing to remind about. The `p6-accept` prefix also matches
+ * the `p6-acceptance-packet` gate the acceptance path records.
+ *
+ * @param {string} gate  the recorded gate name
+ * @param {string|undefined} ticket  the --ticket id, if any
+ * @returns {string|null}
+ */
+export function ticketCompletionReminder(gate, ticket) {
+  if (typeof gate !== 'string' || typeof ticket !== 'string' || ticket === '') return null;
+  if (!/^p6-accept/.test(gate)) return null;
+  return `reminder: recording ${gate} is evidence, not completion — conclude P6 with ` +
+    `\`adlc ticket complete ${ticket} --write\` (add \`--authorize\` when the ticket is railed).`;
+}

--- a/packages/gate-manifest/test/gate-manifest.test.mjs
+++ b/packages/gate-manifest/test/gate-manifest.test.mjs
@@ -375,6 +375,23 @@ describe('repairChain', () => {
     }
   });
 
+  it('CLI: a p6-accept record prints the ticket-completion reminder to stderr, a plain gate does not (T74)', () => {
+    const dir = makeTmp();
+    const bin = new URL('../bin/gate-manifest.mjs', import.meta.url).pathname;
+    try {
+      // p6-accept names a ticket → the bin must print the "you still have to complete it"
+      // reminder on stderr (not stdout, so --json stays clean). Guards the `if (reminder)`
+      // print branch: inverting it drops the reminder here.
+      const accept = spawnSync(process.execPath, [bin, 'record', 'p6-accept', '--ticket', 'T9', '--dir', dir], { encoding: 'utf8' });
+      assert.equal(accept.status, 0, accept.stderr);
+      assert.match(accept.stderr, /adlc ticket complete T9 --write/, 'a p6-accept prints the completion reminder to stderr');
+      // A non-acceptance gate prints NO reminder (the other side of the same guard).
+      const plain = spawnSync(process.execPath, [bin, 'record', 'p4-gate', '--ticket', 'T9', '--dir', dir], { encoding: 'utf8' });
+      assert.equal(plain.status, 0, plain.stderr);
+      assert.doesNotMatch(plain.stderr, /ticket complete/, 'a non-acceptance gate prints no reminder');
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
   it('requires and audits explicit unsigned attestation through the CLI', () => {
     const dir = makeTmp();
     const bin = new URL('../bin/gate-manifest.mjs', import.meta.url).pathname;

--- a/packages/gate-manifest/test/ticket-completion-reminder.test.mjs
+++ b/packages/gate-manifest/test/ticket-completion-reminder.test.mjs
@@ -1,0 +1,44 @@
+// T74 — the p6-accept → ticket-complete reminder bridge. A pure, side-effect-free
+// hint: recording an acceptance verdict is evidence, not completion. The reminder
+// never mutates the ticket or the ledger — it only points at the command that does.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ticketCompletionReminder, record } from '../lib/record.mjs';
+
+test('reminds for a p6-accept gate that names a ticket', () => {
+  const r = ticketCompletionReminder('p6-accept', 'T74');
+  assert.match(r, /adlc ticket complete T74 --write/);
+  assert.match(r, /--authorize/, 'mentions the railed-ticket authorization');
+});
+
+test('also matches the p6-acceptance-packet gate the acceptance path records', () => {
+  assert.match(ticketCompletionReminder('p6-acceptance-packet', 'T9'), /adlc ticket complete T9 --write/);
+});
+
+test('is silent when there is nothing to remind about', () => {
+  assert.equal(ticketCompletionReminder('p6-accept', undefined), null, 'no ticket → no reminder');
+  assert.equal(ticketCompletionReminder('p6-accept', ''), null, 'empty ticket → no reminder');
+  assert.equal(ticketCompletionReminder('p4-gate', 'T1'), null, 'non-acceptance gate → no reminder');
+  assert.equal(ticketCompletionReminder(undefined, 'T1'), null, 'no gate → no reminder');
+});
+
+test('the reminder does NOT change recording semantics (no auto-mutation)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gm-reminder-'));
+  try {
+    const entry = record({ gate: 'p6-accept', ticket: 'T1', dir });
+    // What was recorded is exactly a p6-accept evidence entry for T1 — no
+    // completed flag, no ticket mutation, nothing the reminder injected.
+    assert.equal(entry.gate, 'p6-accept');
+    assert.equal(entry.ticket, 'T1');
+    assert.equal(entry.data, undefined, 'reminder adds no payload to the recorded entry');
+    const manifest = readFileSync(join(dir, 'manifest.jsonl'), 'utf8').trim().split('\n');
+    assert.equal(manifest.length, 1, 'exactly one entry recorded — the reminder writes nothing');
+    assert.doesNotMatch(manifest[0], /completed/, 'no completion state leaked into the ledger');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/ticket-prune/lib/archive-order.mjs
+++ b/packages/ticket-prune/lib/archive-order.mjs
@@ -1,0 +1,56 @@
+// archive-order.mjs (T75) — order archive candidates so an edge SOURCE is
+// archived before the ticket it points to (its TARGET).
+//
+// archiveTicket fails closed on inbound edges (ARCHIVE_INBOUND_EDGE): archiving
+// removes a ticket from the active store, so if A holds an edge `{to: B}` and
+// both A and B are being archived, B still shows an inbound edge from A until A
+// is gone. Archiving B first would falsely block it. Processing SOURCES before
+// TARGETS lets the whole eligible batch archive in one sweep.
+//
+// Only edges BETWEEN candidates constrain the order. An edge from a
+// non-candidate (an active ticket that stays) can never be satisfied by
+// reordering — that is a genuine block the caller reports and continues past.
+
+/**
+ * @param {string[]} candidateIds  ids to archive, in their discovered order
+ * @param {Map<string, object>} ticketsById  id → ticket (read for `edges`)
+ * @returns {string[]} the same ids, reordered sources-before-targets (stable on ties)
+ */
+export function orderArchiveCandidates(candidateIds, ticketsById) {
+  const candidates = candidateIds.filter((id) => ticketsById.has(id));
+  const inBatch = new Set(candidates);
+
+  // edge A→B (A holds `{to: B}`) ⇒ A must precede B.
+  const mustPrecede = new Map(candidates.map((id) => [id, []])); // A → [B, …]
+  const indegree = new Map(candidates.map((id) => [id, 0]));     // # of in-batch sources referencing it
+  for (const a of candidates) {
+    for (const edge of ticketsById.get(a)?.edges ?? []) {
+      const b = edge?.to;
+      if (typeof b === 'string' && b !== a && inBatch.has(b)) {
+        mustPrecede.get(a).push(b);
+        indegree.set(b, indegree.get(b) + 1);
+      }
+    }
+  }
+
+  // Kahn's algorithm, stable: among ready nodes keep the input order so the
+  // sweep is deterministic regardless of filesystem read order.
+  const ordered = [];
+  const emitted = new Set();
+  const ready = candidates.filter((id) => indegree.get(id) === 0);
+  while (ready.length) {
+    const id = ready.shift();
+    if (emitted.has(id)) continue;
+    emitted.add(id);
+    ordered.push(id);
+    for (const b of mustPrecede.get(id)) {
+      indegree.set(b, indegree.get(b) - 1);
+      if (indegree.get(b) === 0) ready.push(b);
+    }
+  }
+
+  // The ticket DAG is validated acyclic, but never silently drop a node if a
+  // cycle ever slips through — append leftovers in their input order.
+  for (const id of candidates) if (!emitted.has(id)) ordered.push(id);
+  return ordered;
+}

--- a/packages/ticket-prune/lib/format.mjs
+++ b/packages/ticket-prune/lib/format.mjs
@@ -1,7 +1,7 @@
 // format.mjs — human-readable + JSON rendering for a runTicketPrune() result.
 
 export function renderReport(result) {
-  const { baseRef, write, stale, active, tombstoned = [], archived = [], needsCeremony = [] } = result;
+  const { baseRef, write, stale, active, tombstoned = [], archived = [], needsCeremony = [], blocked = [] } = result;
   const lines = [];
   // `--ceremony` is deprecated (#208) and returns before rendering, so the only
   // in-place write this tool reports is tombstoning under --write.
@@ -56,6 +56,15 @@ export function renderReport(result) {
     for (const t of manual) lines.push(`  - ${t.id}: ${t.reason}`);
   }
 
+  if (blocked.length > 0) {
+    // Eligible for archive but blocked by an inbound edge from a ticket that is
+    // NOT being archived (T75). The sweep skipped past them rather than wedging —
+    // they need the referencing ticket handled first, or the edge removed.
+    lines.push('');
+    lines.push(`Skipped — still referenced by a ticket that is not being archived (${blocked.length}):`);
+    for (const b of blocked) lines.push(`  - ${b.id}: ${b.error ?? b.code ?? 'archive blocked'}`);
+  }
+
   lines.push('');
   lines.push(`Active tickets (${active.length}):`);
   if (active.length === 0) {
@@ -68,8 +77,10 @@ export function renderReport(result) {
 }
 
 export function toJson(result) {
-  const { baseRef, write, ceremony = false, stale, active, tombstoned = [], archived = [], ceremonyCompleted = [], needsCeremony = [] } = result;
+  const { baseRef, write, ceremony = false, stale, active, tombstoned = [], archived = [], ceremonyCompleted = [], needsCeremony = [], blocked = [] } = result;
   // `archived` is the directory-store mutation (moved shards); omitting it would
   // make `--json` under-report what --write actually changed on that backend.
-  return { baseRef, write, ceremony, stale, active, tombstoned, archived, ceremonyCompleted, needsCeremony };
+  // `blocked` is the skip-and-continue set (T75) — tickets left unarchived because
+  // a ticket outside the batch still references them.
+  return { baseRef, write, ceremony, stale, active, tombstoned, archived, ceremonyCompleted, needsCeremony, blocked };
 }

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -163,13 +163,25 @@ export function runTicketPrune(options = {}) {
         });
         archivedEntries.push(result.archived);
       } catch (error) {
-        // Each archive is its own committed transaction. A single ticket failing
-        // closed — e.g. ARCHIVE_INBOUND_EDGE because a ticket OUTSIDE this batch
-        // still references it — must NOT wedge the whole sweep (T75). Collect it,
-        // the way needsCeremony surfaces rail-freezing ones, and CONTINUE, so every
-        // still-eligible ticket archives and the operator gets a report instead of
-        // a half-processed store behind a bare {ok:false}.
-        blocked.push({ id, reason: item?.reason ?? null, code: error.code ?? 'ARCHIVE_FAILED', error: error.message });
+        // ONLY the expected, per-ticket, recoverable block is swallowed-and-continued:
+        // ARCHIVE_INBOUND_EDGE, where a ticket OUTSIDE this batch still references
+        // `id`. That is the wedge T75 exists to fix — collect it (like needsCeremony)
+        // and keep archiving the rest. EVERYTHING else — a corrupt/unreadable store,
+        // a lock or CAS failure, an I/O or disk error, a transaction fault — is NOT
+        // recoverable and must fail the sweep, or automation reading exit 0 would take
+        // a broken store for a clean one. Preserve what was archived + the blocked set.
+        if (error?.code === 'ARCHIVE_INBOUND_EDGE') {
+          blocked.push({ id, reason: item?.reason ?? null, code: 'ARCHIVE_INBOUND_EDGE', error: error.message });
+          continue;
+        }
+        return {
+          ok: false,
+          baseRef, write, ceremony, stale, active,
+          archived: archivedEntries, needsCeremony, blocked,
+          failedId: id,
+          code: error?.code ?? 'ARCHIVE_FAILED',
+          error: `archiving ${id} failed: ${error.message}`,
+        };
       }
     }
     return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries, needsCeremony, blocked };

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 import { loadTickets } from '@adlc/core';
 import { classifyTicket, classifyTickets, ceremonyDisposition, listTrackedFiles } from './detect.mjs';
 import { acquireLock, releaseLock, readJson, writeJsonAtomic } from './store.mjs';
+import { orderArchiveCandidates } from './archive-order.mjs';
 import { DirectoryTicketStore, archiveTicket, detectTicketStore } from '@adlc/tickets';
 
 /**
@@ -126,7 +127,16 @@ export function runTicketPrune(options = {}) {
     // `adlc ticket complete`, exactly as on the legacy backend.
     const archivedEntries = [];
     const needsCeremony = [];
-    for (const item of stale) {
+    const blocked = [];
+    // Archive edge SOURCES before their TARGETS (T75). archiveTicket fails closed
+    // on inbound edges, so a candidate referenced by another IN-BATCH candidate
+    // must be archived only AFTER that referencing source is gone. Ordering by the
+    // initial snapshot's edges is enough — each iteration still re-reads and
+    // re-classifies against the CURRENT store below.
+    const staleById = new Map(stale.map((r) => [r.id, r]));
+    const orderedIds = orderArchiveCandidates(stale.map((r) => r.id), ticketsById);
+    for (const id of orderedIds) {
+      const item = staleById.get(id);
       try {
         // Re-read and re-classify against the CURRENT snapshot, then pass THAT
         // snapshot's hash to archiveTicket, so the disposition and the CAS come
@@ -135,7 +145,7 @@ export function runTicketPrune(options = {}) {
         // status changed, completed:false set) slip a reclassified ticket through
         // the CAS. This mirrors the legacy path's under-lock re-read.
         const current = canonicalStore.load();
-        const ticket = current.get(item.id);
+        const ticket = current.get(id);
         if (!ticket) continue; // vanished under us since the first pass
         const reclassified = classifyTicket(ticket, trackedFiles);
         if (!reclassified.stale) continue; // un-staled since the first pass
@@ -145,7 +155,7 @@ export function runTicketPrune(options = {}) {
           needsCeremony.push(disposition.entry); // rails-freeze / preexisting-completed-field → reported, not archived
           continue;
         }
-        const result = archiveTicket(canonicalStore, resolve(cwd, '.adlc/ticket-archive'), item.id, {
+        const result = archiveTicket(canonicalStore, resolve(cwd, '.adlc/ticket-archive'), id, {
           root: cwd,
           expectedSnapshotHash: current.hash,
           reason: item.reason,
@@ -153,14 +163,16 @@ export function runTicketPrune(options = {}) {
         });
         archivedEntries.push(result.archived);
       } catch (error) {
-        // Each archive is its own committed transaction. On failure mid-batch,
-        // report what ALREADY archived (and which id failed) alongside the error,
-        // so the caller can recover rather than see a bare {ok:false} after an
-        // in-place mutation already landed.
-        return { ok: false, error: error.message, archived: archivedEntries, needsCeremony, failedId: item.id };
+        // Each archive is its own committed transaction. A single ticket failing
+        // closed — e.g. ARCHIVE_INBOUND_EDGE because a ticket OUTSIDE this batch
+        // still references it — must NOT wedge the whole sweep (T75). Collect it,
+        // the way needsCeremony surfaces rail-freezing ones, and CONTINUE, so every
+        // still-eligible ticket archives and the operator gets a report instead of
+        // a half-processed store behind a bare {ok:false}.
+        blocked.push({ id, reason: item?.reason ?? null, code: error.code ?? 'ARCHIVE_FAILED', error: error.message });
       }
     }
-    return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries, needsCeremony };
+    return { ok: true, baseRef, write, ceremony, stale, active, archived: archivedEntries, needsCeremony, blocked };
   }
 
   const locked = acquireLock(cwd);

--- a/packages/ticket-prune/lib/run.mjs
+++ b/packages/ticket-prune/lib/run.mjs
@@ -158,7 +158,10 @@ export function runTicketPrune(options = {}) {
         const result = archiveTicket(canonicalStore, resolve(cwd, '.adlc/ticket-archive'), id, {
           root: cwd,
           expectedSnapshotHash: current.hash,
-          reason: item.reason,
+          // The RE-classified reason, not the first pass's: archiveTicket embeds this
+          // permanently in _adlcArchive, and the disposition + CAS already come from
+          // `current`. Using the stale reason would immortalise a pre-edit rationale.
+          reason: reclassified.reason,
           authorized: true,
         });
         archivedEntries.push(result.archived);

--- a/packages/ticket-prune/test/format.test.mjs
+++ b/packages/ticket-prune/test/format.test.mjs
@@ -90,6 +90,7 @@ test('toJson projects exactly the machine-readable fields, defaulting the new ar
     archived: [],
     ceremonyCompleted: [],
     needsCeremony: [],
+    blocked: [],
   });
 });
 

--- a/packages/ticket-prune/test/run.test.mjs
+++ b/packages/ticket-prune/test/run.test.mjs
@@ -738,12 +738,12 @@ test('#208: directory --write surfaces archived ids in the result (observability
   });
 });
 
-test('#208: a directory batch that fails mid-way reports what already archived and which id failed', () => {
+test('#208/T75: a directory batch with one inbound-edge-blocked ticket archives the rest and reports the blocked one (no mid-batch wedge)', () => {
   withScratchRepo((dir) => {
     rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
     // A and B are both rails-less shipped (archivable). B is referenced by active
     // ticket C via an edge, so archiveTicket rejects B with ARCHIVE_INBOUND_EDGE.
-    // A must archive first, then B fails — a partial batch.
+    // A archives; B is a genuine block (C stays active). The sweep must continue.
     mkdirSync(join(dir, 'packages', 'a2'), { recursive: true });
     writeFileSync(join(dir, 'packages', 'a2', 'x.mjs'), '// a\n');
     mkdirSync(join(dir, 'packages', 'b2'), { recursive: true });
@@ -758,15 +758,15 @@ test('#208: a directory batch that fails mid-way reports what already archived a
 
     const result = runTicketPrune({ cwd: dir, write: true });
 
-    assert.equal(result.ok, false);
-    assert.match(result.error, /BBB|inbound|referenced/i);
-    // The already-committed archive of AAA is reported, not lost behind the error.
+    // T75: the blocked ticket is a report, not a hard failure.
+    assert.equal(result.ok, true);
     assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['AAA']);
-    assert.equal(result.failedId, 'BBB');
+    assert.deepEqual((result.blocked ?? []).map((b) => b.id), ['BBB']);
+    assert.match(result.blocked[0].error, /BBB|inbound|referenced|CCC/i);
   });
 });
 
-test('#208: bin --write --json surfaces partial-batch data (archived + failedId) on a mid-batch failure', () => {
+test('#208/T75: bin --write --json exits 0 and surfaces the blocked set on a partial sweep', () => {
   withScratchRepo((dir) => {
     rmSync(join(dir, '.adlc', 'tickets.json'), { force: true });
     mkdirSync(join(dir, 'packages', 'a3'), { recursive: true });
@@ -788,10 +788,10 @@ test('#208: bin --write --json surfaces partial-batch data (archived + failedId)
       code = err.status ?? 1;
       out = (err.stdout?.toString() ?? '') + (err.stderr?.toString() ?? '');
     }
-    assert.equal(code, 1);
-    // The committed archive of AAA and the failed id must be visible, not hidden behind the bare error.
-    assert.match(out, /"archived"/);
-    assert.match(out, /AAA/);
-    assert.match(out, /"failedId": ?"BBB"/);
+    // No hard failure: the archived one and the blocked one are both visible.
+    assert.equal(code, 0);
+    const parsed = JSON.parse(out);
+    assert.deepEqual(parsed.archived.map((a) => a?.id ?? a), ['AAA']);
+    assert.deepEqual(parsed.blocked.map((b) => b.id), ['BBB']);
   });
 });

--- a/packages/ticket-prune/test/wedge-fix.test.mjs
+++ b/packages/ticket-prune/test/wedge-fix.test.mjs
@@ -1,0 +1,130 @@
+// T75 — ticket-prune must not wedge the whole sweep on the first archive that
+// fails closed (ARCHIVE_INBOUND_EDGE). Two guarantees:
+//   (a) a batch with one inbound-edge-blocked ticket still archives the rest and
+//       names the blocked one (skip-and-continue instead of a mid-batch return);
+//   (b) archive candidates are ordered topologically — an in-batch edge SOURCE is
+//       archived before its TARGET, so neither is falsely blocked.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runTicketPrune } from '../lib/run.mjs';
+import { orderArchiveCandidates } from '../lib/archive-order.mjs';
+import { ticketFilename } from '@adlc/tickets';
+
+function git(args, cwd) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function setupScratchRepo(dir) {
+  git(['init', '-q'], dir);
+  git(['config', 'user.email', 'test@example.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  git(['commit', '-q', '--allow-empty', '-m', 'root'], dir);
+}
+
+function withScratchRepo(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'ticket-prune-wedge-'));
+  try {
+    setupScratchRepo(dir);
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function shipScope(dir, rel) {
+  mkdirSync(join(dir, rel), { recursive: true });
+  writeFileSync(join(dir, rel, 'index.mjs'), '// shipped\n');
+}
+
+function writeDirectoryStore(dir, tickets) {
+  const store = join(dir, '.adlc', 'tickets');
+  mkdirSync(store, { recursive: true });
+  writeFileSync(join(store, '.store.json'), JSON.stringify({ format: 'adlc-ticket-directory', version: 1 }));
+  for (const t of tickets) writeFileSync(join(store, ticketFilename(t.id)), JSON.stringify(t));
+}
+
+// ── (b) pure topological ordering ──────────────────────────────────────────
+
+test('orderArchiveCandidates puts an edge source before its target, even if the target is listed first', () => {
+  const ticketsById = new Map([
+    ['TGT', { id: 'TGT', edges: [] }],
+    ['SRC', { id: 'SRC', edges: [{ to: 'TGT' }] }],
+  ]);
+  assert.deepEqual(orderArchiveCandidates(['TGT', 'SRC'], ticketsById), ['SRC', 'TGT']);
+});
+
+test('orderArchiveCandidates topologically sorts a chain A→B→C regardless of input order', () => {
+  const ticketsById = new Map([
+    ['A', { id: 'A', edges: [{ to: 'B' }] }],
+    ['B', { id: 'B', edges: [{ to: 'C' }] }],
+    ['C', { id: 'C', edges: [] }],
+  ]);
+  assert.deepEqual(orderArchiveCandidates(['C', 'B', 'A'], ticketsById), ['A', 'B', 'C']);
+});
+
+test('orderArchiveCandidates ignores edges to non-candidates (only in-batch edges constrain order)', () => {
+  const ticketsById = new Map([
+    ['X', { id: 'X', edges: [{ to: 'ACTIVE' }] }],
+    ['Y', { id: 'Y', edges: [] }],
+    ['ACTIVE', { id: 'ACTIVE', edges: [] }],
+  ]);
+  assert.deepEqual(orderArchiveCandidates(['X', 'Y'], ticketsById), ['X', 'Y']);
+});
+
+// ── (a) skip-and-continue on a genuinely blocked ticket ─────────────────────
+
+test('a batch with one inbound-edge-blocked ticket still archives the rest and names the blocked one', () => {
+  withScratchRepo((dir) => {
+    shipScope(dir, join('packages', 'a2'));
+    shipScope(dir, join('packages', 'b2'));
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship a2 b2'], dir);
+    // AAA and BBB are both rails-less shipped (archivable). BBB is referenced by
+    // ACTIVE ticket CCC (which is NOT a candidate), so archiveTicket rejects BBB
+    // with ARCHIVE_INBOUND_EDGE — a genuine block no reordering can satisfy.
+    writeDirectoryStore(dir, [
+      { id: 'AAA', title: 'rails-less shipped', scope: ['packages/a2/**'] },
+      { id: 'BBB', title: 'rails-less shipped', scope: ['packages/b2/**'] },
+      { id: 'CCC', title: 'still building', scope: ['packages/never-built/**'], edges: [{ to: 'BBB' }] },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    // The blocked ticket no longer wedges the sweep: it is a report, not a hard failure.
+    assert.equal(result.ok, true);
+    assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['AAA'], 'the eligible ticket still archives');
+    assert.deepEqual((result.blocked ?? []).map((b) => b.id), ['BBB'], 'the blocked ticket is named, not swallowed');
+    assert.match(result.blocked[0].error ?? '', /inbound|referenced|CCC/i);
+    // AAA really left the active store; BBB's shard is still there (never archived).
+    assert.ok(!existsSync(join(dir, '.adlc', 'tickets', ticketFilename('AAA'))));
+    assert.ok(existsSync(join(dir, '.adlc', 'tickets', ticketFilename('BBB'))));
+  });
+});
+
+test('an in-batch edge source is archived before its target, so neither is falsely blocked (topological write path)', () => {
+  withScratchRepo((dir) => {
+    shipScope(dir, join('packages', 'src2'));
+    shipScope(dir, join('packages', 'tgt2'));
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship src2 tgt2'], dir);
+    // SRC holds an edge to TGT; both are rails-less shipped. Archiving TGT first
+    // would fail (SRC still references it) — only source-before-target archives both.
+    writeDirectoryStore(dir, [
+      { id: 'TGT', title: 'rails-less shipped', scope: ['packages/tgt2/**'] },
+      { id: 'SRC', title: 'rails-less shipped', scope: ['packages/src2/**'], edges: [{ to: 'TGT' }] },
+    ]);
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual((result.blocked ?? []).map((b) => b.id), [], 'nothing is blocked when ordered topologically');
+    assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['SRC', 'TGT'], 'source archived before target');
+    assert.ok(!existsSync(join(dir, '.adlc', 'tickets', ticketFilename('SRC'))));
+    assert.ok(!existsSync(join(dir, '.adlc', 'tickets', ticketFilename('TGT'))));
+  });
+});

--- a/packages/ticket-prune/test/wedge-fix.test.mjs
+++ b/packages/ticket-prune/test/wedge-fix.test.mjs
@@ -100,6 +100,10 @@ test('a batch with one inbound-edge-blocked ticket still archives the rest and n
     assert.deepEqual((result.archived ?? []).map((a) => a?.id ?? a), ['AAA'], 'the eligible ticket still archives');
     assert.deepEqual((result.blocked ?? []).map((b) => b.id), ['BBB'], 'the blocked ticket is named, not swallowed');
     assert.match(result.blocked[0].error ?? '', /inbound|referenced|CCC/i);
+    // The blocked entry carries the stale record's classification reason (from staleById),
+    // not null — a report that dropped the reason would tell the operator nothing.
+    assert.equal(typeof result.blocked[0].reason, 'string');
+    assert.ok(result.blocked[0].reason.length > 0, 'the blocked entry names WHY it was stale');
     // AAA really left the active store; BBB's shard is still there (never archived).
     assert.ok(!existsSync(join(dir, '.adlc', 'tickets', ticketFilename('AAA'))));
     assert.ok(existsSync(join(dir, '.adlc', 'tickets', ticketFilename('BBB'))));

--- a/packages/ticket-prune/test/wedge-fix.test.mjs
+++ b/packages/ticket-prune/test/wedge-fix.test.mjs
@@ -106,6 +106,31 @@ test('a batch with one inbound-edge-blocked ticket still archives the rest and n
   });
 });
 
+test('an UNEXPECTED archive failure (not an inbound edge) fails the sweep — never reports ok:true', () => {
+  withScratchRepo((dir) => {
+    shipScope(dir, join('packages', 'c2'));
+    git(['add', '-A'], dir);
+    git(['commit', '-q', '-m', 'ship c2'], dir);
+    writeDirectoryStore(dir, [
+      { id: 'AAA', title: 'rails-less shipped', scope: ['packages/c2/**'] },
+    ]);
+    // Make the archive destination a FILE so archiveTicket hits a filesystem error
+    // (ENOTDIR) — an unexpected, non-recoverable failure, NOT an inbound-edge block.
+    // The old broad catch swallowed this into `blocked` and still returned ok:true;
+    // a corrupt/unwritable store must fail the sweep so automation never reads a
+    // broken store as clean.
+    writeFileSync(join(dir, '.adlc', 'ticket-archive'), 'not a directory\n');
+
+    const result = runTicketPrune({ cwd: dir, write: true });
+
+    assert.equal(result.ok, false, 'a genuine I/O failure must not report success');
+    assert.equal(result.failedId, 'AAA');
+    assert.notEqual(result.code, 'ARCHIVE_INBOUND_EDGE', 'this was not an inbound-edge block');
+    // The ticket was NOT archived (the failure was real, not skipped).
+    assert.ok(existsSync(join(dir, '.adlc', 'tickets', ticketFilename('AAA'))));
+  });
+});
+
 test('an in-batch edge source is archived before its target, so neither is falsely blocked (topological write path)', () => {
   withScratchRepo((dir) => {
     shipScope(dir, join('packages', 'src2'));

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -73,16 +73,14 @@ function storeHashBindingCheck(root, snapshot) {
     return { ...check, ok: false, code: 'MANIFEST_UNREADABLE', message: `cannot read the evidence ledger: ${error.message}` };
   }
 
+  // The last store-level evidence entry is the most recent CHECKPOINT the store was
+  // hash-bound at. We report only whether the store still matches that checkpoint.
   let boundStoreHash = null;
-  const evidencedTicketHashes = new Map(); // ticketId → last recorded ticketHash
   for (const line of lines) {
     let entry;
     try { entry = JSON.parse(line); } catch { continue; } // a malformed line is another check's concern
     const data = entry?.data;
     if (data && typeof data.storeHash === 'string') boundStoreHash = data.storeHash;
-    if (data && data.bindingScope === 'ticket' && typeof entry.ticket === 'string' && typeof data.ticketHash === 'string') {
-      evidencedTicketHashes.set(entry.ticket, data.ticketHash);
-    }
   }
 
   if (!boundStoreHash) return { ...check, bound: false, reason: 'no evidence-required transaction recorded yet' };
@@ -91,34 +89,18 @@ function storeHashBindingCheck(root, snapshot) {
   check.storeHash = snapshot.hash;
   check.boundStoreHash = boundStoreHash;
 
-  const tampered = [];
-  for (const [id, recordedHash] of evidencedTicketHashes) {
-    const liveHash = snapshot.ticketHashes[id];
-    if (liveHash !== undefined && liveHash !== recordedHash) tampered.push(id);
-  }
-  if (tampered.length > 0) {
-    return {
-      ...check,
-      ok: false,
-      code: 'STOREHASH_MANIFEST_MISMATCH',
-      tampered,
-      message: `ticket(s) changed outside a recorded transaction — live storeHash no longer matches the manifest evidence: ${tampered.join(', ')}`,
-    };
-  }
-
+  // This check does NOT attribute drift to specific tickets or claim tampering.
+  // The ticket model permits ordinary UNEVIDENCED create/update between checkpoints,
+  // so a per-ticket "changed since its evidence" signal is unsound in both
+  // directions: false positives (an evidenced ticket later edited legitimately) and
+  // false negatives (a never-evidenced ticket hand-edited). Sound out-of-band tamper
+  // detection needs a store hash recorded on EVERY transaction — tracked as a
+  // follow-up. Here we report an honest fact: is the store at its last evidenced
+  // checkpoint, or has it drifted (unverified) since?
   if (snapshot.hash !== boundStoreHash) {
     check.drift = true;
-    // Tampering can only be detected relative to a recorded baseline. A ticket with
-    // NO ticket-scoped evidence entry has none here, so a hand-edit to it is
-    // indistinguishable from a legitimate unevidenced create/update — this check
-    // cannot catch it. Do NOT imply the store is confirmed clean: report the blind
-    // spot honestly and name git history as the primary record for those shards.
-    const unverified = Object.keys(snapshot.ticketHashes ?? {}).filter((id) => !evidencedTicketHashes.has(id));
-    check.unverified = unverified.length;
     check.message =
-      unverified.length > 0
-        ? `live storeHash differs from the last recorded evidence; every EVIDENCED ticket is intact, but ${unverified.length} ticket(s) have no evidence baseline and are NOT integrity-verified by this check (rely on git history for those shards) — reported, not failed`
-        : 'live storeHash differs from the last recorded evidence, but every evidenced ticket is intact — unevidenced non-sensitive op(s) since; reported, not failed';
+      'live storeHash differs from the last evidenced checkpoint — unevidenced change(s) since. This check does not verify those (git history is the record for those shards); reported, not failed';
   }
   return check;
 }

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -108,7 +108,17 @@ function storeHashBindingCheck(root, snapshot) {
 
   if (snapshot.hash !== boundStoreHash) {
     check.drift = true;
-    check.message = 'live storeHash differs from the last recorded evidence, but every evidenced ticket is intact — unevidenced non-sensitive op(s) since; reported, not failed';
+    // Tampering can only be detected relative to a recorded baseline. A ticket with
+    // NO ticket-scoped evidence entry has none here, so a hand-edit to it is
+    // indistinguishable from a legitimate unevidenced create/update — this check
+    // cannot catch it. Do NOT imply the store is confirmed clean: report the blind
+    // spot honestly and name git history as the primary record for those shards.
+    const unverified = Object.keys(snapshot.ticketHashes ?? {}).filter((id) => !evidencedTicketHashes.has(id));
+    check.unverified = unverified.length;
+    check.message =
+      unverified.length > 0
+        ? `live storeHash differs from the last recorded evidence; every EVIDENCED ticket is intact, but ${unverified.length} ticket(s) have no evidence baseline and are NOT integrity-verified by this check (rely on git history for those shards) — reported, not failed`
+        : 'live storeHash differs from the last recorded evidence, but every evidenced ticket is intact — unevidenced non-sensitive op(s) since; reported, not failed';
   }
   return check;
 }

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { createHash } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { join } from 'node:path';
+import { canonicalJson } from './canonical.mjs';
 import { ARCHIVE_DIRECTORY, CURRENT_TICKET_FILE, LOCK_DIRECTORY } from './constants.mjs';
 import { readTicketLock } from './lock.mjs';
 import { readActiveTicketPointer, resolveActiveTicketAgainst } from './pointer.mjs';
@@ -58,6 +59,40 @@ function currentTicketCheck(root, snapshot) {
  * removes the shard the same way a hand-delete would and records no evidence
  * either, so absence is inherently ambiguous and left to the archive/graph checks.
  */
+// Manifest HMAC verification, mirroring @adlc/gate-manifest's sign.mjs byte-for-byte.
+// It cannot be imported: the package graph is tickets ← core ← gate-manifest, so
+// tickets (the base layer) would create a cycle. The v1 form is a fixed key order;
+// v2 signs canonical JSON of every field but `sig` (this package's canonicalJson is
+// byte-identical to core's, verified by test). Keep in lockstep with sign.mjs.
+const MANIFEST_KEY_ENV = 'ADLC_MANIFEST_KEY';
+
+function manifestKey(env = process.env) {
+  const k = env[MANIFEST_KEY_ENV];
+  return typeof k === 'string' && k.length > 0 ? k : null;
+}
+
+function canonicalEntryBytes(entry) {
+  if (entry.sigVersion === 2) {
+    const { sig: _sig, ...signed } = entry;
+    return canonicalJson(signed);
+  }
+  const canonical = { seq: entry.seq, gate: entry.gate, ts: entry.ts };
+  if (entry.ticket !== undefined) canonical.ticket = entry.ticket;
+  if (entry.data !== undefined) canonical.data = entry.data;
+  canonical.files = entry.files;
+  canonical.prev = entry.prev;
+  return JSON.stringify(canonical);
+}
+
+function entrySigValid(key, entry) {
+  if (typeof entry.sig !== 'string' || entry.sig.length === 0) return false;
+  const expected = createHmac('sha256', key).update(canonicalEntryBytes(entry)).digest('hex');
+  const a = Buffer.from(entry.sig, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
 function storeHashBindingCheck(root, snapshot) {
   const check = { name: 'storehash-manifest-bind', ok: true };
   // No live storeHash to compare — the active-store check already carries that
@@ -79,6 +114,7 @@ function storeHashBindingCheck(root, snapshot) {
   // arbitrary "bound" hash, and a malformed line silently skipped could hide a break.
   // The chain format is the ledger writer's (evidence.mjs / ledger.mjs): each entry's
   // `prev` is sha256 of the previous raw line, and `seq` increments from 1.
+  const key = manifestKey();
   let boundStoreHash = null;
   let prevLine = null;
   let prevSeq = 0;
@@ -94,6 +130,12 @@ function storeHashBindingCheck(root, snapshot) {
     if (entry?.prev !== expectedPrev || entry?.seq !== prevSeq + 1) {
       return { ...check, ok: false, code: 'MANIFEST_CHAIN_INVALID', reason: `manifest hash chain breaks at line ${i + 1}; integrity check FAILED` };
     }
+    // With a key configured EVERY entry must carry a valid signature. The backward
+    // hash chain alone leaves the FINAL entry unprotected — nothing links forward
+    // from it — so its data.storeHash could be edited in place undetected.
+    if (key !== null && !entrySigValid(key, entry)) {
+      return { ...check, ok: false, code: 'MANIFEST_SIGNATURE_INVALID', reason: `manifest entry at line ${i + 1} is unsigned or its signature does not verify; integrity check FAILED` };
+    }
     if (entry?.data && typeof entry.data.storeHash === 'string') boundStoreHash = entry.data.storeHash;
     prevLine = lines[i];
     prevSeq = entry.seq;
@@ -104,6 +146,9 @@ function storeHashBindingCheck(root, snapshot) {
   check.bound = true;
   check.storeHash = snapshot.hash;
   check.boundStoreHash = boundStoreHash;
+  // Honest about the strength of what was checked: with no key configured only the
+  // structural chain was verified, so the ledger is not cryptographically attested.
+  check.signaturesVerified = key !== null;
 
   // This check does NOT attribute drift to specific tickets or claim tampering.
   // The ticket model permits ordinary UNEVIDENCED create/update between checkpoints,

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -85,11 +85,14 @@ function storeHashBindingCheck(root, snapshot) {
   for (let i = 0; i < lines.length; i++) {
     let entry;
     try { entry = JSON.parse(lines[i]); } catch {
-      return { ...check, bound: false, reason: `manifest ledger has a malformed entry at line ${i + 1}; integrity not verifiable` };
+      // A corrupt/tampered ledger is a real integrity FAILURE, not an inert state:
+      // it must fail the check (and the report), distinct from the legitimately-inert
+      // "no manifest yet" cases above which stay ok:true.
+      return { ...check, ok: false, code: 'MANIFEST_MALFORMED', reason: `manifest ledger has a malformed entry at line ${i + 1}; integrity check FAILED` };
     }
     const expectedPrev = prevLine === null ? null : createHash('sha256').update(prevLine).digest('hex');
     if (entry?.prev !== expectedPrev || entry?.seq !== prevSeq + 1) {
-      return { ...check, bound: false, reason: `manifest hash chain breaks at line ${i + 1}; integrity not verifiable` };
+      return { ...check, ok: false, code: 'MANIFEST_CHAIN_INVALID', reason: `manifest hash chain breaks at line ${i + 1}; integrity check FAILED` };
     }
     if (entry?.data && typeof entry.data.storeHash === 'string') boundStoreHash = entry.data.storeHash;
     prevLine = lines[i];

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -146,9 +146,20 @@ function storeHashBindingCheck(root, snapshot) {
   check.bound = true;
   check.storeHash = snapshot.hash;
   check.boundStoreHash = boundStoreHash;
-  // Honest about the strength of what was checked: with no key configured only the
-  // structural chain was verified, so the ledger is not cryptographically attested.
+  // Be honest about the STRENGTH of the binding, not just that one exists. With a key, every
+  // entry's signature was verified above, so the final checkpoint cannot be edited in place
+  // undetected. WITHOUT a key only the backward hash chain was checked — and nothing links
+  // forward from the FINAL entry, so an editor can change a ticket shard, recompute the
+  // (public) store hash, and rewrite that entry's data.storeHash: the chain still validates,
+  // no drift shows, and this check would otherwise present a fully forgeable checkpoint as a
+  // clean, bound one. Surface that limitation loudly (the emitted object is what the operator
+  // and any CI consumer see) instead of implying an attestation we did not make.
   check.signaturesVerified = key !== null;
+  check.authenticated = key !== null;
+  if (key === null) {
+    check.warning =
+      'manifest checkpoint is NOT cryptographically authenticated: ADLC_MANIFEST_KEY is not set, so only the backward hash chain was verified. The final checkpoint is therefore forgeable — a coordinated ticket-shard edit + recomputed final-entry storeHash would pass undetected (no signature to break, no drift to show). Set ADLC_MANIFEST_KEY to make the storeHash binding tamper-evident.';
+  }
 
   // This check does NOT attribute drift to specific tickets or claim tampering.
   // The ticket model permits ordinary UNEVIDENCED create/update between checkpoints,

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -1,6 +1,6 @@
-import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { ARCHIVE_DIRECTORY, CURRENT_TICKET_FILE, LOCK_DIRECTORY, TRANSACTION_DIRECTORY } from './constants.mjs';
+import { ARCHIVE_DIRECTORY, CURRENT_TICKET_FILE, LOCK_DIRECTORY } from './constants.mjs';
 import { readTicketLock } from './lock.mjs';
 import { readActiveTicketPointer, resolveActiveTicketAgainst } from './pointer.mjs';
 import { pendingTransactions } from './store.mjs';

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readdirSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ARCHIVE_DIRECTORY, CURRENT_TICKET_FILE, LOCK_DIRECTORY, TRANSACTION_DIRECTORY } from './constants.mjs';
 import { readTicketLock } from './lock.mjs';
@@ -36,6 +36,83 @@ function currentTicketCheck(root, snapshot) {
   return check;
 }
 
+/**
+ * Bind the live storeHash to the last evidence-required manifest entry (T77).
+ *
+ * `.adlc/tickets/.store.json` is a FORMAT marker, not a content bind, so a silent
+ * shard hand-edit between transactions changed the store with nothing to catch it.
+ * Every evidence-required transaction (complete/archive/reassign/sensitive update)
+ * records `storeHash` AND, for ticket-scoped ops, the ticket's hash. This check
+ * reads that ledger (read-only, offline like every other doctor check) and asks:
+ *
+ *   - live storeHash == the last recorded storeHash → clean, bound;
+ *   - it drifted, but every ticket that carries evidence still hashes to its
+ *     recorded value → unevidenced non-sensitive op(s) (a plain create/discard of
+ *     OTHER tickets); a legitimate state — REPORTED, not failed;
+ *   - a ticket that carries evidence is PRESENT but no longer hashes to its
+ *     recorded value → it was altered outside a recorded transaction (a
+ *     hand-edited shard) → FLAGGED.
+ *
+ * An ABSENT evidenced ticket is not treated as tamper: a legitimate `discard`
+ * removes the shard the same way a hand-delete would and records no evidence
+ * either, so absence is inherently ambiguous and left to the archive/graph checks.
+ */
+function storeHashBindingCheck(root, snapshot) {
+  const check = { name: 'storehash-manifest-bind', ok: true };
+  // No live storeHash to compare — the active-store check already carries that
+  // failure; stay inert here rather than double-reporting or throwing.
+  if (!snapshot) return { ...check, bound: false, reason: 'active store did not load; storeHash binding not checked' };
+
+  const manifestPath = join(root, '.adlc/manifest.jsonl');
+  if (!existsSync(manifestPath)) return { ...check, bound: false, reason: 'no evidence ledger yet' };
+
+  let lines;
+  try {
+    lines = readFileSync(manifestPath, 'utf8').split('\n').filter((line) => line.trim());
+  } catch (error) {
+    return { ...check, ok: false, code: 'MANIFEST_UNREADABLE', message: `cannot read the evidence ledger: ${error.message}` };
+  }
+
+  let boundStoreHash = null;
+  const evidencedTicketHashes = new Map(); // ticketId → last recorded ticketHash
+  for (const line of lines) {
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; } // a malformed line is another check's concern
+    const data = entry?.data;
+    if (data && typeof data.storeHash === 'string') boundStoreHash = data.storeHash;
+    if (data && data.bindingScope === 'ticket' && typeof entry.ticket === 'string' && typeof data.ticketHash === 'string') {
+      evidencedTicketHashes.set(entry.ticket, data.ticketHash);
+    }
+  }
+
+  if (!boundStoreHash) return { ...check, bound: false, reason: 'no evidence-required transaction recorded yet' };
+
+  check.bound = true;
+  check.storeHash = snapshot.hash;
+  check.boundStoreHash = boundStoreHash;
+
+  const tampered = [];
+  for (const [id, recordedHash] of evidencedTicketHashes) {
+    const liveHash = snapshot.ticketHashes[id];
+    if (liveHash !== undefined && liveHash !== recordedHash) tampered.push(id);
+  }
+  if (tampered.length > 0) {
+    return {
+      ...check,
+      ok: false,
+      code: 'STOREHASH_MANIFEST_MISMATCH',
+      tampered,
+      message: `ticket(s) changed outside a recorded transaction — live storeHash no longer matches the manifest evidence: ${tampered.join(', ')}`,
+    };
+  }
+
+  if (snapshot.hash !== boundStoreHash) {
+    check.drift = true;
+    check.message = 'live storeHash differs from the last recorded evidence, but every evidenced ticket is intact — unevidenced non-sensitive op(s) since; reported, not failed';
+  }
+  return check;
+}
+
 export function doctorTicketStore(store, { root = '.', archive = false } = {}) {
   const checks = [];
   let snapshot = null;
@@ -50,6 +127,7 @@ export function doctorTicketStore(store, { root = '.', archive = false } = {}) {
   const lockPath = join(root, LOCK_DIRECTORY);
   checks.push({ name: 'writer-lock', ok: !existsSync(lockPath), present: existsSync(lockPath), metadata: readTicketLock(root) });
   checks.push(currentTicketCheck(root, snapshot));
+  checks.push(storeHashBindingCheck(root, snapshot));
   if (archive) {
     const path = join(root, ARCHIVE_DIRECTORY);
     if (!existsSync(path)) checks.push({ name: 'archive', ok: true, present: false, ticketCount: 0 });

--- a/packages/tickets/lib/doctor.mjs
+++ b/packages/tickets/lib/doctor.mjs
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { ARCHIVE_DIRECTORY, CURRENT_TICKET_FILE, LOCK_DIRECTORY } from './constants.mjs';
 import { readTicketLock } from './lock.mjs';
@@ -73,14 +74,26 @@ function storeHashBindingCheck(root, snapshot) {
     return { ...check, ok: false, code: 'MANIFEST_UNREADABLE', message: `cannot read the evidence ledger: ${error.message}` };
   }
 
-  // The last store-level evidence entry is the most recent CHECKPOINT the store was
-  // hash-bound at. We report only whether the store still matches that checkpoint.
+  // Verify the manifest is a well-formed, unbroken hash chain BEFORE trusting any
+  // storeHash it records. Otherwise a forged or tampered ledger could assert an
+  // arbitrary "bound" hash, and a malformed line silently skipped could hide a break.
+  // The chain format is the ledger writer's (evidence.mjs / ledger.mjs): each entry's
+  // `prev` is sha256 of the previous raw line, and `seq` increments from 1.
   let boundStoreHash = null;
-  for (const line of lines) {
+  let prevLine = null;
+  let prevSeq = 0;
+  for (let i = 0; i < lines.length; i++) {
     let entry;
-    try { entry = JSON.parse(line); } catch { continue; } // a malformed line is another check's concern
-    const data = entry?.data;
-    if (data && typeof data.storeHash === 'string') boundStoreHash = data.storeHash;
+    try { entry = JSON.parse(lines[i]); } catch {
+      return { ...check, bound: false, reason: `manifest ledger has a malformed entry at line ${i + 1}; integrity not verifiable` };
+    }
+    const expectedPrev = prevLine === null ? null : createHash('sha256').update(prevLine).digest('hex');
+    if (entry?.prev !== expectedPrev || entry?.seq !== prevSeq + 1) {
+      return { ...check, bound: false, reason: `manifest hash chain breaks at line ${i + 1}; integrity not verifiable` };
+    }
+    if (entry?.data && typeof entry.data.storeHash === 'string') boundStoreHash = entry.data.storeHash;
+    prevLine = lines[i];
+    prevSeq = entry.seq;
   }
 
   if (!boundStoreHash) return { ...check, bound: false, reason: 'no evidence-required transaction recorded yet' };

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -150,7 +150,45 @@ test('doctor storehash-manifest-bind: a clean store (unchanged since the last ev
     assert.equal(check.ok, true);
     assert.equal(check.bound, true);
     assert.notEqual(check.drift, true, 'no drift on a clean store');
+    // No ADLC_MANIFEST_KEY here → the binding is NOT cryptographically authenticated, and
+    // the check must say so rather than implying an attestation it did not make.
+    assert.equal(check.authenticated, false, 'without a key the checkpoint is not authenticated');
+    assert.match(check.warning ?? '', /not cryptographically authenticated|forgeable/i, 'and the unauthenticated risk is surfaced');
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('doctor storehash-manifest-bind: WITHOUT a key, a coordinated shard+final-entry edit hides drift — but is flagged UNAUTHENTICATED', () => {
+  // The reviewer's exploit (round-34): with no key, an editor changes a shard, recomputes the
+  // public store hash, and rewrites the FINAL manifest entry's data.storeHash to match. The
+  // backward chain still validates and no drift shows, so a naive reading is "bound + clean".
+  // Doctor cannot DETECT this without a signing key — but it must not present it as attested:
+  // authenticated:false + a warning are the honest signal (WITH a key this same edit fails the
+  // signature check, proven separately).
+  const prevKey = process.env.ADLC_MANIFEST_KEY;
+  delete process.env.ADLC_MANIFEST_KEY;
+  const { root, store } = storeWithEvidence();
+  try {
+    // 1) Tamper with A's shard.
+    const shard = join(root, '.adlc', 'tickets', ticketFilename('A'));
+    writeFileSync(shard, prettyCanonicalJson({ ...JSON.parse(readFileSync(shard, 'utf8')), title: 'Coordinated tamper' }));
+    const forgedHash = store.load().hash; // the new, public store hash
+
+    // 2) Rewrite the final manifest entry's bound storeHash to match — hiding the drift.
+    const manifestPath = join(root, '.adlc', 'manifest.jsonl');
+    const mlines = readFileSync(manifestPath, 'utf8').split('\n').filter((l) => l.trim());
+    const last = JSON.parse(mlines[mlines.length - 1]);
+    last.data = { ...last.data, storeHash: forgedHash };
+    mlines[mlines.length - 1] = JSON.stringify(last);
+    writeFileSync(manifestPath, mlines.join('\n') + '\n');
+
+    const check = bindCheck(doctorTicketStore(store, { root }));
+    assert.notEqual(check.drift, true, 'the coordinated edit hides drift (why signatures are needed)');
+    assert.equal(check.authenticated, false, 'so doctor must NOT present it as authenticated');
+    assert.match(check.warning ?? '', /not cryptographically authenticated|forgeable/i, 'the forgeability is surfaced, not hidden');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    if (prevKey === undefined) delete process.env.ADLC_MANIFEST_KEY; else process.env.ADLC_MANIFEST_KEY = prevKey;
+  }
 });
 
 test('doctor storehash-manifest-bind: a hand-edited shard surfaces as drift, deliberately NOT adjudicated as tamper', () => {

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -223,9 +223,10 @@ test('doctor storehash-manifest-bind: a forged / chain-broken manifest is NOT tr
 
     const report = doctorTicketStore(store, { root });
     const check = bindCheck(report);
-    assert.equal(check.bound, false, 'a chain-invalid manifest is not trusted as a binding');
+    assert.equal(check.ok, false, 'a chain-invalid manifest FAILS the integrity check');
+    assert.equal(report.ok, false, 'and fails the overall report — a detected corruption is never reported healthy');
     assert.notEqual(check.boundStoreHash, 'deadbeefdeadbeef', 'the forged storeHash is never adopted');
-    assert.match(check.reason ?? '', /chain|verifiable|malformed/i, 'the broken chain is reported');
+    assert.match(check.reason ?? '', /chain|FAILED|malformed/i, 'the broken chain is reported');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createHmac } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DirectoryTicketStore, TicketService, doctorTicketStore, prettyCanonicalJson, ticketFilename } from '../index.mjs';
@@ -228,6 +229,79 @@ test('doctor storehash-manifest-bind: a forged / chain-broken manifest is NOT tr
     assert.notEqual(check.boundStoreHash, 'deadbeefdeadbeef', 'the forged storeHash is never adopted');
     assert.match(check.reason ?? '', /chain|FAILED|malformed/i, 'the broken chain is reported');
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// Signature verification (adversarial-review round 6): the backward hash chain
+// leaves the FINAL entry unprotected, so with a key configured every entry must
+// also carry a valid HMAC or the last entry's storeHash could be edited in place.
+function signManifestEntry(key, entry) {
+  const canonical = { seq: entry.seq, gate: entry.gate, ts: entry.ts };
+  if (entry.ticket !== undefined) canonical.ticket = entry.ticket;
+  if (entry.data !== undefined) canonical.data = entry.data;
+  canonical.files = entry.files;
+  canonical.prev = entry.prev;
+  return createHmac('sha256', key).update(JSON.stringify(canonical)).digest('hex');
+}
+
+function writeSignedManifest(root, key, { storeHash }) {
+  const entry = { seq: 1, gate: 'ticket-complete', ts: '2026-01-01T00:00:00.000Z', data: { storeHash, bindingScope: 'store' }, files: {}, prev: null };
+  entry.sig = signManifestEntry(key, entry);
+  writeFileSync(join(root, '.adlc', 'manifest.jsonl'), `${JSON.stringify(entry)}\n`);
+  return entry;
+}
+
+test('doctor storehash-manifest-bind: with a key set, a validly-signed manifest verifies (signaturesVerified)', () => {
+  const { root, store } = storeWithEvidence();
+  const prevKey = process.env.ADLC_MANIFEST_KEY;
+  try {
+    process.env.ADLC_MANIFEST_KEY = 'test-signing-key';
+    const live = store.load().hash;
+    writeSignedManifest(root, 'test-signing-key', { storeHash: live });
+
+    const check = bindCheck(doctorTicketStore(store, { root }));
+    assert.equal(check.ok, true, 'a correctly-signed ledger verifies');
+    assert.equal(check.signaturesVerified, true, 'and reports that signatures WERE checked');
+    assert.notEqual(check.drift, true, 'the bound hash matches the live store');
+  } finally {
+    if (prevKey === undefined) delete process.env.ADLC_MANIFEST_KEY; else process.env.ADLC_MANIFEST_KEY = prevKey;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('doctor storehash-manifest-bind: an in-place edit of the FINAL entry storeHash fails signature verification', () => {
+  const { root, store } = storeWithEvidence();
+  const prevKey = process.env.ADLC_MANIFEST_KEY;
+  try {
+    process.env.ADLC_MANIFEST_KEY = 'test-signing-key';
+    const entry = writeSignedManifest(root, 'test-signing-key', { storeHash: store.load().hash });
+    // The exploit: rewrite the last entry's storeHash but leave its signature (and
+    // the chain, which does not protect the final line) untouched.
+    const forged = { ...entry, data: { ...entry.data, storeHash: 'deadbeefdeadbeef' } };
+    writeFileSync(join(root, '.adlc', 'manifest.jsonl'), `${JSON.stringify(forged)}\n`);
+
+    const report = doctorTicketStore(store, { root });
+    const check = bindCheck(report);
+    assert.equal(check.ok, false, 'the tampered final entry fails verification');
+    assert.equal(check.code, 'MANIFEST_SIGNATURE_INVALID');
+    assert.equal(report.ok, false, 'and fails the overall report');
+    assert.notEqual(check.boundStoreHash, 'deadbeefdeadbeef', 'the forged storeHash is never adopted');
+  } finally {
+    if (prevKey === undefined) delete process.env.ADLC_MANIFEST_KEY; else process.env.ADLC_MANIFEST_KEY = prevKey;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('doctor storehash-manifest-bind: with NO key configured, it reports signatures were not verified', () => {
+  const { root, store } = storeWithEvidence();
+  const prevKey = process.env.ADLC_MANIFEST_KEY;
+  try {
+    delete process.env.ADLC_MANIFEST_KEY;
+    const check = bindCheck(doctorTicketStore(store, { root }));
+    assert.equal(check.signaturesVerified, false, 'no false assurance — only the structural chain was checked');
+  } finally {
+    if (prevKey !== undefined) process.env.ADLC_MANIFEST_KEY = prevKey;
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('doctor storehash-manifest-bind: a store with no recorded evidence yet is inert (not a failure)', () => {

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DirectoryTicketStore, doctorTicketStore } from '../index.mjs';
+import { DirectoryTicketStore, TicketService, doctorTicketStore, prettyCanonicalJson, ticketFilename } from '../index.mjs';
 import { ticket, writeDirectory } from './helpers.mjs';
 
 test('doctor is read-only and reports active/archive/runtime health', () => {
@@ -108,6 +108,89 @@ test('doctor current-ticket: a pointer pinning no ticketHash is reported (strict
     assert.equal(d.check.ok, false);
     assert.equal(d.check.code, 'ACTIVE_TICKET_HASH_MISSING');
   } finally { d.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// storeHash ↔ manifest evidence binding (T77).
+//
+// doctor reported the live storeHash but never compared it to the storeHash the
+// last evidence-required transaction bound in .adlc/manifest.jsonl, so a silent
+// shard hand-edit between transactions went undetected. The check now binds them:
+//   - clean store (hash == last bound storeHash) → pass;
+//   - hash drifted but the evidenced ticket(s) still match → legit unevidenced
+//     non-sensitive op(s), REPORTED not failed;
+//   - an evidenced ticket that no longer matches its bound hash → tamper, FLAGGED.
+// ---------------------------------------------------------------------------
+
+/** A directory store with ticket A authored and COMPLETED (so A carries manifest evidence). */
+function storeWithEvidence(extra = []) {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-doctor-bind-'));
+  writeDirectory(root, []); // empty directory store (.store.json only)
+  const store = new DirectoryTicketStore(join(root, '.adlc', 'tickets'));
+  const service = new TicketService(store, { root });
+  service.apply(service.planCreate(ticket('A')));
+  for (const t of extra) service.apply(service.planCreate(t));
+  service.apply(service.planComplete('A')); // evidence-required → records bound storeHash + A's hash
+  return { root, store, service };
+}
+
+const bindCheck = (report) => report.checks.find((c) => c.name === 'storehash-manifest-bind');
+
+test('doctor storehash-manifest-bind: a clean store (unchanged since the last evidence) passes and binds', () => {
+  const { root, store } = storeWithEvidence();
+  try {
+    const report = doctorTicketStore(store, { root });
+    const check = bindCheck(report);
+    assert.ok(check, 'the storeHash↔manifest check is present');
+    assert.equal(check.ok, true);
+    assert.equal(check.bound, true);
+    assert.notEqual(check.drift, true, 'no drift on a clean store');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('doctor storehash-manifest-bind: a hand-edited shard (tamper) is flagged and fails the report', () => {
+  const { root, store } = storeWithEvidence();
+  try {
+    // Hand-edit A's shard directly, bypassing the transaction machinery: keep the
+    // id (so the filename still matches) but change the title. A's hash — and the
+    // whole storeHash — now diverge from the evidence with no new manifest entry.
+    const shard = join(root, '.adlc', 'tickets', ticketFilename('A'));
+    const tampered = { ...JSON.parse(readFileSync(shard, 'utf8')), title: 'Silently edited' };
+    writeFileSync(shard, prettyCanonicalJson(tampered));
+
+    const report = doctorTicketStore(store, { root });
+    const check = bindCheck(report);
+    assert.equal(check.ok, false, 'the tamper is flagged');
+    assert.equal(check.code, 'STOREHASH_MANIFEST_MISMATCH');
+    assert.equal(report.ok, false, 'a tampered store fails the whole report');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('doctor storehash-manifest-bind: a legitimate unevidenced op (create) is reported as drift, not failed', () => {
+  const { root, store, service } = storeWithEvidence();
+  try {
+    // Creating B is a non-sensitive op that records NO manifest evidence, so the
+    // live storeHash drifts from the last bound one — but A (the evidenced ticket)
+    // is untouched. That is a legitimate state: reported, never failed.
+    service.apply(service.planCreate(ticket('B')));
+
+    const report = doctorTicketStore(store, { root });
+    const check = bindCheck(report);
+    assert.equal(check.ok, true, 'a legitimate unevidenced op does not fail the check');
+    assert.equal(check.drift, true, 'but the drift is surfaced');
+    assert.equal(report.ok, true, 'and the report stays green');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('doctor storehash-manifest-bind: a store with no recorded evidence yet is inert (not a failure)', () => {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-doctor-noevidence-'));
+  try {
+    const path = writeDirectory(root, [ticket('A')]); // shards written directly; no manifest
+    const report = doctorTicketStore(new DirectoryTicketStore(path), { root });
+    const check = bindCheck(report);
+    assert.equal(check.ok, true);
+    assert.equal(check.bound, false, 'nothing to bind against yet');
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
 test('doctor current-ticket: reports that it could not validate when the store is unreadable', () => {

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -114,12 +114,16 @@ test('doctor current-ticket: a pointer pinning no ticketHash is reported (strict
 // storeHash ↔ manifest evidence binding (T77).
 //
 // doctor reported the live storeHash but never compared it to the storeHash the
-// last evidence-required transaction bound in .adlc/manifest.jsonl, so a silent
-// shard hand-edit between transactions went undetected. The check now binds them:
-//   - clean store (hash == last bound storeHash) → pass;
-//   - hash drifted but the evidenced ticket(s) still match → legit unevidenced
-//     non-sensitive op(s), REPORTED not failed;
-//   - an evidenced ticket that no longer matches its bound hash → tamper, FLAGGED.
+// last evidence-required transaction bound in .adlc/manifest.jsonl. The check now
+// binds the store to that last evidenced CHECKPOINT and reports honestly — it does
+// NOT adjudicate per-ticket tamper (unsound in this model: the ticket layer permits
+// ordinary unevidenced updates, so a "changed since its evidence" signal both
+// false-flags legitimately-edited evidenced tickets and misses hand-edits to
+// never-evidenced ones — sound tamper-detection needs a store hash per transaction,
+// a follow-up). Contract:
+//   - clean store (hash == last bound storeHash) → pass, no drift;
+//   - hash differs from the checkpoint → drift, REPORTED not failed (git history is
+//     the record for the changed shards).
 // ---------------------------------------------------------------------------
 
 /** A directory store with ticket A authored and COMPLETED (so A carries manifest evidence). */
@@ -148,21 +152,42 @@ test('doctor storehash-manifest-bind: a clean store (unchanged since the last ev
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('doctor storehash-manifest-bind: a hand-edited shard (tamper) is flagged and fails the report', () => {
+test('doctor storehash-manifest-bind: a hand-edited shard surfaces as drift, deliberately NOT adjudicated as tamper', () => {
   const { root, store } = storeWithEvidence();
   try {
-    // Hand-edit A's shard directly, bypassing the transaction machinery: keep the
-    // id (so the filename still matches) but change the title. A's hash — and the
-    // whole storeHash — now diverge from the evidence with no new manifest entry.
+    // Hand-edit A's shard directly, bypassing the transaction machinery. The store
+    // hash now diverges from the last evidenced checkpoint. This check reports the
+    // drift but must NOT claim tamper — a per-ticket tamper signal is unsound here
+    // (see the file header), so the honest output is drift, with git history as the
+    // record for the changed shard.
     const shard = join(root, '.adlc', 'tickets', ticketFilename('A'));
-    const tampered = { ...JSON.parse(readFileSync(shard, 'utf8')), title: 'Silently edited' };
-    writeFileSync(shard, prettyCanonicalJson(tampered));
+    const edited = { ...JSON.parse(readFileSync(shard, 'utf8')), title: 'Silently edited' };
+    writeFileSync(shard, prettyCanonicalJson(edited));
 
     const report = doctorTicketStore(store, { root });
     const check = bindCheck(report);
-    assert.equal(check.ok, false, 'the tamper is flagged');
-    assert.equal(check.code, 'STOREHASH_MANIFEST_MISMATCH');
-    assert.equal(report.ok, false, 'a tampered store fails the whole report');
+    assert.equal(check.drift, true, 'the divergence from the checkpoint is surfaced');
+    assert.notEqual(check.code, 'STOREHASH_MANIFEST_MISMATCH', 'but no false tamper claim is made');
+    assert.equal(check.ok, true, 'and it is not failed — this check does not adjudicate tamper');
+    assert.equal(report.ok, true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('doctor storehash-manifest-bind: a legit later update of an EVIDENCED ticket is NOT flagged as tamper (no false positive)', () => {
+  // The round-2 adversarial-review finding: an evidenced ticket that later receives
+  // an ordinary non-sensitive update (permitted, unevidenced) must not be reported
+  // as tampering. It is drift, reported, never a failure.
+  const { root, store, service } = storeWithEvidence();
+  try {
+    const current = store.load().get('A');
+    service.apply(service.planUpdate('A', { ...current, title: 'Legitimately edited later' }));
+
+    const report = doctorTicketStore(store, { root });
+    const check = bindCheck(report);
+    assert.equal(check.ok, true, 'a legit unevidenced update of an evidenced ticket does not fail');
+    assert.notEqual(check.code, 'STOREHASH_MANIFEST_MISMATCH', 'no false tamper claim');
+    assert.equal(check.drift, true, 'it is surfaced as drift');
+    assert.equal(report.ok, true, 'the report stays green on a valid repo');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -179,11 +204,9 @@ test('doctor storehash-manifest-bind: a legitimate unevidenced op (create) is re
     assert.equal(check.ok, true, 'a legitimate unevidenced op does not fail the check');
     assert.equal(check.drift, true, 'but the drift is surfaced');
     assert.equal(report.ok, true, 'and the report stays green');
-    // Honesty (adversarial-review finding): B has no evidence baseline, so this
-    // check CANNOT detect a tamper of it. The drift report must say so rather than
-    // imply the store is confirmed clean.
-    assert.ok(check.unverified >= 1, 'the count of tickets with no integrity baseline is surfaced');
-    assert.match(check.message, /not integrity-verified|no evidence baseline/i, 'the blind spot is stated, not hidden');
+    // The message is honest that the drift is unverified by this check, not a claim
+    // that the store is confirmed clean.
+    assert.match(check.message, /does not verify|git history/i, 'the drift is reported as unverified, not adjudicated');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -210,6 +210,25 @@ test('doctor storehash-manifest-bind: a legitimate unevidenced op (create) is re
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('doctor storehash-manifest-bind: a forged / chain-broken manifest is NOT trusted (no arbitrary checkpoint)', () => {
+  const { root, store } = storeWithEvidence();
+  try {
+    // Append a forged entry asserting an arbitrary storeHash but with a broken
+    // prev-link and out-of-sequence seq. The check must verify the hash chain and
+    // refuse to adopt the forged hash — reporting the ledger unverifiable instead of
+    // silently trusting the last syntactically-valid storeHash.
+    const manifestPath = join(root, '.adlc', 'manifest.jsonl');
+    const forged = JSON.stringify({ seq: 999, gate: 'forged', ts: '2026-01-01T00:00:00.000Z', data: { storeHash: 'deadbeefdeadbeef', bindingScope: 'store' }, prev: 'not-a-real-hash' });
+    writeFileSync(manifestPath, readFileSync(manifestPath, 'utf8') + forged + '\n');
+
+    const report = doctorTicketStore(store, { root });
+    const check = bindCheck(report);
+    assert.equal(check.bound, false, 'a chain-invalid manifest is not trusted as a binding');
+    assert.notEqual(check.boundStoreHash, 'deadbeefdeadbeef', 'the forged storeHash is never adopted');
+    assert.match(check.reason ?? '', /chain|verifiable|malformed/i, 'the broken chain is reported');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('doctor storehash-manifest-bind: a store with no recorded evidence yet is inert (not a failure)', () => {
   const root = mkdtempSync(join(tmpdir(), 'adlc-doctor-noevidence-'));
   try {

--- a/packages/tickets/test/doctor.test.mjs
+++ b/packages/tickets/test/doctor.test.mjs
@@ -179,6 +179,11 @@ test('doctor storehash-manifest-bind: a legitimate unevidenced op (create) is re
     assert.equal(check.ok, true, 'a legitimate unevidenced op does not fail the check');
     assert.equal(check.drift, true, 'but the drift is surfaced');
     assert.equal(report.ok, true, 'and the report stays green');
+    // Honesty (adversarial-review finding): B has no evidence baseline, so this
+    // check CANNOT detect a tamper of it. The drift report must say so rather than
+    // imply the store is confirmed clean.
+    assert.ok(check.unverified >= 1, 'the count of tickets with no integrity baseline is surfaced');
+    assert.match(check.message, /not integrity-verified|no evidence baseline/i, 'the blind spot is stated, not hidden');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/plugins/adlc-claude-code/skills/adlc/SKILL.md
+++ b/plugins/adlc-claude-code/skills/adlc/SKILL.md
@@ -126,11 +126,6 @@ downstream reads the logical store.
 This gate is a human decision, not something an agent passes. Surface the
 evidence: `adlc gate-manifest show` and the `behavior-diff compare` output, then
 let the human decide. Record outcomes with `adlc gate-manifest record <gate>`.
-Once the human accepts, **close the ticket**: `adlc gate-manifest record
-p6-accept --ticket <id>` then `adlc ticket complete <id> --write` (add
-`--authorize` when the ticket is railed). Completion sets `completed:true` so the
-ticket stops surfacing in backlog enumerations — acceptance without it leaves the
-ticket open forever.
 
 ### P7 — Distill (turn findings into defenses) → `/adlc:adlc-distill`
 - `adlc lesson-foundry --prompt-only` — mine repeated findings into deterministic

--- a/plugins/adlc-claude-code/skills/adlc/SKILL.md
+++ b/plugins/adlc-claude-code/skills/adlc/SKILL.md
@@ -126,6 +126,11 @@ downstream reads the logical store.
 This gate is a human decision, not something an agent passes. Surface the
 evidence: `adlc gate-manifest show` and the `behavior-diff compare` output, then
 let the human decide. Record outcomes with `adlc gate-manifest record <gate>`.
+Once the human accepts, **close the ticket**: `adlc gate-manifest record
+p6-accept --ticket <id>` then `adlc ticket complete <id> --write` (add
+`--authorize` when the ticket is railed). Completion sets `completed:true` so the
+ticket stops surfacing in backlog enumerations — acceptance without it leaves the
+ticket open forever.
 
 ### P7 — Distill (turn findings into defenses) → `/adlc:adlc-distill`
 - `adlc lesson-foundry --prompt-only` — mine repeated findings into deterministic

--- a/plugins/adlc-pi/lib/commands.mjs
+++ b/plugins/adlc-pi/lib/commands.mjs
@@ -164,6 +164,9 @@ export function registerCommands(pi, { env = process.env, reload, getActive, get
         const cwd = typeof getCwd === 'function' ? getCwd() : process.cwd();
         const { tickets } = loadTickets(ticketsPathFor(cwd));
         const items = tickets
+          // #104: backlog ENUMERATIONS filter completed:true. A shipped ticket is
+          // not an activation candidate; only open work is offered for completion.
+          .filter((t) => t.completed !== true)
           .filter((t) => typeof t.id === 'string' && t.id.startsWith(prefix ?? ''))
           .map((t) => ({ value: t.id, label: ticketLabel(t) }));
         return items.length > 0 ? items : null;
@@ -201,7 +204,15 @@ export function registerCommands(pi, { env = process.env, reload, getActive, get
           ctx.ui.notify('ADLC: /adlc-ticket needs a ticket id in non-interactive mode (e.g. /adlc-ticket T1).', 'warning');
           return;
         }
-        const options = tickets.map(ticketLabel);
+        // #104: the picker is a backlog ENUMERATION — offer only OPEN tickets, so
+        // shipped (completed:true) ones are not presented as activation candidates.
+        // A completed ticket is still activatable by explicit id above (a lookup).
+        const openTickets = tickets.filter((t) => t.completed !== true);
+        if (openTickets.length === 0) {
+          ctx.ui.notify('ADLC: every ticket is completed — nothing open to activate.', 'info');
+          return;
+        }
+        const options = openTickets.map(ticketLabel);
         const picked = await ctx.ui.select('Select the active ADLC ticket', options);
         if (picked === undefined) {
           // Cancelled / timed out — leave state untouched (spec AC3).
@@ -213,8 +224,8 @@ export function registerCommands(pi, { env = process.env, reload, getActive, get
           ctx.ui.notify('ADLC: selection did not match a known ticket — active ticket unchanged.', 'warning');
           return;
         }
-        chosenId = tickets[idx].id;
-        chosenTicket = tickets[idx];
+        chosenId = openTickets[idx].id;
+        chosenTicket = openTickets[idx];
       }
 
       // Activate: write the pointer DIRECTLY. This is the human acting through

--- a/plugins/adlc-pi/test/commands.test.mjs
+++ b/plugins/adlc-pi/test/commands.test.mjs
@@ -192,6 +192,51 @@ test('AC2: /adlc-ticket getArgumentCompletions completes ticket ids by prefix', 
 });
 
 // =========================================================================
+// #104 (T76) — completed tickets are filtered OUT of BOTH enumerations (the
+// argument completions and the interactive picker), so 40 shipped tickets stop
+// being offered as activation candidates. Named-id activation of a completed
+// ticket stays allowed — that is a lookup, not an enumeration.
+// =========================================================================
+
+const T2_DONE = { ...T2, completed: true };
+
+test('#104: getArgumentCompletions excludes a completed ticket and keeps the open one', async () => {
+  const root = makeRepo({ tickets: [T1, T2_DONE], current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const all = pi.commands['adlc-ticket'].getArgumentCompletions('');
+    assert.deepEqual(all.map((i) => i.value), ['T1'], 'the completed ticket is not offered as a completion');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('#104: the interactive picker offers only open tickets, and activates the right one', async () => {
+  const root = makeRepo({ tickets: [T1, T2_DONE], current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    let offered = null;
+    const ctx = fakeCtx(root, { select: (_title, options) => { offered = options; return options[0]; } });
+    await pi.commands['adlc-ticket'].handler('', ctx);
+    assert.equal(offered.length, 1, 'the completed ticket is not an option');
+    assert.ok(offered[0].startsWith('T1'), 'the open ticket is the only option');
+    // The picked label maps back to the OPEN ticket, not a filtered-away index.
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T1');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('#104: a completed ticket is still activatable by explicit id (lookup, not enumeration)', async () => {
+  const root = makeRepo({ tickets: [T1, T2_DONE], current: 'T1' });
+  try {
+    const { pi } = await boot(root);
+    const ctx = fakeCtx(root);
+    await pi.commands['adlc-ticket'].handler('T2', ctx);
+    assert.ok(!ctx.notices.some((n) => n.level === 'error'), 'no error activating a completed id by name');
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T2', 'named activation of a completed ticket resolves');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// =========================================================================
 // AC3 — /adlc-ticket with no args surfaces ui.select; undefined leaves state
 // =========================================================================
 

--- a/plugins/adlc-pi/test/commands.test.mjs
+++ b/plugins/adlc-pi/test/commands.test.mjs
@@ -224,6 +224,25 @@ test('#104: the interactive picker offers only open tickets, and activates the r
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('#104: the selection maps back through the FILTERED list, not the raw ticket index', async () => {
+  // Regression guard for the index remap: the completed ticket sorts FIRST, so
+  // the open ticket lives at openTickets[0] but tickets[1]. If the handler mapped
+  // the pick through the unfiltered `tickets` it would activate the COMPLETED
+  // ticket the human never saw. A fixture whose open ticket sorts first cannot
+  // tell the two apart — this one deliberately puts the completed ticket first.
+  const root = makeRepo({ tickets: [{ ...T1, completed: true }, T2], current: 'T2' });
+  try {
+    const { pi } = await boot(root);
+    let offered = null;
+    const ctx = fakeCtx(root, { select: (_title, options) => { offered = options; return options[0]; } });
+    await pi.commands['adlc-ticket'].handler('', ctx);
+    assert.equal(offered.length, 1, 'only the open ticket is offered');
+    assert.ok(offered[0].startsWith('T2'), 'the single option is the open ticket');
+    const pointer = JSON.parse(readFileSync(join(root, '.adlc', 'current-ticket.json'), 'utf8'));
+    assert.equal(pointer.id, 'T2', 'activates the open ticket that was picked, not the completed one at the same raw index');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('#104: a completed ticket is still activatable by explicit id (lookup, not enumeration)', async () => {
   const root = makeRepo({ tickets: [T1, T2_DONE], current: 'T1' });
   try {

--- a/scripts/test/p6-close-step-docs.test.mjs
+++ b/scripts/test/p6-close-step-docs.test.mjs
@@ -1,0 +1,40 @@
+// T74 — the documented P6 lifecycle must conclude with ticket completion.
+// Before this, ADLC.md's P6 section and the adlc skill's P6 block ended at
+// "human behavioral acceptance" / "record gate-manifest" and never told the
+// operator to actually mark the ticket done, so accepted tickets stayed open
+// forever. These grep asserts pin the close step into BOTH docs so it can't
+// silently regress.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (rel) => readFileSync(join(ROOT, rel), 'utf8');
+
+/** Slice the section that starts at `heading` and ends at the next same-or-higher heading. */
+function section(text, heading) {
+  const start = text.indexOf(heading);
+  assert.notEqual(start, -1, `heading not found: ${heading}`);
+  const level = heading.match(/^#+/)[0].length;
+  const rest = text.slice(start + heading.length);
+  const nextHeading = rest.search(new RegExp(`\\n#{1,${level}} `, 'm'));
+  return nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+}
+
+test('ADLC.md P6 section documents concluding acceptance with ticket completion', () => {
+  const p6 = section(read('ADLC.md'), '### P6 — Integrate');
+  assert.match(p6, /adlc ticket complete/, 'P6 must name the `adlc ticket complete` close step');
+  assert.match(p6, /gate-manifest record p6-accept/, 'P6 must name recording the p6-accept verdict');
+  assert.match(p6, /--authorize/, 'P6 must note the railed-ticket authorization/ceremony');
+});
+
+test('adlc skill P6 block documents concluding acceptance with ticket completion', () => {
+  const skill = read('plugins/adlc-claude-code/skills/adlc/SKILL.md');
+  const p6 = section(skill, '### P6 — Integrate (the human gate)');
+  assert.match(p6, /adlc ticket complete/, 'SKILL.md P6 must name the `adlc ticket complete` close step');
+  assert.match(p6, /gate-manifest record\s+p6-accept/, 'SKILL.md P6 must name recording the p6-accept verdict');
+  assert.match(p6, /--authorize/, 'SKILL.md P6 must note the railed-ticket authorization');
+});

--- a/scripts/test/p6-close-step-docs.test.mjs
+++ b/scripts/test/p6-close-step-docs.test.mjs
@@ -1,9 +1,14 @@
 // T74 — the documented P6 lifecycle must conclude with ticket completion.
-// Before this, ADLC.md's P6 section and the adlc skill's P6 block ended at
-// "human behavioral acceptance" / "record gate-manifest" and never told the
-// operator to actually mark the ticket done, so accepted tickets stayed open
-// forever. These grep asserts pin the close step into BOTH docs so it can't
-// silently regress.
+// Before this, ADLC.md's P6 section ended at "human behavioral acceptance" and
+// never told the operator to actually mark the ticket done, so accepted tickets
+// stayed open forever. The close step is pinned into ADLC.md (the full process doc).
+//
+// It is DELIBERATELY NOT in the generated adlc-skill router (SKILL.md): that file is
+// the terse phase -> `adlc <gate>` skeleton, frozen by the consolidation routing guard
+// (scripts/router/check-consolidation.mjs). Adding `adlc ticket complete` to its P6
+// block registers a new routing token and fails that guard — the completion CEREMONY
+// is process detail, not a phase gate. Both directions are asserted so neither
+// regresses: ADLC.md must keep the step, the router must NOT grow it.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -31,10 +36,12 @@ test('ADLC.md P6 section documents concluding acceptance with ticket completion'
   assert.match(p6, /--authorize/, 'P6 must note the railed-ticket authorization/ceremony');
 });
 
-test('adlc skill P6 block documents concluding acceptance with ticket completion', () => {
+test('the adlc-skill router P6 stays the terse gate-manifest routing (ceremony lives in ADLC.md)', () => {
   const skill = read('plugins/adlc-claude-code/skills/adlc/SKILL.md');
   const p6 = section(skill, '### P6 — Integrate (the human gate)');
-  assert.match(p6, /adlc ticket complete/, 'SKILL.md P6 must name the `adlc ticket complete` close step');
-  assert.match(p6, /gate-manifest record\s+p6-accept/, 'SKILL.md P6 must name recording the p6-accept verdict');
-  assert.match(p6, /--authorize/, 'SKILL.md P6 must note the railed-ticket authorization');
+  // The router's P6 routes to its gate (gate-manifest) and nothing more. The
+  // completion ceremony must NOT be here: `adlc ticket complete` would add a routing
+  // token and break the consolidation guard. This asserts the routing-freeze holds.
+  assert.match(p6, /adlc gate-manifest/, 'the router P6 still names its gate-manifest gate');
+  assert.doesNotMatch(p6, /adlc ticket complete/, 'the completion ceremony belongs in ADLC.md, not the frozen router');
 });


### PR DESCRIPTION
## Summary

Closes the **missing ticket-completion step** in the ADLC lifecycle — the reason shipped tickets accumulated open — and hardens the machinery around it through 35 rounds of cross-model adversarial review. One of two parallel ADLC workstreams (the other is `feat/distill-pipeline-hardening`, PR #344). **No code overlap with `main`.**

## The root gap (T144–T148, née T73–T77)

The fleet computed the merged-ticket set and discarded it; nothing in the lifecycle ever set `completed:true`, so every shipped ticket stayed open. Five work items close that:

- **T144 — fleet auto-complete.** After a ticket's post-merge gate passes, complete it on the integration branch via `planComplete` + apply, committing the add-only `completed:true` diff so it rides the single PR fleet already opens. Idempotent; a gate-failed ticket is never completed.
- **T145 — P6 close step.** The documented P6 gate ended at "human behavioral acceptance" and never told the operator to mark the ticket done. Pin the `adlc ticket complete` close step into `ADLC.md` (the router stays the terse gate skeleton, frozen by the consolidation guard).
- **T146 — prune wedge fix.** `ticket-prune` wedged mid-batch on an `ARCHIVE_INBOUND_EDGE`; skip-and-continue with a topological archive order so one blocked ticket can't stall the rest.
- **T147 — pi picker #104 filter.** Filter `completed:true` tickets out of the pi `/adlc-ticket` picker and completions (the completion-lifecycle invariant every backlog consumer must honor).
- **T148 — doctor storeHash binding.** Bind the live store hash to the last recorded manifest evidence entry, so doctor reports whether the store is at its last evidenced checkpoint — and, without a signing key, honestly flags the binding as unauthenticated rather than presenting a forgeable checkpoint as attested.

## Adversarial-review hardening (35 rounds → `approve`)

The deep vein was the fleet's **dedicated integration worktree** and its recovery paths. Highlights:

- **Structural isolation.** Every integration step runs in a dedicated worktree, never the shared checkout — git *refuses* to check out a branch already checked out elsewhere, so a whole class of "wrong-branch attribution" races becomes impossible rather than merely detected.
- **Fail-closed recovery.** Resume/recreate no longer runs a detect-and-destroy heuristic (which repeatedly risked data loss); it **refuses** to reuse or force-remove a dirty *or unreadable* integration worktree, so an orphaned completion can never ride onto a later commit and no operator recovery work is ever silently destroyed.
- **Await the post-merge gate.** `runGates` is async; the HEAD-pin race check now awaits it, so a commit landing *during* the gate is actually caught (it was a no-op before).
- **Honest PR + exit code.** `openPR`'s reported outcome is trusted (no fabricated PR count), and a merged-but-unpublished run exits non-zero so automation isn't told it's complete.
- **Real producer→consumer test.** A fleet completion commit is round-tripped through the *actual* `scripts/rails-guard-ci.mjs` gate, not a re-implementation of it.

## Ticket renumber (T73–T77 → T144–T148)

While this branch was in flight, `main` claimed t73–t77 for unrelated work (pi/herdr/misc). The five reconciliation tickets were re-authored under the next free ids via the ticket tooling; content is unchanged and no implementation commit referenced ticket ids.

## Test plan

- [x] `fleet` 303 · `tickets` 128 · `gate-manifest` 68 · `ticket-prune` 71 · `adlc-pi` 207 · `p6-docs` 2 — all green
- [x] `adversarial-review --base main` → **approve**, 0 findings (round 35)
- [x] `scripts/rails-guard-ci.mjs origin/main` → all checks passed
- [x] `doctor` → ok; store loads (95 tickets), storeHash binding present
- [ ] CI green on the PR
- [ ] P6 human merge gate

## Follow-up

After this merges, the ~29 already-shipped-but-open tickets on `main` can be closed via the workspace prune/complete ceremony (this branch's prune wedge fix + completion path unblock that).
