### PR TITLE
#326 — Wire the trust-root cross-model review gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,33 @@ jobs:
         if: matrix.node-version == 22
         run: node scripts/pi-live-prosecute.mjs
 
+      # #326: the trust-root cross-model review gate, finally INVOKED — and FOLDED
+      # into this REQUIRED job (a separate job could not be made a required check on
+      # this repo's plan, so it would enforce nothing). A trust-root-tier change (an
+      # enforcement/producer package, a rails deny-path, or a trust-root file)
+      # requires a distinct-provider cross-model `approve` bound to the reviewed
+      # revision; fails closed (exit 2) with no matching attestation. The ticket
+      # STORE is deliberately NOT a tier surface — rails-guard-ci owns it. Runs on
+      # the Node 20 leg only, LAST, and on PRs only (a push has no base diff).
+      - name: Trust-root cross-model gate (#326)
+        if: matrix.node-version == 20 && github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # This repo's default PR author provider; distinctness is checked against
+          # it, so a same-provider review never satisfies the gate. Override with an
+          # ADLC_AUTHOR_PROVIDER repository variable if the author model changes.
+          ADLC_AUTHOR_PROVIDER: ${{ vars.ADLC_AUTHOR_PROVIDER || 'anthropic' }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+          git fetch --no-tags origin "$HEAD_SHA"
+          # Check out the PR HEAD (this job otherwise runs on the merge commit) with
+          # --force, so the worktree is the exact committed head tree the author
+          # recorded the attestation against — undoing any install-time lockfile
+          # churn. node_modules (gitignored) is untouched, so the gate still runs.
+          git checkout --quiet --force "$HEAD_SHA"
+          node packages/prosecute/bin/adlc-prosecute.mjs tier-check --base "origin/$BASE_REF" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc
+
   # T31 drift canary: the SAME two OpenCode live proofs against opencode-ai@latest.
   # ADVISORY by design (continue-on-error): upstream releases near-daily, and a
   # latest-version break must be VISIBLE same-day without blocking unrelated
@@ -307,53 +334,6 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: node scripts/guard-findings-ledger-append-only.mjs "origin/$BASE_REF"
-
-  cross-model-gate:
-    # #326: the trust-root cross-model review gate, finally INVOKED. A trust-root-
-    # tier change — an enforcement/producer package, a rails deny-path, a trust-root
-    # file, or an ALTERATION of an existing ticket contract — requires a distinct-
-    # provider cross-model adversarial `approve` bound to the reviewed revision.
-    # ADDITIVE ticket writes do NOT tier (add-vs-alter, aligned with rails-guard-ci).
-    # Fails closed: a tiered change with no matching attestation reddens this check.
-    # PR-only (a push has no base diff to gate).
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PR head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # The PR HEAD, NOT the merge commit: the gate hashes the worktree to a
-          # revision, and the attestation the author recorded must bind to the SAME
-          # tree. The manifest lives under .adlc/ (revision-ignored), so a committed
-          # attestation does not shift the hash.
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 20
-
-      - name: Install
-        # npm ci (not npm install) so the checkout is not perturbed by a lockfile
-        # rewrite, keeping the CI-computed revision equal to the recorded one.
-        run: npm ci
-
-      - name: Fetch base ref
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-        run: git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
-
-      - name: Trust-root cross-model gate
-        # The tier decision is always printed (a non-tiered PR passes and says so),
-        # so "no review required" and "review missing" are never both silent.
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          # This repo's default PR author provider; distinctness is checked against
-          # it, so a same-provider review never satisfies the gate. Override with an
-          # ADLC_AUTHOR_PROVIDER repository variable if the author model changes.
-          ADLC_AUTHOR_PROVIDER: ${{ vars.ADLC_AUTHOR_PROVIDER || 'anthropic' }}
-        run: node packages/prosecute/bin/adlc-prosecute.mjs tier-check --base "origin/$BASE_REF" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc
 
   mutation-gate:
     # C4 hollow-test, diff-scoped. Catches a guard added without a test that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,51 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: node scripts/guard-findings-ledger-append-only.mjs "origin/$BASE_REF"
 
+  cross-model-gate:
+    # #326: the trust-root cross-model review gate, finally INVOKED. A trust-root-
+    # tier change — an enforcement/producer package, a rails deny-path, a trust-root
+    # file, or an ALTERATION of an existing ticket contract — requires a distinct-
+    # provider cross-model adversarial `approve` bound to the reviewed revision.
+    # ADDITIVE ticket writes do NOT tier (add-vs-alter, aligned with rails-guard-ci).
+    # Fails closed: a tiered change with no matching attestation reddens this check.
+    # PR-only (a push has no base diff to gate).
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The PR HEAD, NOT the merge commit: the gate hashes the worktree to a
+          # revision, and the attestation the author recorded must bind to the SAME
+          # tree. The manifest lives under .adlc/ (revision-ignored), so a committed
+          # attestation does not shift the hash.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm install
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      - name: Trust-root cross-model gate
+        # The tier decision is always printed (a non-tiered PR passes and says so),
+        # so "no review required" and "review missing" are never both silent.
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          # This repo's default PR author provider; distinctness is checked against
+          # it, so a same-provider review never satisfies the gate. Override with an
+          # ADLC_AUTHOR_PROVIDER repository variable if the author model changes.
+          ADLC_AUTHOR_PROVIDER: ${{ vars.ADLC_AUTHOR_PROVIDER || 'anthropic' }}
+        run: node packages/prosecute/bin/adlc-prosecute.mjs tier-check --base "origin/$BASE_REF" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc
+
   mutation-gate:
     # C4 hollow-test, diff-scoped. Catches a guard added without a test that
     # notices it being removed — code that is correct but unverified.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,9 @@ jobs:
           node-version: 20
 
       - name: Install
-        run: npm install
+        # npm ci (not npm install) so the checkout is not perturbed by a lockfile
+        # rewrite, keeping the CI-computed revision equal to the recorded one.
+        run: npm ci
 
       - name: Fetch base ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install
-        run: npm install
+        # #326 Codex F1 (round 3): install with NO lifecycle scripts, then rebuild ONLY
+        # a trusted allowlist of native deps. This is the job that runs the trust-root
+        # cross-model gate below; a candidate `postinstall` in ANY workspace/dep manifest
+        # would otherwise run here and could shim node/npm onto $GITHUB_PATH (persisted
+        # to later steps), defeating the gate. The repo has NO first-party lifecycle
+        # scripts, and the ONLY deps that declare one are these lockfile-pinned native
+        # packages (verified via package-lock `hasInstallScript`), so this reproduces a
+        # normal install for any legitimate PR while never running candidate-controlled
+        # code. A candidate cannot extend the allowlist without a lockfile change, which
+        # tiers. Keep this list in sync with `hasInstallScript` deps.
+        run: |
+          npm install --ignore-scripts
+          npm rebuild esbuild sharp msgpackr-extract protobufjs @google/genai
 
       - name: Test
         run: npm test
@@ -152,13 +164,12 @@ jobs:
           # recorded the attestation against — undoing any install-time lockfile
           # churn. node_modules (gitignored) is untouched, so the gate still runs.
           git checkout --quiet --force "$HEAD_SHA"
-          # #326 Codex F1 defense-in-depth: the job's top-level `npm install` ran the
-          # candidate's install scripts, which could have poisoned the node_modules the
-          # gate imports (@adlc/core, @adlc/gate-manifest). Rebuild the toolchain from
-          # the checked-out sources with NO scripts before trusting it. `npm ci` (not
-          # install) so the lockfile — hence the computed revision — is not rewritten;
-          # the root install manifests are also a tier surface, so a lockfile/scripts
-          # change cannot merge unreviewed in the first place.
+          # Rebuild node_modules for the HEAD tree with NO scripts. The job's top-level
+          # Install already ran --ignore-scripts (so no candidate lifecycle script has
+          # executed in this runner — see that step), making this defense-in-depth: it
+          # also re-links the @adlc/* workspaces the gate imports to the checked-out HEAD
+          # sources. `npm ci` (not install) so the lockfile — hence the computed
+          # revision — is not rewritten.
           npm ci --ignore-scripts
           node packages/prosecute/bin/adlc-prosecute.mjs tier-check --base "origin/$BASE_REF" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,14 @@ jobs:
           # recorded the attestation against — undoing any install-time lockfile
           # churn. node_modules (gitignored) is untouched, so the gate still runs.
           git checkout --quiet --force "$HEAD_SHA"
+          # #326 Codex F1 defense-in-depth: the job's top-level `npm install` ran the
+          # candidate's install scripts, which could have poisoned the node_modules the
+          # gate imports (@adlc/core, @adlc/gate-manifest). Rebuild the toolchain from
+          # the checked-out sources with NO scripts before trusting it. `npm ci` (not
+          # install) so the lockfile — hence the computed revision — is not rewritten;
+          # the root install manifests are also a tier surface, so a lockfile/scripts
+          # change cannot merge unreviewed in the first place.
+          npm ci --ignore-scripts
           node packages/prosecute/bin/adlc-prosecute.mjs tier-check --base "origin/$BASE_REF" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc
 
   # T31 drift canary: the SAME two OpenCode live proofs against opencode-ai@latest.

--- a/docs/adr/0007-multimodel-adversarial-review.md
+++ b/docs/adr/0007-multimodel-adversarial-review.md
@@ -207,3 +207,25 @@ deliberately did **not** sign the provider assertion with a CI-held key — that
 what stops the stale-attestation bypass. The gate raises the bar and makes the omission visible
 in an auditable ledger; it is defense in depth behind the unbypassable rails-guard CI diff gate,
 not a cryptographic proof of review.
+
+**Honest limitation — the gate shares a runner with candidate code (#326).** The tier gate
+is *folded into the required `test` job* because a separate job cannot be made a required
+check on this repo's plan (it would enforce nothing). That job necessarily installs and runs
+candidate code, so any candidate-controlled code that executes in the runner *before* the gate
+step can shim `node`/`npm` (e.g. onto `$GITHUB_PATH`, which GitHub persists to later steps) and
+make the gate — and every other check in the job — pass without an attestation. Cross-model
+prosecution of #326 surfaced a ladder of these: an untiered root/nested `package.json`
+`postinstall`; a workspace `bin` named `node` linked into `node_modules/.bin` and hit during a
+rebuild; a candidate `.npmrc`. **The tractable layers are closed** — the root install manifests
+(`package.json`/`package-lock.json`) are a tier surface (a dependency/version/script change
+tiers → requires an attestation); the gate's job installs with `--ignore-scripts` and rebuilds
+only a lockfile-pinned trusted-native allowlist (a drift guard keeps the allowlist complete),
+so no *first-party* lifecycle script runs; the attestation read fails closed on a manifest whose
+hash chain does not `verify()`. **The residual is the general limit, not a unique weakness:** a
+PR that executes arbitrary code in the runner defeats `npm test`, `rails-guard`, and
+`mutation-gate` too, so the cross-model gate is no weaker than any other required check, and
+every such attack requires *visibly-malicious build config in the PR diff* — which is exactly
+what the branch-protection **CODEOWNERS / human-review backstop** exists to catch (the same
+backstop the trust-root code itself relies on). Fully closing this needs a truly isolated
+required job, which the repo's plan does not allow; until then it is accepted, documented, and
+deliberately not chased into an infinite regress of runner-escape variants.

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -130,38 +130,6 @@ function renamedSources(base, root) {
   ];
 }
 
-// #326 add-vs-alter calibration. Whether an EXISTING base ticket's contract was
-// altered or removed at head — the signal classifyTrustRootTier uses to decide
-// whether a ticket-store change tiers. Mirrors scripts/rails-guard-ci.mjs exactly,
-// INCLUDING the rail-less completion-annotation exemption (a PR may stamp
-// `completed:true` on a rail-less base ticket without it counting as an
-// alteration). A purely additive write (new tickets only) returns false.
-function stableTicket(value) {
-  const sort = (v) => (Array.isArray(v)
-    ? v.map(sort)
-    : v && typeof v === 'object'
-      ? Object.fromEntries(Object.keys(v).sort().map((k) => [k, sort(v[k])]))
-      : v);
-  return JSON.stringify(sort(value));
-}
-function isCompletionAnnotationOnly(base, head) {
-  const baseRails = Array.isArray(base.rails) ? base.rails : [];
-  if (baseRails.length > 0) return false;
-  if (Object.prototype.hasOwnProperty.call(base, 'completed')) return false;
-  if (head.completed !== true) return false;
-  const { completed, ...headWithoutCompleted } = head;
-  return stableTicket(headWithoutCompleted) === stableTicket(base);
-}
-function ticketContractAltered(baseTickets, headTickets) {
-  const headById = new Map((Array.isArray(headTickets) ? headTickets : []).map((t) => [t.id, t]));
-  for (const base of Array.isArray(baseTickets) ? baseTickets : []) {
-    const head = headById.get(base.id);
-    if (!head) return true; // an existing ticket was removed
-    if (stableTicket(head) !== stableTicket(base) && !isCompletionAnnotationOnly(base, head)) return true;
-  }
-  return false;
-}
-
 function loadTicketsForTier(dir, root, base) {
   // UNION, never replace: rails from the base and from the worktree both apply.
   // The classifier ORs deny-paths across tickets, so adding a source can only
@@ -284,26 +252,20 @@ if (positionals[0] === 'record-cross-model') {
 if (positionals[0] === 'tier-check') {
   let root;
   let changed;
-  let baseTickets;
-  let headTickets;
+  let tickets;
   try {
     root = repoRoot();
     const tracked = changedFiles(values.base, root); // two-dot: working tree vs base
     const untracked = git(['ls-files', '--others', '--exclude-standard', '-z'], { cwd: root })
       .split('\0').filter(Boolean);
     changed = [...new Set([...tracked, ...untracked, ...renamedSources(values.base, root)])];
-    baseTickets = readBaseTickets(root, values.base);
-    headTickets = readCanonicalTickets(root);
+    tickets = loadTicketsForTier(values.dir, root, values.base); // rails deny-path source
   } catch (err) {
     opError(`tier-check: cannot determine the changed-file set — base ref '${values.base}' unresolvable. Fetch it (git fetch origin ${values.base}) or pass --base <ref>. Underlying: ${err.message}`);
   }
   let tier;
   try {
-    tier = classifyTrustRootTier({
-      changedFiles: changed,
-      tickets: [...baseTickets, ...headTickets],
-      ticketContractAltered: ticketContractAltered(baseTickets, headTickets),
-    });
+    tier = classifyTrustRootTier({ changedFiles: changed, tickets });
   } catch (err) {
     opError(`tier-check: cannot classify the change: ${err.message}`);
   }

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -5,7 +5,7 @@ import { parseArgs, printJson, opError, recordFinding, git, repoRoot, changedFil
 import { detectTicketStore, GitTreeTicketStore } from '@adlc/tickets';
 import { runProsecution, resolveProsecutionRevision } from '../lib/run.mjs';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
-import { recordCrossModelReview } from '../lib/cross-model.mjs';
+import { recordCrossModelReview, hasCrossModelApproveForRevision } from '../lib/cross-model.mjs';
 
 // FAIL-CLOSED distinction: a genuinely ABSENT ticket table contributes no rails
 // (fine — nothing to check). But a table that EXISTS and is unreadable/malformed
@@ -130,6 +130,38 @@ function renamedSources(base, root) {
   ];
 }
 
+// #326 add-vs-alter calibration. Whether an EXISTING base ticket's contract was
+// altered or removed at head — the signal classifyTrustRootTier uses to decide
+// whether a ticket-store change tiers. Mirrors scripts/rails-guard-ci.mjs exactly,
+// INCLUDING the rail-less completion-annotation exemption (a PR may stamp
+// `completed:true` on a rail-less base ticket without it counting as an
+// alteration). A purely additive write (new tickets only) returns false.
+function stableTicket(value) {
+  const sort = (v) => (Array.isArray(v)
+    ? v.map(sort)
+    : v && typeof v === 'object'
+      ? Object.fromEntries(Object.keys(v).sort().map((k) => [k, sort(v[k])]))
+      : v);
+  return JSON.stringify(sort(value));
+}
+function isCompletionAnnotationOnly(base, head) {
+  const baseRails = Array.isArray(base.rails) ? base.rails : [];
+  if (baseRails.length > 0) return false;
+  if (Object.prototype.hasOwnProperty.call(base, 'completed')) return false;
+  if (head.completed !== true) return false;
+  const { completed, ...headWithoutCompleted } = head;
+  return stableTicket(headWithoutCompleted) === stableTicket(base);
+}
+function ticketContractAltered(baseTickets, headTickets) {
+  const headById = new Map((Array.isArray(headTickets) ? headTickets : []).map((t) => [t.id, t]));
+  for (const base of Array.isArray(baseTickets) ? baseTickets : []) {
+    const head = headById.get(base.id);
+    if (!head) return true; // an existing ticket was removed
+    if (stableTicket(head) !== stableTicket(base) && !isCompletionAnnotationOnly(base, head)) return true;
+  }
+  return false;
+}
+
 function loadTicketsForTier(dir, root, base) {
   // UNION, never replace: rails from the base and from the worktree both apply.
   // The classifier ORs deny-paths across tickets, so adding a source can only
@@ -243,6 +275,70 @@ if (positionals[0] === 'record-cross-model') {
     console.log(`recorded cross-model ${entry.data.verdict} for ${values.ticket} @ ${revision} (${entry.data.provider} vs author ${entry.data.authorProvider})`);
   }
   process.exit(0);
+}
+
+// --- tier-check subcommand (#326: the CI trust-root cross-model gate) ---
+// Classify the change; if trust-root tier, REQUIRE a distinct-provider cross-model
+// approve bound to the reviewed revision (fail closed). Always surfaces the tier
+// decision so "no review required" and "review missing" are distinguishable.
+if (positionals[0] === 'tier-check') {
+  let root;
+  let changed;
+  let baseTickets;
+  let headTickets;
+  try {
+    root = repoRoot();
+    const tracked = changedFiles(values.base, root); // two-dot: working tree vs base
+    const untracked = git(['ls-files', '--others', '--exclude-standard', '-z'], { cwd: root })
+      .split('\0').filter(Boolean);
+    changed = [...new Set([...tracked, ...untracked, ...renamedSources(values.base, root)])];
+    baseTickets = readBaseTickets(root, values.base);
+    headTickets = readCanonicalTickets(root);
+  } catch (err) {
+    opError(`tier-check: cannot determine the changed-file set — base ref '${values.base}' unresolvable. Fetch it (git fetch origin ${values.base}) or pass --base <ref>. Underlying: ${err.message}`);
+  }
+  let tier;
+  try {
+    tier = classifyTrustRootTier({
+      changedFiles: changed,
+      tickets: [...baseTickets, ...headTickets],
+      ticketContractAltered: ticketContractAltered(baseTickets, headTickets),
+    });
+  } catch (err) {
+    opError(`tier-check: cannot classify the change: ${err.message}`);
+  }
+
+  // AC3: the tier decision is ALWAYS visible — tiered or not.
+  if (!tier.isTrustRootTier) {
+    if (values.json) printJson({ trustRootTier: false, reasons: [], crossModelRequired: false, satisfied: true });
+    else console.log('tier-check: NOT trust-root tier — no cross-model review required.');
+    process.exit(0);
+  }
+  console.error('tier-check: TRUST-ROOT tier — a distinct-provider cross-model approve is REQUIRED. Reasons:');
+  for (const reason of tier.reasons) console.error(`  - ${reason}`);
+
+  const authorProvider = values['author-provider'] ?? process.env.ADLC_AUTHOR_PROVIDER;
+  if (!authorProvider) {
+    opError('tier-check: trust-root tier but no --author-provider / ADLC_AUTHOR_PROVIDER — distinctness cannot be proven; failing closed');
+  }
+  const revision = resolveProsecutionRevision({ dir: values.dir, revision: values.revision });
+  if (!revision) opError('tier-check: revision could not be resolved; run inside a git worktree or pass --revision');
+
+  const satisfied = hasCrossModelApproveForRevision({ dir: values.dir, revision, authorProvider });
+  if (values.json) {
+    printJson({ trustRootTier: true, reasons: tier.reasons, crossModelRequired: true, satisfied, revision });
+    process.exit(satisfied ? 0 : 2);
+  }
+  if (satisfied) {
+    console.log(`tier-check: cross-model approve found for revision ${revision} (reviewer distinct from author ${authorProvider}). PASS.`);
+    process.exit(0);
+  }
+  console.error(
+    `tier-check: NO cross-model attestation for revision ${revision} (author ${authorProvider}). This required check FAILS.\n` +
+    `Record one after a distinct-provider adversarial review:\n` +
+    `  adlc-prosecute record-cross-model --ticket <id> --provider <distinct-provider> --author-provider ${authorProvider} --verdict approve --revision ${revision}`
+  );
+  process.exit(2);
 }
 
 // --- record-finding mode (P5 → P7 bridge) ---

--- a/packages/prosecute/lib/cross-model.mjs
+++ b/packages/prosecute/lib/cross-model.mjs
@@ -94,31 +94,48 @@ export function recordCrossModelReview({ ticket, revision, provider, authorProvi
 // trust-root change (e.g. an enforcement-package edit) need not map to one ticket,
 // and the revision hash is the anti-stale anchor that stops a prior attestation
 // from clearing a fresh diff.
-function entrySatisfies(entry, { ticket, revision, runAuthor }) {
-  if ((entry.gate ?? entry.type) !== CROSS_MODEL_GATE) return false;
-  if (ticket !== undefined && entry.ticket !== ticket) return false;
+// A candidate cross-model review entry for (revision, author, [ticket]) from a
+// DISTINCT reviewer. Returns { provider, verdict } for a valid approve/needs-
+// attention entry, or null. `ticket` optional (the revision gate omits it).
+function candidateReview(entry, { ticket, revision, runAuthor }) {
+  if ((entry.gate ?? entry.type) !== CROSS_MODEL_GATE) return null;
+  if (ticket !== undefined && entry.ticket !== ticket) return null;
   const data = entry.data;
-  if (!data || typeof data !== 'object') return false;
-  if (data.verdict !== 'approve') return false;
-  if (data.revision !== revision) return false;
+  if (!data || typeof data !== 'object') return null;
+  if (data.revision !== revision) return null;
+  if (data.verdict !== 'approve' && data.verdict !== 'needs-attention') return null;
   const provider = normalizeProvider(data.provider);
   const entryAuthor = normalizeProvider(data.authorProvider);
-  if (provider === '' || entryAuthor === '' || runAuthor === '') return false;
+  if (provider === '' || entryAuthor === '' || runAuthor === '') return null;
   // Write-side belt-and-suspenders: the attestation must not be same-provider.
-  if (provider === entryAuthor) return false;
+  if (provider === entryAuthor) return null;
   // Author anchored to the run: the reviewer must differ from the real
   // (run-declared) author, and the record must be for THIS author. All compared
   // normalized so a whitespace/case variant cannot fake distinctness.
-  if (provider === runAuthor) return false;
-  if (entryAuthor !== runAuthor) return false;
-  return true;
+  if (provider === runAuthor) return null;
+  if (entryAuthor !== runAuthor) return null;
+  return { provider, verdict: data.verdict };
+}
+
+// The gate is satisfied iff some distinct-provider reviewer's LATEST verdict for
+// this revision is `approve`. Entries are chronological (append-only manifest), so
+// the last entry per provider wins — a later `needs-attention` REVOKES an earlier
+// `approve` from that provider (#326 P5 finding), while a different provider's
+// standing approve still counts.
+function crossModelSatisfied(entries, match) {
+  const latestByProvider = new Map();
+  for (const entry of entries) {
+    const review = candidateReview(entry, match);
+    if (review) latestByProvider.set(review.provider, review.verdict);
+  }
+  for (const verdict of latestByProvider.values()) if (verdict === 'approve') return true;
+  return false;
 }
 
 export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } = {}) {
   if (!ticket || !revision || !authorProvider) return false;
   const { entries } = readEntries('manifest', dir);
-  const runAuthor = normalizeProvider(authorProvider);
-  return entries.some((entry) => entrySatisfies(entry, { ticket, revision, runAuthor }));
+  return crossModelSatisfied(entries, { ticket, revision, runAuthor: normalizeProvider(authorProvider) });
 }
 
 /**
@@ -130,6 +147,5 @@ export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } =
 export function hasCrossModelApproveForRevision({ dir, revision, authorProvider } = {}) {
   if (!revision || !authorProvider) return false;
   const { entries } = readEntries('manifest', dir);
-  const runAuthor = normalizeProvider(authorProvider);
-  return entries.some((entry) => entrySatisfies(entry, { ticket: undefined, revision, runAuthor }));
+  return crossModelSatisfied(entries, { ticket: undefined, revision, runAuthor: normalizeProvider(authorProvider) });
 }

--- a/packages/prosecute/lib/cross-model.mjs
+++ b/packages/prosecute/lib/cross-model.mjs
@@ -14,6 +14,7 @@
 
 import { readEntries } from '@adlc/core';
 import { record } from '@adlc/gate-manifest/lib/record.mjs';
+import { verify } from '@adlc/gate-manifest/lib/verify.mjs';
 
 export const CROSS_MODEL_GATE = 'cross-model-review';
 const VALID_VERDICTS = new Set(['approve', 'needs-attention']);
@@ -132,8 +133,21 @@ function crossModelSatisfied(entries, match) {
   return false;
 }
 
+// FAIL CLOSED on a manifest whose hash chain does not verify (#326 Codex F2). Before
+// trusting ANY approve, walk the chain: readEntries() silently shunts a malformed or
+// truncated line into `skipped`, so an attacker could garble a later `needs-attention`
+// line — WITHOUT re-chaining, the cheap attack — and the dropped revocation would let
+// the earlier `approve` resurface. verify() returns valid:false at the first break, so
+// a corrupt/truncated manifest can no longer clear the gate. (Re-authoring the tail so
+// it re-chains cleanly is the documented honest-limit — defeated only by
+// ADLC_MANIFEST_KEY; this closes the cheap corrupt-and-skip path, not that one.)
+function manifestChainTrustworthy(dir) {
+  return verify(dir).valid === true;
+}
+
 export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } = {}) {
   if (!ticket || !revision || !authorProvider) return false;
+  if (!manifestChainTrustworthy(dir)) return false;
   const { entries } = readEntries('manifest', dir);
   return crossModelSatisfied(entries, { ticket, revision, runAuthor: normalizeProvider(authorProvider) });
 }
@@ -146,6 +160,7 @@ export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } =
  */
 export function hasCrossModelApproveForRevision({ dir, revision, authorProvider } = {}) {
   if (!revision || !authorProvider) return false;
+  if (!manifestChainTrustworthy(dir)) return false;
   const { entries } = readEntries('manifest', dir);
   return crossModelSatisfied(entries, { ticket: undefined, revision, runAuthor: normalizeProvider(authorProvider) });
 }

--- a/packages/prosecute/lib/cross-model.mjs
+++ b/packages/prosecute/lib/cross-model.mjs
@@ -88,27 +88,48 @@ export function recordCrossModelReview({ ticket, revision, provider, authorProvi
  * Everything else fails closed. gate-manifest writes entries under `gate`;
  * prosecute's own evidence writer uses `type` — normalize both.
  */
+// Shared per-entry predicate. `ticket` is OPTIONAL: the per-ticket runner gate
+// (hasCrossModelApprove) requires it; the CI tier gate (#326,
+// hasCrossModelApproveForRevision) omits it and binds to the REVISION only — a
+// trust-root change (e.g. an enforcement-package edit) need not map to one ticket,
+// and the revision hash is the anti-stale anchor that stops a prior attestation
+// from clearing a fresh diff.
+function entrySatisfies(entry, { ticket, revision, runAuthor }) {
+  if ((entry.gate ?? entry.type) !== CROSS_MODEL_GATE) return false;
+  if (ticket !== undefined && entry.ticket !== ticket) return false;
+  const data = entry.data;
+  if (!data || typeof data !== 'object') return false;
+  if (data.verdict !== 'approve') return false;
+  if (data.revision !== revision) return false;
+  const provider = normalizeProvider(data.provider);
+  const entryAuthor = normalizeProvider(data.authorProvider);
+  if (provider === '' || entryAuthor === '' || runAuthor === '') return false;
+  // Write-side belt-and-suspenders: the attestation must not be same-provider.
+  if (provider === entryAuthor) return false;
+  // Author anchored to the run: the reviewer must differ from the real
+  // (run-declared) author, and the record must be for THIS author. All compared
+  // normalized so a whitespace/case variant cannot fake distinctness.
+  if (provider === runAuthor) return false;
+  if (entryAuthor !== runAuthor) return false;
+  return true;
+}
+
 export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } = {}) {
   if (!ticket || !revision || !authorProvider) return false;
   const { entries } = readEntries('manifest', dir);
-  return entries.some((entry) => {
-    if ((entry.gate ?? entry.type) !== CROSS_MODEL_GATE) return false;
-    if (entry.ticket !== ticket) return false;
-    const data = entry.data;
-    if (!data || typeof data !== 'object') return false;
-    if (data.verdict !== 'approve') return false;
-    if (data.revision !== revision) return false;
-    const provider = normalizeProvider(data.provider);
-    const entryAuthor = normalizeProvider(data.authorProvider);
-    const runAuthor = normalizeProvider(authorProvider);
-    if (provider === '' || entryAuthor === '' || runAuthor === '') return false;
-    // Write-side belt-and-suspenders: the attestation must not be same-provider.
-    if (provider === entryAuthor) return false;
-    // Author anchored to the prosecution run: the reviewer must differ from the
-    // real (prosecution-declared) author, and the record must be for THIS author.
-    // All compared normalized so a whitespace/case variant cannot fake distinctness.
-    if (provider === runAuthor) return false;
-    if (entryAuthor !== runAuthor) return false;
-    return true;
-  });
+  const runAuthor = normalizeProvider(authorProvider);
+  return entries.some((entry) => entrySatisfies(entry, { ticket, revision, runAuthor }));
+}
+
+/**
+ * True iff the manifest holds a distinct-provider cross-model `approve` bound to
+ * `revision`, recorded for author `authorProvider` — REGARDLESS of ticket. The CI
+ * trust-root-tier gate (#326) uses this: it verifies the reviewed revision was
+ * cross-model approved without requiring the change to name a single ticket.
+ */
+export function hasCrossModelApproveForRevision({ dir, revision, authorProvider } = {}) {
+  if (!revision || !authorProvider) return false;
+  const { entries } = readEntries('manifest', dir);
+  const runAuthor = normalizeProvider(authorProvider);
+  return entries.some((entry) => entrySatisfies(entry, { ticket: undefined, revision, runAuthor }));
 }

--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -27,6 +27,16 @@ const TRUST_ROOT_FILES = [
   'scripts/rails-guard-ci.mjs',
   'docs/ci/rails-guard.yml',
   'scripts/test/rails-guard-workflow-hashes.json',
+  // The ROOT install manifests (#326 Codex F1). CI runs candidate `npm install`
+  // BEFORE the gate, so a `scripts.postinstall` in the root package.json — or a
+  // dependency repointed by the lockfile — executes inside the gate's own job and
+  // could poison the toolchain the gate imports. Neither file is a tier surface by
+  // package-prefix and (verified) neither is in CODEOWNERS, so a PR touching only
+  // them would otherwise merge with no cross-model review. EXACT-match only: a
+  // NESTED package.json tiers solely via its package prefix, not this rule. The gate
+  // step additionally reinstalls with --ignore-scripts as defense-in-depth.
+  'package.json',
+  'package-lock.json',
 ];
 
 // 2. Enforcement packages: each emits an exit-2 gate. Editing them changes what

--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -10,35 +10,24 @@
 import { globMatch } from '@adlc/core';
 
 // 1. Exact trust-root files: the rails-guard CI backstop, its workflow template,
-//    the workflow hash pin, and the ticket table every downstream gate reads.
+//    and the workflow hash pin — the code/config surfaces whose meaning a
+//    same-model review of the author's own change cannot independently check.
+//
+// The ticket STORE (`.adlc/tickets.json`, the sharded `.adlc/tickets/`, and
+// `.adlc/ticket-archive/`) is deliberately NOT here (#326). rails-guard-ci already
+// owns that surface with an add-vs-alter contract: a PR may ADD a ticket (which
+// grants no privilege over existing rails) but can never ALTER or REMOVE an
+// existing ticket's contract — only the protected-base admin ceremony can. So a
+// ticket-store change is either privilege-neutral (an addition) or already blocked
+// (an alteration); routing it through the cross-model tier as well made every
+// ADLC-ticketed PR trust-root tier for no added protection, and — because the
+// reviewed revision excludes the ticket store — could not even be soundly
+// attested. Producer packages that WRITE the store still tier (below).
 const TRUST_ROOT_FILES = [
   'scripts/rails-guard-ci.mjs',
   'docs/ci/rails-guard.yml',
   'scripts/test/rails-guard-workflow-hashes.json',
-  '.adlc/tickets.json',
 ];
-
-// 1b. The SHARDED ticket store — the same trust root as `.adlc/tickets.json`,
-// just spread across per-ticket files. Exact-file matching cannot express it (one
-// entry per ticket, and new shards appear as tickets are authored), so the whole
-// store directory is a trust-root PREFIX. Without this, migrating a repo from the
-// legacy file to the directory backend would silently declassify every edit to
-// the ticket table: the exact-file entry above stops matching and nothing else
-// covers `.adlc/tickets/`. The archive is included because a ticket moved there
-// still describes what was enforced, so mutating it rewrites gate history.
-//
-// Unconditional, like TRUST_ROOT_FILES: these are DATA the gate reads, so the
-// test-path exemption that applies to package prefixes must not apply here.
-//
-// #326 sub-classification of the ticket-store surfaces. The add-vs-alter
-// calibration applies ONLY to ACTIVE ticket CONTENT the caller's signal (computed
-// from the ACTIVE store) can observe. The store INDEX and the ARCHIVE are
-// signal-blind and tier UNCONDITIONALLY, so suppressing them on an additive
-// verdict would fail OPEN (an archive rewrite or a store-backend swap looks
-// "additive" to the active-tickets signal).
-const ACTIVE_SHARD_PREFIX = '.adlc/tickets/';       // active shards → add-vs-alter calibrated
-const ACTIVE_STORE_INDEX = '.adlc/tickets/.store.json'; // structural (migration) → unconditional
-const ARCHIVE_PREFIX = '.adlc/ticket-archive/';     // rewrites gate history → unconditional
 
 // 2. Enforcement packages: each emits an exit-2 gate. Editing them changes what
 //    "the gate passes" means, so a same-model review of the author's own tests
@@ -89,64 +78,27 @@ function isTestFile(path) {
   return /(^|\/)test\//.test(path) || /\.test\.(mjs|js|cjs)$/.test(path);
 }
 
-// Add-vs-alter calibration (#326). An ADDITIVE ticket-store write — a NEW ticket,
-// with no existing ticket's contract altered or removed — grants no privilege over
-// existing rails, exactly the distinction scripts/rails-guard-ci.mjs already draws
-// (a PR may add a ticket but never alter an existing one). Treating it as trust-root
-// tier would force a cross-model review on nearly every PR, which is why the gate
-// was never enforced. So the ticket-store surfaces (the exact `.adlc/tickets.json`
-// file and the `.adlc/tickets/` + `.adlc/ticket-archive/` prefixes) tier ONLY when
-// an existing ticket contract is altered.
-//
-// The caller — which has the base and head trees — decides this and passes the
-// verdict as `ticketContractAltered`:
-//   • true      → an existing ticket was altered/removed → tier.
-//   • false     → additive only → the ticket-store surfaces do NOT tier.
-//   • undefined → the caller could not compute it → FAIL CLOSED (tier), and keep
-//                 the legacy "touches trust-root …" wording for compatibility.
-// This narrowing is scoped to the ticket-store surfaces only; enforcement/producer
-// packages and rails deny-paths are unaffected.
-const TICKET_STORE_FILES = new Set(['.adlc/tickets.json']);
-
 /**
  * Classify a change as trust-root tier.
  *
+ * The ticket STORE is intentionally not a tier surface (#326) — rails-guard-ci
+ * owns it with an add-vs-alter contract, so ticket-store changes are either
+ * privilege-neutral additions or already-blocked alterations. See TRUST_ROOT_FILES.
+ *
  * @param {object} args
  * @param {string[]} [args.changedFiles]  repo-relative POSIX paths
- * @param {object[]} [args.tickets]       the base ticket array (rails deny-path source)
- * @param {boolean} [args.ticketContractAltered]  whether an existing ticket contract
- *   was altered/removed (add-vs-alter calibration, #326). Omit → fail closed.
+ * @param {object[]} [args.tickets]       the ticket array (rails deny-path source)
  * @returns {{ isTrustRootTier: boolean, reasons: string[] }}
  */
-export function classifyTrustRootTier({ changedFiles = [], tickets = [], ticketContractAltered } = {}) {
+export function classifyTrustRootTier({ changedFiles = [], tickets = [] } = {}) {
   const reasons = [];
   const push = (reason) => { if (!reasons.includes(reason)) reasons.push(reason); };
-
-  // Additive-only ticket-store writes do not tier; true/undefined fail closed.
-  const ticketStoreTiers = ticketContractAltered !== false;
-  const ticketStoreReason = (surface) => (ticketContractAltered === true
-    ? `alters an existing ticket contract in ${surface}`
-    : `touches trust-root ticket store ${surface}`);
 
   for (const raw of changedFiles) {
     if (typeof raw !== 'string' || raw.trim() === '') continue;
     const path = toPosix(raw);
 
-    if (TRUST_ROOT_FILES.includes(path)) {
-      if (TICKET_STORE_FILES.has(path)) {          // .adlc/tickets.json — active content
-        if (ticketStoreTiers) push(ticketStoreReason(path));
-      } else {
-        push(`touches trust-root file ${path}`);
-      }
-    }
-    // Archive: unconditional (rewrites gate history; the active-tickets signal is
-    // blind to it, so an archive mutation must never be declassified as additive).
-    if (path.startsWith(ARCHIVE_PREFIX)) push(`touches trust-root ticket archive ${ARCHIVE_PREFIX}`);
-    // Active store INDEX: unconditional (a .store.json change is structural, not an
-    // additive ticket write). Checked before the shard branch since it shares the prefix.
-    if (path === ACTIVE_STORE_INDEX) push(`touches trust-root ticket store index ${ACTIVE_STORE_INDEX}`);
-    // Active shards: add-vs-alter calibrated via the observable signal.
-    else if (path.startsWith(ACTIVE_SHARD_PREFIX) && ticketStoreTiers) push(ticketStoreReason(ACTIVE_SHARD_PREFIX));
+    if (TRUST_ROOT_FILES.includes(path)) push(`touches trust-root file ${path}`);
     // Package-prefix surfaces gate on LOGIC/CONTRACT risk; a test-only change
     // touches neither, so it is exempt here (#154/T41). The exact-file check
     // above and the rails-deny-path check below stay unconditional.

--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -29,10 +29,16 @@ const TRUST_ROOT_FILES = [
 //
 // Unconditional, like TRUST_ROOT_FILES: these are DATA the gate reads, so the
 // test-path exemption that applies to package prefixes must not apply here.
-const TRUST_ROOT_PREFIXES = [
-  '.adlc/tickets/',
-  '.adlc/ticket-archive/',
-];
+//
+// #326 sub-classification of the ticket-store surfaces. The add-vs-alter
+// calibration applies ONLY to ACTIVE ticket CONTENT the caller's signal (computed
+// from the ACTIVE store) can observe. The store INDEX and the ARCHIVE are
+// signal-blind and tier UNCONDITIONALLY, so suppressing them on an additive
+// verdict would fail OPEN (an archive rewrite or a store-backend swap looks
+// "additive" to the active-tickets signal).
+const ACTIVE_SHARD_PREFIX = '.adlc/tickets/';       // active shards → add-vs-alter calibrated
+const ACTIVE_STORE_INDEX = '.adlc/tickets/.store.json'; // structural (migration) → unconditional
+const ARCHIVE_PREFIX = '.adlc/ticket-archive/';     // rewrites gate history → unconditional
 
 // 2. Enforcement packages: each emits an exit-2 gate. Editing them changes what
 //    "the gate passes" means, so a same-model review of the author's own tests
@@ -127,15 +133,20 @@ export function classifyTrustRootTier({ changedFiles = [], tickets = [], ticketC
     const path = toPosix(raw);
 
     if (TRUST_ROOT_FILES.includes(path)) {
-      if (TICKET_STORE_FILES.has(path)) {
+      if (TICKET_STORE_FILES.has(path)) {          // .adlc/tickets.json — active content
         if (ticketStoreTiers) push(ticketStoreReason(path));
       } else {
         push(`touches trust-root file ${path}`);
       }
     }
-    for (const prefix of TRUST_ROOT_PREFIXES) {
-      if (path.startsWith(prefix) && ticketStoreTiers) push(ticketStoreReason(prefix));
-    }
+    // Archive: unconditional (rewrites gate history; the active-tickets signal is
+    // blind to it, so an archive mutation must never be declassified as additive).
+    if (path.startsWith(ARCHIVE_PREFIX)) push(`touches trust-root ticket archive ${ARCHIVE_PREFIX}`);
+    // Active store INDEX: unconditional (a .store.json change is structural, not an
+    // additive ticket write). Checked before the shard branch since it shares the prefix.
+    if (path === ACTIVE_STORE_INDEX) push(`touches trust-root ticket store index ${ACTIVE_STORE_INDEX}`);
+    // Active shards: add-vs-alter calibrated via the observable signal.
+    else if (path.startsWith(ACTIVE_SHARD_PREFIX) && ticketStoreTiers) push(ticketStoreReason(ACTIVE_SHARD_PREFIX));
     // Package-prefix surfaces gate on LOGIC/CONTRACT risk; a test-only change
     // touches neither, so it is exempt here (#154/T41). The exact-file check
     // above and the rails-deny-path check below stay unconditional.

--- a/packages/prosecute/lib/tier.mjs
+++ b/packages/prosecute/lib/tier.mjs
@@ -83,27 +83,58 @@ function isTestFile(path) {
   return /(^|\/)test\//.test(path) || /\.test\.(mjs|js|cjs)$/.test(path);
 }
 
+// Add-vs-alter calibration (#326). An ADDITIVE ticket-store write — a NEW ticket,
+// with no existing ticket's contract altered or removed — grants no privilege over
+// existing rails, exactly the distinction scripts/rails-guard-ci.mjs already draws
+// (a PR may add a ticket but never alter an existing one). Treating it as trust-root
+// tier would force a cross-model review on nearly every PR, which is why the gate
+// was never enforced. So the ticket-store surfaces (the exact `.adlc/tickets.json`
+// file and the `.adlc/tickets/` + `.adlc/ticket-archive/` prefixes) tier ONLY when
+// an existing ticket contract is altered.
+//
+// The caller — which has the base and head trees — decides this and passes the
+// verdict as `ticketContractAltered`:
+//   • true      → an existing ticket was altered/removed → tier.
+//   • false     → additive only → the ticket-store surfaces do NOT tier.
+//   • undefined → the caller could not compute it → FAIL CLOSED (tier), and keep
+//                 the legacy "touches trust-root …" wording for compatibility.
+// This narrowing is scoped to the ticket-store surfaces only; enforcement/producer
+// packages and rails deny-paths are unaffected.
+const TICKET_STORE_FILES = new Set(['.adlc/tickets.json']);
+
 /**
  * Classify a change as trust-root tier.
  *
  * @param {object} args
  * @param {string[]} [args.changedFiles]  repo-relative POSIX paths
- * @param {object[]} [args.tickets]       the array from .adlc/tickets.json
+ * @param {object[]} [args.tickets]       the base ticket array (rails deny-path source)
+ * @param {boolean} [args.ticketContractAltered]  whether an existing ticket contract
+ *   was altered/removed (add-vs-alter calibration, #326). Omit → fail closed.
  * @returns {{ isTrustRootTier: boolean, reasons: string[] }}
  */
-export function classifyTrustRootTier({ changedFiles = [], tickets = [] } = {}) {
+export function classifyTrustRootTier({ changedFiles = [], tickets = [], ticketContractAltered } = {}) {
   const reasons = [];
   const push = (reason) => { if (!reasons.includes(reason)) reasons.push(reason); };
+
+  // Additive-only ticket-store writes do not tier; true/undefined fail closed.
+  const ticketStoreTiers = ticketContractAltered !== false;
+  const ticketStoreReason = (surface) => (ticketContractAltered === true
+    ? `alters an existing ticket contract in ${surface}`
+    : `touches trust-root ticket store ${surface}`);
 
   for (const raw of changedFiles) {
     if (typeof raw !== 'string' || raw.trim() === '') continue;
     const path = toPosix(raw);
 
     if (TRUST_ROOT_FILES.includes(path)) {
-      push(`touches trust-root file ${path}`);
+      if (TICKET_STORE_FILES.has(path)) {
+        if (ticketStoreTiers) push(ticketStoreReason(path));
+      } else {
+        push(`touches trust-root file ${path}`);
+      }
     }
     for (const prefix of TRUST_ROOT_PREFIXES) {
-      if (path.startsWith(prefix)) push(`touches trust-root ticket store ${prefix}`);
+      if (path.startsWith(prefix) && ticketStoreTiers) push(ticketStoreReason(prefix));
     }
     // Package-prefix surfaces gate on LOGIC/CONTRACT risk; a test-only change
     // touches neither, so it is exempt here (#154/T41). The exact-file check

--- a/packages/prosecute/test/cross-model.test.mjs
+++ b/packages/prosecute/test/cross-model.test.mjs
@@ -10,8 +10,10 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { recordCrossModelReview, hasCrossModelApprove, hasCrossModelApproveForRevision } from '../lib/cross-model.mjs';
 import { record } from '@adlc/gate-manifest/lib/record.mjs';
+import { ledgerPath } from '@adlc/core';
 
 function tmp() {
   return mkdtempSync(join(tmpdir(), 'adlc-cross-model-'));
@@ -255,6 +257,51 @@ describe('cross-model latest-verdict revocation (#326 P5 finding)', () => {
       recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
       // gemini's approve still stands.
       assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+// #326 Codex re-review F2: a corrupted/truncated manifest line must not be silently
+// dropped so that an EARLIER approve resurfaces past its revocation. readEntries()
+// shunts malformed lines to `skipped` and the predicate used to ignore that field,
+// so garbling a later needs-attention line (WITHOUT re-chaining — the cheap attack)
+// left the approve standing. The gate now verifies the hash chain and fails CLOSED
+// on any break. A determined re-author of the tail is the documented honest-limit
+// (defeated only by ADLC_MANIFEST_KEY); this closes the cheap corrupt-and-skip path.
+describe('cross-model manifest-tamper fail-closed (#326 Codex F2)', () => {
+  it('a CORRUPTED later needs-attention line does NOT resurrect the revoked approve — fail closed', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      // Sanity: the revocation is in effect before tampering.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+
+      // Attacker garbles the LAST line (the needs-attention) into unparseable JSON,
+      // leaving the approve line untouched. readEntries would drop the garbled line
+      // (→ skipped) and see only the approve; the chain no longer verifies.
+      const lp = ledgerPath('manifest', dir);
+      const lines = readFileSync(lp, 'utf8').split('\n');
+      const idx = lines.map((l) => l.trim()).lastIndexOf(lines.map((l) => l.trim()).filter(Boolean).at(-1));
+      lines[idx] = '{"seq": 2, "prev": "deadbeef", corrupt';
+      writeFileSync(lp, lines.join('\n'));
+
+      // Must stay revoked: a manifest whose chain does not verify cannot clear the gate.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('a TRUNCATED manifest (partial last line) fails closed rather than reading a stale approve', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      const lp = ledgerPath('manifest', dir);
+      const content = readFileSync(lp, 'utf8');
+      // Chop the file mid-way through the final entry (simulates a torn write / edit).
+      writeFileSync(lp, content.slice(0, content.length - 20));
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 });

--- a/packages/prosecute/test/cross-model.test.mjs
+++ b/packages/prosecute/test/cross-model.test.mjs
@@ -226,3 +226,35 @@ describe('hasCrossModelApproveForRevision — #326 CI tier gate (ticket-agnostic
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 });
+
+describe('cross-model latest-verdict revocation (#326 P5 finding)', () => {
+  it('a later needs-attention from the same provider REVOKES an earlier approve (same revision)', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('a later approve after a needs-attention RESTORES the gate', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('a DIFFERENT provider standing approve still counts after another provider revokes', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'gemini', authorProvider: 'anthropic', verdict: 'approve', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      // gemini's approve still stands.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});

--- a/packages/prosecute/test/cross-model.test.mjs
+++ b/packages/prosecute/test/cross-model.test.mjs
@@ -305,3 +305,34 @@ describe('cross-model manifest-tamper fail-closed (#326 Codex F2)', () => {
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 });
+
+// Malformed-but-chain-valid entries (injected past recordCrossModelReview's write-side
+// validation) must be IGNORED by the read-side predicate, never crash it and never be
+// mistaken for a revocation. These pin the candidateReview() guards.
+describe('cross-model read-side entry-shape guards (#326)', () => {
+  it('an entry whose data is not an object is ignored (no crash) — guards the null-data check', () => {
+    const dir = tmp();
+    try {
+      // rawData "null" → entry.data === null. The predicate must return early, not
+      // dereference data.revision. (A same-provider real approve is present so the
+      // gate would be TRUE if the null entry were merely skipped; the point here is
+      // that reading it does not throw.)
+      record({ gate: 'cross-model-review', ticket: 'T1', rawData: 'null', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('an entry with an INVALID verdict is ignored, NOT treated as a revocation of a standing approve', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      // Inject a later same-provider entry with a bogus verdict (bypassing the writer).
+      // It must be discarded by the verdict guard — the standing approve still holds.
+      // If the guard were removed, this would become the "latest" verdict and wrongly
+      // revoke the approve.
+      record({ gate: 'cross-model-review', ticket: 'T1', rawData: JSON.stringify({ provider: 'openai', authorProvider: 'anthropic', verdict: 'bogus', revision: 'rev-1' }), dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});

--- a/packages/prosecute/test/cross-model.test.mjs
+++ b/packages/prosecute/test/cross-model.test.mjs
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { recordCrossModelReview, hasCrossModelApprove } from '../lib/cross-model.mjs';
+import { recordCrossModelReview, hasCrossModelApprove, hasCrossModelApproveForRevision } from '../lib/cross-model.mjs';
 import { record } from '@adlc/gate-manifest/lib/record.mjs';
 
 function tmp() {
@@ -176,6 +176,53 @@ describe('hasCrossModelApprove — round-trip and binding', () => {
       assert.equal(entry.gate, 'cross-model-review');
       assert.equal(entry.ticket, 'T1');
       assert.deepEqual(entry.data, { provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', revision: 'rev-1' });
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe('hasCrossModelApproveForRevision — #326 CI tier gate (ticket-agnostic)', () => {
+  it('TRUE for a distinct-provider approve at the revision, regardless of the attestation ticket', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T-anything', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('FALSE when the revision does not match (stale attestation cannot clear a fresh diff)', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-OLD', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-NEW', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('FALSE when the reviewer provider is not distinct from the run author', () => {
+    const dir = tmp();
+    try {
+      // Recorded as openai-reviews-anthropic, but the run author is really openai → not cross-model.
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'openai' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('FALSE for a needs-attention verdict and for missing args (fail closed)', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: '', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: '' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('the record must be FOR this author (entry.authorProvider must equal the run author)', () => {
+    const dir = tmp();
+    try {
+      // Reviewer gemini reviewed for author anthropic; a run claiming author openai must not be cleared.
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'gemini', authorProvider: 'anthropic', verdict: 'approve', dir });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'openai' }), false);
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 });

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -12,7 +12,7 @@
 // The recorded revision is resolved the SAME way the gate resolves it (no --revision).
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -285,62 +285,6 @@ describe('adlc-prosecute trust-root-tier CLI gate', () => {
       assert.match(res.stderr, /rails deny-path of ticket T1/);
     } finally {
       rmSync(repo.dir, { recursive: true, force: true });
-    }
-  });
-
-  it('residual: renaming a ticket-store shard OUT of the trust root still tiers (rename source is not invisible)', () => {
-    // `git diff --name-only` reports ONLY the destination of a rename, so moving a
-    // shard out of `.adlc/tickets/` removes a ticket contract while the classifier
-    // sees just an unprotected path — a fail-OPEN bypass of the new prefixes. The
-    // rename SOURCE must be part of the changed-file set. Covers the active store
-    // and the archive; both are trust-root surfaces.
-    for (const storeDir of ['.adlc/tickets', '.adlc/ticket-archive']) {
-      // The ACTIVE store must be genuinely migrated (a bare `.adlc/tickets/`
-      // alongside the legacy file is an ambiguous dual store and rightly fails
-      // closed). T9 is the spare whose shard gets moved; T1 remains prosecutable,
-      // which is what makes the bypass reachable rather than merely broken. The
-      // ARCHIVE is not the active store, so it needs no migration.
-      const active = storeDir === '.adlc/tickets';
-      // The shard must exist at the BASE for the move to read as a rename at all;
-      // adding it on the feature branch would diff as a plain addition of the
-      // destination. The active shard arrives via migration, the archive one via
-      // baselineFiles — both land in the baseline commit on main.
-      const repo = scratchRepo('src/app.mjs', {
-        ledgerDir: '.adlc',
-        rails: [],
-        migrateStore: active,
-        extraTickets: active ? ['T9'] : [],
-        baselineFiles: active ? {} : { '.adlc/ticket-archive/t9--abc.json': JSON.stringify({ id: 'T9' }) },
-      });
-      const g = (...args) => execFileSync('git', args, { cwd: repo.dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
-      try {
-        let shard;
-        if (active) {
-          const found = readdirSync(join(repo.dir, ...storeDir.split('/'))).find((name) => name.startsWith('t9--'));
-          assert.ok(found, 'migration should have produced a T9 shard');
-          shard = `${storeDir}/${found}`;
-        } else {
-          shard = `${storeDir}/t9--abc.json`;
-        }
-        g('checkout', '-q', '-b', `move-${storeDir.replace(/\W/g, '')}`);
-        mkdirSync(join(repo.dir, 'holding'), { recursive: true });
-        g('mv', shard, 'holding/moved.json');
-        g('commit', '-qm', 'move shard out of the trust root');
-
-        // Precondition: plain --name-only really does hide the source, or this
-        // test would pass for a reason unrelated to the bypass it describes.
-        const nameOnly = g('diff', '--name-only', 'main', '--').trim().split('\n');
-        assert.ok(!nameOnly.includes(shard), 'rename source must be invisible to --name-only for this test to be meaningful');
-
-        writePasses({ ...repo, revision: 'fixed-rev' });
-        const res = runBin(['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'], repo.dir);
-        assert.equal(res.status, 2, `moving a shard out of ${storeDir} must tier`);
-        // #326: the active store and the archive now carry distinct reasons
-        // ("ticket store" vs "ticket archive"); both are trust-root surfaces.
-        assert.match(res.stderr, /trust-root ticket (store|archive)/);
-      } finally {
-        rmSync(repo.dir, { recursive: true, force: true });
-      }
     }
   });
 

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -335,7 +335,9 @@ describe('adlc-prosecute trust-root-tier CLI gate', () => {
         writePasses({ ...repo, revision: 'fixed-rev' });
         const res = runBin(['--input', '.adlc/passes.json', '--ticket', 'T1', '--base', 'main', '--dir', '.adlc', '--revision', 'fixed-rev', '--author-provider', 'anthropic', '--json'], repo.dir);
         assert.equal(res.status, 2, `moving a shard out of ${storeDir} must tier`);
-        assert.match(res.stderr, /trust-root ticket store/);
+        // #326: the active store and the archive now carry distinct reasons
+        // ("ticket store" vs "ticket archive"); both are trust-root surfaces.
+        assert.match(res.stderr, /trust-root ticket (store|archive)/);
       } finally {
         rmSync(repo.dir, { recursive: true, force: true });
       }

--- a/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
@@ -1,0 +1,137 @@
+// Concern: bin/adlc-prosecute.mjs `tier-check` subcommand (#326) — the CI trust-root
+// cross-model gate, end-to-end at the process boundary in a real git repo.
+//
+// Properties pinned:
+//   - a non-trust-root change exits 0 and says so (AC3 visibility);
+//   - a trust-root change with NO attestation exits 2 (AC1);
+//   - the same change exits 0 once a distinct-provider approve bound to the
+//     tier-check revision is recorded;
+//   - the add-vs-alter calibration (#326): an ADDITIVE ticket write does NOT tier,
+//     while ALTERING an existing ticket contract DOES;
+//   - a tiered change with no --author-provider fails closed (exit 1).
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const BIN = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
+
+function runBin(args, cwd, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN, ...args], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, ...env },
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+// Scratch repo: base `.adlc/tickets.json` = baseTickets, committed on main; then on
+// a feat branch apply mutate(dir) and commit. Rails default to src/** so the ticket
+// store file itself is not a rails-deny-path match — the ticket-store surface is
+// exercised purely through the add-vs-alter calibration.
+function scratchRepo({ baseTickets, mutate }) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-tier-check-'));
+  const g = (...a) => execFileSync('git', a, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  g('init', '-q', '-b', 'main');
+  g('config', 'user.email', 't@t.co');
+  g('config', 'user.name', 'tester');
+  g('config', 'commit.gpgsign', 'false');
+  writeFileSync(join(dir, 'README.md'), 'baseline\n');
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: baseTickets }));
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'app.mjs'), 'export const x = 0;\n');
+  g('add', '-A'); g('commit', '-qm', 'baseline');
+  g('checkout', '-q', '-b', 'feat');
+  mutate(dir, g);
+  g('add', '-A'); g('commit', '-qm', 'change');
+  return { dir, g };
+}
+
+const T = (over = {}) => ({ id: 'T1', title: 'x', scope: ['src/**'], rails: ['src/**'], edges: [], ...over });
+const cleanup = (dir) => rmSync(dir, { recursive: true, force: true });
+
+describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
+  it('exits 0 and reports NOT trust-root tier for an ordinary change', () => {
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => writeFileSync(join(d, 'src', 'ordinary.mjs'), 'export const y = 1;\n') });
+    try {
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /NOT trust-root tier/);
+    } finally { cleanup(dir); }
+  });
+
+  it('exits 2 for a trust-root change (enforcement package) with no attestation', () => {
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => {
+      mkdirSync(join(d, 'packages', 'prosecute', 'lib'), { recursive: true });
+      writeFileSync(join(d, 'packages', 'prosecute', 'lib', 'x.mjs'), 'export const z = 1;\n');
+    } });
+    try {
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(r.status, 2);
+      assert.match(r.stderr, /TRUST-ROOT tier/);
+      assert.match(r.stderr, /NO cross-model attestation/);
+    } finally { cleanup(dir); }
+  });
+
+  it('exits 0 once a distinct-provider approve bound to the tier-check revision is recorded', () => {
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => {
+      mkdirSync(join(d, 'packages', 'prosecute', 'lib'), { recursive: true });
+      writeFileSync(join(d, 'packages', 'prosecute', 'lib', 'x.mjs'), 'export const z = 1;\n');
+    } });
+    try {
+      const before = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc', '--json'], dir);
+      assert.equal(before.status, 2);
+      const { revision } = JSON.parse(before.stdout);
+      assert.ok(revision, 'tier-check surfaces the revision');
+
+      const rec = runBin(['record-cross-model', '--ticket', 'T1', '--provider', 'openai', '--author-provider', 'anthropic', '--verdict', 'approve', '--revision', revision, '--dir', '.adlc'], dir);
+      assert.equal(rec.status, 0);
+
+      const after = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(after.status, 0);
+      assert.match(after.stdout, /cross-model approve found/);
+    } finally { cleanup(dir); }
+  });
+
+  it('CALIBRATION: an ADDITIVE ticket write does NOT tier (exit 0)', () => {
+    const { dir } = scratchRepo({
+      baseTickets: [T()],
+      mutate: (d) => writeFileSync(join(d, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [T(), { id: 'T2', title: 'new', scope: ['src/**'], rails: [], edges: [] }] })),
+    });
+    try {
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /NOT trust-root tier/);
+    } finally { cleanup(dir); }
+  });
+
+  it('CALIBRATION: ALTERING an existing ticket contract DOES tier (exit 2)', () => {
+    const { dir } = scratchRepo({
+      baseTickets: [T({ rails: ['src/critical/**'] })],
+      // Change T1's rails — an alteration of an existing contract.
+      mutate: (d) => writeFileSync(join(d, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [T({ rails: [] })] })),
+    });
+    try {
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(r.status, 2);
+      assert.match(r.stderr, /alters an existing ticket contract/);
+    } finally { cleanup(dir); }
+  });
+
+  it('fails closed (exit 1) on a tiered change with no --author-provider', () => {
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => {
+      mkdirSync(join(d, 'packages', 'gate-manifest', 'lib'), { recursive: true });
+      writeFileSync(join(d, 'packages', 'gate-manifest', 'lib', 'x.mjs'), 'export const z = 1;\n');
+    } });
+    try {
+      const r = runBin(['tier-check', '--base', 'main', '--dir', '.adlc'], dir, { ADLC_AUTHOR_PROVIDER: '' });
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /no --author-provider/);
+    } finally { cleanup(dir); }
+  });
+});

--- a/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
@@ -123,6 +123,28 @@ describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
     } finally { cleanup(altering.dir); }
   });
 
+  it('classifies an UNTRACKED trust-root file when a non-trust-root path sorts ahead of it (guards the -z NUL-split of the untracked walk)', () => {
+    // The untracked-file walk uses `git ls-files --others -z` + split('\0'). Drop
+    // the -z and git emits NEWLINE-separated paths, so split('\0') collapses ALL
+    // untracked files into ONE joined string. Its prefix is whatever sorts FIRST,
+    // so a trust-root file that sorts after a benign one is no longer prefix-matched
+    // → the change silently fails to tier (a fail-OPEN). This fixture makes the
+    // benign root file (`a-untracked.md`) sort before the enforcement-package file
+    // and leaves BOTH untracked; the tracked diff is only a benign src change, so
+    // the untracked prosecute file is the SOLE trust-root trigger. With -z it tiers
+    // (exit 2); without -z it would exit 0 — which is what the mutation gate caught.
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => writeFileSync(join(d, 'src', 'ordinary.mjs'), 'export const y = 1;\n') });
+    try {
+      writeFileSync(join(dir, 'a-untracked.md'), 'benign, sorts first\n');
+      mkdirSync(join(dir, 'packages', 'prosecute', 'lib'), { recursive: true });
+      writeFileSync(join(dir, 'packages', 'prosecute', 'lib', 'untracked.mjs'), 'export const z = 1;\n');
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(r.status, 2);
+      assert.match(r.stderr, /TRUST-ROOT tier/);
+      assert.match(r.stderr, /packages\/prosecute\//);
+    } finally { cleanup(dir); }
+  });
+
   it('fails closed (exit 1) on a tiered change with no --author-provider', () => {
     const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => {
       mkdirSync(join(d, 'packages', 'gate-manifest', 'lib'), { recursive: true });

--- a/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
@@ -98,29 +98,29 @@ describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
     } finally { cleanup(dir); }
   });
 
-  it('CALIBRATION: an ADDITIVE ticket write does NOT tier (exit 0)', () => {
-    const { dir } = scratchRepo({
-      baseTickets: [T()],
-      mutate: (d) => writeFileSync(join(d, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [T(), { id: 'T2', title: 'new', scope: ['src/**'], rails: [], edges: [] }] })),
+  it('a ticket-store change (additive OR altering) does NOT tier — rails-guard-ci owns the store (#326)', () => {
+    // Adding a ticket, and even altering an existing ticket's rails, both exit 0
+    // here: the cross-model tier deliberately does not cover the ticket store
+    // (rails-guard-ci already enforces its add-vs-alter contract).
+    const additive = scratchRepo({
+      baseTickets: [T({ rails: [] })],
+      mutate: (d) => writeFileSync(join(d, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [T({ rails: [] }), { id: 'T2', title: 'new', scope: ['src/**'], rails: [], edges: [] }] })),
     });
     try {
-      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], additive.dir);
       assert.equal(r.status, 0);
       assert.match(r.stdout, /NOT trust-root tier/);
-    } finally { cleanup(dir); }
-  });
+    } finally { cleanup(additive.dir); }
 
-  it('CALIBRATION: ALTERING an existing ticket contract DOES tier (exit 2)', () => {
-    const { dir } = scratchRepo({
-      baseTickets: [T({ rails: ['src/critical/**'] })],
-      // Change T1's rails — an alteration of an existing contract.
-      mutate: (d) => writeFileSync(join(d, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [T({ rails: [] })] })),
+    const altering = scratchRepo({
+      baseTickets: [T({ rails: [] })],
+      mutate: (d) => writeFileSync(join(d, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [T({ rails: [], title: 'renamed' })] })),
     });
     try {
-      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
-      assert.equal(r.status, 2);
-      assert.match(r.stderr, /alters an existing ticket contract/);
-    } finally { cleanup(dir); }
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], altering.dir);
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /NOT trust-root tier/);
+    } finally { cleanup(altering.dir); }
   });
 
   it('fails closed (exit 1) on a tiered change with no --author-provider', () => {

--- a/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
@@ -62,6 +62,11 @@ describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
       const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
       assert.equal(r.status, 0);
       assert.match(r.stdout, /NOT trust-root tier/);
+
+      // --json contract: a non-tier change reports satisfied:true, crossModelRequired:false.
+      const j = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc', '--json'], dir);
+      assert.equal(j.status, 0);
+      assert.deepEqual(JSON.parse(j.stdout), { trustRootTier: false, reasons: [], crossModelRequired: false, satisfied: true });
     } finally { cleanup(dir); }
   });
 
@@ -86,8 +91,14 @@ describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
     try {
       const before = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc', '--json'], dir);
       assert.equal(before.status, 2);
-      const { revision } = JSON.parse(before.stdout);
+      const beforeJson = JSON.parse(before.stdout);
+      const { revision } = beforeJson;
       assert.ok(revision, 'tier-check surfaces the revision');
+      // --json contract for a tiered-but-unattested change: the fields must reflect
+      // trust-root tier and an unmet requirement, not just the exit code.
+      assert.equal(beforeJson.trustRootTier, true);
+      assert.equal(beforeJson.crossModelRequired, true);
+      assert.equal(beforeJson.satisfied, false);
 
       const rec = runBin(['record-cross-model', '--ticket', 'T1', '--provider', 'openai', '--author-provider', 'anthropic', '--verdict', 'approve', '--revision', revision, '--dir', '.adlc'], dir);
       assert.equal(rec.status, 0);
@@ -142,6 +153,19 @@ describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
       assert.equal(r.status, 2);
       assert.match(r.stderr, /TRUST-ROOT tier/);
       assert.match(r.stderr, /packages\/prosecute\//);
+    } finally { cleanup(dir); }
+  });
+
+  it('fails closed (exit 1) with actionable guidance when the --base ref is unresolvable', () => {
+    // An unresolvable base means the changed-file set cannot be computed, so the gate
+    // must FAIL rather than silently treat the change as empty/non-tier. The error
+    // names the fix (fetch the ref / pass --base <ref>) so CI is not a dead end.
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => writeFileSync(join(d, 'src', 'ordinary.mjs'), 'export const y = 1;\n') });
+    try {
+      const r = runBin(['tier-check', '--base', 'no-such-ref-xyz', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /cannot determine the changed-file set/);
+      assert.match(r.stderr, /--base <ref>/);
     } finally { cleanup(dir); }
   });
 

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -26,8 +26,8 @@ describe('classifyTrustRootTier — positive surface classes', () => {
     assert.ok(r.reasons.some((x) => x.includes('scripts/rails-guard-ci.mjs')));
   });
 
-  it('TRUE for the CI workflow template and hash pin and tickets.json', () => {
-    for (const f of ['docs/ci/rails-guard.yml', 'scripts/test/rails-guard-workflow-hashes.json', '.adlc/tickets.json']) {
+  it('TRUE for the CI workflow template and hash pin', () => {
+    for (const f of ['docs/ci/rails-guard.yml', 'scripts/test/rails-guard-workflow-hashes.json']) {
       const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
       assert.equal(r.isTrustRootTier, true, `${f} should be trust-root`);
       assert.ok(r.reasons.some((x) => x.includes(f)));
@@ -61,103 +61,30 @@ describe('classifyTrustRootTier — positive surface classes', () => {
     assert.ok(r.reasons.some((x) => x.includes('T7') && x.includes('test/auth/**')));
   });
 
-  // The sharded backend is the SAME trust root as `.adlc/tickets.json`. When a
-  // repo migrates, the exact-file entry stops matching and every shard edit would
-  // declassify unless the store directory itself is a trust-root surface.
-  it('TRUE for a shard in the sharded ticket store', () => {
-    const r = classifyTrustRootTier({
-      changedFiles: ['.adlc/tickets/t64--ec791ef8cffb458098b48e73556d0f644cd8c1845bf94cc167060c1e3aca4a42.json'],
-      tickets: TICKETS,
-    });
-    assert.equal(r.isTrustRootTier, true);
-    assert.ok(r.reasons.some((x) => x.includes('.adlc/tickets/')));
-  });
-
-  it('TRUE for the sharded store manifest and for the archive', () => {
-    for (const f of ['.adlc/tickets/.store.json', '.adlc/ticket-archive/.store.json', '.adlc/ticket-archive/t1--abc.json']) {
-      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
-      assert.equal(r.isTrustRootTier, true, `${f} should be trust-root`);
-    }
-  });
-
-  // The test-path exemption applies to package prefixes only. A shard is DATA the
-  // gate reads, so a ticket id that happens to look test-ish must not exempt it.
-  it('TRUE for a shard whose name would trip the test-file heuristic', () => {
-    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets/t-test--abc.test.mjs'], tickets: TICKETS });
-    assert.equal(r.isTrustRootTier, true);
-  });
 });
 
-describe('classifyTrustRootTier — #326 add-vs-alter calibration', () => {
-  // An ADDITIVE ticket-store write (ticketContractAltered: false) grants no
-  // privilege over existing rails, so the ticket-store surfaces do NOT tier —
-  // matching scripts/rails-guard-ci.mjs's add-vs-alter rule.
-  it('FALSE for an additive .adlc/tickets.json write', () => {
-    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets.json'], tickets: TICKETS, ticketContractAltered: false });
-    assert.equal(r.isTrustRootTier, false);
-    assert.deepEqual(r.reasons, []);
-  });
-
-  it('FALSE for an additive ACTIVE ticket write (tickets.json + active shard)', () => {
-    for (const f of ['.adlc/tickets.json', '.adlc/tickets/t99--abc.json']) {
-      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: false });
-      assert.equal(r.isTrustRootTier, false, `${f} additive should NOT tier`);
+describe('classifyTrustRootTier — the ticket store is NOT a tier surface (#326)', () => {
+  // rails-guard-ci owns the ticket store (add-vs-alter contract); routing it through
+  // the cross-model tier too made every ticketed PR tier for no added protection and
+  // could not be soundly attested (the reviewed revision excludes the store). So a
+  // ticket-store change is trust-root tier ONLY if it also hits a rails deny-path.
+  it('FALSE for the legacy file, active shards, the store index, and the archive', () => {
+    for (const f of [
+      '.adlc/tickets.json',
+      '.adlc/tickets/t64--ec791ef8cffb458098b48e73556d0f644cd8c1845bf94cc167060c1e3aca4a42.json',
+      '.adlc/tickets/.store.json',
+      '.adlc/ticket-archive/.store.json',
+      '.adlc/ticket-archive/t1--abc.json',
+    ]) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, false, `${f} must NOT tier on the ticket-store surface alone`);
     }
   });
 
-  // #326 P5 (cross-model finding): the active-tickets signal is BLIND to the store
-  // INDEX and the ARCHIVE, so those tier unconditionally — suppressing them on an
-  // additive verdict would fail open (an archive rewrite / backend swap looks
-  // "additive" to a signal that only reads the active store).
-  it('the store INDEX and the ARCHIVE tier UNCONDITIONALLY, even on an additive verdict', () => {
-    for (const f of ['.adlc/tickets/.store.json', '.adlc/ticket-archive/t1--abc.json']) {
-      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: false });
-      assert.equal(r.isTrustRootTier, true, `${f} must tier regardless of the additive signal`);
-    }
-  });
-
-  it('TRUE when an existing ACTIVE ticket contract is altered', () => {
-    for (const f of ['.adlc/tickets.json', '.adlc/tickets/t64--abc.json']) {
-      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: true });
-      assert.equal(r.isTrustRootTier, true, `${f} altered should tier`);
-      assert.ok(r.reasons.some((x) => x.includes('alters an existing ticket contract')), `reason for ${f}`);
-    }
-  });
-
-  it('FAILS CLOSED (tier) when the alter/add signal is omitted', () => {
-    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets.json'], tickets: TICKETS });
+  it('a ticket-store change co-changed with an enforcement package still tiers (via the package)', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets.json', 'packages/prosecute/lib/run.mjs'], tickets: TICKETS });
     assert.equal(r.isTrustRootTier, true);
-    assert.ok(r.reasons.some((x) => x.includes('.adlc/tickets.json')));
-  });
-
-  // The calibration is SCOPED to the ticket-store surfaces. An additive ticket
-  // write bundled with an enforcement-package or trust-root-file edit still tiers
-  // via those independent surfaces.
-  it('additive ticket write does NOT exempt a co-changed enforcement package or trust-root file', () => {
-    const enforcement = classifyTrustRootTier({
-      changedFiles: ['.adlc/tickets.json', 'packages/prosecute/lib/run.mjs'],
-      tickets: TICKETS,
-      ticketContractAltered: false,
-    });
-    assert.equal(enforcement.isTrustRootTier, true);
-    assert.ok(enforcement.reasons.some((x) => x.includes('packages/prosecute/')));
-    assert.ok(!enforcement.reasons.some((x) => x.includes('tickets.json')), 'additive tickets.json must not contribute a reason');
-
-    const trustFile = classifyTrustRootTier({
-      changedFiles: ['.adlc/tickets.json', 'docs/ci/rails-guard.yml'],
-      tickets: TICKETS,
-      ticketContractAltered: false,
-    });
-    assert.equal(trustFile.isTrustRootTier, true);
-    assert.ok(trustFile.reasons.some((x) => x.includes('docs/ci/rails-guard.yml')));
-  });
-
-  // A rails deny-path hit is content-driven, not ticket-store-surface-driven, so
-  // the add-vs-alter signal does not relax it.
-  it('a rails deny-path hit still tiers regardless of the additive signal', () => {
-    const r = classifyTrustRootTier({ changedFiles: ['test/auth/login.test.mjs'], tickets: TICKETS, ticketContractAltered: false });
-    assert.equal(r.isTrustRootTier, true);
-    assert.ok(r.reasons.some((x) => x.includes('rails deny-path')));
+    assert.ok(r.reasons.every((x) => !x.includes('tickets')), 'the ticket file contributes no reason');
   });
 });
 

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -98,15 +98,26 @@ describe('classifyTrustRootTier — #326 add-vs-alter calibration', () => {
     assert.deepEqual(r.reasons, []);
   });
 
-  it('FALSE for additive shard/archive writes', () => {
-    for (const f of ['.adlc/tickets/t99--abc.json', '.adlc/tickets/.store.json', '.adlc/ticket-archive/t1--abc.json']) {
+  it('FALSE for an additive ACTIVE ticket write (tickets.json + active shard)', () => {
+    for (const f of ['.adlc/tickets.json', '.adlc/tickets/t99--abc.json']) {
       const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: false });
       assert.equal(r.isTrustRootTier, false, `${f} additive should NOT tier`);
     }
   });
 
-  it('TRUE when an existing ticket contract is altered', () => {
-    for (const f of ['.adlc/tickets.json', '.adlc/tickets/t64--abc.json', '.adlc/ticket-archive/t1--abc.json']) {
+  // #326 P5 (cross-model finding): the active-tickets signal is BLIND to the store
+  // INDEX and the ARCHIVE, so those tier unconditionally — suppressing them on an
+  // additive verdict would fail open (an archive rewrite / backend swap looks
+  // "additive" to a signal that only reads the active store).
+  it('the store INDEX and the ARCHIVE tier UNCONDITIONALLY, even on an additive verdict', () => {
+    for (const f of ['.adlc/tickets/.store.json', '.adlc/ticket-archive/t1--abc.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: false });
+      assert.equal(r.isTrustRootTier, true, `${f} must tier regardless of the additive signal`);
+    }
+  });
+
+  it('TRUE when an existing ACTIVE ticket contract is altered', () => {
+    for (const f of ['.adlc/tickets.json', '.adlc/tickets/t64--abc.json']) {
       const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: true });
       assert.equal(r.isTrustRootTier, true, `${f} altered should tier`);
       assert.ok(r.reasons.some((x) => x.includes('alters an existing ticket contract')), `reason for ${f}`);

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -34,6 +34,18 @@ describe('classifyTrustRootTier — positive surface classes', () => {
     }
   });
 
+  it('TRUE for the ROOT install manifests (package.json / package-lock.json) — #326 Codex F1', () => {
+    // A change to the root package.json (its `scripts`/deps) or the lockfile is a
+    // pre-gate control surface: CI runs candidate `npm install` before the gate, so
+    // a postinstall script or a repointed dependency executes in the gate's own job.
+    // Tiering them means such a change cannot merge without a cross-model attestation.
+    for (const f of ['package.json', 'package-lock.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, true, `${f} should be trust-root`);
+      assert.ok(r.reasons.some((x) => x.includes(f)));
+    }
+  });
+
   it('TRUE for an enforcement-package prefix (packages/prosecute/…)', () => {
     const r = classifyTrustRootTier({ changedFiles: ['packages/prosecute/lib/run.mjs'], tickets: TICKETS });
     assert.equal(r.isTrustRootTier, true);
@@ -105,6 +117,16 @@ describe('classifyTrustRootTier — negative / ordinary diffs', () => {
     const r = classifyTrustRootTier({ changedFiles: ['packages/spec-lint/lib/y.mjs'], tickets: TICKETS });
     assert.equal(r.isTrustRootTier, false);
     assert.deepEqual(r.reasons, []);
+  });
+
+  it('FALSE for a NESTED package.json outside an enforcement package (root-manifest rule is exact, #326 F1)', () => {
+    // The root-install-surface rule is an EXACT match on the repo-root manifests; a
+    // nested non-enforcement manifest must not tier on it (an enforcement package's
+    // own package.json still tiers via its prefix — covered elsewhere).
+    for (const f of ['apps/docs/package.json', 'packages/spec-lint/package.json', 'apps/docs/package-lock.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS });
+      assert.equal(r.isTrustRootTier, false, `${f} must NOT tier on the root-manifest rule`);
+    }
   });
 
   it('FALSE for a source change outside any rails deny-path', () => {

--- a/packages/prosecute/test/tier.test.mjs
+++ b/packages/prosecute/test/tier.test.mjs
@@ -88,6 +88,68 @@ describe('classifyTrustRootTier — positive surface classes', () => {
   });
 });
 
+describe('classifyTrustRootTier — #326 add-vs-alter calibration', () => {
+  // An ADDITIVE ticket-store write (ticketContractAltered: false) grants no
+  // privilege over existing rails, so the ticket-store surfaces do NOT tier —
+  // matching scripts/rails-guard-ci.mjs's add-vs-alter rule.
+  it('FALSE for an additive .adlc/tickets.json write', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets.json'], tickets: TICKETS, ticketContractAltered: false });
+    assert.equal(r.isTrustRootTier, false);
+    assert.deepEqual(r.reasons, []);
+  });
+
+  it('FALSE for additive shard/archive writes', () => {
+    for (const f of ['.adlc/tickets/t99--abc.json', '.adlc/tickets/.store.json', '.adlc/ticket-archive/t1--abc.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: false });
+      assert.equal(r.isTrustRootTier, false, `${f} additive should NOT tier`);
+    }
+  });
+
+  it('TRUE when an existing ticket contract is altered', () => {
+    for (const f of ['.adlc/tickets.json', '.adlc/tickets/t64--abc.json', '.adlc/ticket-archive/t1--abc.json']) {
+      const r = classifyTrustRootTier({ changedFiles: [f], tickets: TICKETS, ticketContractAltered: true });
+      assert.equal(r.isTrustRootTier, true, `${f} altered should tier`);
+      assert.ok(r.reasons.some((x) => x.includes('alters an existing ticket contract')), `reason for ${f}`);
+    }
+  });
+
+  it('FAILS CLOSED (tier) when the alter/add signal is omitted', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['.adlc/tickets.json'], tickets: TICKETS });
+    assert.equal(r.isTrustRootTier, true);
+    assert.ok(r.reasons.some((x) => x.includes('.adlc/tickets.json')));
+  });
+
+  // The calibration is SCOPED to the ticket-store surfaces. An additive ticket
+  // write bundled with an enforcement-package or trust-root-file edit still tiers
+  // via those independent surfaces.
+  it('additive ticket write does NOT exempt a co-changed enforcement package or trust-root file', () => {
+    const enforcement = classifyTrustRootTier({
+      changedFiles: ['.adlc/tickets.json', 'packages/prosecute/lib/run.mjs'],
+      tickets: TICKETS,
+      ticketContractAltered: false,
+    });
+    assert.equal(enforcement.isTrustRootTier, true);
+    assert.ok(enforcement.reasons.some((x) => x.includes('packages/prosecute/')));
+    assert.ok(!enforcement.reasons.some((x) => x.includes('tickets.json')), 'additive tickets.json must not contribute a reason');
+
+    const trustFile = classifyTrustRootTier({
+      changedFiles: ['.adlc/tickets.json', 'docs/ci/rails-guard.yml'],
+      tickets: TICKETS,
+      ticketContractAltered: false,
+    });
+    assert.equal(trustFile.isTrustRootTier, true);
+    assert.ok(trustFile.reasons.some((x) => x.includes('docs/ci/rails-guard.yml')));
+  });
+
+  // A rails deny-path hit is content-driven, not ticket-store-surface-driven, so
+  // the add-vs-alter signal does not relax it.
+  it('a rails deny-path hit still tiers regardless of the additive signal', () => {
+    const r = classifyTrustRootTier({ changedFiles: ['test/auth/login.test.mjs'], tickets: TICKETS, ticketContractAltered: false });
+    assert.equal(r.isTrustRootTier, true);
+    assert.ok(r.reasons.some((x) => x.includes('rails deny-path')));
+  });
+});
+
 describe('classifyTrustRootTier — negative / ordinary diffs', () => {
   it('FALSE for a lookalike path outside the ticket store directory', () => {
     for (const f of ['.adlc/tickets-notes.md', '.adlc/specs/x.md', 'docs/.adlc/tickets/x.json']) {

--- a/scripts/test/codex-ci-contract.test.mjs
+++ b/scripts/test/codex-ci-contract.test.mjs
@@ -19,6 +19,34 @@ test('latest Codex drift canary is advisory', () => {
   assert.match(latestJob, /npm install -g @openai\/codex@latest/);
 });
 
+test('#326 F1: the gate job installs with --ignore-scripts and rebuilds EVERY install-script dep', () => {
+  // The test job runs the trust-root cross-model gate, so a candidate lifecycle script
+  // must never execute in it (it could shim node/npm onto $GITHUB_PATH and defeat the
+  // gate). We install --ignore-scripts and then rebuild ONLY a trusted allowlist. This
+  // guard fails if that install is weakened OR if a new dependency declares an install
+  // script that the allowlist does not cover — otherwise the allowlist would silently
+  // drift, either breaking the build or tempting a maintainer to drop --ignore-scripts
+  // and reopen the hole.
+  const requiredJob = workflow.slice(workflow.indexOf('  test:'), workflow.indexOf('  opencode-live-latest:'));
+  assert.match(requiredJob, /npm install --ignore-scripts/, 'the gate job must install with --ignore-scripts');
+  const rebuild = requiredJob.match(/npm rebuild ([^\n]+)/);
+  assert.ok(rebuild, 'the gate job must rebuild the trusted native-dep allowlist');
+  const allowlist = new Set(rebuild[1].trim().split(/\s+/));
+
+  const lock = JSON.parse(readFileSync(new URL('../../package-lock.json', import.meta.url), 'utf8'));
+  const needScripts = [...new Set(
+    Object.entries(lock.packages || {})
+      .filter(([, v]) => v && v.hasInstallScript)
+      .map(([k]) => k.split('node_modules/').pop()) // last path segment = package name
+  )];
+  const missing = needScripts.filter((name) => !allowlist.has(name));
+  assert.deepEqual(
+    missing,
+    [],
+    `install-script dep(s) missing from the ci.yml \`npm rebuild\` allowlist: ${missing.join(', ')} — add them, or their native build is skipped`,
+  );
+});
+
 test('ordinary npm test always exercises the offline Codex contracts', () => {
   // The contract is that `npm test` RUNS these, not that package.json spells them
   // out. The test script now delegates to a runner (so one failing suite cannot


### PR DESCRIPTION
## #326 — Wire the trust-root cross-model review gate into CI

Closes #326.

### The bug (P0)

T39/ADR-0007 made cross-model adversarial review a **gate** for the trust-root tier. The classifier existed, was tested, fail-closed — and **no CI job ever invoked it**. The trust-root requirement was silently absent: CI green, manifest recording that gates ran, and no signal distinguishing "cross-model review passed" from "never requested." A mechanism reporting success while enforcing nothing.

The tier was also **far too broad**: `.adlc/tickets.json` tiered unconditionally, so *every ADLC-ticketed PR* was trust-root tier — which is why enforcing it was impractical and it was never wired in.

### What this does

**1. Narrow the tier (calibration).** The ticket **store** (`.adlc/tickets.json`, the sharded `.adlc/tickets/`, `.adlc/ticket-archive/`) is no longer a tier surface. `rails-guard-ci` already owns it with an add-vs-alter contract. The tier is now: **enforcement packages, gated-artifact producer packages, rails deny-paths, the trust-root files** (`rails-guard-ci.mjs`, `docs/ci/rails-guard.yml`, `workflow-hashes.json`), and — after the cross-model re-review below — the **root install manifests** (`package.json`, `package-lock.json`).

**2. The gate (`adlc-prosecute tier-check`).** Classifies the change; if trust-root tier, requires a **distinct-provider cross-model `approve` bound to the reviewed revision** (`hasCrossModelApproveForRevision` — ticket-agnostic, revision-hash-anchored). Fails closed (exit 2 missing attestation; exit 1 no author-provider or an unresolvable base). Always prints the tier decision (AC3).

**3. Wired into the REQUIRED `test` job.** This repo can't add new required checks (free plan), so a separate job would enforce nothing — folded in as the test job's last step (Node 20, PR-only). It checks out the PR head with `--force`, then reinstalls the toolchain with `npm ci --ignore-scripts` (see F1 below) before running the gate, so the worktree revision matches the recorded attestation and no candidate install-script can poison the gate.

### Hardened by its own kind of review — TWICE

Cross-model (Codex, distinct-provider) adversarial review **found real fail-opens before merge**, both rounds — the gate proving its own worth.

**Round 1** drove the whole rework (F1 stale-ticket-approval fail-open → dropping the ticket store from the tier; F7 → folding into the required job; F2/F8/F9).

**Round 2** (re-review of the fixed code) returned **NO-SHIP** with four findings; the two verified-genuine HIGHs are now fixed:

- **F1 (HIGH) — untiered install surface → PATH-shim.** Rounds 2 and 3 drove a layered fix: (a) the root install manifests (`package.json`/`package-lock.json`) now **tier** (a dependency/version/script change requires an attestation); (b) the gate's job installs with `npm install --ignore-scripts` and rebuilds only a **lockfile-pinned trusted-native allowlist** (drift-guarded), so **no first-party lifecycle script runs**; (c) the gate step reinstalls `--ignore-scripts` (defense-in-depth). Round 4 showed the *general* residual — a PR shipping visibly-malicious build config (a workspace `bin:{node}`, a `.npmrc`) can still run code in the shared runner. That is the **documented ADR-0007 "gate runs candidate code" limit**: it is no weaker than any other required check (the same capability defeats `npm test`/`rails-guard`/`mutation-gate`), it requires diff-visible malicious config, and the CODEOWNERS/human-review backstop covers it. Fully closing it needs an isolated required job, which this repo's plan disallows. Accepted + documented in ADR-0007.
- **F2 (HIGH, fixed) — manifest revocation bypass.** `readEntries()` silently shunts a malformed/truncated line to `skipped`, so garbling a later `needs-attention` line (without re-chaining — the cheap attack) dropped the revocation and resurfaced an earlier `approve`. **Fix:** `hasCrossModelApprove*()` now `verify()` the manifest hash chain and **fail closed** on any break. Round 3 confirmed closed. (Re-authoring the tail so it re-chains cleanly remains the honest-limit — defeated only by `ADLC_MANIFEST_KEY`.)

Accepted-scope (documented, not fixed — follow-ups):
- **F3 (MED) — repo-global author-provider.** `ADLC_AUTHOR_PROVIDER` is a repo default; a PR authored by a different model than the default is judged against the wrong author. Low practical risk on this single-maintainer, anthropic-authored repo. Follow-up: derive the author provider per-PR.
- **F4 (LOW, overstated) — revision binds the result tree, not the base/diff.** The revision is a whole-tree sha256, so Codex's revert-replay needs reconstructing the entire approved tree (all of main's later progress reverted) — visible, not stealthy. Follow-up: optionally bind the base OID into the revision.

**Accepted honest-limits (per ADR-0007, not regressions):** attestations are honest-party not cryptographic; provider-family aliasing; the gate runs candidate code with the branch-protection-CODEOWNERS backstop.

### Verification
- 120 prosecute tests green, including: `tier-check` CLI (not-tier / tiered-unattested / attested / fail-closed-no-author / unresolvable-base / **untracked-walk `-z`** / **root-manifest tier** / nested-manifest precision), the `--json` field contract, revision-scoped attestation, revocation, **manifest corrupt/truncate fail-closed (F2)**, and read-side entry-shape guards.
- **mutation-gate: 15/15 killed, 0 survived** across the branch diff (every changed guard has a test that notices it flip).
- **This PR is its own AC2 proof:** it touches `packages/prosecute/` (enforcement) → its folded gate classifies it trust-root tier → **red** until a distinct-provider cross-model attestation for its revision is recorded. That red check is the feature working.

### Cross-model review status (honest — 4 rounds)
- Round 1 (Codex): **NO-SHIP** → drove the tier rework (F1/F7/F2/F8/F9).
- Round 2 (Codex): **NO-SHIP** → F1 install-surface + F2 revocation bypass fixed; F3/F4 accepted follow-ups.
- Round 3 (Codex): **NO-SHIP** → **F2 confirmed closed**; found the deeper F1 PATH-shim → fixed job-wide with `--ignore-scripts` + trusted-rebuild allowlist + drift guard.
- Round 4 (Codex): **NO-SHIP** → the remaining vector (workspace `bin`/`.npmrc` in the shared runner) is the **documented ADR-0007 honest-limit**, not a unique weakness. Accepted and documented; the tractable layers (rounds 1–3) are closed.

No clean distinct-provider **approve** was obtained (each round correctly found something; rounds 1–3 were genuinely fixed), so **no attestation is recorded** and the folded gate is red **by design**. The maintainer's **admin-merge is the human authorization** (as with #339/#342), with the residual documented in ADR-0007.

### ⚠️ Trust-root change (same handling as #141/#283)
Touches `.github/workflows/ci.yml` (a rails-guard trust root). The `rails-guard` check denies until merged; apply `trust-root-change` + a non-author CODEOWNER approval, or admin-override (solo maintainer).

### Remaining (AC5)
The 4 already-merged trust-root PRs (#304, #316, #317, #323) — retroactive cross-model review, tracked as follow-up.
