### PR TITLE
#314 — rails-guard-ci: decide manifest-creation from the diff, not the filesystem

### DIFF
--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -46,11 +46,14 @@ function deny(msg) {
   process.exit(2);
 }
 
-function git(args, label) {
+function git(args, label, { raw = false } = {}) {
   // maxBuffer well above Node's 1 MiB default: the append-only manifest is an ever-growing
   // ledger and `git cat-file`/`git show`/`git diff` output can exceed 1 MiB legitimately.
   // The default would ENOBUFS a large-but-valid manifest and fail the gate (#314 round 6).
-  const result = spawnSync('git', args, { encoding: 'utf8', timeout: 60000, maxBuffer: 512 * 1024 * 1024 });
+  // raw:true omits encoding so stdout is a Buffer — the manifest evidence is compared
+  // BYTE-for-byte (utf8 decode is non-injective: distinct invalid byte sequences both become
+  // U+FFFD, so a decoded-string prefix check could miss a raw-byte rewrite — #314 round 7).
+  const result = spawnSync('git', args, { encoding: raw ? 'buffer' : 'utf8', timeout: 60000, maxBuffer: 512 * 1024 * 1024 });
   if (result.error) fail(`${label} failed: ${result.error.message}`);
   if (result.signal) fail(`${label} timed out or was killed by ${result.signal}`);
   return result;
@@ -182,28 +185,41 @@ function manifestLines(text, label) {
 // HEAD and could bind content to a different tree than the mode check saw (a TOCTOU). The blob
 // hash is immutable, so metadata and content provably describe the same object (#314 round 5).
 function committedManifestAtHead() {
-  // Ancestor guard (#314 round 6): `git ls-tree HEAD -- .adlc/manifest.jsonl` does NOT descend
+  // Pin HEAD to ONE immutable commit sha and resolve every lookup against it (#314 round 7).
+  // Otherwise the ancestor and leaf checks each re-resolve the mutable `HEAD`; a concurrent
+  // ref change between them (tree A with a normal `.adlc`, tree B with a symlinked `.adlc`)
+  // would pass the ancestor guard on A while the leaf reads absent on B.
+  const rev = git(['rev-parse', 'HEAD'], 'git rev-parse HEAD');
+  if (rev.status !== 0) fail('git rev-parse HEAD failed (operational error) — failing closed.');
+  const head = rev.stdout.trim();
+  // Ancestor guard (#314 round 6): `git ls-tree <head> -- .adlc/manifest.jsonl` does NOT descend
   // a symlinked/submodule `.adlc`, so an ANCESTOR symlink (`.adlc` → some `state/` dir holding
   // a forged manifest) would make the leaf lookup return "absent" while filesystem consumers
   // follow the link and read the pre-populated evidence. Require `.adlc` itself to be a real
   // tree at HEAD before trusting the leaf. Absent `.adlc` (dir not created yet) is fine.
-  const adlcDir = git(['ls-tree', 'HEAD', '--', '.adlc'], 'git ls-tree HEAD .adlc');
+  const adlcDir = git(['ls-tree', head, '--', '.adlc'], 'git ls-tree HEAD .adlc');
   if (adlcDir.status !== 0) fail('git ls-tree failed for the HEAD .adlc directory (operational error) — failing closed.');
   const adlcRow = adlcDir.stdout.trim();
   if (adlcRow && adlcRow.split(/\s+/)[0] !== '040000') {
     deny('.adlc must be a directory, not a symlink or submodule');
   }
-  const ls = git(['ls-tree', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
+  const ls = git(['ls-tree', head, '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
   if (ls.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
   const row = ls.stdout.trim();
+  // No `bytes` on the absent return: the only bytes consumer (the append-only branch) checks
+  // `present` first, so an absent manifest's bytes are never read — carrying a Buffer here
+  // would just be an unkillable equivalent mutant.
   if (!row) return { present: false, text: '' };
   const [mode, type, hash] = row.split(/\s+/);
   if (type !== 'blob' || mode !== '100644') {
     deny('.adlc/manifest.jsonl must be a regular tracked file, not a symlink or submodule');
   }
-  const blob = git(['cat-file', 'blob', hash], 'git cat-file HEAD manifest blob');
+  // Read the exact object by its immutable hash, as raw BYTES — the append-only comparison is
+  // byte-for-byte (see git() `raw`). `text` is the utf8 view for the semantic checks (trim,
+  // JSON parse) that don't need byte fidelity.
+  const blob = git(['cat-file', 'blob', hash], 'git cat-file HEAD manifest blob', { raw: true });
   if (blob.status !== 0) fail('git cat-file failed for the HEAD manifest blob (operational error) — failing closed.');
-  return { present: true, text: blob.stdout };
+  return { present: true, text: blob.stdout.toString('utf8'), bytes: blob.stdout };
 }
 
 function validateMigrationEvidence(baseText, headText, expectedStoreHash, expectedArchiveHash) {
@@ -539,12 +555,15 @@ if (manifestLs.stdout.trim()) {
   if (!head.present) {
     deny('.adlc/manifest.jsonl exists at base but is absent at HEAD');
   }
-  const baseManifest = git(['show', `${trustedBase}:.adlc/manifest.jsonl`], 'git show base manifest');
+  const baseManifest = git(['show', `${trustedBase}:.adlc/manifest.jsonl`], 'git show base manifest', { raw: true });
   if (baseManifest.status !== 0) fail('git show failed for an existing base manifest (operational error) — failing closed.');
-  if (!head.text.startsWith(baseManifest.stdout)) {
+  const baseBytes = baseManifest.stdout; // Buffer
+  // Append-only is a BYTE-for-byte prefix check (#314 round 7): a utf8-decoded comparison
+  // could miss a raw-byte rewrite of the base region (invalid sequences collapse to U+FFFD).
+  if (head.bytes.length < baseBytes.length || !head.bytes.subarray(0, baseBytes.length).equals(baseBytes)) {
     deny('.adlc/manifest.jsonl must be append-only in PRs');
   }
-  if (verifiedMigration) validateMigrationEvidence(baseManifest.stdout, head.text, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
+  if (verifiedMigration) validateMigrationEvidence(baseBytes.toString('utf8'), head.text, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
 } else if (verifiedMigration) {
   // Verified migration ceremony (protected-base runner): the migration evidence lives in
   // the gitignored WORKING-TREE manifest by design. Read it EXACTLY ONCE and make both the

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -537,19 +537,22 @@ if (manifestLs.stdout.trim()) {
   if (verifiedMigration) validateMigrationEvidence(baseManifest.stdout, head.text, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
 } else if (verifiedMigration) {
   // Verified migration ceremony (protected-base runner): the migration evidence lives in
-  // the gitignored WORKING-TREE manifest by design, so read it here as before. The diff
-  // shape and CODEOWNERS attestation were already verified upstream, which is what makes
-  // trusting this local file sound in this branch only.
+  // the gitignored WORKING-TREE manifest by design. Read it EXACTLY ONCE and make both the
+  // presence and validation decisions on that single snapshot — a two-read pattern (validate
+  // one snapshot, presence-check a second) is a TOCTOU fail-open: an empty file skips
+  // validation, then a swapped non-empty file satisfies presence with evidence never checked
+  // (#314 round 4). The diff shape and CODEOWNERS attestation were verified upstream, which
+  // is what makes trusting this local file sound in this branch only.
   const headManifest = workingManifestText();
-  if (headManifest.trim()) validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
+  // validateMigrationEvidence itself denies empty/whitespace evidence (appended.length 0),
+  // so ONE read + one unconditional validation covers both presence and content — no second
+  // read to race against.
+  validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
 } else if (committedManifestAtHead().text.trim()) {
   // Ordinary PR (#314): only a TRACKED manifest ADDED by the diff with non-empty evidence
   // denies. An untracked gitignored manifest reads as '' (not tracked at HEAD) and passes,
   // so the local verdict equals CI's clean checkout.
   deny('.adlc/manifest.jsonl cannot be created with evidence in a PR; create it empty during bootstrap or use the protected-base runner ceremony');
-}
-if (verifiedMigration && !workingManifestText().trim()) {
-  deny('legacy-to-directory migration requires hash-bound migration evidence');
 }
 
 const immutableTrustRoots = rails.length || baseHasConfig

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -155,6 +155,30 @@ function manifestLines(text, label) {
   return text.split('\n').filter((line) => line.trim()).map((line, index) => parseJson(line, `${label} line ${index + 1}`));
 }
 
+// #314: the committed HEAD content of `.adlc/manifest.jsonl`, or '' when it is NOT tracked
+// at HEAD. Whether a PR "creates the manifest" is a DIFF question, not a filesystem one — a
+// gitignored, untracked manifest (which every dev who has run the toolkit has locally) is in
+// zero commits and must not be read, so the local verdict equals CI's clean checkout.
+//
+// FAIL CLOSED on a non-regular object: a manifest committed as a SYMLINK (or submodule) must
+// not smuggle evidence. `git show` returns a symlink's TARGET STRING, not the target's
+// content, so a whitespace-target symlink would slip past `.trim()` while downstream readers
+// that follow the link consume forged entries — the old readFileSync check denied this by
+// following the link, so preserve that by rejecting any non-`100644 blob` object.
+function committedManifestText() {
+  const ls = git(['ls-tree', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
+  if (ls.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
+  const row = ls.stdout.trim();
+  if (!row) return '';
+  const [mode, type] = row.split(/\s+/);
+  if (type !== 'blob' || mode !== '100644') {
+    deny('.adlc/manifest.jsonl must be a regular tracked file, not a symlink or submodule');
+  }
+  const show = git(['show', 'HEAD:.adlc/manifest.jsonl'], 'git show HEAD manifest');
+  if (show.status !== 0) fail('git show failed for the tracked HEAD manifest (operational error) — failing closed.');
+  return show.stdout;
+}
+
 function validateMigrationEvidence(baseText, headText, expectedStoreHash, expectedArchiveHash) {
   const baseEntries = manifestLines(baseText, 'base manifest');
   const headEntries = manifestLines(headText, 'HEAD manifest');
@@ -392,7 +416,11 @@ try {
   if (baseHasConfig) {
     console.log(`rails-guard-ci: no ticket store at ${base} — protecting ADLC trust roots only.`);
   } else {
-    if (existsSync('.adlc/manifest.jsonl') && readFileSync('.adlc/manifest.jsonl', 'utf8').trim()) {
+    // #314: same diff-not-filesystem rule as the main manifest block — a first-bootstrap
+    // PR that ADDS a tracked non-empty manifest is rejected, but a gitignored untracked
+    // manifest in the developer's tree is not (it is in zero commits), so local == CI here
+    // too. committedManifestText() also fails closed on a symlink/submodule manifest.
+    if (committedManifestText().trim()) {
       fail('first bootstrap PR cannot introduce pre-populated .adlc/manifest.jsonl evidence');
     }
     console.log(`rails-guard-ci: no ticket store at ${base} — nothing was frozen.`);
@@ -494,20 +522,11 @@ if (manifestLs.stdout.trim()) {
   // trusting this local file sound in this branch only.
   const headManifest = existsSync('.adlc/manifest.jsonl') ? readFileSync('.adlc/manifest.jsonl', 'utf8') : '';
   if (headManifest.trim()) validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
-} else {
-  // Ordinary PR (#314): whether the CHANGE "creates the manifest with evidence" is a DIFF
-  // question, not a filesystem one. A gitignored, untracked manifest — which every dev who
-  // has run the toolkit has locally — is in zero commits and not in the diff, so it must
-  // not deny (the local verdict must equal CI's clean checkout). Reading the working tree
-  // (existsSync/readFileSync) made them disagree. Only a TRACKED manifest ADDED by the
-  // diff triggers the deny; read the committed HEAD content, never the filesystem.
-  const manifestAtHead = git(['ls-tree', '--name-only', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
-  if (manifestAtHead.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
-  if (manifestAtHead.stdout.trim()) {
-    const headManifest = git(['show', 'HEAD:.adlc/manifest.jsonl'], 'git show HEAD manifest');
-    if (headManifest.status !== 0) fail('git show failed for a tracked HEAD manifest (operational error) — failing closed.');
-    if (headManifest.stdout.trim()) deny('.adlc/manifest.jsonl cannot be created with evidence in a PR; create it empty during bootstrap or use the protected-base runner ceremony');
-  }
+} else if (committedManifestText().trim()) {
+  // Ordinary PR (#314): only a TRACKED manifest ADDED by the diff with non-empty evidence
+  // denies. An untracked gitignored manifest reads as '' (not tracked at HEAD) and passes,
+  // so the local verdict equals CI's clean checkout.
+  deny('.adlc/manifest.jsonl cannot be created with evidence in a PR; create it empty during bootstrap or use the protected-base runner ceremony');
 }
 if (verifiedMigration && (!existsSync('.adlc/manifest.jsonl') || !readFileSync('.adlc/manifest.jsonl', 'utf8').trim())) {
   deny('legacy-to-directory migration requires hash-bound migration evidence');

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -47,7 +47,10 @@ function deny(msg) {
 }
 
 function git(args, label) {
-  const result = spawnSync('git', args, { encoding: 'utf8', timeout: 60000 });
+  // maxBuffer well above Node's 1 MiB default: the append-only manifest is an ever-growing
+  // ledger and `git cat-file`/`git show`/`git diff` output can exceed 1 MiB legitimately.
+  // The default would ENOBUFS a large-but-valid manifest and fail the gate (#314 round 6).
+  const result = spawnSync('git', args, { encoding: 'utf8', timeout: 60000, maxBuffer: 512 * 1024 * 1024 });
   if (result.error) fail(`${label} failed: ${result.error.message}`);
   if (result.signal) fail(`${label} timed out or was killed by ${result.signal}`);
   return result;
@@ -179,6 +182,17 @@ function manifestLines(text, label) {
 // HEAD and could bind content to a different tree than the mode check saw (a TOCTOU). The blob
 // hash is immutable, so metadata and content provably describe the same object (#314 round 5).
 function committedManifestAtHead() {
+  // Ancestor guard (#314 round 6): `git ls-tree HEAD -- .adlc/manifest.jsonl` does NOT descend
+  // a symlinked/submodule `.adlc`, so an ANCESTOR symlink (`.adlc` → some `state/` dir holding
+  // a forged manifest) would make the leaf lookup return "absent" while filesystem consumers
+  // follow the link and read the pre-populated evidence. Require `.adlc` itself to be a real
+  // tree at HEAD before trusting the leaf. Absent `.adlc` (dir not created yet) is fine.
+  const adlcDir = git(['ls-tree', 'HEAD', '--', '.adlc'], 'git ls-tree HEAD .adlc');
+  if (adlcDir.status !== 0) fail('git ls-tree failed for the HEAD .adlc directory (operational error) — failing closed.');
+  const adlcRow = adlcDir.stdout.trim();
+  if (adlcRow && adlcRow.split(/\s+/)[0] !== '040000') {
+    deny('.adlc must be a directory, not a symlink or submodule');
+  }
   const ls = git(['ls-tree', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
   if (ls.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
   const row = ls.stdout.trim();

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -165,18 +165,22 @@ function manifestLines(text, label) {
 // content, so a whitespace-target symlink would slip past `.trim()` while downstream readers
 // that follow the link consume forged entries — the old readFileSync check denied this by
 // following the link, so preserve that by rejecting any non-`100644 blob` object.
-function committedManifestText() {
+// Returns { present, text }: `present` is whether the manifest is tracked at HEAD, `text`
+// its committed content ('' when absent OR empty). ALL committed-manifest reads go through
+// here so the symlink/submodule fail-closed applies uniformly (creation, first-bootstrap,
+// AND the append-only branch) — reading the working tree with readFileSync followed a link.
+function committedManifestAtHead() {
   const ls = git(['ls-tree', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
   if (ls.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
   const row = ls.stdout.trim();
-  if (!row) return '';
+  if (!row) return { present: false, text: '' };
   const [mode, type] = row.split(/\s+/);
   if (type !== 'blob' || mode !== '100644') {
     deny('.adlc/manifest.jsonl must be a regular tracked file, not a symlink or submodule');
   }
   const show = git(['show', 'HEAD:.adlc/manifest.jsonl'], 'git show HEAD manifest');
   if (show.status !== 0) fail('git show failed for the tracked HEAD manifest (operational error) — failing closed.');
-  return show.stdout;
+  return { present: true, text: show.stdout };
 }
 
 function validateMigrationEvidence(baseText, headText, expectedStoreHash, expectedArchiveHash) {
@@ -420,7 +424,7 @@ try {
     // PR that ADDS a tracked non-empty manifest is rejected, but a gitignored untracked
     // manifest in the developer's tree is not (it is in zero commits), so local == CI here
     // too. committedManifestText() also fails closed on a symlink/submodule manifest.
-    if (committedManifestText().trim()) {
+    if (committedManifestAtHead().text.trim()) {
       fail('first bootstrap PR cannot introduce pre-populated .adlc/manifest.jsonl evidence');
     }
     console.log(`rails-guard-ci: no ticket store at ${base} — nothing was frozen.`);
@@ -505,16 +509,19 @@ if (manifestLs.status !== 0) {
   fail(`git ls-tree failed for '${base}' manifest (operational error) — failing closed.`);
 }
 if (manifestLs.stdout.trim()) {
-  if (!existsSync('.adlc/manifest.jsonl')) {
+  // Base has a tracked manifest → the PR's HEAD version must be a regular blob (not a
+  // symlink smuggling forged evidence past the prefix check) and append-only over the
+  // base. Read the COMMITTED HEAD content, never the working tree (which follows links).
+  const head = committedManifestAtHead();
+  if (!head.present) {
     deny('.adlc/manifest.jsonl exists at base but is absent at HEAD');
   }
   const baseManifest = git(['show', `${trustedBase}:.adlc/manifest.jsonl`], 'git show base manifest');
   if (baseManifest.status !== 0) fail('git show failed for an existing base manifest (operational error) — failing closed.');
-  const headManifest = readFileSync('.adlc/manifest.jsonl', 'utf8');
-  if (!headManifest.startsWith(baseManifest.stdout)) {
+  if (!head.text.startsWith(baseManifest.stdout)) {
     deny('.adlc/manifest.jsonl must be append-only in PRs');
   }
-  if (verifiedMigration) validateMigrationEvidence(baseManifest.stdout, headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
+  if (verifiedMigration) validateMigrationEvidence(baseManifest.stdout, head.text, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
 } else if (verifiedMigration) {
   // Verified migration ceremony (protected-base runner): the migration evidence lives in
   // the gitignored WORKING-TREE manifest by design, so read it here as before. The diff
@@ -522,7 +529,7 @@ if (manifestLs.stdout.trim()) {
   // trusting this local file sound in this branch only.
   const headManifest = existsSync('.adlc/manifest.jsonl') ? readFileSync('.adlc/manifest.jsonl', 'utf8') : '';
   if (headManifest.trim()) validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
-} else if (committedManifestText().trim()) {
+} else if (committedManifestAtHead().text.trim()) {
   // Ordinary PR (#314): only a TRACKED manifest ADDED by the diff with non-empty evidence
   // denies. An untracked gitignored manifest reads as '' (not tracked at HEAD) and passes,
   // so the local verdict equals CI's clean checkout.

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -27,7 +27,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { DirectoryTicketStore, GitTreeTicketStore, detectTicketStore, storeHash, validateTickets } from '@adlc/tickets';
@@ -166,34 +166,30 @@ function manifestLines(text, label) {
 // that follow the link consume forged entries — the old readFileSync check denied this by
 // following the link, so preserve that by rejecting any non-`100644 blob` object.
 // Returns { present, text }: `present` is whether the manifest is tracked at HEAD, `text`
-// its committed content ('' when absent OR empty). ALL committed-manifest reads go through
-// here so the symlink/submodule fail-closed applies uniformly (creation, first-bootstrap,
-// AND the append-only branch) — reading the working tree with readFileSync followed a link.
+// its committed content ('' when absent OR empty). This is the SOLE manifest reader — every
+// path (creation, first-bootstrap, append-only, AND the migration ceremony) reads through it,
+// so there is no working-tree read left to diverge from CI's clean checkout or to follow a
+// symlink. The migration ceremony's evidence is a TRACKED file (the migration diff-shape
+// allow-list expects `.adlc/manifest.jsonl` in the diff), so committed content is the correct,
+// CI-consistent source; reading the working tree there was the legacy artifact (#314 round 5).
+//
+// FAIL CLOSED on a non-regular object (symlink 120000 / submodule 160000): such a manifest
+// must not smuggle evidence. And read the content by the BLOB HASH from the same ls-tree row
+// (`git cat-file blob <hash>`), NOT `git show HEAD:path` — `git show` re-resolves the mutable
+// HEAD and could bind content to a different tree than the mode check saw (a TOCTOU). The blob
+// hash is immutable, so metadata and content provably describe the same object (#314 round 5).
 function committedManifestAtHead() {
   const ls = git(['ls-tree', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
   if (ls.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
   const row = ls.stdout.trim();
   if (!row) return { present: false, text: '' };
-  const [mode, type] = row.split(/\s+/);
+  const [mode, type, hash] = row.split(/\s+/);
   if (type !== 'blob' || mode !== '100644') {
     deny('.adlc/manifest.jsonl must be a regular tracked file, not a symlink or submodule');
   }
-  const show = git(['show', 'HEAD:.adlc/manifest.jsonl'], 'git show HEAD manifest');
-  if (show.status !== 0) fail('git show failed for the tracked HEAD manifest (operational error) — failing closed.');
-  return { present: true, text: show.stdout };
-}
-
-// The verified-migration ceremony is the ONE path that reads the working-tree manifest (its
-// evidence is a gitignored local file). Refuse a symlink there too (#314 round 3): a manifest
-// symlinked to an ALLOW-LISTED migration path (e.g. ../.gitignore holding forged evidence)
-// would otherwise be followed by readFileSync — the diff-shape allow-list does not reject it
-// because the target IS allow-listed. lstat (not stat) so the link itself is inspected.
-function workingManifestText() {
-  if (!existsSync('.adlc/manifest.jsonl')) return '';
-  if (!lstatSync('.adlc/manifest.jsonl').isFile()) {
-    deny('.adlc/manifest.jsonl must be a regular file, not a symlink or special file');
-  }
-  return readFileSync('.adlc/manifest.jsonl', 'utf8');
+  const blob = git(['cat-file', 'blob', hash], 'git cat-file HEAD manifest blob');
+  if (blob.status !== 0) fail('git cat-file failed for the HEAD manifest blob (operational error) — failing closed.');
+  return { present: true, text: blob.stdout };
 }
 
 function validateMigrationEvidence(baseText, headText, expectedStoreHash, expectedArchiveHash) {
@@ -543,11 +539,12 @@ if (manifestLs.stdout.trim()) {
   // validation, then a swapped non-empty file satisfies presence with evidence never checked
   // (#314 round 4). The diff shape and CODEOWNERS attestation were verified upstream, which
   // is what makes trusting this local file sound in this branch only.
-  const headManifest = workingManifestText();
-  // validateMigrationEvidence itself denies empty/whitespace evidence (appended.length 0),
-  // so ONE read + one unconditional validation covers both presence and content — no second
-  // read to race against.
-  validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
+  // Read the migration evidence from the COMMITTED manifest (it is a tracked file — the
+  // migration diff-shape allow-list expects it in the diff), the same object-bound reader as
+  // every other path. validateMigrationEvidence denies empty/whitespace evidence, so ONE read
+  // + one unconditional validation covers both presence and content — no working-tree read to
+  // diverge from CI and no second snapshot to race against.
+  validateMigrationEvidence('', committedManifestAtHead().text, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
 } else if (committedManifestAtHead().text.trim()) {
   // Ordinary PR (#314): only a TRACKED manifest ADDED by the diff with non-empty evidence
   // denies. An untracked gitignored manifest reads as '' (not tracked at HEAD) and passes,

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -27,7 +27,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { DirectoryTicketStore, GitTreeTicketStore, detectTicketStore, storeHash, validateTickets } from '@adlc/tickets';
@@ -181,6 +181,19 @@ function committedManifestAtHead() {
   const show = git(['show', 'HEAD:.adlc/manifest.jsonl'], 'git show HEAD manifest');
   if (show.status !== 0) fail('git show failed for the tracked HEAD manifest (operational error) — failing closed.');
   return { present: true, text: show.stdout };
+}
+
+// The verified-migration ceremony is the ONE path that reads the working-tree manifest (its
+// evidence is a gitignored local file). Refuse a symlink there too (#314 round 3): a manifest
+// symlinked to an ALLOW-LISTED migration path (e.g. ../.gitignore holding forged evidence)
+// would otherwise be followed by readFileSync — the diff-shape allow-list does not reject it
+// because the target IS allow-listed. lstat (not stat) so the link itself is inspected.
+function workingManifestText() {
+  if (!existsSync('.adlc/manifest.jsonl')) return '';
+  if (!lstatSync('.adlc/manifest.jsonl').isFile()) {
+    deny('.adlc/manifest.jsonl must be a regular file, not a symlink or special file');
+  }
+  return readFileSync('.adlc/manifest.jsonl', 'utf8');
 }
 
 function validateMigrationEvidence(baseText, headText, expectedStoreHash, expectedArchiveHash) {
@@ -527,7 +540,7 @@ if (manifestLs.stdout.trim()) {
   // the gitignored WORKING-TREE manifest by design, so read it here as before. The diff
   // shape and CODEOWNERS attestation were already verified upstream, which is what makes
   // trusting this local file sound in this branch only.
-  const headManifest = existsSync('.adlc/manifest.jsonl') ? readFileSync('.adlc/manifest.jsonl', 'utf8') : '';
+  const headManifest = workingManifestText();
   if (headManifest.trim()) validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
 } else if (committedManifestAtHead().text.trim()) {
   // Ordinary PR (#314): only a TRACKED manifest ADDED by the diff with non-empty evidence
@@ -535,7 +548,7 @@ if (manifestLs.stdout.trim()) {
   // so the local verdict equals CI's clean checkout.
   deny('.adlc/manifest.jsonl cannot be created with evidence in a PR; create it empty during bootstrap or use the protected-base runner ceremony');
 }
-if (verifiedMigration && (!existsSync('.adlc/manifest.jsonl') || !readFileSync('.adlc/manifest.jsonl', 'utf8').trim())) {
+if (verifiedMigration && !workingManifestText().trim()) {
   deny('legacy-to-directory migration requires hash-bound migration evidence');
 }
 

--- a/scripts/rails-guard-ci.mjs
+++ b/scripts/rails-guard-ci.mjs
@@ -487,10 +487,27 @@ if (manifestLs.stdout.trim()) {
     deny('.adlc/manifest.jsonl must be append-only in PRs');
   }
   if (verifiedMigration) validateMigrationEvidence(baseManifest.stdout, headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
-} else if (existsSync('.adlc/manifest.jsonl') && readFileSync('.adlc/manifest.jsonl', 'utf8').trim()) {
-  const headManifest = readFileSync('.adlc/manifest.jsonl', 'utf8');
-  if (verifiedMigration) validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
-  else deny('.adlc/manifest.jsonl cannot be created with evidence in a PR; create it empty during bootstrap or use the protected-base runner ceremony');
+} else if (verifiedMigration) {
+  // Verified migration ceremony (protected-base runner): the migration evidence lives in
+  // the gitignored WORKING-TREE manifest by design, so read it here as before. The diff
+  // shape and CODEOWNERS attestation were already verified upstream, which is what makes
+  // trusting this local file sound in this branch only.
+  const headManifest = existsSync('.adlc/manifest.jsonl') ? readFileSync('.adlc/manifest.jsonl', 'utf8') : '';
+  if (headManifest.trim()) validateMigrationEvidence('', headManifest, verifiedMigrationStoreHash, verifiedMigrationArchiveHash);
+} else {
+  // Ordinary PR (#314): whether the CHANGE "creates the manifest with evidence" is a DIFF
+  // question, not a filesystem one. A gitignored, untracked manifest — which every dev who
+  // has run the toolkit has locally — is in zero commits and not in the diff, so it must
+  // not deny (the local verdict must equal CI's clean checkout). Reading the working tree
+  // (existsSync/readFileSync) made them disagree. Only a TRACKED manifest ADDED by the
+  // diff triggers the deny; read the committed HEAD content, never the filesystem.
+  const manifestAtHead = git(['ls-tree', '--name-only', 'HEAD', '--', '.adlc/manifest.jsonl'], 'git ls-tree HEAD manifest');
+  if (manifestAtHead.status !== 0) fail('git ls-tree failed for the HEAD manifest (operational error) — failing closed.');
+  if (manifestAtHead.stdout.trim()) {
+    const headManifest = git(['show', 'HEAD:.adlc/manifest.jsonl'], 'git show HEAD manifest');
+    if (headManifest.status !== 0) fail('git show failed for a tracked HEAD manifest (operational error) — failing closed.');
+    if (headManifest.stdout.trim()) deny('.adlc/manifest.jsonl cannot be created with evidence in a PR; create it empty during bootstrap or use the protected-base runner ceremony');
+  }
 }
 if (verifiedMigration && (!existsSync('.adlc/manifest.jsonl') || !readFileSync('.adlc/manifest.jsonl', 'utf8').trim())) {
   deny('legacy-to-directory migration requires hash-bound migration evidence');

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -150,7 +150,12 @@ function runMigrationScenario({ mutateTicket = (ticket) => ticket, extraChange =
       symlinkSync('../.gitignore', join(dir, '.adlc/manifest.jsonl'));
     }
     if (extraChange) { mkdirSync(join(dir, 'src'), { recursive: true }); writeFileSync(join(dir, 'src/extra.mjs'), 'export {};\n'); }
-    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'migrate']);
+    git(dir, ['add', '-A']);
+    // The migration commits its evidence manifest (the diff-shape allow-list expects
+    // `.adlc/manifest.jsonl` in the diff); force past the fixture's `.adlc/*` gitignore so it
+    // is tracked, matching the real ceremony and the committed-content reader.
+    try { git(dir, ['add', '-f', '.adlc/manifest.jsonl']); } catch { /* evidence:'missing' — nothing to add */ }
+    git(dir, ['commit', '-qm', 'migrate']);
     try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
     catch (error) { return error.status ?? 1; }
   } finally { rmSync(dir, { recursive: true, force: true }); }

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -8,7 +8,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync, renameSync, unlinkSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync, renameSync, unlinkSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -315,6 +315,82 @@ test('#314: an untracked, gitignored .adlc/manifest.jsonl does NOT trigger a fal
     // sanity: the manifest really is gitignored and untracked
     assert.throws(() => execFileSync('git', ['ls-files', '--error-unmatch', '.adlc/manifest.jsonl'], { cwd: dir, stdio: 'pipe' }));
     assert.equal(run(), 0, 'local (untracked gitignored manifest present) must agree with CI');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('#314: a manifest committed as a SYMLINK is denied (type-confusion fail-closed)', () => {
+  // git show returns a symlink's TARGET STRING, not the target's content — so a manifest
+  // symlinked to a whitespace target would slip past a content-only `.trim()` check while
+  // downstream readers that follow the link consume forged evidence. The committed-object
+  // MODE check denies any non-regular manifest, restoring the deny the old readFileSync
+  // (which followed the link) produced.
+  const dir = mkdtempSync(join(tmpdir(), 'rgci-314sym-'));
+  const run = () => {
+    try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
+    catch (e) { return e.status ?? 1; }
+  };
+  try {
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']); git(dir, ['config', 'user.name', 'x']);
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'T1 fixture', rails: ['src/critical/**'] }] }));
+    mkdirSync(join(dir, 'src', 'critical'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'critical', 'auth.mjs'), 'orig\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+    // The manifest is a symlink whose target is whitespace, so `git show` → "  " → .trim()
+    // is empty (a content-only check would NOT deny). The mode is 120000, so we deny.
+    symlinkSync('  ', join(dir, '.adlc', 'manifest.jsonl'));
+    git(dir, ['add', '-f', '.adlc/manifest.jsonl']);
+    git(dir, ['commit', '-qm', 'symlink manifest']);
+    assert.equal(run(), 2, 'a symlink manifest must be denied, not read as empty');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('#314: the FIRST-BOOTSTRAP path also agrees local == CI for an untracked gitignored manifest', () => {
+  // When the base has no ticket store AND no config, the gate takes an early-exit path that
+  // ALSO used existsSync/readFileSync — so the same local↔CI divergence lived there. A
+  // tracked non-empty manifest add is still rejected; an untracked gitignored one is not.
+  const dir = mkdtempSync(join(tmpdir(), 'rgci-314boot-'));
+  const run = () => {
+    try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
+    catch (e) { return e.status ?? 1; }
+  };
+  try {
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']); git(dir, ['config', 'user.name', 'x']);
+    // TRUE first bootstrap: no .adlc tree at base at all.
+    writeFileSync(join(dir, '.gitignore'), '.adlc/*\n');
+    writeFileSync(join(dir, 'README.md'), 'base\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+    writeFileSync(join(dir, 'README.md'), 'work\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'work']);
+
+    assert.equal(run(), 0, 'first-bootstrap clean checkout must pass');
+    // The toolkit left a gitignored, untracked, non-empty manifest locally.
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
+    assert.equal(run(), 0, 'first-bootstrap with an untracked manifest must agree with CI (was: fail exit 1)');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('#314: a TRACKED non-empty manifest on the first-bootstrap path is still rejected → exit 1', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rgci-314boot2-'));
+  const run = () => {
+    try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
+    catch (e) { return e.status ?? 1; }
+  };
+  try {
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']); git(dir, ['config', 'user.name', 'x']);
+    writeFileSync(join(dir, 'README.md'), 'base\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'prepopulated manifest']);
+    assert.equal(run(), 1, 'a first-bootstrap PR that commits pre-populated evidence is rejected');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -92,7 +92,7 @@ const SIGNED_CONFIG = JSON.stringify({
   signers: { alice: { roles: ['builder'] } },
 });
 
-function runMigrationScenario({ mutateTicket = (ticket) => ticket, extraChange = false, evidence = 'valid', legacyArchive = false, injectArchive = false } = {}) {
+function runMigrationScenario({ mutateTicket = (ticket) => ticket, extraChange = false, evidence = 'valid', legacyArchive = false, injectArchive = false, manifestSymlink = false } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'rgci-migrate-'));
   try {
     git(dir, ['init', '-q', '-b', 'main']);
@@ -142,6 +142,13 @@ function runMigrationScenario({ mutateTicket = (ticket) => ticket, extraChange =
       writeFileSync(join(dir, '.adlc/manifest.jsonl'), `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
     }
     writeFileSync(join(dir, '.gitignore'), '.adlc/*\n!.adlc/tickets.json\n!.adlc/tickets/\n!.adlc/tickets/**\n!.adlc/ticket-archive/\n!.adlc/ticket-archive/**\n');
+    if (manifestSymlink) {
+      // #314 round 3: point the working-tree manifest at an allow-listed path (.gitignore)
+      // — the migration branch reads it via readFileSync and would follow the link to forged
+      // evidence. The lstat regular-file check must deny it.
+      rmSync(join(dir, '.adlc/manifest.jsonl'), { force: true });
+      symlinkSync('../.gitignore', join(dir, '.adlc/manifest.jsonl'));
+    }
     if (extraChange) { mkdirSync(join(dir, 'src'), { recursive: true }); writeFileSync(join(dir, 'src/extra.mjs'), 'export {};\n'); }
     git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'migrate']);
     try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
@@ -165,6 +172,13 @@ test('legacy-to-directory migration mixed with unrelated changes is denied', () 
 test('legacy-to-directory migration requires hash-bound evidence', () => {
   assert.equal(runMigrationScenario({ evidence: 'missing' }), 2);
   assert.equal(runMigrationScenario({ evidence: 'invalid' }), 2);
+});
+
+test('#314: a migration whose manifest is a SYMLINK is denied (working-tree type-confusion)', () => {
+  // The migration branch is the one path that reads the working-tree manifest. A symlink to
+  // an allow-listed target (../.gitignore) passes the diff-shape allow-list, so the lstat
+  // regular-file guard is what stops readFileSync from following the link to forged evidence.
+  assert.equal(runMigrationScenario({ manifestSymlink: true }), 2);
 });
 
 test('legacy archive migration is accepted only with identical archived content', () => {

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -458,6 +458,43 @@ test('#314: a TRACKED non-empty manifest on the first-bootstrap path is still re
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
+test('#314: an ancestor .adlc committed as a SYMLINK is denied (ancestor type-confusion)', () => {
+  // git ls-tree does NOT descend a symlinked `.adlc`, so the leaf lookup would report the
+  // manifest absent while filesystem consumers follow `.adlc` → `state/manifest.jsonl` and
+  // read forged evidence. The `.adlc`-is-a-tree ancestor guard denies it.
+  const dir = mkdtempSync(join(tmpdir(), 'rgci-314anc-'));
+  const run = () => {
+    try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
+    catch (e) { return e.status ?? 1; }
+  };
+  try {
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']); git(dir, ['config', 'user.name', 'x']);
+    writeFileSync(join(dir, 'README.md'), 'base\n'); // no .adlc at base → first bootstrap
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+    mkdirSync(join(dir, 'state'), { recursive: true });
+    writeFileSync(join(dir, 'state', 'manifest.jsonl'), '{"forged":"evidence"}\n');
+    symlinkSync('state', join(dir, '.adlc')); // .adlc itself is a symlink
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'symlink .adlc']);
+    assert.equal(run(), 2, 'a symlinked .adlc must be denied, not read as absent');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('#314: a legitimate append-only manifest update larger than 1 MiB is accepted (maxBuffer)', () => {
+  // Switching the HEAD read to `git cat-file` via spawnSync inherited Node's 1 MiB default
+  // maxBuffer; the append-only ledger grows past that, so a valid large manifest must not
+  // ENOBUFS-fail the gate. readFileSync had no such limit.
+  const big = 'x'.repeat(1_100_000); // > 1 MiB
+  const code = runScenario({
+    baseTickets: RAILED,
+    seedFiles: ['src/critical/auth.mjs', '.adlc/manifest.jsonl'],
+    seedFileContents: { '.adlc/manifest.jsonl': `${big}\n` },
+    mutate: (d) => writeFileSync(join(d, '.adlc', 'manifest.jsonl'), `${big}\nappended\n`),
+  });
+  assert.equal(code, 0);
+});
+
 test('#314: a PR that adds a TRACKED but EMPTY manifest is allowed (empty bootstrap) → exit 0', () => {
   // The deny is for CREATING evidence, i.e. a NON-EMPTY manifest. An empty manifest is
   // the sanctioned bootstrap shape ("create it empty during bootstrap"), so a tracked,

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -347,6 +347,51 @@ test('#314: a manifest committed as a SYMLINK is denied (type-confusion fail-clo
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
+test('#314: deleting a base-tracked manifest at HEAD denies as "absent at HEAD" (present flag)', () => {
+  // Base has a tracked manifest; the PR removes it. The gate must report it is ABSENT at
+  // HEAD (the committed-presence flag), distinct from the append-only-violation reason —
+  // pins that committedManifestAtHead() reports present:false when the manifest is untracked
+  // at HEAD.
+  const dir = mkdtempSync(join(tmpdir(), 'rgci-314del-'));
+  try {
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']); git(dir, ['config', 'user.name', 'x']);
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'T1 fixture', rails: ['src/critical/**'] }] }));
+    writeFileSync(join(dir, '.adlc', 'manifest.jsonl'), '{"seq":1}\n');
+    mkdirSync(join(dir, 'src', 'critical'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'critical', 'auth.mjs'), 'orig\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+    rmSync(join(dir, '.adlc', 'manifest.jsonl'));
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'delete manifest']);
+    let stderr = '';
+    let status = 0;
+    try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'] }); }
+    catch (e) { status = e.status ?? 1; stderr = (e.stderr ?? '').toString(); }
+    assert.equal(status, 2);
+    assert.match(stderr, /absent at HEAD/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('#314: replacing a base manifest with a SYMLINK at HEAD is denied (append-only type-confusion)', () => {
+  // Base has a real tracked manifest. A PR turns it into a symlink pointing at a decoy that
+  // starts with the base content — so a working-tree readFileSync + startsWith would PASS,
+  // then downstream readers follow the link to forged evidence. The committed-object mode
+  // check denies the non-regular manifest before any content is trusted.
+  const code = runScenario({
+    baseTickets: RAILED,
+    seedFiles: ['src/critical/auth.mjs', '.adlc/manifest.jsonl'],
+    seedFileContents: { '.adlc/manifest.jsonl': '{"seq":1}\n' },
+    mutate: (d) => {
+      writeFileSync(join(d, '.adlc', 'decoy'), '{"seq":1}\n{"forged":true}\n');
+      rmSync(join(d, '.adlc', 'manifest.jsonl'));
+      symlinkSync('decoy', join(d, '.adlc', 'manifest.jsonl'));
+    },
+  });
+  assert.equal(code, 2);
+});
+
 test('#314: the FIRST-BOOTSTRAP path also agrees local == CI for an untracked gitignored manifest', () => {
   // When the base has no ticket store AND no config, the gate takes an early-exit path that
   // ALSO used existsSync/readFileSync — so the same local↔CI divergence lived there. A

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -277,6 +277,60 @@ test('mutable state: PR rewrites existing manifest evidence → exit 2', () => {
   assert.equal(code, 2);
 });
 
+test('#314: an untracked, gitignored .adlc/manifest.jsonl does NOT trigger a false deny (local == CI)', () => {
+  // The manifest-evidence check must read the DIFF, not the filesystem. A gitignored,
+  // untracked manifest — which every dev who has run the toolkit has locally — is not
+  // introduced by the commit, so the local verdict must equal CI's clean-checkout
+  // verdict for the same tree. Regression: this used to deny locally (existsSync) while
+  // passing in CI, training people toward the session-lifetime ADLC_RAILS_BYPASS.
+  const dir = mkdtempSync(join(tmpdir(), 'rgci-314-'));
+  const run = () => {
+    try { execFileSync(process.execPath, [SCRIPT, 'main'], { cwd: dir, stdio: 'pipe' }); return 0; }
+    catch (e) { return e.status ?? 1; }
+  };
+  try {
+    git(dir, ['init', '-q', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'a@b.c']);
+    git(dir, ['config', 'user.name', 'x']);
+    mkdirSync(join(dir, '.adlc'), { recursive: true });
+    writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'T1 fixture', rails: ['src/critical/**'] }] }));
+    // The manifest is gitignored exactly as in the real repo, so `git add -A` can never
+    // stage it — it stays untracked no matter what the toolkit writes.
+    writeFileSync(join(dir, '.gitignore'), '.adlc/*\n!.adlc/tickets.json\n');
+    mkdirSync(join(dir, 'src', 'critical'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'critical', 'auth.mjs'), 'orig\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'base']);
+    git(dir, ['checkout', '-q', '-b', 'feat']);
+    // A benign, non-rail change is the entire committed diff.
+    writeFileSync(join(dir, 'README.md'), 'work\n');
+    git(dir, ['add', '-A']); git(dir, ['commit', '-qm', 'work']);
+
+    // CI's view: clean checkout, no untracked manifest present.
+    assert.equal(run(), 0, 'CI (no untracked manifest) must pass');
+
+    // A developer's view of the SAME commit: the toolkit left a gitignored, untracked,
+    // non-empty manifest. It is in zero commits and not in the diff, so the verdict must
+    // be identical to CI's.
+    writeFileSync(join(dir, '.adlc', 'manifest.jsonl'), '{"seq":1,"gate":"x"}\n');
+    // sanity: the manifest really is gitignored and untracked
+    assert.throws(() => execFileSync('git', ['ls-files', '--error-unmatch', '.adlc/manifest.jsonl'], { cwd: dir, stdio: 'pipe' }));
+    assert.equal(run(), 0, 'local (untracked gitignored manifest present) must agree with CI');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('#314: a PR that adds a TRACKED but EMPTY manifest is allowed (empty bootstrap) → exit 0', () => {
+  // The deny is for CREATING evidence, i.e. a NON-EMPTY manifest. An empty manifest is
+  // the sanctioned bootstrap shape ("create it empty during bootstrap"), so a tracked,
+  // empty add must pass. This also pins that the evidence is read from the specific
+  // committed path (git show HEAD:.adlc/manifest.jsonl), not from `git show` writ large.
+  const code = runScenario({
+    baseTickets: RAILED,
+    seedFiles: ['src/critical/auth.mjs'],
+    mutate: (d) => writeFileSync(join(d, '.adlc', 'manifest.jsonl'), ''),
+  });
+  assert.equal(code, 0);
+});
+
 test('trust root: PR edits deployed rails guard workflow while base rails exist → exit 2', () => {
   const code = runScenario({
     baseTickets: RAILED,

--- a/scripts/test/rails-guard-ci.test.mjs
+++ b/scripts/test/rails-guard-ci.test.mjs
@@ -481,6 +481,21 @@ test('#314: an ancestor .adlc committed as a SYMLINK is denied (ancestor type-co
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
+test('#314: append-only is byte-exact — a base-region rewrite that COLLIDES under utf8 is denied', () => {
+  // Base manifest carries an invalid UTF-8 byte (0x80); HEAD flips it to 0x81. Both decode to
+  // U+FFFD, so a decoded-string prefix check would see identical strings and pass. The
+  // byte-for-byte comparison denies the base-region rewrite.
+  const baseBytes = Buffer.concat([Buffer.from('{"seq":1,"pad":"'), Buffer.from([0x80]), Buffer.from('"}\n')]);
+  const headBytes = Buffer.concat([Buffer.from('{"seq":1,"pad":"'), Buffer.from([0x81]), Buffer.from('"}\n')]);
+  const code = runScenario({
+    baseTickets: RAILED,
+    seedFiles: ['src/critical/auth.mjs', '.adlc/manifest.jsonl'],
+    seedFileContents: { '.adlc/manifest.jsonl': baseBytes },
+    mutate: (d) => writeFileSync(join(d, '.adlc', 'manifest.jsonl'), headBytes),
+  });
+  assert.equal(code, 2);
+});
+
 test('#314: a legitimate append-only manifest update larger than 1 MiB is accepted (maxBuffer)', () => {
   // Switching the HEAD read to `git cat-file` via spawnSync inherited Node's 1 MiB default
   // maxBuffer; the append-only ledger grows past that, so a valid large manifest must not


### PR DESCRIPTION
## #314 — rails-guard-ci: decide manifest-creation from the diff, not the filesystem

Closes #314.

### The bug (P1)

`rails-guard-ci` denied on an **untracked, gitignored** `.adlc/manifest.jsonl` — the file every developer who has run the toolkit has locally. The bootstrap-evidence check asked a **filesystem** question (`existsSync('.adlc/manifest.jsonl') && readFileSync(...).trim()`) instead of a **git** one ("is the diff ADDING it?"). CI checks out clean, so the file is absent there and the gate passes; a developer's tree has the file, so the same commit denied locally. That local/CI disagreement on an unmodified tree trained people toward the session-lifetime, unrevocable `ADLC_RAILS_BYPASS` (#162/#204) — the exact erosion the gate exists to prevent.

### The fix

In the "manifest absent at base" branch, read the **committed HEAD** content (`git ls-tree HEAD` + `git show HEAD:.adlc/manifest.jsonl`) instead of the working tree. Only a **tracked** manifest **added by the diff** with non-empty evidence triggers the deny. Consequences:

- An untracked, gitignored manifest is in zero commits and not in the diff → never denies (local verdict now equals CI's clean-checkout verdict).
- A genuine tracked manifest-with-evidence add is **still denied** (regression preserved).
- A tracked but **empty** manifest is allowed — the sanctioned "create it empty during bootstrap" shape.
- The **verified-migration ceremony** still reads its gitignored working-tree evidence (that branch is split out explicitly; the diff shape + CODEOWNERS attestation are verified upstream, which is what makes trusting the local file sound there).

### Verification (all three ACs)

- **AC1** — untracked gitignored manifest + no diff touching it → exit 0.
- **AC2** — a PR that adds a tracked manifest with evidence is still denied (existing regression test retained).
- **AC3** — a test runs the gate on the **same commit** with and without the untracked manifest present and asserts both exit 0 (the divergence *is* the defect).
- 167 rails-guard tests pass (migration, bootstrap, append-only, private-repo-fallback unchanged); **mutation-gate 8/8 killed, 0 survived** on the diff.

### Scope note — the CI template (`docs/ci/rails-guard.yml`)

`docs/ci/rails-guard.yml` carries an **equivalent inline `node -e` copy** of this gate. It is deliberately **not** hand-synced here: its `existsSync` is correct in its only runtime context (CI's clean checkout ⇒ `existsSync` ≡ committed-tree), so it does not exhibit the bug in CI. Hand-patching a frozen rail + regenerating its hash for a non-observable latent case is exactly the fragile duplication **#140** exists to remove by single-sourcing the template from this script — which is the next task, and will fix the template *by construction* (and close the drift-detection gap so the two can never silently diverge again).

### ⚠️ Trust-root change

Touches `scripts/rails-guard-ci.mjs` (a trust root). The folded #326 cross-model gate and `rails-guard` deny by design until merged; apply `trust-root-change` + a non-author CODEOWNER approval, or admin-override (solo maintainer).
