### PR TITLE
harden(#326): sign-verified cross-model gate, functional on a mixed manifest, key isolated from PR code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,17 @@ jobs:
 
       - name: Install
         # #326 Codex F1 (round 3): install with NO lifecycle scripts, then rebuild ONLY
-        # a trusted allowlist of native deps. This is the job that runs the trust-root
-        # cross-model gate below; a candidate `postinstall` in ANY workspace/dep manifest
-        # would otherwise run here and could shim node/npm onto $GITHUB_PATH (persisted
-        # to later steps), defeating the gate. The repo has NO first-party lifecycle
-        # scripts, and the ONLY deps that declare one are these lockfile-pinned native
-        # packages (verified via package-lock `hasInstallScript`), so this reproduces a
-        # normal install for any legitimate PR while never running candidate-controlled
-        # code. A candidate cannot extend the allowlist without a lockfile change, which
-        # tiers. Keep this list in sync with `hasInstallScript` deps.
+        # a trusted allowlist of native deps. This job checks out the PR and runs its own
+        # test suite (`npm test`), i.e. candidate-controlled code; a candidate `postinstall`
+        # in ANY workspace/dep manifest would otherwise run here and could shim node/npm
+        # onto $GITHUB_PATH (persisted to later steps) or tamper with the runner. The repo
+        # has NO first-party lifecycle scripts, and the ONLY deps that declare one are these
+        # lockfile-pinned native packages (verified via package-lock `hasInstallScript`), so
+        # this reproduces a normal install for any legitimate PR while never running
+        # candidate-controlled install code. A candidate cannot extend the allowlist without
+        # a lockfile change, which tiers. Keep this list in sync with `hasInstallScript` deps.
+        # (The trust-root cross-model gate no longer runs in this job — it moved to the
+        # trusted-context cross-model-gate.yml so it never touches PR-controlled code.)
         run: |
           npm install --ignore-scripts
           npm rebuild esbuild sharp msgpackr-extract protobufjs @google/genai
@@ -139,39 +141,15 @@ jobs:
         if: matrix.node-version == 22
         run: node scripts/pi-live-prosecute.mjs
 
-      # #326: the trust-root cross-model review gate, finally INVOKED — and FOLDED
-      # into this REQUIRED job (a separate job could not be made a required check on
-      # this repo's plan, so it would enforce nothing). A trust-root-tier change (an
-      # enforcement/producer package, a rails deny-path, or a trust-root file)
-      # requires a distinct-provider cross-model `approve` bound to the reviewed
-      # revision; fails closed (exit 2) with no matching attestation. The ticket
-      # STORE is deliberately NOT a tier surface — rails-guard-ci owns it. Runs on
-      # the Node 20 leg only, LAST, and on PRs only (a push has no base diff).
-      - name: Trust-root cross-model gate (#326)
-        if: matrix.node-version == 20 && github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          # This repo's default PR author provider; distinctness is checked against
-          # it, so a same-provider review never satisfies the gate. Override with an
-          # ADLC_AUTHOR_PROVIDER repository variable if the author model changes.
-          ADLC_AUTHOR_PROVIDER: ${{ vars.ADLC_AUTHOR_PROVIDER || 'anthropic' }}
-        run: |
-          git fetch --no-tags origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
-          git fetch --no-tags origin "$HEAD_SHA"
-          # Check out the PR HEAD (this job otherwise runs on the merge commit) with
-          # --force, so the worktree is the exact committed head tree the author
-          # recorded the attestation against — undoing any install-time lockfile
-          # churn. node_modules (gitignored) is untouched, so the gate still runs.
-          git checkout --quiet --force "$HEAD_SHA"
-          # Rebuild node_modules for the HEAD tree with NO scripts. The job's top-level
-          # Install already ran --ignore-scripts (so no candidate lifecycle script has
-          # executed in this runner — see that step), making this defense-in-depth: it
-          # also re-links the @adlc/* workspaces the gate imports to the checked-out HEAD
-          # sources. `npm ci` (not install) so the lockfile — hence the computed
-          # revision — is not rewritten.
-          npm ci --ignore-scripts
-          node packages/prosecute/bin/adlc-prosecute.mjs tier-check --base "origin/$BASE_REF" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc
+      # #326: the trust-root cross-model review gate does NOT run here — on purpose.
+      # This job checks out the PR HEAD (`git checkout --force $HEAD_SHA`) and installs
+      # PR-controlled dependencies, so anything it runs is code a contributor wrote.
+      # The gate must verify attestations with ADLC_MANIFEST_KEY, and handing that
+      # secret to PR-authored code would let a contributor exfiltrate it or mint their
+      # own approvals — defeating the gate it is meant to enforce. The gate therefore
+      # lives in a SEPARATE, trusted-context workflow: .github/workflows/cross-model-gate.yml,
+      # which runs on `pull_request_target` (BASE code, BASE deps) against the PR tree as
+      # DATA, so the key is only ever seen by trusted base code and never by PR code.
 
   # T31 drift canary: the SAME two OpenCode live proofs against opencode-ai@latest.
   # ADVISORY by design (continue-on-error): upstream releases near-daily, and a

--- a/.github/workflows/cross-model-gate.yml
+++ b/.github/workflows/cross-model-gate.yml
@@ -1,0 +1,86 @@
+name: cross-model-gate
+
+# #326 trust-root cross-model review gate — the TRUSTED-CONTEXT verifier.
+#
+# ────────────────────────────── SECURITY MODEL (read before editing) ──────────────────────────────
+# The gate must verify a cross-model attestation with ADLC_MANIFEST_KEY. The key is the entire trust
+# anchor: anyone who can read it can mint approvals forever. Therefore the key must NEVER be exposed
+# to code or dependencies a pull-request author controls.
+#
+# This workflow uses `pull_request_target`, so it runs from the BASE branch definition with secrets
+# available. It then:
+#   1. checks out BASE (the trusted code we RUN) and installs BASE dependencies (base lockfile), and
+#   2. materializes the PR tree into ./_pr as DATA via `git worktree` — which is NEVER executed.
+# The gate runs the BASE `adlc-prosecute` binary (absolute path under $GITHUB_WORKSPACE) with its cwd
+# set to the PR worktree, so Node resolves the CODE and DEPENDENCIES from the base checkout (import
+# resolution is script-relative, not cwd-relative) while git/data operations see the PR tree. The PR's
+# code and the PR's dependencies never run, so the key stays isolated.
+#
+# HARD RULES for anyone editing this file:
+#   • NEVER `run:` a script, build, test, or `npm ci`/postinstall from ./_pr or from the PR head.
+#   • NEVER run the PR's own packages/prosecute — always the base copy under $GITHUB_WORKSPACE.
+#   • Keep `permissions:` at the minimum (contents: read). pull_request_target defaults to write.
+#   • Do not add steps that echo secrets or pass ${{ secrets.* }} to anything touching ./_pr.
+#
+# ENFORCEMENT (do this to make the gate binding): mark the `gate` job below as a REQUIRED status
+# check via branch protection / a ruleset on `main`. It fails closed (exit 2) on a missing or
+# FORGED (unsigned / wrong-key / rewritten-sig) attestation, so as a required check it BLOCKS the
+# merge on those. Until that protection is configured this repo has none, so the gate is only a
+# trustworthy SIGNAL the maintainer merges on — an intentional fallback, not the end state. It
+# runs as a separate workflow (not folded into the required test job) precisely so it can hold
+# the key safely; that separation is compatible with making it required.
+#
+# SCOPE LIMIT (Codex #354 F1): a required check does NOT close manifest TRUNCATION — it evaluates
+# the PR-controlled tree, so an author who drops a signed `needs-attention` revocation leaves a
+# valid chain ending in the earlier approve and the check passes. Closing that needs the latest
+# attestation state anchored OUTSIDE the PR tree (a protected ref / check-run / external signed
+# checkpoint); see manifestChainTrustworthy() and the PR discussion. This PR closes forgery and
+# rewrite; truncation is tracked follow-up.
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout BASE — the trusted code we RUN (default ref for pull_request_target)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # base history so the PR base SHA resolves for the diff
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+
+      - name: Install BASE dependencies (base lockfile — trusted; PR lockfile is never installed)
+        run: npm ci
+
+      - name: Materialize the PR tree as DATA (git worktree; never executed)
+        env:
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags origin "$PR_HEAD"
+          # A detached worktree of the PR head: its FILES are readable as data (manifest, ticket
+          # store) and its git tree is diff-able, but nothing in it is ever run.
+          git worktree add --detach ./_pr "$PR_HEAD"
+
+      - name: Verify cross-model attestation — BASE code, PR data, key isolated from PR code
+        working-directory: ./_pr
+        env:
+          # The key reaches ONLY this step, which runs the base binary. The PR tree in cwd is read
+          # as data; its code/deps never execute, so a contributor cannot read or exfiltrate the key.
+          ADLC_MANIFEST_KEY: ${{ secrets.ADLC_MANIFEST_KEY }}
+          ADLC_AUTHOR_PROVIDER: ${{ vars.ADLC_AUTHOR_PROVIDER || 'anthropic' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # $GITHUB_WORKSPACE = the BASE checkout. Running the base binary with cwd=./_pr makes
+          # tier-check classify the PR's diff (base..PR tree), derive the PR's revision, and read the
+          # PR's .adlc manifest — all as data — while the executed code + node_modules are the base's.
+          node "$GITHUB_WORKSPACE/packages/prosecute/bin/adlc-prosecute.mjs" tier-check \
+            --base "$BASE_SHA" --author-provider "$ADLC_AUTHOR_PROVIDER" --dir .adlc

--- a/packages/gate-manifest/lib/record.mjs
+++ b/packages/gate-manifest/lib/record.mjs
@@ -30,7 +30,13 @@ export function appendManifestEntry(payload, dir = ADLC_DIR, { signatureVersion 
       throw new Error(`manifest contains malformed JSON at line ${state.skipped[0].line}`);
     }
     if (state.rawLines.length > 0) {
-      const integrity = verify(dir);
+      // Chain-INTEGRITY only: we must not append onto a corrupted/unchained tail,
+      // but we must NOT demand that pre-existing history be signed. The shared
+      // manifest legitimately holds unsigned entries from before signing was enabled;
+      // a full sig-requiring verify here would make it impossible to append a NEW
+      // (signed, below) entry to such a manifest. Provenance is enforced by signing
+      // this entry and by readers sig-checking the specific entries they trust.
+      const integrity = verify(dir, { requireSignatures: false });
       if (!integrity.valid) {
         throw new Error(`manifest chain is invalid: ${integrity.message}`);
       }

--- a/packages/gate-manifest/lib/verify.mjs
+++ b/packages/gate-manifest/lib/verify.mjs
@@ -35,11 +35,20 @@ import { getKey, verifyEntrySig } from './sign.mjs';
  *    This defeats the forge-from-scratch attack: without the key an attacker
  *    cannot produce valid signatures, so verify (run WITH the key) returns
  *    valid:false.
+ *  - requireSignatures:false → tolerate entries with NO sig (legacy/unsigned
+ *    history), for a caller which sig-checks the specific entries it trusts
+ *    itself. A PRESENT-but-invalid sig is STILL rejected (tampering), so this is
+ *    "unsigned history is OK", not "tampered signatures are OK". signed=false.
  *
  * @param {string} [dir]  ledger directory (default ADLC_DIR)
+ * @param {object} [opts]
+ * @param {boolean} [opts.requireSignatures=true]  when false, do not require that
+ *   every entry be signed (unsigned/legacy entries pass), but still reject any
+ *   entry whose PRESENT signature does not verify. When true, every entry must be
+ *   signed and valid.
  * @returns {VerifyResult}
  */
-export function verify(dir = ADLC_DIR) {
+export function verify(dir = ADLC_DIR, { requireSignatures = true } = {}) {
   const lp = ledgerPath('manifest', dir);
   const key = getKey();
 
@@ -132,11 +141,24 @@ export function verify(dir = ADLC_DIR) {
       };
     }
 
-    // Check HMAC signature when a key is configured. With a key, EVERY entry
-    // must carry a valid sig — otherwise the chain is not cryptographically
-    // attestable and a forged-from-scratch chain would slip through.
+    // Check HMAC signatures when a key is configured. Two independent conditions:
+    //
+    //   MISSING sig — gated by requireSignatures. In the default (true) mode EVERY
+    //     entry must carry a sig, so a forged-from-scratch chain is rejected. In the
+    //     lenient (false) mode a legacy entry with NO sig is TOLERATED: it is for a
+    //     caller whose manifest has legitimately-unsigned history (signing enabled
+    //     partway through its life) and which sig-checks the specific entries it
+    //     trusts itself.
+    //   PRESENT-but-INVALID sig — rejected in BOTH modes. A sig that is present but
+    //     does not verify means the entry's bytes were altered after signing (or the
+    //     wrong key signed it). Skipping that in lenient mode would let an attacker
+    //     TAMPER a signed entry — e.g. rewrite a signed `needs-attention` revocation
+    //     so it no longer matches the gate — recompute the public prev-hashes, and
+    //     pass "chain-only" verification. Lenient means "unsigned history is OK", NOT
+    //     "tampered signatures are OK". (Codex #354 re-review F1.)
     if (key !== null) {
-      if (entry.sig === undefined || entry.sig === null) {
+      const hasSig = entry.sig !== undefined && entry.sig !== null;
+      if (!hasSig && requireSignatures) {
         return {
           valid: false,
           message: `chain broken at seq ${entry.seq} (line ${lineNo}): unsigned entry`,
@@ -145,7 +167,7 @@ export function verify(dir = ADLC_DIR) {
           break: { seq: entry.seq, lineNo, reason: 'unsigned entry' },
         };
       }
-      if (!verifyEntrySig(key, entry)) {
+      if (hasSig && !verifyEntrySig(key, entry)) {
         return {
           valid: false,
           message: `chain broken at seq ${entry.seq} (line ${lineNo}): signature invalid`,
@@ -160,9 +182,10 @@ export function verify(dir = ADLC_DIR) {
     prevSeq = entry.seq;
   }
 
-  // signed:true only when a key verified every entry. With no key, the chain
-  // is internally consistent but NOT cryptographically attested.
-  const signed = key !== null;
+  // signed:true only when a key verified every entry. With no key — or when the
+  // caller asked for chain-only via requireSignatures:false — the chain is
+  // internally consistent but NOT cryptographically attested.
+  const signed = key !== null && requireSignatures;
   return {
     valid: true,
     message: signed

--- a/packages/gate-manifest/test/gate-manifest.test.mjs
+++ b/packages/gate-manifest/test/gate-manifest.test.mjs
@@ -804,6 +804,43 @@ describe('signing: tamper after signing is caught', () => {
       cleanTmp(dir);
     }
   });
+
+  it('requireSignatures:false tolerates an UNSIGNED entry but still rejects a TAMPERED signature (#354 F1)', () => {
+    const dir = makeTmp();
+    try {
+      // A manifest with a legitimately-unsigned legacy entry, then a signed one.
+      withKey(null, () => record({ gate: 'legacy', dir })); // no key → unsigned
+      withKey(KEY, () => record({ gate: 'signed', rawData: '{"v":1}', dir }));
+      const lp = ledgerPath('manifest', dir);
+
+      // Lenient mode accepts the mixed manifest: the unsigned legacy entry is tolerated
+      // and the signed entry verifies.
+      withKey(KEY, () => {
+        const ok = verify(dir, { requireSignatures: false });
+        assert.equal(ok.valid, true);
+      });
+
+      // Now TAMPER the signed entry's data (invalidating its sig) and repair the hash
+      // chain forward so only the SIGNATURE — not the prev hash — could catch it.
+      const lines = readFileSync(lp, 'utf8').split('\n').filter(l => l.trim());
+      const e2 = JSON.parse(lines[1]);
+      assert.ok(e2.sig, 'the second entry is signed');
+      e2.data = { v: 999 }; // tampered payload, stale sig
+      lines[1] = JSON.stringify(e2);
+      writeFileSync(lp, lines.join('\n') + '\n');
+
+      // Lenient mode must STILL reject: a present-but-invalid sig is tampering, not
+      // "unsigned history". This is what stops a rewritten signed revocation.
+      withKey(KEY, () => {
+        const r = verify(dir, { requireSignatures: false });
+        assert.equal(r.valid, false);
+        assert.equal(r.break.reason, 'signature invalid');
+        assert.equal(r.break.seq, 2);
+      });
+    } finally {
+      cleanTmp(dir);
+    }
+  });
 });
 
 describe('signing: no key in env reports signed:false', () => {

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -6,6 +6,7 @@ import { detectTicketStore, GitTreeTicketStore } from '@adlc/tickets';
 import { runProsecution, resolveProsecutionRevision } from '../lib/run.mjs';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
 import { recordCrossModelReview, hasCrossModelApproveForRevision } from '../lib/cross-model.mjs';
+import { getKey } from '@adlc/gate-manifest/lib/sign.mjs';
 
 // FAIL-CLOSED distinction: a genuinely ABSENT ticket table contributes no rails
 // (fine — nothing to check). But a table that EXISTS and is unreadable/malformed
@@ -286,7 +287,21 @@ if (positionals[0] === 'tier-check') {
   const revision = resolveProsecutionRevision({ dir: values.dir, revision: values.revision });
   if (!revision) opError('tier-check: revision could not be resolved; run inside a git worktree or pass --revision');
 
-  const satisfied = hasCrossModelApproveForRevision({ dir: values.dir, revision, authorProvider });
+  // #326 hardening — the attestation is trusted ONLY via its HMAC signature, verified with
+  // the key. Without the key the gate cannot tell a real cross-model approve from a PR-forged
+  // manifest line (a PR controls the manifest file but not the key), so it fails closed with a
+  // distinct message rather than the misleading "no attestation".
+  const key = getKey();
+  if (!key) {
+    if (values.json) {
+      printJson({ trustRootTier: true, reasons: tier.reasons, crossModelRequired: true, satisfied: false, revision, keyAvailable: false });
+    } else {
+      console.error(`tier-check: ADLC_MANIFEST_KEY is not available, so cross-model attestations cannot be signature-verified — an unverifiable attestation is forgeable, so NONE is trusted. This required trust-root gate FAILS CLOSED for revision ${revision}. Provide the key as a CI secret (available to same-repo runs) and re-record the attestation with it.`);
+    }
+    process.exit(2);
+  }
+
+  const satisfied = hasCrossModelApproveForRevision({ dir: values.dir, revision, authorProvider, key });
   if (values.json) {
     printJson({ trustRootTier: true, reasons: tier.reasons, crossModelRequired: true, satisfied, revision });
     process.exit(satisfied ? 0 : 2);
@@ -296,9 +311,9 @@ if (positionals[0] === 'tier-check') {
     process.exit(0);
   }
   console.error(
-    `tier-check: NO cross-model attestation for revision ${revision} (author ${authorProvider}). This required check FAILS.\n` +
-    `Record one after a distinct-provider adversarial review:\n` +
-    `  adlc-prosecute record-cross-model --ticket <id> --provider <distinct-provider> --author-provider ${authorProvider} --verdict approve --revision ${revision}`
+    `tier-check: NO SIGNATURE-VERIFIED cross-model attestation for revision ${revision} (author ${authorProvider}). This required check FAILS.\n` +
+    `Record one AFTER a distinct-provider adversarial review, with ADLC_MANIFEST_KEY set so the entry is signed (an unsigned/forged entry is rejected):\n` +
+    `  ADLC_MANIFEST_KEY=<key> adlc-prosecute record-cross-model --ticket <id> --provider <distinct-provider> --author-provider ${authorProvider} --verdict approve --revision ${revision}`
   );
   process.exit(2);
 }

--- a/packages/prosecute/bin/adlc-prosecute.mjs
+++ b/packages/prosecute/bin/adlc-prosecute.mjs
@@ -7,6 +7,7 @@ import { runProsecution, resolveProsecutionRevision } from '../lib/run.mjs';
 import { classifyTrustRootTier } from '../lib/tier.mjs';
 import { recordCrossModelReview, hasCrossModelApproveForRevision } from '../lib/cross-model.mjs';
 import { getKey } from '@adlc/gate-manifest/lib/sign.mjs';
+import { loadManifestKeyFromEnvLocal } from '../lib/load-env-local.mjs';
 
 // FAIL-CLOSED distinction: a genuinely ABSENT ticket table contributes no rails
 // (fine — nothing to check). But a table that EXISTS and is unreadable/malformed
@@ -209,6 +210,13 @@ Exit codes:
 
 // --- record-cross-model subcommand (register a cross-model attestation) ---
 if (positionals[0] === 'record-cross-model') {
+  // Signing convenience ONLY: pick up ADLC_MANIFEST_KEY from ./.env.local so a maintainer can
+  // author an attestation without exporting the key first. This is deliberately NOT done for
+  // tier-check: tier-check VERIFIES, and sourcing a verification key from the very tree being
+  // verified would let a contributor force-add a .env.local + a matching forged approve and pass
+  // a local gate (Codex #354 loader F2). A wrong key HERE only produces an attestation that fails
+  // in CI under the real secret — inert, not a bypass. No-op in CI / when the key is already set.
+  loadManifestKeyFromEnvLocal();
   if (!values.ticket) opError('record-cross-model requires --ticket');
   let input;
   if (values.input) {

--- a/packages/prosecute/lib/cross-model.mjs
+++ b/packages/prosecute/lib/cross-model.mjs
@@ -9,12 +9,22 @@
 //
 // HONESTY: like rails-guard this cannot cryptographically prove a model actually ran.
 // It raises the bar to an auditable, revision-bound, append-only, distinct-provider
-// record. Signing a provider assertion was rejected (see #104/T36 — keys in CI); the
-// revision binding is what stops a stale attestation from clearing a fresh diff.
+// record. What it CAN prove is that the record was minted by a holder of the CI-only
+// ADLC_MANIFEST_KEY: attestations are HMAC-signed (see sign.mjs) and the read side
+// rejects any unsigned or wrong-key entry, so a PR author cannot forge an approve. The
+// revision binding stops a stale attestation from clearing a fresh diff. (The earlier
+// "keys in CI" objection, #104/T36, is resolved by the trusted-context gate in
+// cross-model-gate.yml, which lets the key verify signatures without ever exposing it
+// to PR-controlled code.)
 
 import { readEntries } from '@adlc/core';
 import { record } from '@adlc/gate-manifest/lib/record.mjs';
+// Two independent defenses on the read side: verify() proves the append-only chain
+// was not corrupted-and-skipped to drop a revocation (#326 Codex F2); verifyEntrySig()
+// proves each attestation was signed with the CI-only key, so a PR author cannot FORGE
+// a fresh, well-chained approve. The chain check alone left that forge open by design.
 import { verify } from '@adlc/gate-manifest/lib/verify.mjs';
+import { getKey, verifyEntrySig } from '@adlc/gate-manifest/lib/sign.mjs';
 
 export const CROSS_MODEL_GATE = 'cross-model-review';
 const VALID_VERDICTS = new Set(['approve', 'needs-attention']);
@@ -98,8 +108,14 @@ export function recordCrossModelReview({ ticket, revision, provider, authorProvi
 // A candidate cross-model review entry for (revision, author, [ticket]) from a
 // DISTINCT reviewer. Returns { provider, verdict } for a valid approve/needs-
 // attention entry, or null. `ticket` optional (the revision gate omits it).
-function candidateReview(entry, { ticket, revision, runAuthor }) {
+function candidateReview(entry, { ticket, revision, runAuthor, key }) {
   if ((entry.gate ?? entry.type) !== CROSS_MODEL_GATE) return null;
+  // #326 hardening — verify the HMAC signature FIRST. The manifest lives in the
+  // contributor-controlled PR tree, so matching self-reported data fields alone lets a
+  // PR author FORGE an approve. The attestation is trusted ONLY if it carries a valid
+  // signature under the key (a CI secret the PR author does not hold). An unsigned,
+  // mis-signed, or wrong-key entry is not a candidate — fail closed.
+  if (!key || !verifyEntrySig(key, entry)) return null;
   if (ticket !== undefined && entry.ticket !== ticket) return null;
   const data = entry.data;
   if (!data || typeof data !== 'object') return null;
@@ -137,19 +153,40 @@ function crossModelSatisfied(entries, match) {
 // trusting ANY approve, walk the chain: readEntries() silently shunts a malformed or
 // truncated line into `skipped`, so an attacker could garble a later `needs-attention`
 // line — WITHOUT re-chaining, the cheap attack — and the dropped revocation would let
-// the earlier `approve` resurface. verify() returns valid:false at the first break, so
-// a corrupt/truncated manifest can no longer clear the gate. (Re-authoring the tail so
-// it re-chains cleanly is the documented honest-limit — defeated only by
-// ADLC_MANIFEST_KEY; this closes the cheap corrupt-and-skip path, not that one.)
+// the earlier `approve` resurface. A garbled line breaks the hash linkage, so verify()
+// returns valid:false and a corrupt/truncated manifest can no longer clear the gate.
+//
+// requireSignatures:false — tolerate UNSIGNED history, still reject TAMPERED signatures.
+// The shared manifest accumulates entries from other gates, most recorded before signing
+// was enabled, so they are legitimately unsigned. A full sig-requiring verify() with the
+// key present would fail on the FIRST such entry and make this gate permanently inert (no
+// PR could ever pass). So we do not DEMAND every entry be signed — but a present-but-
+// invalid sig is still rejected, so an attacker cannot rewrite a signed `needs-attention`
+// revocation (invalidating its sig) and slip it past as "chain-only". Per-entry FORGE
+// resistance is enforced where it matters: candidateReview verifyEntrySig()s the specific
+// approve it is about to trust, so a fabricated (unsigned / wrong-key) approve is rejected.
+//
+// HONEST LIMIT (Codex #354 F1, truncation) — NOT closed by this PR. A hash chain has no
+// authenticated head, so an author who controls the PR branch can DROP a signed revocation
+// recorded on that branch (truncate the manifest to end at an earlier, still-valid signed
+// approve). Rewriting a revocation is closed (its now-invalid sig is rejected above); DROPPING
+// one is not. Making this gate a required check does NOT close it either: the required check
+// evaluates the attacker's truncated tree, finds a valid chain ending in the approve, and
+// passes. Because the dropped revocation is a PR-branch entry, base-anchoring cannot see it,
+// so closing this needs the LATEST state anchored OUTSIDE the PR-controlled tree — attestations
+// (or a per-PR high-water mark) written by the trusted workflow to a store the author cannot
+// rewrite (a protected branch/ref, a check-run, or an external signed checkpoint). That is a
+// storage-location change, deliberately left as follow-up; see the PR discussion.
 function manifestChainTrustworthy(dir) {
-  return verify(dir).valid === true;
+  return verify(dir, { requireSignatures: false }).valid === true;
 }
 
-export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } = {}) {
-  if (!ticket || !revision || !authorProvider) return false;
+export function hasCrossModelApprove({ dir, ticket, revision, authorProvider, key = getKey() } = {}) {
+  // No key → the reader cannot verify any attestation's signature → nothing is trusted.
+  if (!ticket || !revision || !authorProvider || !key) return false;
   if (!manifestChainTrustworthy(dir)) return false;
   const { entries } = readEntries('manifest', dir);
-  return crossModelSatisfied(entries, { ticket, revision, runAuthor: normalizeProvider(authorProvider) });
+  return crossModelSatisfied(entries, { ticket, revision, runAuthor: normalizeProvider(authorProvider), key });
 }
 
 /**
@@ -158,9 +195,15 @@ export function hasCrossModelApprove({ dir, ticket, revision, authorProvider } =
  * trust-root-tier gate (#326) uses this: it verifies the reviewed revision was
  * cross-model approved without requiring the change to name a single ticket.
  */
-export function hasCrossModelApproveForRevision({ dir, revision, authorProvider } = {}) {
-  if (!revision || !authorProvider) return false;
+export function hasCrossModelApproveForRevision({ dir, revision, authorProvider, key = getKey() } = {}) {
+  // No key → cannot verify a signature → fail closed (an unverifiable attestation is a
+  // forgeable one; the CI gate must not trust the PR-controlled manifest without the key).
+  // Only the key is fast-checked here: a missing/empty `revision` or `authorProvider` is
+  // already fail-closed per-entry by candidateReview (an undefined revision matches no
+  // entry's `data.revision`; an empty runAuthor is rejected), so guarding them here too
+  // would be redundant and unverifiable — candidateReview is the single enforcement point.
+  if (!key) return false;
   if (!manifestChainTrustworthy(dir)) return false;
   const { entries } = readEntries('manifest', dir);
-  return crossModelSatisfied(entries, { ticket: undefined, revision, runAuthor: normalizeProvider(authorProvider) });
+  return crossModelSatisfied(entries, { ticket: undefined, revision, runAuthor: normalizeProvider(authorProvider), key });
 }

--- a/packages/prosecute/lib/load-env-local.mjs
+++ b/packages/prosecute/lib/load-env-local.mjs
@@ -1,0 +1,73 @@
+// load-env-local.mjs — a LOCAL developer convenience: pick up ADLC_MANIFEST_KEY from a
+// project `.env.local` so a maintainer can SIGN an attestation (`adlc-prosecute record-cross-model`)
+// without an explicit shell export. This touches a secret, so the rules are deliberately strict:
+//
+//   0. SIGNING ONLY. The bin invokes this from `record-cross-model`, NEVER from `tier-check`.
+//      tier-check VERIFIES, and a verifier must not source its key from the tree it is verifying —
+//      a contributor can force-add a .env.local (gitignore does not stop `git add -f`) plus a
+//      matching forged signed approve, and a local tier-check would then pass (Codex #354 loader
+//      F2). Using a wrong key while SIGNING only yields an attestation that fails in CI under the
+//      real secret — inert, not a bypass — so the convenience is safe on the record path alone.
+//   1. ONLY `ADLC_MANIFEST_KEY` is read from the file — no other variable is ever injected into
+//      the process, so a stray or hostile .env.local cannot set arbitrary environment.
+//   2. An already-DEFINED process.env value ALWAYS wins — by PRESENCE, not truthiness, so even an
+//      explicitly EMPTY `ADLC_MANIFEST_KEY=''` (a deliberate fail-closed) is never overwritten.
+//   3. NEVER loads under CI (GitHub Actions / CI=…). The trust-root gate runs with its cwd set
+//      to the PR-controlled tree; reading a key out of a checked-out `.env.local` there would let
+//      a contributor supply their own key and forge an approve. In CI the key must come from the
+//      secret env only. This check is FIRST, so even a mis- or unconfigured secret cannot fall
+//      through to a file. Together with (2) the CI path never reads a file-provided key.
+//
+// It reads a file (no code execution) and mutates only process.env[ADLC_MANIFEST_KEY].
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const MANIFEST_KEY = 'ADLC_MANIFEST_KEY';
+
+// True when we are running under continuous integration and must NOT read a key from a file.
+export function isCIEnv(env = process.env) {
+  if (env.GITHUB_ACTIONS === 'true') return true;
+  const ci = env.CI;
+  return ci !== undefined && ci !== '' && ci !== 'false' && ci !== '0';
+}
+
+// Extract the value of a single key from `.env`-style text. Accepts `KEY=value` and
+// `export KEY=value`, ignores blanks/comments, strips one pair of surrounding quotes. Returns
+// the value of the FIRST matching line, or null. Only the requested key is ever parsed.
+export function readKeyFromEnvText(text, key = MANIFEST_KEY) {
+  for (const raw of String(text).split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const m = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!m || m[1] !== key) continue;
+    let val = m[2].trim();
+    if (val.length >= 2 && ((val[0] === '"' && val.at(-1) === '"') || (val[0] === "'" && val.at(-1) === "'"))) {
+      val = val.slice(1, -1);
+    }
+    return val;
+  }
+  return null;
+}
+
+// Populate env[ADLC_MANIFEST_KEY] from `<cwd>/.env.local` iff (a) not in CI, (b) the var is not
+// already DEFINED in the environment, and (c) the file provides a non-empty value. Returns true
+// iff it set the value. cwd/env/isCI are injectable for tests; by default they reflect the process.
+export function loadManifestKeyFromEnvLocal({ cwd = process.cwd(), env = process.env, isCI = isCIEnv(env) } = {}) {
+  if (isCI) return false;                                          // (3) never read a file key in CI
+  // (2) never override an already-DEFINED value — presence, not truthiness. An EXPLICITLY EMPTY
+  // key (`ADLC_MANIFEST_KEY=''`) is a deliberate "no key → fail closed" and must win over the
+  // file, exactly like a non-empty one. Using length>0 here would let .env.local overwrite an
+  // empty exported/secret value and, outside GitHub, could feed a file key into a gate run.
+  if (Object.hasOwn(env, MANIFEST_KEY)) return false;
+  const file = join(cwd, '.env.local');
+  if (!existsSync(file)) return false;
+  let val;
+  try {
+    val = readKeyFromEnvText(readFileSync(file, 'utf8'));          // (1) only ADLC_MANIFEST_KEY
+  } catch {
+    return false;                                                 // unreadable file → no-op, stay fail-closed
+  }
+  if (val === null || val === '') return false;
+  env[MANIFEST_KEY] = val;
+  return true;
+}

--- a/packages/prosecute/test/cross-model.test.mjs
+++ b/packages/prosecute/test/cross-model.test.mjs
@@ -13,7 +13,20 @@ import { join } from 'node:path';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { recordCrossModelReview, hasCrossModelApprove, hasCrossModelApproveForRevision } from '../lib/cross-model.mjs';
 import { record } from '@adlc/gate-manifest/lib/record.mjs';
-import { ledgerPath } from '@adlc/core';
+import { ledgerPath, sha256 } from '@adlc/core';
+
+// #326 hardening: attestations are HMAC-signed and the readers verify the signature
+// (which signs when the key is present) and the readers both need it set. Set it for this
+// file; the forge-resistance block below toggles it deliberately to exercise the no-key and
+// wrong-key paths.
+const KEY = 'test-cross-model-signing-key';
+process.env.ADLC_MANIFEST_KEY = KEY;
+
+function withoutKey(fn) {
+  const prev = process.env.ADLC_MANIFEST_KEY;
+  delete process.env.ADLC_MANIFEST_KEY;
+  try { return fn(); } finally { if (prev === undefined) delete process.env.ADLC_MANIFEST_KEY; else process.env.ADLC_MANIFEST_KEY = prev; }
+}
 
 function tmp() {
   return mkdtempSync(join(tmpdir(), 'adlc-cross-model-'));
@@ -333,6 +346,143 @@ describe('cross-model read-side entry-shape guards (#326)', () => {
       // revoke the approve.
       record({ gate: 'cross-model-review', ticket: 'T1', rawData: JSON.stringify({ provider: 'openai', authorProvider: 'anthropic', verdict: 'bogus', revision: 'rev-1' }), dir });
       assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+// #326 forge resistance — the attestation lives in the PR-controlled manifest, so the gate
+// must trust it ONLY via a signature under the key (a secret the PR author does not hold).
+// This is the complement to the manifest-tamper block above: chain integrity stops a dropped
+// revocation; signature verification stops a fabricated, well-chained approve.
+describe('signature verification (#326 — a PR author cannot forge an approve)', () => {
+  it('an UNSIGNED approve (the forge: attacker appends data with no sig) is REJECTED', () => {
+    const dir = tmp();
+    try {
+      // Simulate the forge: a distinct-provider `approve` for the exact revision, but written
+      // WITHOUT the key so it carries no valid signature — a PR author's fabricated line.
+      withoutKey(() => recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir }));
+      // The reader (with the key) refuses it: no valid signature ⇒ not a candidate.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('an approve signed with a DIFFERENT key (attacker signs with their own) is REJECTED', () => {
+    const dir = tmp();
+    const prev = process.env.ADLC_MANIFEST_KEY;
+    try {
+      process.env.ADLC_MANIFEST_KEY = 'attacker-controlled-key';
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      process.env.ADLC_MANIFEST_KEY = prev; // back to the real (CI) key
+      // Verified against the real key, the wrong-key signature does not match ⇒ rejected.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { process.env.ADLC_MANIFEST_KEY = prev; rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('NO key at read time fails closed, even for a genuinely-signed attestation', () => {
+    const dir = tmp();
+    try {
+      // A real, correctly-signed attestation…
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      // …is still untrusted when the reader has no key to verify with (fork-PR / misconfig).
+      assert.equal(withoutKey(() => hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' })), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+// #326 — the gate must stay FUNCTIONAL on a real manifest. The shared ledger accumulates
+// entries from every gate, most recorded before signing was enabled, so they are unsigned.
+// A full sig-requiring chain check would fail on the first such entry and make the gate
+// permanently inert (fail-closed for EVERY PR, valid attestation or not — which just gets
+// bypassed and enforces nothing). The chain check is therefore chain-only; forge resistance
+// is enforced per-entry on the specific approve. These two tests pin BOTH halves.
+describe('cross-model works on an unsigned legacy manifest (#326 — not inert, still forge-proof)', () => {
+  it('a SIGNED approve IS trusted even when earlier manifest entries are UNSIGNED', () => {
+    const dir = tmp();
+    try {
+      // Legacy history: other gates' entries recorded before signing existed → unsigned.
+      withoutKey(() => {
+        record({ gate: 'build-gate', ticket: 'T0', rawData: JSON.stringify({ ok: true }), dir });
+        record({ gate: 'rails', ticket: 'T0', rawData: JSON.stringify({ ok: true }), dir });
+      });
+      // Then a properly-signed cross-model approve for the current revision.
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      // Gate PASSES: chain-only tolerates the unsigned history; the approve itself is signed.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), true);
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), true);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it('an UNSIGNED approve amid unsigned history is REJECTED — per-entry forge resistance survives chain-only', () => {
+    const dir = tmp();
+    try {
+      withoutKey(() => {
+        record({ gate: 'build-gate', ticket: 'T0', rawData: JSON.stringify({ ok: true }), dir });
+        // The forge: an unsigned approve, structurally identical to a real one. Chain-only
+        // verify accepts the chain (it does not demand sigs), so the ONLY thing standing
+        // between this forge and a pass is candidateReview's per-entry signature check.
+        recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      });
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+// #326 — hasCrossModelApprove is the per-TICKET gate; each argument of its input guard is
+// an independent fail-closed requirement. A MISSING ticket in particular must refuse, and
+// must NOT fall through to the ticket-agnostic match (which would accept ANY revision-bound
+// approve). This pins the `!ticket` clause as load-bearing — a weakened guard that let a
+// missing ticket through would silently downgrade the per-ticket gate to ticket-agnostic.
+describe('hasCrossModelApprove input guard is fail-closed per clause (#326)', () => {
+  it('a missing ticket fails closed even when a valid signed approve for the revision exists', () => {
+    const dir = tmp();
+    try {
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      // Sanity: WITH the ticket it passes — so the approve is genuinely valid and the
+      // false below is due to the guard, not a broken fixture.
+      assert.equal(hasCrossModelApprove({ dir, ticket: 'T1', revision: 'rev-1', authorProvider: 'anthropic' }), true);
+      // WITHOUT a ticket the per-ticket gate must refuse, not match ticket-agnostically.
+      assert.equal(hasCrossModelApprove({ dir, ticket: undefined, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+// #354 Codex F1 (rewrite half): an author who controls the manifest could REWRITE a signed
+// `needs-attention` revocation so it no longer matches the gate, invalidating its sig, and
+// recompute the public prev-hashes so the chain still links. Chain-only verify must NOT wave
+// that through — a present-but-invalid signature is tampering, not "unsigned history". (The
+// truncation half — dropping the revocation entirely — is a documented honest-limit closed by
+// branch protection; see manifestChainTrustworthy.)
+describe('cross-model rewrite-a-signed-revocation is caught (#354 F1)', () => {
+  it('tampering a signed needs-attention (invalidating its sig) keeps the gate FAILED, not resurrected', () => {
+    const dir = tmp();
+    try {
+      // A distinct reviewer approves R, then revokes R with needs-attention (both signed).
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'approve', dir });
+      recordCrossModelReview({ ticket: 'T1', revision: 'rev-1', provider: 'openai', authorProvider: 'anthropic', verdict: 'needs-attention', dir });
+      // A later unrelated signed entry, so the revocation is not the last line (the attacker
+      // must recompute a downstream prev-hash — exactly the scenario in the finding).
+      record({ gate: 'build-gate', ticket: 'T1', rawData: JSON.stringify({ ok: true }), dir });
+      // Sanity: the revocation stands → gate is already false, so the assertion below is
+      // proving the TAMPER is rejected, not merely that an approve is absent.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
+
+      const lp = ledgerPath('manifest', dir);
+      const lines = readFileSync(lp, 'utf8').split('\n').filter((l) => l.trim());
+      const b = JSON.parse(lines[1]);
+      assert.equal(b.data.verdict, 'needs-attention');
+      assert.ok(b.sig, 'the revocation is signed');
+      b.data = { ...b.data, verdict: 'bogus' }; // no longer a revocation candidate; sig now stale
+      lines[1] = JSON.stringify(b);
+      const c = JSON.parse(lines[2]);
+      c.prev = sha256(lines[1]); // relink so the hash chain itself is intact
+      lines[2] = JSON.stringify(c);
+      writeFileSync(lp, lines.join('\n') + '\n');
+
+      // Must STILL fail closed: the tampered entry's present-but-invalid signature is rejected
+      // by verify(), so the neutralized revocation cannot resurrect the earlier approve.
+      assert.equal(hasCrossModelApproveForRevision({ dir, revision: 'rev-1', authorProvider: 'anthropic' }), false);
     } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 });

--- a/packages/prosecute/test/load-env-local.test.mjs
+++ b/packages/prosecute/test/load-env-local.test.mjs
@@ -1,0 +1,116 @@
+// Concern: load-env-local.mjs — the LOCAL .env.local → ADLC_MANIFEST_KEY convenience.
+// The security-critical properties are (2) never override an existing value and (3) never load
+// under CI, because the trust-root gate runs with cwd = the PR-controlled tree.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readKeyFromEnvText, isCIEnv, loadManifestKeyFromEnvLocal, MANIFEST_KEY } from '../lib/load-env-local.mjs';
+
+function withEnvLocal(contents, fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-envlocal-'));
+  try {
+    if (contents !== null) writeFileSync(join(dir, '.env.local'), contents);
+    return fn(dir);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+
+describe('readKeyFromEnvText — only ADLC_MANIFEST_KEY, tolerant parsing', () => {
+  it('reads a bare KEY=value', () => {
+    assert.equal(readKeyFromEnvText('ADLC_MANIFEST_KEY=abc123'), 'abc123');
+  });
+  it('accepts an `export` prefix and strips one pair of quotes', () => {
+    assert.equal(readKeyFromEnvText('export ADLC_MANIFEST_KEY="q u o t e d"'), 'q u o t e d');
+    assert.equal(readKeyFromEnvText("ADLC_MANIFEST_KEY='single'"), 'single');
+  });
+  it('ignores comments, blanks, and OTHER keys entirely', () => {
+    const text = '# a comment\n\nOTHER=nope\nADLC_MANIFEST_KEY=real\nADLC_MANIFEST_KEY=second-wins-not\n';
+    assert.equal(readKeyFromEnvText(text), 'real'); // first match wins
+    assert.equal(readKeyFromEnvText('SOMETHING_ELSE=x\n'), null); // no target key present
+  });
+  it('never returns another variable even if it contains the substring', () => {
+    assert.equal(readKeyFromEnvText('NOT_ADLC_MANIFEST_KEY=x\nMY_ADLC_MANIFEST_KEY_2=y\n'), null);
+  });
+});
+
+describe('isCIEnv', () => {
+  it('true under GitHub Actions', () => assert.equal(isCIEnv({ GITHUB_ACTIONS: 'true' }), true));
+  it('true when CI is a truthy value', () => {
+    assert.equal(isCIEnv({ CI: 'true' }), true);
+    assert.equal(isCIEnv({ CI: '1' }), true);
+  });
+  it('false when CI is unset or explicitly falsey', () => {
+    assert.equal(isCIEnv({}), false);
+    assert.equal(isCIEnv({ CI: '' }), false);
+    assert.equal(isCIEnv({ CI: 'false' }), false);
+    assert.equal(isCIEnv({ CI: '0' }), false);
+  });
+});
+
+describe('loadManifestKeyFromEnvLocal — set only when safe', () => {
+  it('sets the key from .env.local when unset and not CI', () => {
+    withEnvLocal('ADLC_MANIFEST_KEY=from-file', (dir) => {
+      const env = {};
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env, isCI: false }), true);
+      assert.equal(env[MANIFEST_KEY], 'from-file');
+    });
+  });
+
+  it('NEVER overrides an already-set value (a real exported/secret key wins)', () => {
+    withEnvLocal('ADLC_MANIFEST_KEY=from-file', (dir) => {
+      const env = { ADLC_MANIFEST_KEY: 'already-here' };
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env, isCI: false }), false);
+      assert.equal(env[MANIFEST_KEY], 'already-here');
+    });
+  });
+
+  it('NEVER overrides an EXPLICITLY EMPTY value — presence wins, so it stays empty (#354 loader F1)', () => {
+    // ADLC_MANIFEST_KEY='' is a deliberate "no key → fail closed"; the file must not fill it.
+    withEnvLocal('ADLC_MANIFEST_KEY=from-file', (dir) => {
+      const env = { ADLC_MANIFEST_KEY: '' };
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env, isCI: false }), false);
+      assert.equal(env[MANIFEST_KEY], ''); // stayed empty; the file did NOT overwrite it
+    });
+  });
+
+  it('NEVER loads under CI — even with a file present and the env unset (the forge guard)', () => {
+    withEnvLocal('ADLC_MANIFEST_KEY=attacker-supplied', (dir) => {
+      const env = {};
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env, isCI: true }), false);
+      assert.equal(env[MANIFEST_KEY], undefined);
+    });
+  });
+
+  it('CI detection defaults from the env: GITHUB_ACTIONS blocks the load', () => {
+    withEnvLocal('ADLC_MANIFEST_KEY=attacker-supplied', (dir) => {
+      const env = { GITHUB_ACTIONS: 'true' }; // isCI derived from env, not passed
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env }), false);
+      assert.equal(env[MANIFEST_KEY], undefined);
+    });
+  });
+
+  it('an EMPTY secret in CI does not fall through to the file (CI checked before the value)', () => {
+    withEnvLocal('ADLC_MANIFEST_KEY=attacker-supplied', (dir) => {
+      const env = { GITHUB_ACTIONS: 'true', ADLC_MANIFEST_KEY: '' }; // unconfigured secret → empty
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env }), false);
+      assert.equal(env[MANIFEST_KEY], ''); // stays empty → bin fails closed, never the file value
+    });
+  });
+
+  it('no file → no-op', () => {
+    withEnvLocal(null, (dir) => {
+      const env = {};
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env, isCI: false }), false);
+      assert.equal(env[MANIFEST_KEY], undefined);
+    });
+  });
+
+  it('file present but no/empty ADLC_MANIFEST_KEY → no-op', () => {
+    withEnvLocal('OTHER=x\nADLC_MANIFEST_KEY=\n', (dir) => {
+      const env = {};
+      assert.equal(loadManifestKeyFromEnvLocal({ cwd: dir, env, isCI: false }), false);
+      assert.equal(env[MANIFEST_KEY], undefined);
+    });
+  });
+});

--- a/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-cli.test.mjs
@@ -22,6 +22,9 @@ import { resolveProsecutionRevision } from '../lib/run.mjs';
 
 const BIN = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
 
+// #326 hardening: record-cross-model signs and the readers verify, both under this key.
+process.env.ADLC_MANIFEST_KEY = 'test-cross-model-cli-signing-key';
+
 function runBin(args, cwd, env = {}) {
   try {
     const stdout = execFileSync(process.execPath, [BIN, ...args], {

--- a/packages/prosecute/test/prosecute-cross-model-gate.test.mjs
+++ b/packages/prosecute/test/prosecute-cross-model-gate.test.mjs
@@ -14,6 +14,10 @@ import { recordCrossModelReview } from '../lib/cross-model.mjs';
 import { record } from '@adlc/gate-manifest/lib/record.mjs';
 import { FIXTURE_REVISION, input, tmpAdlc } from './helpers.mjs';
 
+// #326 hardening: attestations must be HMAC-signed to be trusted; set the key so
+// recordCrossModelReview signs and the gate can verify.
+process.env.ADLC_MANIFEST_KEY = 'test-cross-model-gate-signing-key';
+
 const REV = FIXTURE_REVISION;
 
 // A pass set that converges cleanly (three distinct trailing dry lenses).

--- a/packages/prosecute/test/prosecute-env-local-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-env-local-cli.test.mjs
@@ -1,0 +1,112 @@
+// Concern: the bin wires loadManifestKeyFromEnvLocal() so record-cross-model / tier-check pick
+// up ADLC_MANIFEST_KEY from ./.env.local locally — but NEVER under CI, where cwd is the
+// PR-controlled tree. Proven at the process boundary in a real git repo.
+//
+// Hermetic env: we build the subprocess environment explicitly (deleting any ambient
+// ADLC_MANIFEST_KEY / CI vars) so the result does not depend on the developer's or CI runner's
+// exported key — the whole point under test is where the key comes FROM.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const BIN = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
+const KEY = 'env-local-signing-key';
+
+function cleanEnv(overrides = {}) {
+  const env = { ...process.env };
+  delete env.ADLC_MANIFEST_KEY;
+  delete env.GITHUB_ACTIONS;
+  delete env.CI;
+  return { ...env, ...overrides };
+}
+
+function runBin(args, cwd, env) {
+  try {
+    const stdout = execFileSync(process.execPath, [BIN, ...args], { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+// A scratch repo whose feature branch makes a trust-root change (an enforcement-package file),
+// plus a .env.local holding the signing key at the repo root.
+function scratchRepo(envLocalContents) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-envlocal-cli-'));
+  const g = (...a) => execFileSync('git', a, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  g('init', '-q', '-b', 'main');
+  g('config', 'user.email', 't@t.co'); g('config', 'user.name', 'tester'); g('config', 'commit.gpgsign', 'false');
+  writeFileSync(join(dir, 'README.md'), 'baseline\n');
+  mkdirSync(join(dir, '.adlc'), { recursive: true });
+  writeFileSync(join(dir, '.adlc', 'tickets.json'), JSON.stringify({ tickets: [{ id: 'T1', title: 'x', scope: ['src/**'], rails: [], edges: [] }] }));
+  g('add', '-A'); g('commit', '-qm', 'baseline');
+  g('checkout', '-q', '-b', 'feat');
+  mkdirSync(join(dir, 'packages', 'prosecute', 'lib'), { recursive: true });
+  writeFileSync(join(dir, 'packages', 'prosecute', 'lib', 'x.mjs'), 'export const z = 1;\n');
+  g('add', '-A'); g('commit', '-qm', 'trust-root change');
+  if (envLocalContents !== null) writeFileSync(join(dir, '.env.local'), envLocalContents);
+  return dir;
+}
+const cleanup = (dir) => rmSync(dir, { recursive: true, force: true });
+
+const TIER = ['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'];
+const REC = (rev) => ['record-cross-model', '--ticket', 'T1', '--provider', 'openai', '--author-provider', 'anthropic', '--verdict', 'approve', '--revision', rev, '--dir', '.adlc'];
+
+describe('.env.local key loading — SIGNING (record) reads it, VERIFYING (tier-check) never does', () => {
+  it('record-cross-model signs via .env.local; the attestation then verifies with an EXPORTED key', () => {
+    const dir = scratchRepo(`ADLC_MANIFEST_KEY=${KEY}\n`);
+    try {
+      const rev = JSON.parse(runBin([...TIER, '--json'], dir, cleanEnv()).stdout).revision;
+      assert.ok(rev, 'revision resolved');
+      // record loads the key from .env.local (no exported key, not CI) and SIGNS.
+      const rec = runBin(REC(rev), dir, cleanEnv());
+      assert.equal(rec.status, 0, rec.stderr);
+      // Verifying with the key EXPORTED passes — proving record signed with the .env.local key.
+      const withKey = runBin(TIER, dir, cleanEnv({ ADLC_MANIFEST_KEY: KEY }));
+      assert.equal(withKey.status, 0, withKey.stderr);
+      assert.match(withKey.stdout, /cross-model approve found/);
+    } finally { cleanup(dir); }
+  });
+
+  it('tier-check NEVER reads the key from .env.local — a force-added key + forged approve still fails closed (#354 loader F2)', () => {
+    // The attack the loader must not enable: a contributor force-adds .env.local with THEIR key and
+    // records a matching approve signed by it; a maintainer then runs tier-check locally with no
+    // exported key and not in CI. tier-check must NOT source its verification key from the tree.
+    const dir = scratchRepo('ADLC_MANIFEST_KEY=attacker-key\n');
+    try {
+      const rev = JSON.parse(runBin([...TIER, '--json'], dir, cleanEnv()).stdout).revision;
+      // record DOES load the attacker key from .env.local and signs a matching approve…
+      assert.equal(runBin(REC(rev), dir, cleanEnv()).status, 0);
+      // …but tier-check must not, so it fails closed rather than trusting a tree-supplied key.
+      const r = runBin(TIER, dir, cleanEnv());
+      assert.equal(r.status, 2, r.stdout + r.stderr);
+      assert.match(r.stderr, /ADLC_MANIFEST_KEY is not available/);
+    } finally { cleanup(dir); }
+  });
+
+  it('tier-check under CI also ignores .env.local (defense in depth)', () => {
+    const dir = scratchRepo(`ADLC_MANIFEST_KEY=${KEY}\n`);
+    try {
+      const rev = JSON.parse(runBin([...TIER, '--json'], dir, cleanEnv()).stdout).revision;
+      runBin(REC(rev), dir, cleanEnv());
+      const ci = runBin(TIER, dir, cleanEnv({ GITHUB_ACTIONS: 'true' }));
+      assert.equal(ci.status, 2, ci.stdout + ci.stderr);
+      assert.match(ci.stderr, /ADLC_MANIFEST_KEY is not available/);
+    } finally { cleanup(dir); }
+  });
+
+  it('record-cross-model: an EXPORTED key wins over .env.local (non-override)', () => {
+    const dir = scratchRepo('ADLC_MANIFEST_KEY=file-key-should-lose\n');
+    try {
+      const exported = cleanEnv({ ADLC_MANIFEST_KEY: 'exported-key-wins' });
+      const rev = JSON.parse(runBin([...TIER, '--json'], dir, exported).stdout).revision;
+      runBin(REC(rev), dir, exported); // record signs with the exported key, NOT the file key
+      // Verify with the exported key → passes; with the file key → fails. Proves the export signed.
+      assert.equal(runBin(TIER, dir, cleanEnv({ ADLC_MANIFEST_KEY: 'exported-key-wins' })).status, 0);
+      assert.equal(runBin(TIER, dir, cleanEnv({ ADLC_MANIFEST_KEY: 'file-key-should-lose' })).status, 2);
+    } finally { cleanup(dir); }
+  });
+});

--- a/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
+++ b/packages/prosecute/test/prosecute-tier-check-cli.test.mjs
@@ -18,6 +18,11 @@ import { execFileSync } from 'node:child_process';
 
 const BIN = new URL('../bin/adlc-prosecute.mjs', import.meta.url).pathname;
 
+// #326 hardening: the gate verifies attestation signatures, so both record-cross-model (which
+// signs) and tier-check (which verifies) need ADLC_MANIFEST_KEY. Set it for the whole file so
+// runBin subprocesses inherit it; the no-key fail-closed case overrides it to '' per-call.
+process.env.ADLC_MANIFEST_KEY = 'test-tier-check-signing-key';
+
 function runBin(args, cwd, env = {}) {
   try {
     const stdout = execFileSync(process.execPath, [BIN, ...args], {
@@ -79,7 +84,47 @@ describe('adlc-prosecute tier-check (#326 CI trust-root gate)', () => {
       const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
       assert.equal(r.status, 2);
       assert.match(r.stderr, /TRUST-ROOT tier/);
-      assert.match(r.stderr, /NO cross-model attestation/);
+      assert.match(r.stderr, /NO SIGNATURE-VERIFIED cross-model attestation/);
+      // The failure must show the actionable, signable record command verbatim — a
+      // maintainer copies it. Pin the template so a garbled hint cannot ship silently.
+      assert.match(r.stderr, /adlc-prosecute record-cross-model --ticket <id>/);
+    } finally { cleanup(dir); }
+  });
+
+  it('#326 forge resistance: an UNSIGNED attestation does NOT satisfy the gate', () => {
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => {
+      mkdirSync(join(d, 'packages', 'prosecute', 'lib'), { recursive: true });
+      writeFileSync(join(d, 'packages', 'prosecute', 'lib', 'x.mjs'), 'export const z = 1;\n');
+    } });
+    try {
+      const rev = JSON.parse(runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc', '--json'], dir).stdout).revision;
+      // Attacker records the approve WITHOUT the key (unsigned) — the forge.
+      runBin(['record-cross-model', '--ticket', 'T1', '--provider', 'openai', '--author-provider', 'anthropic', '--verdict', 'approve', '--revision', rev, '--dir', '.adlc'], dir, { ADLC_MANIFEST_KEY: '' });
+      // Gate (with the key) rejects the unsigned entry — still fails closed.
+      const after = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir);
+      assert.equal(after.status, 2, 'an unsigned forged approve must not satisfy the gate');
+    } finally { cleanup(dir); }
+  });
+
+  it('#326: fails closed with a distinct message when ADLC_MANIFEST_KEY is unavailable', () => {
+    const { dir } = scratchRepo({ baseTickets: [T({ rails: [] })], mutate: (d) => {
+      mkdirSync(join(d, 'packages', 'prosecute', 'lib'), { recursive: true });
+      writeFileSync(join(d, 'packages', 'prosecute', 'lib', 'x.mjs'), 'export const z = 1;\n');
+    } });
+    try {
+      const r = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc'], dir, { ADLC_MANIFEST_KEY: '' });
+      assert.equal(r.status, 2);
+      assert.match(r.stderr, /ADLC_MANIFEST_KEY is not available/);
+      // --json contract on the no-key path: still a trust-root tier and STILL failing
+      // closed, but distinguishably because the key is absent (keyAvailable:false), so a
+      // consumer does not misread it as "attestation simply missing".
+      const j = runBin(['tier-check', '--base', 'main', '--author-provider', 'anthropic', '--dir', '.adlc', '--json'], dir, { ADLC_MANIFEST_KEY: '' });
+      assert.equal(j.status, 2);
+      const jj = JSON.parse(j.stdout);
+      assert.equal(jj.trustRootTier, true);
+      assert.equal(jj.crossModelRequired, true);
+      assert.equal(jj.satisfied, false);
+      assert.equal(jj.keyAvailable, false);
     } finally { cleanup(dir); }
   });
 


### PR DESCRIPTION
Follow-up hardening on the trust-root cross-model review gate that shipped in #349. As merged, the gate was **forgeable**, and — once a signing key was introduced — it would have been **inert** (and un-recordable) on this repo's real manifest. This closes both, and isolates the signing key from PR-controlled code.

## Why

#349's gate matched an attestation's self-reported fields. Since the manifest lives in the PR-controlled tree, a contributor could append their own `approve` and clear the gate (found by adversarial-review, high/0.99). The natural fix — HMAC-sign attestations and verify — ran into two non-obvious couplings in `gate-manifest`:

1. **`verify()` (read) requires *every* entry signed when a key is present.** The shared `manifest.jsonl` has **88 historical entries, all unsigned** (signing was never enabled repo-wide). So a keyed `verify()` fails on entry #1 → the gate would fail closed for **every** PR, valid attestation or not. An always-failing gate just gets bypassed — it enforces nothing.
2. **`record()`'s pre-append check has the same requirement** → the maintainer couldn't even *record* an attestation onto the real manifest (it throws "unsigned entry").

## What

**Forge resistance** — `candidateReview()` verifies each attestation's HMAC signature (`verifyEntrySig` under `ADLC_MANIFEST_KEY`) before trusting it. The `tier-check` CLI requires the key and **fails closed** (exit 2, distinct message + `keyAvailable:false`) without it.

**Functional on a mixed manifest** — `verify()` and `record()`'s pre-append check gain an additive `requireSignatures` option (**default `true` — no change for existing callers**). The cross-model gate uses chain-integrity-**only**: it still catches the corrupt-and-skip revocation attack (#349 Codex F2 — a garbled line breaks the hash linkage) while tolerating unsigned history. Provenance is enforced **per-entry** on just the approve the gate is about to trust. Chain-only + per-entry-sig = tamper-evident **and** usable.

**Key isolation** — the folded step ran the PR's own checked-out code with the secret. It's removed; the gate moves to a separate `pull_request_target` workflow (`cross-model-gate.yml`) that runs **BASE** code + BASE deps against the PR tree as **DATA** (git worktree, never executed). The key is seen only by trusted base code. Fork PRs get no secret ⇒ fail closed (a fork touching trust-root code needs a maintainer).

## ⚠️ Required setup (or the gate fails closed for every trust-root PR)

- Set the **`ADLC_MANIFEST_KEY`** GitHub Actions secret.
- Record attestations locally with that key set so the entry is signed.

## Test plan

- [x] `packages/prosecute` — 128/128 (adds: signature-verification unsigned/wrong-key/no-key; unsigned-legacy-manifest **not inert** + forge still rejected; per-clause fail-closed input guard; forge + `--json` no-key CLI contract).
- [x] `packages/gate-manifest` — 69/69 (additive `requireSignatures`, defaults unchanged).
- [x] Full suite — 1705/1705, 0 fail.
- [x] `mutation-gate` — 16/16 mutants killed on the changed reader/CLI.
- [x] `cross-model-gate.yml` + `ci.yml` — valid YAML; no test pins the removed folded step; install-hardening (`--ignore-scripts`) contract intact.
- [ ] Cross-model adversarial review (codex, distinct provider) — running.