### PR TITLE
feat(marketing): add Copilot to the integration set; make @adlc/herdr a publish target

### DIFF
--- a/apps/docs/content/docs/integrations/copilot.mdx
+++ b/apps/docs/content/docs/integrations/copilot.mdx
@@ -1,0 +1,94 @@
+---
+title: GitHub Copilot
+description: "Native ADLC integration for the GitHub Copilot CLI: seven lifecycle hooks, six phase skills, allowlisted MCP gate tools, and six read-only prosecution agents, backed by the unbypassable CI rail gate."
+---
+
+# ADLC × GitHub Copilot CLI
+
+Native ADLC integration for the **GitHub Copilot CLI**, built against Copilot's own
+plugin surfaces rather than as a compatibility shim. It ships as
+`plugins/adlc-copilot` with a `plugin.json` manifest and installs from this repo's
+Git plugin marketplace.
+
+Two enforcement layers, and it matters which one you rely on:
+
+1. **In-session rail hook (best-effort).** A `preToolUse` hook denies edits to a
+   frozen ticket's rails, and `build-gate` checks context fitness before a
+   high-risk build starts. A shell cannot be reliably parsed, so a rail write via
+   Bash can still land in the diff.
+2. **CI diff gate (the guarantee).** `scripts/rails-guard-ci.mjs` rejects any PR
+   whose diff touches a rail frozen on the base branch, in any spelling. This is
+   the control to depend on.
+
+## Install
+
+```sh
+npm install -g @adlc/cli
+copilot plugin marketplace add voodootikigod/adlc
+copilot plugin install adlc-copilot@adlc
+adlc init --no-codex-agents
+```
+
+<Callout type="warn">
+`adlc init --harness copilot` is **not available in `@adlc/cli` 1.6.0**, the
+current published release — it exits with `--harness must be codex or cursor`.
+The flag exists in the repository and ships in the next release; until then use
+`--no-codex-agents`, which creates the same `.adlc/` runtime without the
+Codex agent templates. What you lose in the meantime is only the
+`.github/copilot-instructions.md` block and the `copilot-setup-steps.yml`
+snippet, which can be added by hand.
+</Callout>
+
+The plugin installs from the **Git marketplace, not npm**. The `@adlc/copilot`
+npm package is not the install path — the marketplace command above does not go
+through npm at all.
+
+`adlc init --harness copilot` is a *separate* step that scaffolds repository
+state: a `.github/copilot-instructions.md` block and a `copilot-setup-steps.yml`
+snippet. It does **not** install the plugin, and is not a substitute for the
+marketplace commands.
+
+**Or let the installer do it.** The universal installer detects the `copilot`
+CLI and runs the marketplace install automatically:
+
+```sh
+curl -fsSL https://www.agenticlifecycle.ai/install.sh | sh
+```
+
+## What the plugin wires
+
+| Primitive | Copilot surface | Count |
+| --- | --- | --- |
+| Phase skills | `skills/` | 6 — `adlc`, `adlc-init`, `adlc-ticket`, `adlc-prosecute`, `adlc-distill`, `adlc-maintain` |
+| Lifecycle hooks | `hooks/hooks.json` | 7 — `sessionStart`, `preToolUse`, `postToolUse`, `preCompact`, `subagentStart`, `subagentStop`, `agentStop` |
+| Gate tools | `.mcp.json` → `adlc mcp-server` | 2 — `adlc_gate`, `adlc_prosecute` |
+| Prosecution agents | `agents/` | 6 — five read-only lenses plus an independent verifier |
+
+The skills use progressive disclosure: `adlc` routes to a phase, then a focused
+skill loads just that P0–P7 workflow rather than the entire lifecycle.
+
+## Wire the CI control
+
+The in-session hook is a nudge. The commit-time gate is the control, and it needs
+a deliberate bootstrap:
+
+```sh
+mkdir -p .github/workflows
+test -e .github/workflows/adlc-rails-guard.yml \
+  && echo "REFUSING: a workflow already exists — diff before replacing it" \
+  || curl -fsSL https://raw.githubusercontent.com/voodootikigod/adlc/main/docs/ci/rails-guard.yml \
+       -o .github/workflows/adlc-rails-guard.yml
+```
+
+The filename is not cosmetic — the workflow protects itself by name, and any
+other name leaves it editable by the PRs it is meant to gate. **Read the file's
+header before marking the check required**: it documents a multi-stage bootstrap
+(the bootstrap commit merges first, the base branch needs
+`trustedCodeownersAttested`, and `.adlc/manifest.jsonl` must be absent or empty
+until reviewed). Enabling it early fails every subsequent PR.
+
+## Further reading
+
+- [Ground-truth integration guide](https://github.com/voodootikigod/adlc/blob/main/docs/integrations/copilot.md)
+- [Plugin source](https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-copilot)
+- [ADR 0013 — Copilot integration rationale](https://github.com/voodootikigod/adlc/blob/main/docs/adr/0013-adlc-copilot-integration.md)

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -1,1 +1,1 @@
-{ "title": "Integrations", "pages": ["index", "claude-code", "codex", "cursor", "opencode", "pi", "antigravity"] }
+{ "title": "Integrations", "pages": ["index", "claude-code", "codex", "cursor", "opencode", "pi", "antigravity", "copilot"] }

--- a/apps/docs/lib/agent-guide.mjs
+++ b/apps/docs/lib/agent-guide.mjs
@@ -176,9 +176,11 @@ ${fence([
   'copilot plugin install adlc-copilot@adlc',
 ])}
 
-\`adlc init --harness copilot\` is a *different* step. It scaffolds repository
-state (a \`.github/copilot-instructions.md\` block and a setup-steps snippet);
-it does **not** install the plugin. Do not offer it as a substitute.
+\`adlc init --harness copilot\` is a *different* step, and it is NOT available in
+the published \`@adlc/cli\` 1.6.0 — it exits with \`--harness must be codex or
+cursor\`. Use \`adlc init --no-codex-agents\` until the next release. Either way
+it only scaffolds repository state; it does **not** install the plugin, so never
+offer it as a substitute.
 
 ## Install: any other agent
 
@@ -197,8 +199,8 @@ and say so rather than quietly installing the weaker option.
 
 Walk the human through this sequence.
 
-1. **Create the runtime.** \`adlc init\` (add \`--harness cursor\` or
-   \`--harness copilot\` where relevant). It is idempotent and confines all
+1. **Create the runtime.** \`adlc init\` (add \`--harness cursor\` where relevant;
+   \`--harness copilot\` is unreleased in 1.6.0 — use \`--no-codex-agents\`). It is idempotent and confines all
    writes to the repo root. If \`.adlc/config.json\` is already a frozen rail, do
    not overwrite it.
 2. **Wire the CI control.** This matters more than it looks: in-session rail
@@ -265,7 +267,8 @@ Walk the human through this sequence.
 - **GitHub Copilot** installs from its Git marketplace, not npm. The
   \`@adlc/copilot\` NPM package is unpublished, but that is irrelevant — the
   marketplace path does not use npm. See the Copilot section above.
-  \`adlc init --harness copilot\` scaffolds repo state and is NOT an install.
+  \`adlc init --harness copilot\` scaffolds repo state, is NOT an install, and is
+  unreleased in 1.6.0 — use \`--no-codex-agents\` for now.
 - **skills.sh installs skills only** — no hooks, MCP, agents, or rails.
 
 ## Diagnosis

--- a/apps/docs/lib/integration-facts.mjs
+++ b/apps/docs/lib/integration-facts.mjs
@@ -1,6 +1,12 @@
 // @ts-check
 // Single source of truth for the native-integration marketing pages.
 // Grounded in docs/integrations/<slug>.md. The test cross-checks existence.
+//
+// The universal install command is imported rather than repeated: install-commands.mjs
+// owns it, and hand-typing it here would be a second copy that drifts when the served
+// script moves. (install-commands.mjs imports nothing, so there is no cycle.)
+
+import { UNIVERSAL_INSTALL } from './install-commands.mjs';
 
 /** @typedef {{ key: string, count: number, label: string, title: string, detail: string, items: string[] }} IntegrationSurface */
 /** @typedef {{ phase: string, entry: string, evidence: string }} PhaseRoute */
@@ -823,6 +829,143 @@ export const ANTIGRAVITY_INTEGRATION = {
   ],
 };
 
+/** @type {IntegrationFact} */
+export const COPILOT_INTEGRATION = {
+  slug: 'copilot',
+  name: 'GitHub Copilot',
+  status: 'marketplace',
+  tagline: 'A native Copilot CLI plugin: seven lifecycle hooks, six phase skills, allowlisted MCP gate tools, and six read-only prosecution agents.',
+  install: [
+    'npm install -g @adlc/cli',
+    'copilot plugin marketplace add voodootikigod/adlc',
+    'copilot plugin install adlc-copilot@adlc',
+    'adlc init --no-codex-agents',
+  ],
+  note: 'Installs from this repo\'s Git plugin marketplace, not npm — the @adlc/copilot npm package is not the install path. The universal installer performs these steps automatically when it detects the copilot CLI. adlc init --harness copilot is NOT available in the published @adlc/cli 1.6.0 (it exits: --harness must be codex or cursor); use --no-codex-agents until the next release. Either way it only scaffolds repository state and is not a substitute for installing the plugin.',
+  pluginDir: 'plugins/adlc-copilot',
+  hero: {
+    kicker: 'Copilot integration',
+    title: 'ADLC as a GitHub Copilot plugin',
+    identity: 'Built against Copilot\'s own plugin surfaces. The in-session rail hook is best-effort; CI is the guarantee.',
+    badges: [
+      { label: 'Native plugin', accent: true },
+      { label: 'Git marketplace' },
+    ],
+  },
+  bundle: {
+    title: 'adlc-copilot / native bundle',
+    ariaLabel: 'Native Copilot plugin payload',
+    root: 'adlc-copilot/',
+    entries: [
+      { path: '├─ plugin.json', note: 'manifest' },
+      { path: '├─ skills/', surfaceKey: 'skills', note: 'phase-aware workflows' },
+      { path: '├─ hooks/hooks.json', surfaceKey: 'hooks', note: 'lifecycle events' },
+      { path: '├─ .mcp.json', surfaceKey: 'mcp', note: 'allowlisted tools' },
+      { path: '└─ agents/', surfaceKey: 'agents', note: 'prosecution lenses' },
+    ],
+  },
+  surfaces: [
+    {
+      key: 'skills',
+      count: 6,
+      label: 'skills',
+      title: 'Skills load only the phase you need',
+      detail: 'The adlc skill routes to a phase, then a focused skill loads just that P0-P7 workflow instead of the whole lifecycle.',
+      items: ['adlc', 'adlc-init', 'adlc-ticket', 'adlc-prosecute', 'adlc-distill', 'adlc-maintain'],
+    },
+    {
+      key: 'hooks',
+      count: 7,
+      label: 'hook events',
+      title: 'Hooks for context, rails, and compaction',
+      detail: 'Hooks restore ticket context at session start, check frozen-rail writes before a tool runs, survive compaction, and coordinate subagents.',
+      items: [
+        'sessionStart',
+        'preToolUse',
+        'postToolUse',
+        'preCompact',
+        'subagentStart',
+        'subagentStop',
+        'agentStop',
+      ],
+    },
+    {
+      key: 'mcp',
+      count: 2,
+      label: 'MCP tools',
+      title: 'Two MCP tools, tightly scoped',
+      detail: 'A local MCP server exposes allowlisted adlc_gate (no shell) and adlc_prosecute for evidence-producing review.',
+      items: ['adlc_gate', 'adlc_prosecute'],
+    },
+    {
+      key: 'agents',
+      count: 6,
+      label: 'prosecution agents',
+      title: 'Five lenses plus an independent verifier',
+      detail: 'P5 fans out five read-only specialist lenses, then an independent verifier refutes findings before they gate the merge.',
+      items: [
+        'prosecutor-correctness',
+        'prosecutor-security',
+        'prosecutor-contract',
+        'prosecutor-diff',
+        'prosecutor-tests',
+        'prosecutor-verifier',
+      ],
+    },
+  ],
+  surfacesSection: {
+    kicker: 'Native surfaces',
+    title: 'What the Copilot plugin installs',
+  },
+  phaseRoutes: [
+    { phase: 'P0', entry: 'adlc-ticket', evidence: 'ticket in the canonical store' },
+    { phase: 'P1-P2', entry: 'adlc skill', evidence: 'spec-lint · premortem · coldstart' },
+    { phase: 'P3-P4', entry: 'preToolUse + CI', evidence: 'rail deny · rails-guard-ci' },
+    { phase: 'P5-P6', entry: 'adlc-prosecute', evidence: 'hollow-test · behavior diff · manifest' },
+    { phase: 'P7', entry: 'adlc-distill', evidence: 'foundry · rejection mining' },
+  ],
+  phaseSection: {
+    kicker: 'Phase routing',
+    title: 'Skills route, CI enforces',
+    intro: 'The `adlc` skill picks the phase and a focused skill loads that workflow. The preToolUse hook is an in-session nudge; treat CI as the control you rely on.',
+    entryHeader: 'Copilot entry',
+  },
+  enforcement: {
+    session: {
+      kicker: 'In the session',
+      title: 'Best-effort rail deny',
+      body: 'The preToolUse hook denies edits to a frozen ticket\'s rails, then build-gate checks context fitness. Bash is not reliably parseable, so a shell write can still reach the diff — that is what the CI gate exists for.',
+    },
+    ci: {
+      kicker: 'In CI',
+      title: 'The unbypassable control',
+      body: 'scripts/rails-guard-ci.mjs rejects any PR whose diff touches a rail frozen on the base branch, in any spelling. Install docs/ci/rails-guard.yml as .github/workflows/adlc-rails-guard.yml and follow its bootstrap ceremony before making it required.',
+    },
+  },
+  railsSection: {
+    kicker: 'Frozen rails',
+    title: 'Best-effort in session, required in CI',
+  },
+  installSection: {
+    kicker: 'Install',
+    title: 'Install from the Git plugin marketplace',
+  },
+  operate: {
+    title: 'operate: Copilot plugin',
+    lines: [
+      '# Or let the universal installer detect Copilot and do it for you',
+      UNIVERSAL_INSTALL,
+      '',
+      '# Scaffold repository state (NOT a plugin install)',
+      'adlc init --no-codex-agents',
+    ],
+  },
+  resources: [
+    { href: '/docs/integrations/copilot', label: 'Read the complete integration guide →' },
+    { href: 'https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-copilot', label: 'Inspect the plugin source →', external: true },
+  ],
+};
+
 /** @type {IntegrationFact[]} */
 export const INTEGRATIONS = [
   CLAUDE_CODE_INTEGRATION,
@@ -831,6 +974,7 @@ export const INTEGRATIONS = [
   OPENCODE_INTEGRATION,
   PI_INTEGRATION,
   ANTIGRAVITY_INTEGRATION,
+  COPILOT_INTEGRATION,
 ];
 
 /**

--- a/apps/docs/test/integration-facts.test.mjs
+++ b/apps/docs/test/integration-facts.test.mjs
@@ -103,6 +103,10 @@ test('every integration carries Codex-depth marketing structure', () => {
     assert.ok(i.hero?.title, `${i.slug}: hero.title`);
     assert.ok(i.hero?.identity, `${i.slug}: hero.identity`);
     assert.ok(Array.isArray(i.hero?.badges) && i.hero.badges.length >= 1, `${i.slug}: hero.badges`);
+    assert.ok(
+      i.hero.badges.some((b) => b.accent === true),
+      `${i.slug}: hero has an accented (primary) badge`,
+    );
     assert.ok(i.bundle?.title && i.bundle?.ariaLabel && i.bundle?.root, `${i.slug}: bundle meta`);
     assert.ok(Array.isArray(i.bundle.entries) && i.bundle.entries.length >= 3, `${i.slug}: bundle entries`);
     assert.ok(i.surfacesSection?.kicker && i.surfacesSection?.title, `${i.slug}: surfacesSection`);

--- a/plugins/adlc-herdr/README.md
+++ b/plugins/adlc-herdr/README.md
@@ -37,6 +37,16 @@ herdr plugin install voodootikigod/adlc/plugins/adlc-herdr
 Requires herdr ≥ 0.7.4 (`min_herdr_version`). The plugin is zero-dependency
 Node and declares no `[[build]]` commands — installation executes nothing.
 
+### About the npm package
+
+`@adlc/herdr` is published to npm alongside the rest of the suite, but **npm is
+not an install path for this plugin** — herdr resolves plugins from a GitHub
+subdirectory or a local directory, and has no `npm:` source scheme. The package
+exists so the integration is discoverable next to its siblings and so its
+version tracks the suite; installing it with `npm i @adlc/herdr` gives you the
+files but does not register anything with herdr. Use one of the two commands
+above.
+
 ## Keybindings
 
 The board and the palette actions are reachable from herdr's action palette out

--- a/plugins/adlc-herdr/package.json
+++ b/plugins/adlc-herdr/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@adlc/herdr",
+  "type": "module",
+  "version": "1.6.0",
+  "description": "ADLC surfaced at the terminal-multiplexer layer: a herdr plugin showing per-pane ticket/phase/gate state, a backlog board, and gate actions. Published for discovery — herdr itself installs this plugin from the GitHub subdirectory, not from npm.",
+  "license": "MIT",
+  "author": "Chris Williams (@voodootikigod)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voodootikigod/adlc.git",
+    "directory": "plugins/adlc-herdr"
+  },
+  "homepage": "https://github.com/voodootikigod/adlc/tree/main/plugins/adlc-herdr#readme",
+  "bugs": "https://github.com/voodootikigod/adlc/issues",
+  "keywords": [
+    "adlc",
+    "agentic",
+    "ai",
+    "herdr",
+    "tmux",
+    "observability"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "dependencies": {},
+  "files": [
+    "bin/",
+    "lib/",
+    "herdr-plugin.toml",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
Follow-on to #351. Two items that were explicitly out of scope there.

## Copilot joins the marketing integration set

Copilot was the only harness with a native plugin and **no marketing presence** — which is also why its handling drifted twice during #351's review, and why I twice assumed the wrong distribution channel.

The entry is grounded in the plugin's actual surfaces, counted from the tree rather than asserted:

| Primitive | Count |
| --- | --- |
| Phase skills | 6 — `adlc`, `adlc-init`, `adlc-ticket`, `adlc-prosecute`, `adlc-distill`, `adlc-maintain` |
| Lifecycle hooks | 7 — `sessionStart`, `preToolUse`, `postToolUse`, `preCompact`, `subagentStart`, `subagentStop`, `agentStop` |
| MCP tools | 2 — `adlc_gate`, `adlc_prosecute` |
| Prosecution agents | 6 — five read-only lenses plus an independent verifier |

`integration-facts.test.mjs` enforces this bidirectionally — a marketing entry needs both a docs-site page and a `docs/integrations` ground truth — so this also adds `apps/docs/content/docs/integrations/copilot.mdx` and registers it in `meta.json`. The ground truth already existed.

## A version-skew bug found while writing it

The docs told users to run `adlc init --harness copilot`.

**That flag does not exist in the published `@adlc/cli` 1.6.0.** It exits with `--harness must be codex or cursor`. The flag is in this repository and ships in the next release, but every Copilot surface was already promising it.

Corrected across the new page, `integration-facts.mjs`, and the agent guide: each now states the limitation and points at `--no-codex-agents`, which produces the same `.adlc/` runtime on the released CLI. What is lost until release is only the `.github/copilot-instructions.md` block and the `copilot-setup-steps.yml` snippet.

This is exactly the mixed-release-state class the cross-model reviews kept raising on #351, reaching a user-facing instruction. I would have shipped it.

## `@adlc/herdr` becomes a publish target

Adds `plugins/adlc-herdr/package.json`, so `release.mjs` picks it up — `publishTargets()` auto-discovers any non-private `plugins/*` package.json. All seven plugin packages are now targets.

**npm is a discovery channel here, not an install path, and the README says so.** herdr resolves plugins from a GitHub subdirectory or a local directory and has no `npm:` source scheme, so `npm i @adlc/herdr` yields the files but registers nothing with herdr. The documented installs remain:

```sh
herdr plugin install voodootikigod/adlc/plugins/adlc-herdr
herdr plugin link /path/to/adlc/plugins/adlc-herdr
```

Recorded in the README rather than left for someone to discover. **Neither package is published by this PR** — that is a release action requiring human approval and OIDC trusted publishing.

## Deliberately not here

**herdr in the marketing integration set.** It is documented as an observability surface, not an enforcement tier, and the capability matrix deliberately keeps seven harness columns. Adding it means inventing an enforcement framing for a plugin that has none. Left as its own decision rather than smuggled in alongside Copilot.

## Gate state

| Gate | Result |
| --- | --- |
| `tier-check` | NOT trust-root tier — no cross-model review required |
| `rails-guard-ci` | exit 0 |
| docs suite | 157 pass |
| scripts suite | 608 pass |
| `types:check`, `next build` | clean |
| lockfile | identical to main |

My own single-source test caught me hand-typing the install command into the new entry; `integration-facts.mjs` now imports `UNIVERSAL_INSTALL` like every other surface.

## Test plan

- [ ] Confirm the `/integrations/copilot` and `/docs/integrations/copilot` pages render on the preview deploy
- [ ] After the next release: verify `adlc init --harness copilot` works and drop the interim `--no-codex-agents` guidance
- [ ] After the next release: verify `@adlc/copilot` and `@adlc/herdr` publish
