### PR TITLE
feat(marketing): rebuild the marketing site as a controlled-change record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ node_modules/
 # Local env files (may contain secrets, e.g. ATTIO_API_TOKEN)
 .env.local
 .env*.local
+
+# Impeccable working state: decision-server sessions and local live-mode config
+# are per-machine and ephemeral. The design system (DESIGN.md, design.json),
+# the surface brief, and the approved comps are tracked deliberately.
+apps/docs/.impeccable/questions/
+apps/docs/.impeccable/live/
+apps/docs/.impeccable/mocks/mobile.html

--- a/apps/docs/.impeccable/design.json
+++ b/apps/docs/.impeccable/design.json
@@ -35,7 +35,7 @@
         "tonalRamp": [
           "#171920",
           "#464c5c",
-          "#6b7283"
+          "#5a616f"
         ]
       },
       "green": {
@@ -88,6 +88,18 @@
         "tonalRamp": [
           "#ef7c2a",
           "#b4571a"
+        ]
+      },
+      "print-paper": {
+        "role": "neutral",
+        "displayName": "Print Paper",
+        "canonical": "#ffffff",
+        "tonalRamp": [
+          "#ffffff",
+          "#f4f4f4",
+          "#999999",
+          "#444444",
+          "#000000"
         ]
       }
     },
@@ -168,7 +180,7 @@
       "refersTo": "exhibit",
       "description": "A verbatim capture, numbered and attached to a clause. Keeps the terminal ground on every surface.",
       "html": "<figure class=\"ds-exh\"><figcaption><b>EXHIBIT 5.2</b> <span>Are the frozen tests untouched?</span></figcaption><div class=\"ds-term\"><div class=\"ds-bar\"><span>adlc rails-guard</span><em>EXIT 2 \u2014 REFUSED</em></div><pre><span class=\"p\">$</span> adlc rails-guard --base main\n<span class=\"no\">\u2717 FAIL: a frozen rail changed</span></pre></div></figure>",
-      "css": ".ds-exh figcaption{margin-bottom:10px;font-size:12.5px;color:#6b7283}.ds-exh figcaption b{font-family:'Azeret Mono',monospace;font-size:11px;letter-spacing:.1em;color:#171920;margin-right:12px}.ds-term{background:#1c1d21;border:1px solid #34363d}.ds-bar{display:flex;justify-content:space-between;padding:8px 14px;border-bottom:1px solid #2c2e34;font-family:'Azeret Mono',monospace;font-size:10px;letter-spacing:.1em;color:#686b78}.ds-bar em{font-style:normal;color:#eb3d54}.ds-term pre{padding:14px 16px;font-family:'Azeret Mono',monospace;font-size:12.5px;line-height:1.75;color:#cbcdd2}.ds-term .p{color:#686b78}.ds-term .no{color:#eb3d54}"
+      "css": ".ds-exh figcaption{margin-bottom:10px;font-size:12.5px;color:#5a616f}.ds-exh figcaption b{font-family:'Azeret Mono',monospace;font-size:11px;letter-spacing:.1em;color:#171920;margin-right:12px}.ds-term{background:#1c1d21;border:1px solid #34363d}.ds-bar{display:flex;justify-content:space-between;padding:8px 14px;border-bottom:1px solid #2c2e34;font-family:'Azeret Mono',monospace;font-size:10px;letter-spacing:.1em;color:#686b78}.ds-bar em{font-style:normal;color:#eb3d54}.ds-term pre{padding:14px 16px;font-family:'Azeret Mono',monospace;font-size:12.5px;line-height:1.75;color:#cbcdd2}.ds-term .p{color:#686b78}.ds-term .no{color:#eb3d54}"
     },
     {
       "name": "Attestation Block",
@@ -184,7 +196,7 @@
       "refersTo": "chain-row",
       "description": "The layout unit of every marketing surface: numbered label in a 104px gutter, content in the measure beside it.",
       "html": "<section class=\"ds-clause\"><div class=\"g\">\u00a73 CHAIN</div><div class=\"b\"><h2>Eight control points. A gate closes every one.</h2><p>Each phase ends on an exit code.</p></div></section>",
-      "css": ".ds-clause{display:flex;gap:24px;padding:48px 32px;border-bottom:1px solid #c6cbd6;border-left:1px solid #c6cbd6;border-right:1px solid #c6cbd6;background:#e7eaef}.ds-clause .g{width:104px;flex:none;font-family:'Azeret Mono',monospace;font-size:9.5px;letter-spacing:.13em;text-transform:uppercase;color:#6b7283}.ds-clause h2{margin:0;font-family:Archivo,sans-serif;font-size:26px;font-weight:700;letter-spacing:-.018em;color:#171920}.ds-clause p{margin:16px 0 0;font-size:16.5px;line-height:1.55;color:#464c5c;max-width:62ch}"
+      "css": ".ds-clause{display:flex;gap:24px;padding:48px 32px;border-bottom:1px solid #c6cbd6;border-left:1px solid #c6cbd6;border-right:1px solid #c6cbd6;background:#e7eaef}.ds-clause .g{width:104px;flex:none;font-family:'Azeret Mono',monospace;font-size:9.5px;letter-spacing:.13em;text-transform:uppercase;color:#5a616f}.ds-clause h2{margin:0;font-family:Archivo,sans-serif;font-size:26px;font-weight:700;letter-spacing:-.018em;color:#171920}.ds-clause p{margin:16px 0 0;font-size:16.5px;line-height:1.55;color:#464c5c;max-width:72ch}"
     }
   ],
   "narrative": {

--- a/apps/docs/.impeccable/design.json
+++ b/apps/docs/.impeccable/design.json
@@ -1,0 +1,247 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-27T00:00:00.000Z",
+  "title": "Design System: ADLC Marketing \u2014 The Change Record",
+  "extensions": {
+    "colorMeta": {
+      "ground": {
+        "role": "neutral",
+        "displayName": "Terminal Ground",
+        "canonical": "#1c1d21",
+        "tonalRamp": [
+          "#1c1d21",
+          "#26272c",
+          "#2c2e34",
+          "#34363d",
+          "#3f4044"
+        ]
+      },
+      "rec-paper": {
+        "role": "neutral",
+        "displayName": "Cool Record Paper",
+        "canonical": "#e7eaef",
+        "tonalRamp": [
+          "#f2f4f7",
+          "#e7eaef",
+          "#dde1e8",
+          "#c6cbd6",
+          "#a7aebd"
+        ]
+      },
+      "rec-ink": {
+        "role": "neutral",
+        "displayName": "Record Ink",
+        "canonical": "#171920",
+        "tonalRamp": [
+          "#171920",
+          "#464c5c",
+          "#6b7283"
+        ]
+      },
+      "green": {
+        "role": "success",
+        "displayName": "Gate Pass Green",
+        "canonical": "#78bd65",
+        "tonalRamp": [
+          "#e2efdd",
+          "#9dc492",
+          "#78bd65",
+          "#2f6a22"
+        ]
+      },
+      "red": {
+        "role": "danger",
+        "displayName": "Refusal Red",
+        "canonical": "#eb3d54",
+        "tonalRamp": [
+          "#f7e2e5",
+          "#dda3ad",
+          "#eb3d54",
+          "#a81d31"
+        ]
+      },
+      "yellow": {
+        "role": "warning",
+        "displayName": "Human Gate Amber",
+        "canonical": "#e5cd52",
+        "tonalRamp": [
+          "#faf3d8",
+          "#cbb44a",
+          "#e5cd52",
+          "#6f5a0d"
+        ]
+      },
+      "blue": {
+        "role": "info",
+        "displayName": "Reference Blue",
+        "canonical": "#4fb4d8",
+        "tonalRamp": [
+          "#a9cede",
+          "#4fb4d8",
+          "#17627f"
+        ]
+      },
+      "orange": {
+        "role": "accent",
+        "displayName": "Failure-Mode Orange",
+        "canonical": "#ef7c2a",
+        "tonalRamp": [
+          "#ef7c2a",
+          "#b4571a"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "statement": {
+        "displayName": "Statement",
+        "purpose": "The \u00a71 thesis at panel scale, and interior page leads. The only place the Archivo width axis is used (wdth 92)."
+      },
+      "legend": {
+        "displayName": "Field Legend",
+        "purpose": "Field labels, clause numbers, column headers, exit codes. Azeret Mono at 9.5px / 0.13em."
+      },
+      "evidence": {
+        "displayName": "Evidence",
+        "purpose": "Captured gate output inside exhibits. Never used on the paper surface."
+      },
+      "row-title": {
+        "displayName": "Row Title",
+        "purpose": "Names the subject of a row in every register \u2014 approval chain, failure map, rollout schedule, harness list, dial settings. The workhorse step; the only small size carrying semibold."
+      },
+      "metric": {
+        "displayName": "Metric",
+        "purpose": "A bare count standing alone in a cell. Used by the surface counts on every harness integration page."
+      }
+    },
+    "shadows": [],
+    "motion": [
+      {
+        "name": "rec-settle",
+        "value": "cubic-bezier(0.16, 1, 0.3, 1) 0.44s, stagger 32ms",
+        "purpose": "Approval-chain rows settling in sequence on load. The record resolving."
+      },
+      {
+        "name": "rec-stamp",
+        "value": "cubic-bezier(0.16, 1, 0.3, 1) 0.34s, scale 1.32 to 1, offset +150ms",
+        "purpose": "The verdict landing just after its row settles. Kept short so a chip never reads as missing data."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "sm",
+        "value": "640px"
+      },
+      {
+        "name": "md",
+        "value": "768px"
+      },
+      {
+        "name": "lg",
+        "value": "1024px"
+      },
+      {
+        "name": "record",
+        "value": "1180px"
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Install Field",
+      "kind": "input",
+      "refersTo": "install-field",
+      "description": "The record's primary control \u2014 the executable value of the IMPLEMENTATION field, not a button.",
+      "html": "<div class=\"ds-install\"><code><s>$</s>curl -fsSL https://www.agenticlifecycle.ai/install.sh | sh</code><button>COPY</button></div>",
+      "css": ".ds-install{display:flex;align-items:stretch;border:1px solid #171920;background:#1c1d21}.ds-install code{flex:1;font-family:'Azeret Mono',monospace;font-size:13.5px;color:#cbcdd2;padding:12px 16px;white-space:pre-wrap;word-break:break-all}.ds-install code s{color:#78bd65;text-decoration:none;padding-right:10px}.ds-install button{border:0;border-left:1px solid #34363d;background:#26272c;color:#cbcdd2;font-family:'Azeret Mono',monospace;font-size:10px;letter-spacing:.14em;padding:0 16px}@media(min-width:768px){.ds-install code{white-space:pre;word-break:normal;overflow-x:auto}}"
+    },
+    {
+      "name": "Exit Code Chip",
+      "kind": "chip",
+      "refersTo": "exit-code-pass",
+      "description": "A verdict. Always glyph plus word; machine verdicts also carry the exit code, because the exit code is the contract.",
+      "html": "<span class=\"ds-code ds-pass\">\u2713 PASS <b>0</b></span> <span class=\"ds-code ds-fail\">\u2717 FAIL <b>2</b></span> <span class=\"ds-code ds-attest\">\u25c6 ATTEST</span>",
+      "css": ".ds-code{display:inline-flex;align-items:center;gap:6px;font-family:'Azeret Mono',monospace;font-size:10.5px;font-weight:600;border:1px solid;padding:2px 6px;border-radius:0}.ds-pass{color:#2f6a22;border-color:#9dc492;background:#e2efdd}.ds-fail{color:#a81d31;border-color:#dda3ad;background:#f7e2e5}.ds-attest{color:#6f5a0d;border-color:#cbb44a;background:#faf3d8}"
+    },
+    {
+      "name": "Exhibit",
+      "kind": "card",
+      "refersTo": "exhibit",
+      "description": "A verbatim capture, numbered and attached to a clause. Keeps the terminal ground on every surface.",
+      "html": "<figure class=\"ds-exh\"><figcaption><b>EXHIBIT 5.2</b> <span>Are the frozen tests untouched?</span></figcaption><div class=\"ds-term\"><div class=\"ds-bar\"><span>adlc rails-guard</span><em>EXIT 2 \u2014 REFUSED</em></div><pre><span class=\"p\">$</span> adlc rails-guard --base main\n<span class=\"no\">\u2717 FAIL: a frozen rail changed</span></pre></div></figure>",
+      "css": ".ds-exh figcaption{margin-bottom:10px;font-size:12.5px;color:#6b7283}.ds-exh figcaption b{font-family:'Azeret Mono',monospace;font-size:11px;letter-spacing:.1em;color:#171920;margin-right:12px}.ds-term{background:#1c1d21;border:1px solid #34363d}.ds-bar{display:flex;justify-content:space-between;padding:8px 14px;border-bottom:1px solid #2c2e34;font-family:'Azeret Mono',monospace;font-size:10px;letter-spacing:.1em;color:#686b78}.ds-bar em{font-style:normal;color:#eb3d54}.ds-term pre{padding:14px 16px;font-family:'Azeret Mono',monospace;font-size:12.5px;line-height:1.75;color:#cbcdd2}.ds-term .p{color:#686b78}.ds-term .no{color:#eb3d54}"
+    },
+    {
+      "name": "Attestation Block",
+      "kind": "custom",
+      "refersTo": "chain-row-human",
+      "description": "The record's signature panel for the two gates a machine cannot close. Must not be demoted back into a table cell.",
+      "html": "<div class=\"ds-att\"><div class=\"k\">ATTESTATION \u00b7 P1 INTERROGATE</div><p>Is this what I meant?</p><div class=\"sig\"><span class=\"line\"></span><span class=\"by\">SIGNED BY A PERSON</span></div></div>",
+      "css": ".ds-att{background:#faf3d8;border:1px solid #a7aebd;padding:14px 16px}.ds-att .k{font-family:'Azeret Mono',monospace;font-size:9.5px;letter-spacing:.13em;text-transform:uppercase;color:#6f5a0d}.ds-att p{margin:8px 0 0;font-size:13.5px;color:#464c5c}.ds-att .sig{display:flex;align-items:flex-end;gap:12px;margin-top:24px}.ds-att .line{flex:1;height:1px;background:#cbb44a}.ds-att .by{font-family:'Azeret Mono',monospace;font-size:10px;letter-spacing:.12em;color:#6f5a0d}"
+    },
+    {
+      "name": "Clause",
+      "kind": "custom",
+      "refersTo": "chain-row",
+      "description": "The layout unit of every marketing surface: numbered label in a 104px gutter, content in the measure beside it.",
+      "html": "<section class=\"ds-clause\"><div class=\"g\">\u00a73 CHAIN</div><div class=\"b\"><h2>Eight control points. A gate closes every one.</h2><p>Each phase ends on an exit code.</p></div></section>",
+      "css": ".ds-clause{display:flex;gap:24px;padding:48px 32px;border-bottom:1px solid #c6cbd6;border-left:1px solid #c6cbd6;border-right:1px solid #c6cbd6;background:#e7eaef}.ds-clause .g{width:104px;flex:none;font-family:'Azeret Mono',monospace;font-size:9.5px;letter-spacing:.13em;text-transform:uppercase;color:#6b7283}.ds-clause h2{margin:0;font-family:Archivo,sans-serif;font-size:26px;font-weight:700;letter-spacing:-.018em;color:#171920}.ds-clause p{margin:16px 0 0;font-size:16.5px;line-height:1.55;color:#464c5c;max-width:62ch}"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Change Record",
+    "overview": "The marketing surfaces are one controlled-change record: what changed, why, who assessed the impact, what the back-out is, who approved it, and what evidence was attached. That record is what makes a change defensible rather than merely done, which is the question ADLC's buyer has about agents. The site is therefore not a page describing the product; it is the record for adopting it.\n\nThe system has two surfaces and the split between them carries the argument. The record is paper \u2014 cool, ruled, squared, fixed fields and numbered clauses \u2014 and is what a person reads and a non-engineer could audit. The evidence is terminal \u2014 real gate output on #1c1d21 in the unmodified An Old Hope palette \u2014 and is what a machine produced. Evidence is never restyled to match the page around it.\n\nThe register is deliberately corporate and unwhimsical. The audience is engineers and the leadership accountable for what agents merge, and for them charm reads as the opposite of defensible.",
+    "keyCharacteristics": [
+      "Two committed surfaces: paper record, terminal evidence. The contrast is the argument.",
+      "Zero radius, zero shadow. Elevation is declared once, as a 1px rule.",
+      "Numbered clauses in a 104px gutter as the universal layout unit.",
+      "Verdicts always pair a glyph with a word, and machine verdicts carry the exit code.",
+      "Archivo with a width axis for the record; Azeret Mono only for identifiers, codes, commands, and captured output.",
+      "One authored motion moment: the record resolving, once, on load."
+    ],
+    "rules": [
+      {
+        "name": "The Exhibit Rule",
+        "body": "No claim about what the toolkit does ships without an attached exhibit or the name of the gate that produces it. Argument may be argument; capability may not.",
+        "section": "colors"
+      },
+      {
+        "name": "The Two-Surface Rule",
+        "body": "The record is paper and the evidence is terminal. An exhibit keeps the An Old Hope ground wherever it appears, and paper never borrows the terminal-bright verdict hues for text.",
+        "section": "colors"
+      },
+      {
+        "name": "The Doubled Verdict Rule",
+        "body": "Gate state is never carried by colour alone. Glyph plus word always; exit code as well for machine verdicts. Shape doubles it too: the human gate is a diamond, the machine gate an open ring.",
+        "section": "colors"
+      },
+      {
+        "name": "The Flat Record Rule",
+        "body": "Radius is zero and shadows do not exist. Grouping uses a hairline, a gap-px lattice over a rule-coloured container, or a shift between the three paper tones.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Derived Count Rule",
+        "body": "Counts and names come from the data modules, never typed. Where the repository cannot back a per-item fact, the column is dropped rather than guessed \u2014 which is why the approval chain has no evidence column.",
+        "section": "typography"
+      }
+    ],
+    "dos": [
+      "Do attach an exhibit to every capability claim.",
+      "Do keep evidence on the terminal ground, including on paper.",
+      "Do pair every verdict with a glyph and a word, plus the exit code for machine verdicts.",
+      "Do derive counts from phase-graph.mjs and toolkit-packages.mjs.",
+      "Do label authored framing \u2014 ADLC-CR-0001 and its status are illustrative and say so.",
+      "Do name limits plainly: Windows unsupported, hooks best-effort, CI the unbypassable control."
+    ],
+    "donts": [
+      "Don't round a corner, add a shadow, or reach for glass, glow, or gradient text.",
+      "Don't put terminal-bright green, red, or yellow on paper as text.",
+      "Don't use monospace for prose, or put a tracked uppercase eyebrow over every section.",
+      "Don't restyle an exhibit to match the paper around it.",
+      "Don't add a second entrance animation; the record resolves once.",
+      "Don't claim a per-phase evidence artifact the repository cannot back.",
+      "Don't invent customers, benchmarks, or logos, and don't pluralize the single public testimonial.",
+      "Don't reintroduce the rejected worlds: instrument panels, split-flap boards, near-black-plus-neon-glow, or clean enterprise-SaaS card grids."
+    ]
+  }
+}

--- a/apps/docs/.impeccable/mocks/comp-a-record-header.html
+++ b/apps/docs/.impeccable/mocks/comp-a-record-header.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Comp A — Record header leads</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wdth,wght@75..125,400..700&family=Azeret+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --ink:#171920; --ink-2:#464c5c; --ink-3:#767d8d;
+  --paper:#e7eaef; --paper-2:#f2f4f7; --paper-3:#dde1e8;
+  --rule:#c6cbd6; --rule-2:#a7aebd;
+  --ground:#1c1d21; --fg:#cbcdd2; --dim:#686b78;
+  --green:#78bd65; --yellow:#e5cd52; --blue:#4fb4d8; --orange:#ef7c2a; --red:#eb3d54;
+  --pass-ink:#2f6a22; --fail-ink:#a81d31; --gate-ink:#7a6410;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-font-smoothing:antialiased}
+body{background:var(--paper);color:var(--ink);font-family:Archivo,system-ui,sans-serif;font-variation-settings:"wdth" 100}
+.mono{font-family:"Azeret Mono",ui-monospace,monospace;font-feature-settings:"tnum" 1}
+.lbl{font-family:"Azeret Mono",monospace;font-size:9.5px;font-weight:500;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-3)}
+.wrap{max-width:1180px;margin:0 auto;padding:0 32px}
+
+/* masthead */
+.mast{background:var(--ground);color:var(--fg);border-bottom:1px solid #000}
+.mast .wrap{display:flex;align-items:center;justify-content:space-between;height:52px}
+.mark{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.14em;font-size:12.5px;font-family:"Azeret Mono",monospace}
+.mark i{display:block;width:9px;height:9px;background:var(--green);border-radius:1px}
+.nav{display:flex;gap:26px;font-size:12.5px;color:#9599a6;font-weight:500}
+.nav a{color:inherit;text-decoration:none}
+.nav a.on{color:var(--fg);box-shadow:0 9px 0 -8px var(--blue)}
+
+/* record rail */
+.rail{background:var(--paper-3);border-bottom:1px solid var(--rule-2)}
+.rail .wrap{display:flex;align-items:center;gap:0;height:34px;font-size:10px}
+.rail span{padding-right:20px;margin-right:20px;border-right:1px solid var(--rule-2);color:var(--ink-2);font-family:"Azeret Mono",monospace;letter-spacing:.1em;text-transform:uppercase}
+.rail span:last-child{border:0}
+.rail b{color:var(--ink);font-weight:600}
+.open{color:var(--gate-ink)}
+.open::before{content:"";display:inline-block;width:6px;height:6px;background:var(--yellow);border-radius:50%;margin-right:7px;vertical-align:1px}
+
+/* header block */
+.record{border-left:1px solid var(--rule);border-right:1px solid var(--rule);max-width:1180px;margin:0 auto}
+.fields{display:grid;grid-template-columns:repeat(4,1fr);border-bottom:1px solid var(--rule)}
+.f{padding:18px 24px;border-right:1px solid var(--rule)}
+.f:last-child{border-right:0}
+.f .v{margin-top:7px;font-size:14px;font-weight:500;color:var(--ink);line-height:1.35}
+.f .v.m{font-family:"Azeret Mono",monospace;font-size:13px;letter-spacing:-.01em}
+
+/* statement */
+.stmt{padding:56px 24px 44px;border-bottom:1px solid var(--rule)}
+.clause{display:flex;gap:22px;align-items:baseline}
+.cn{font-family:"Azeret Mono",monospace;font-size:11px;color:var(--ink-3);font-weight:500;padding-top:10px;white-space:nowrap}
+h1{font-size:clamp(30px,4.3vw,54px);line-height:1.02;letter-spacing:-.022em;font-weight:700;max-width:17ch;font-variation-settings:"wdth" 92}
+h1 em{font-style:normal;color:var(--ink-2);display:block;font-weight:600}
+.sub{margin-top:22px;margin-left:calc(11ch + 22px);max-width:62ch;font-size:16.5px;line-height:1.55;color:var(--ink-2)}
+.sub b{color:var(--ink);font-weight:600}
+
+/* implementation */
+.impl{display:grid;grid-template-columns:11ch 1fr 300px;border-bottom:1px solid var(--rule)}
+.impl>div{padding:22px 24px}
+.impl .c1{border-right:1px solid var(--rule);display:flex;align-items:center}
+.impl .c3{border-left:1px solid var(--rule)}
+.cmd{display:flex;align-items:stretch;border:1px solid var(--ink);background:var(--ground)}
+.cmd code{flex:1;font-family:"Azeret Mono",monospace;font-size:13.5px;color:var(--fg);padding:13px 16px;white-space:nowrap;overflow:hidden}
+.cmd code s{color:var(--green);text-decoration:none;padding-right:9px}
+.cmd button{border:0;border-left:1px solid #34363d;background:#26272c;color:var(--fg);font-family:"Azeret Mono",monospace;font-size:10px;letter-spacing:.14em;padding:0 18px;cursor:pointer}
+.note{margin-top:11px;font-size:12.5px;color:var(--ink-3);line-height:1.5}
+.note a{color:#1b6f92;text-decoration:none;border-bottom:1px solid #a9cede}
+.c3 .v{font-size:12.5px;color:var(--ink-2);line-height:1.55;margin-top:8px}
+
+/* approval chain */
+.chain{border-bottom:1px solid var(--rule)}
+.chead{display:flex;align-items:baseline;justify-content:space-between;padding:26px 24px 14px}
+.chead h2{font-size:15px;font-weight:700;letter-spacing:-.01em}
+.chead p{font-size:12.5px;color:var(--ink-3);margin-top:5px}
+table{width:100%;border-collapse:collapse}
+thead th{text-align:left;padding:9px 14px;border-top:1px solid var(--rule-2);border-bottom:1px solid var(--rule-2);background:var(--paper-3);
+  font-family:"Azeret Mono",monospace;font-size:9.5px;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-2);font-weight:500}
+tbody td{padding:11px 14px;border-bottom:1px solid var(--rule);font-size:13.5px;vertical-align:middle}
+tbody tr:hover{background:var(--paper-2)}
+td.id{font-family:"Azeret Mono",monospace;font-size:12px;color:var(--ink-3);width:44px}
+td.ph{font-weight:600;width:132px}
+td.gt{font-family:"Azeret Mono",monospace;font-size:12.5px;color:var(--ink-2)}
+td.ex{width:92px}
+td.ap{width:190px;font-size:12.5px;color:var(--ink-2)}
+td.ev{width:210px;font-family:"Azeret Mono",monospace;font-size:11.5px;color:#1b6f92}
+.code{font-family:"Azeret Mono",monospace;font-size:11px;font-weight:600;padding:2px 7px;border:1px solid;letter-spacing:.03em}
+.c0{color:var(--pass-ink);border-color:#9dc492;background:#e2efdd}
+.c2{color:var(--fail-ink);border-color:#dda3ad;background:#f7e2e5}
+.human{background:#faf3d8}
+.human:hover{background:#f7eecb}
+.human td.ap{color:var(--gate-ink);font-weight:600}
+.human td.ap::before{content:"";display:inline-block;width:6px;height:6px;background:var(--yellow);border:1px solid #b99f24;margin-right:8px;transform:rotate(45deg)}
+
+/* exhibit */
+.exhibit{padding:30px 24px 44px}
+.exh-h{display:flex;align-items:baseline;gap:14px;margin-bottom:14px}
+.exh-h b{font-family:"Azeret Mono",monospace;font-size:11px;letter-spacing:.1em;color:var(--ink)}
+.exh-h span{font-size:12.5px;color:var(--ink-3)}
+.term{background:var(--ground);border:1px solid #34363d}
+.term .bar{display:flex;justify-content:space-between;padding:9px 14px;border-bottom:1px solid #2c2e34;
+  font-family:"Azeret Mono",monospace;font-size:10px;letter-spacing:.1em;color:var(--dim)}
+.term pre{padding:16px 18px;font-family:"Azeret Mono",monospace;font-size:12.5px;line-height:1.75;color:var(--fg);overflow-x:auto}
+.term pre .p{color:var(--dim)}
+.term pre .ok{color:var(--green)}
+.term pre .no{color:var(--red)}
+.foot{padding:20px 24px 60px;font-size:12px;color:var(--ink-3);border-top:1px solid var(--rule);display:flex;justify-content:space-between}
+</style>
+</head>
+<body>
+
+<header class="mast"><div class="wrap">
+  <div class="mark"><i></i>ADLC</div>
+  <nav class="nav"><a class="on" href="#">Record</a><a href="#">Lifecycle</a><a href="#">Failure modes</a><a href="#">Toolkit</a><a href="#">Integrations</a><a href="#">Enterprise</a></nav>
+</div></header>
+
+<div class="rail"><div class="wrap">
+  <span>Record <b>ADLC-CR-0001</b></span>
+  <span class="open">Open — awaiting implementation</span>
+  <span>Control points <b>8</b></span>
+  <span>Gates <b>26</b></span>
+  <span>Human attestations <b>2</b></span>
+</div></div>
+
+<main class="record">
+
+  <section class="fields">
+    <div class="f"><div class="lbl">Subject</div><div class="v">Adopt the Agentic Development Lifecycle</div></div>
+    <div class="f"><div class="lbl">Class</div><div class="v">Process change · software delivery</div></div>
+    <div class="f"><div class="lbl">Scope</div><div class="v m">macOS · Linux · Node 18+</div></div>
+    <div class="f"><div class="lbl">Back-out</div><div class="v m">git revert · no runtime deps</div></div>
+  </section>
+
+  <section class="stmt">
+    <div class="clause">
+      <div class="cn">§1 &nbsp;STATEMENT</div>
+      <h1>The SDLC defends against human failure.<em>Your agents fail differently.</em></h1>
+    </div>
+    <p class="sub">Models fail <b>confidently, quickly, and at scale</b> — a process built for forgetting and fatigue is not adequate for hallucination and reward hacking. ADLC gives every phase an explicit exit contract: deterministic gates leave machine-checkable evidence, and two human gates record attestation.</p>
+  </section>
+
+  <section class="impl">
+    <div class="c1"><div class="lbl">§2 Implement</div></div>
+    <div>
+      <div class="cmd">
+        <code><s>$</s>curl -fsSL https://www.agenticlifecycle.ai/install.sh | sh</code>
+        <button>COPY</button>
+      </div>
+      <p class="note">Installs the toolkit and every native harness integration. Then <span class="mono" style="color:var(--ink)">adlc init</span> in your repository. Cursor and OpenCode need one manual step, which the installer prints — <a href="#">see what gets installed</a>.</p>
+    </div>
+    <div class="c3">
+      <div class="lbl">Enforcement</div>
+      <div class="v">In-session hooks are best-effort and harness-dependent. The commit-time CI gate is the unbypassable control.</div>
+    </div>
+  </section>
+
+  <section class="chain">
+    <div class="chead">
+      <div><h2>§3 &nbsp;Approval chain</h2><p>Eight control points. Each closes on an exit code, and each leaves the artifact named in the evidence column.</p></div>
+      <div class="lbl">Exit 0 pass · 1 error · 2 refused</div>
+    </div>
+    <table>
+      <thead><tr><th></th><th>Phase</th><th>Exit gate</th><th>Code</th><th>Approver</th><th>Evidence</th></tr></thead>
+      <tbody>
+        <tr><td class="id">P0</td><td class="ph">Triage</td><td class="gt">routed</td><td class="ex"><span class="code c0">0</span></td><td class="ap">adlc ticket</td><td class="ev">tickets.json</td></tr>
+        <tr class="human"><td class="id">P1</td><td class="ph">Interrogate</td><td class="gt">human gate</td><td class="ex"><span class="code c0">0</span></td><td class="ap">A person</td><td class="ev">attestation.json</td></tr>
+        <tr><td class="id">P2</td><td class="ph">Decompose</td><td class="gt">cold-start</td><td class="ex"><span class="code c0">0</span></td><td class="ap">adlc coldstart</td><td class="ev">coldstart.log</td></tr>
+        <tr><td class="id">P3</td><td class="ph">Rail</td><td class="gt">RED gate</td><td class="ex"><span class="code c2">2</span></td><td class="ap">adlc rails-guard</td><td class="ev">rails-guard.json</td></tr>
+        <tr><td class="id">P4</td><td class="ph">Build</td><td class="gt">green gate</td><td class="ex"><span class="code c0">0</span></td><td class="ap">adlc gate</td><td class="ev">gate.json</td></tr>
+        <tr><td class="id">P5</td><td class="ph">Prosecute</td><td class="gt">zero findings</td><td class="ex"><span class="code c0">0</span></td><td class="ap">adlc prosecute</td><td class="ev">findings.json</td></tr>
+        <tr class="human"><td class="id">P6</td><td class="ph">Integrate</td><td class="gt">human gate</td><td class="ex"><span class="code c0">0</span></td><td class="ap">A person</td><td class="ev">attestation.json</td></tr>
+        <tr><td class="id">P7</td><td class="ph">Distill</td><td class="gt">feeds the next run</td><td class="ex"><span class="code c0">0</span></td><td class="ap">adlc lesson-foundry</td><td class="ev">lessons.json</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="exhibit">
+    <div class="exh-h"><b>EXHIBIT 3.1</b><span>Attached to §3 · P3 · the refusal above, as it happened</span></div>
+    <div class="term">
+      <div class="bar"><span>adlc rails-guard</span><span>EXIT 2 — REFUSED</span></div>
+<pre><span class="p">$</span> adlc rails-guard --base main --ticket T42 --tickets .adlc/tickets.json
+<span class="no">✗ FAIL: a frozen rail changed</span></pre>
+    </div>
+    <div class="exh-h" style="margin-top:26px"><b>EXHIBIT 3.2</b><span>Attached to §3 · P5 · the check that answers "would review catch it?"</span></div>
+    <div class="term">
+      <div class="bar"><span>adlc review-calibration</span><span>EXIT 0 — PASS</span></div>
+<pre><span class="p">$</span> adlc review-calibration --review-cmd "adlc review --base {base}" --plants 3
+<span class="ok">✓ PASS: planted-defect recall met the configured threshold</span></pre>
+    </div>
+  </section>
+
+  <div class="foot"><span>ADLC gates this repository in its own CI. Every exhibit on this page is real output.</span><span class="mono">MIT · @adlc on npm</span></div>
+</main>
+
+</body>
+</html>

--- a/apps/docs/.impeccable/mocks/comp-b-chain-leads.html
+++ b/apps/docs/.impeccable/mocks/comp-b-chain-leads.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Comp B — Approval chain leads</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wdth,wght@75..125,400..700&family=Azeret+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --ink:#171920; --ink-2:#464c5c; --ink-3:#767d8d;
+  --paper:#e7eaef; --paper-2:#f2f4f7; --paper-3:#dde1e8;
+  --rule:#c6cbd6; --rule-2:#a7aebd;
+  --ground:#1c1d21; --fg:#cbcdd2; --dim:#686b78;
+  --green:#78bd65; --yellow:#e5cd52; --blue:#4fb4d8; --orange:#ef7c2a; --red:#eb3d54;
+  --pass-ink:#2f6a22; --fail-ink:#a81d31; --gate-ink:#7a6410;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-font-smoothing:antialiased}
+body{background:var(--paper);color:var(--ink);font-family:Archivo,system-ui,sans-serif}
+.mono{font-family:"Azeret Mono",ui-monospace,monospace;font-feature-settings:"tnum" 1}
+.lbl{font-family:"Azeret Mono",monospace;font-size:9.5px;font-weight:500;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-3)}
+.wrap{max-width:1400px;margin:0 auto;padding:0 40px}
+
+.mast{background:var(--ground);color:var(--fg)}
+.mast .wrap{display:flex;align-items:center;justify-content:space-between;height:52px}
+.mark{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.14em;font-size:12.5px;font-family:"Azeret Mono",monospace}
+.mark i{display:block;width:9px;height:9px;background:var(--green);border-radius:1px}
+.nav{display:flex;gap:26px;font-size:12.5px;color:#9599a6;font-weight:500}
+.nav a{color:inherit;text-decoration:none}
+.nav a.on{color:var(--fg);box-shadow:0 9px 0 -8px var(--blue)}
+
+/* thesis strip — one ruled line, deliberately small */
+.thesis{border-bottom:1px solid var(--rule-2);background:var(--paper-3)}
+.thesis .wrap{display:flex;align-items:center;justify-content:space-between;gap:40px;padding-top:22px;padding-bottom:22px}
+.thesis h1{font-size:clamp(17px,1.9vw,25px);font-weight:600;letter-spacing:-.017em;line-height:1.3;max-width:52ch;font-variation-settings:"wdth" 95}
+.thesis h1 span{color:var(--ink-3)}
+.cmd{display:flex;align-items:stretch;border:1px solid var(--ink);background:var(--ground);flex:0 0 auto}
+.cmd code{font-family:"Azeret Mono",monospace;font-size:12.5px;color:var(--fg);padding:11px 15px;white-space:nowrap}
+.cmd code s{color:var(--green);text-decoration:none;padding-right:8px}
+.cmd button{border:0;border-left:1px solid #34363d;background:#26272c;color:var(--fg);font-family:"Azeret Mono",monospace;font-size:9.5px;letter-spacing:.14em;padding:0 16px;cursor:pointer}
+
+/* ledger */
+.ledger{border-bottom:1px solid var(--rule-2)}
+.lhead{display:grid;grid-template-columns:58px 1fr 200px 210px 74px 200px 1fr;gap:0;
+  border-bottom:1px solid var(--rule-2);background:var(--paper-3)}
+.lhead div{padding:10px 16px;border-right:1px solid var(--rule)}
+.lhead div:last-child{border-right:0}
+.row{display:grid;grid-template-columns:58px 1fr 200px 210px 74px 200px 1fr;border-bottom:1px solid var(--rule);background:var(--paper-2)}
+.row>div{padding:15px 16px;border-right:1px solid var(--rule);display:flex;align-items:center}
+.row>div:last-child{border-right:0}
+.row:hover{background:#fff}
+.row .n{font-family:"Azeret Mono",monospace;font-size:12px;color:var(--ink-3)}
+.row .name{font-size:15.5px;font-weight:600;letter-spacing:-.012em}
+.row .gate{font-family:"Azeret Mono",monospace;font-size:12.5px;color:var(--ink-2)}
+.row .who{font-size:13px;color:var(--ink-2)}
+.row .ev{font-family:"Azeret Mono",monospace;font-size:11.5px;color:#1b6f92}
+.row .kill{font-size:12.5px;color:var(--ink-3);line-height:1.45}
+.code{font-family:"Azeret Mono",monospace;font-size:11px;font-weight:600;padding:2px 8px;border:1px solid;letter-spacing:.03em}
+.c0{color:var(--pass-ink);border-color:#9dc492;background:#e2efdd}
+.c2{color:var(--fail-ink);border-color:#dda3ad;background:#f7e2e5}
+.human{background:#faf3d8}
+.human:hover{background:#f9f0cd}
+.human .who{color:var(--gate-ink);font-weight:600}
+.human .who::before{content:"";display:inline-block;width:7px;height:7px;background:var(--yellow);border:1px solid #b99f24;margin-right:9px;transform:rotate(45deg);flex:0 0 auto}
+
+/* inline exhibit under a row */
+.inline-ex{border-bottom:1px solid var(--rule);background:var(--paper-3);padding:0}
+.inline-ex .in{display:grid;grid-template-columns:58px 1fr;}
+.inline-ex .sp{border-right:1px solid var(--rule)}
+.inline-ex .bd{padding:16px 16px 20px}
+.exh-h{display:flex;align-items:baseline;gap:12px;margin-bottom:10px}
+.exh-h b{font-family:"Azeret Mono",monospace;font-size:10.5px;letter-spacing:.1em}
+.exh-h span{font-size:12px;color:var(--ink-3)}
+.term{background:var(--ground);border:1px solid #34363d;max-width:900px}
+.term .bar{display:flex;justify-content:space-between;padding:8px 13px;border-bottom:1px solid #2c2e34;
+  font-family:"Azeret Mono",monospace;font-size:9.5px;letter-spacing:.1em;color:var(--dim)}
+.term pre{padding:14px 16px;font-family:"Azeret Mono",monospace;font-size:12.5px;line-height:1.7;color:var(--fg);overflow-x:auto}
+.term pre .p{color:var(--dim)} .term pre .ok{color:var(--green)} .term pre .no{color:var(--red)}
+
+.strip{background:var(--paper-3);border-bottom:1px solid var(--rule-2)}
+.strip .wrap{display:flex;gap:0;padding:0}
+.strip .s{flex:1;padding:20px 22px;border-right:1px solid var(--rule)}
+.strip .s:last-child{border-right:0}
+.strip .s b{display:block;font-size:22px;font-weight:700;letter-spacing:-.02em;margin-top:6px;font-family:"Azeret Mono",monospace}
+.strip .s p{font-size:12px;color:var(--ink-3);margin-top:5px;line-height:1.45}
+.foot{padding:22px 40px 60px;max-width:1400px;margin:0 auto;font-size:12px;color:var(--ink-3);display:flex;justify-content:space-between}
+</style>
+</head>
+<body>
+
+<header class="mast"><div class="wrap">
+  <div class="mark"><i></i>ADLC</div>
+  <nav class="nav"><a class="on" href="#">Record</a><a href="#">Lifecycle</a><a href="#">Failure modes</a><a href="#">Toolkit</a><a href="#">Integrations</a><a href="#">Enterprise</a></nav>
+</div></header>
+
+<section class="thesis"><div class="wrap">
+  <h1>Your agents don't fail like humans. <span>Every phase closes on an exit code, and leaves the evidence behind it.</span></h1>
+  <div class="cmd"><code><s>$</s>curl -fsSL https://www.agenticlifecycle.ai/install.sh | sh</code><button>COPY</button></div>
+</div></section>
+
+<section class="ledger">
+  <div class="lhead">
+    <div class="lbl"></div><div class="lbl">Control point</div><div class="lbl">Exit gate</div><div class="lbl">Approver</div><div class="lbl">Code</div><div class="lbl">Evidence</div><div class="lbl">Failure mode it kills</div>
+  </div>
+
+  <div class="row"><div class="n">P0</div><div class="name">Triage</div><div class="gate">routed</div><div class="who">adlc ticket</div><div><span class="code c0">0</span></div><div class="ev">tickets.json</div><div class="kill">Work that was never shaped</div></div>
+
+  <div class="row human"><div class="n">P1</div><div class="name">Interrogate</div><div class="gate">human gate</div><div class="who">A person</div><div><span class="code c0">0</span></div><div class="ev">attestation.json</div><div class="kill">Premature satisfaction · confident hallucination</div></div>
+
+  <div class="row"><div class="n">P2</div><div class="name">Decompose</div><div class="gate">cold-start</div><div class="who">adlc coldstart</div><div><span class="code c0">0</span></div><div class="ev">coldstart.log</div><div class="kill">Context rot</div></div>
+
+  <div class="row"><div class="n">P3</div><div class="name">Rail</div><div class="gate">RED gate</div><div class="who">adlc rails-guard</div><div><span class="code c2">2</span></div><div class="ev">rails-guard.json</div><div class="kill">Reward hacking</div></div>
+
+  <div class="inline-ex"><div class="in"><div class="sp"></div><div class="bd">
+    <div class="exh-h"><b>EXHIBIT P3.1</b><span>The refusal above, verbatim. Exit 2 means the gate refused — not that it errored.</span></div>
+    <div class="term"><div class="bar"><span>adlc rails-guard</span><span>EXIT 2 — REFUSED</span></div>
+<pre><span class="p">$</span> adlc rails-guard --base main --ticket T42 --tickets .adlc/tickets.json
+<span class="no">✗ FAIL: a frozen rail changed</span></pre></div>
+  </div></div></div>
+
+  <div class="row"><div class="n">P4</div><div class="name">Build</div><div class="gate">green gate</div><div class="who">adlc gate</div><div><span class="code c0">0</span></div><div class="ev">gate.json</div><div class="kill">Coherence loss</div></div>
+
+  <div class="row"><div class="n">P5</div><div class="name">Prosecute</div><div class="gate">zero findings</div><div class="who">adlc prosecute</div><div><span class="code c0">0</span></div><div class="ev">findings.json</div><div class="kill">Sycophancy · finding-count prior</div></div>
+
+  <div class="row human"><div class="n">P6</div><div class="name">Integrate</div><div class="gate">human gate</div><div class="who">A person</div><div><span class="code c0">0</span></div><div class="ev">attestation.json</div><div class="kill">Merging what nobody vouched for</div></div>
+
+  <div class="row"><div class="n">P7</div><div class="name">Distill</div><div class="gate">feeds the next run</div><div class="who">adlc lesson-foundry</div><div><span class="code c0">0</span></div><div class="ev">lessons.json</div><div class="kill">Generative bloat</div></div>
+</section>
+
+<section class="strip"><div class="wrap">
+  <div class="s"><div class="lbl">Gate CLIs</div><b>26</b><p>One dispatcher, zero runtime dependencies, Node 18+.</p></div>
+  <div class="s"><div class="lbl">Native harnesses</div><b>7</b><p>Plus a harness-neutral skills catalog for everything else.</p></div>
+  <div class="s"><div class="lbl">Exit contract</div><b>0 · 1 · 2</b><p>Pass, operational error, refused. The exit code is the contract.</p></div>
+  <div class="s"><div class="lbl">API keys required</div><b>0</b><p>Every LLM-backed gate supports --prompt-only. The agent in the room is the model.</p></div>
+</div></section>
+
+<div class="foot"><span>ADLC gates this repository in its own CI. Every exhibit on this page is real output.</span><span class="mono">MIT · @adlc on npm</span></div>
+
+</body>
+</html>

--- a/apps/docs/.impeccable/mocks/comp-c-claim-exhibit.html
+++ b/apps/docs/.impeccable/mocks/comp-c-claim-exhibit.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Comp C — Claim / exhibit split</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wdth,wght@75..125,400..700&family=Azeret+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --ink:#171920; --ink-2:#464c5c; --ink-3:#767d8d;
+  --paper:#e7eaef; --paper-2:#f2f4f7; --paper-3:#dde1e8;
+  --rule:#c6cbd6; --rule-2:#a7aebd;
+  --ground:#1c1d21; --fg:#cbcdd2; --dim:#686b78;
+  --green:#78bd65; --yellow:#e5cd52; --blue:#4fb4d8; --orange:#ef7c2a; --red:#eb3d54;
+  --pass-ink:#2f6a22; --fail-ink:#a81d31; --gate-ink:#7a6410;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-font-smoothing:antialiased}
+body{background:var(--paper);color:var(--ink);font-family:Archivo,system-ui,sans-serif}
+.mono{font-family:"Azeret Mono",ui-monospace,monospace;font-feature-settings:"tnum" 1}
+.lbl{font-family:"Azeret Mono",monospace;font-size:9.5px;font-weight:500;letter-spacing:.13em;text-transform:uppercase;color:var(--ink-3)}
+
+.mast{background:var(--ground);color:var(--fg)}
+.mast .in{display:flex;align-items:center;justify-content:space-between;height:52px;padding:0 36px}
+.mark{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.14em;font-size:12.5px;font-family:"Azeret Mono",monospace}
+.mark i{display:block;width:9px;height:9px;background:var(--green);border-radius:1px}
+.nav{display:flex;gap:26px;font-size:12.5px;color:#9599a6;font-weight:500}
+.nav a{color:inherit;text-decoration:none}
+.nav a.on{color:var(--fg);box-shadow:0 9px 0 -8px var(--blue)}
+
+/* split */
+.split{display:grid;grid-template-columns:1fr 540px;min-height:calc(100vh - 52px)}
+.left{border-right:1px solid var(--rule-2);padding:0 0 40px}
+.right{background:var(--ground);position:sticky;top:0;align-self:start;height:calc(100vh - 52px);display:flex;flex-direction:column}
+
+/* left: the record */
+.rail{display:flex;align-items:center;height:34px;border-bottom:1px solid var(--rule);background:var(--paper-3);padding:0 36px;font-size:10px}
+.rail span{padding-right:18px;margin-right:18px;border-right:1px solid var(--rule-2);color:var(--ink-2);font-family:"Azeret Mono",monospace;letter-spacing:.1em;text-transform:uppercase}
+.rail span:last-child{border:0}
+.rail b{color:var(--ink);font-weight:600}
+.pad{padding:0 36px}
+h1{margin-top:46px;font-size:clamp(28px,3.6vw,46px);line-height:1.04;letter-spacing:-.024em;font-weight:700;max-width:16ch;font-variation-settings:"wdth" 92}
+h1 em{font-style:normal;color:var(--ink-2);display:block;font-weight:600}
+.sub{margin-top:20px;max-width:56ch;font-size:16px;line-height:1.55;color:var(--ink-2)}
+.cmd{margin-top:26px;display:flex;align-items:stretch;border:1px solid var(--ink);background:var(--ground);max-width:560px}
+.cmd code{flex:1;font-family:"Azeret Mono",monospace;font-size:13px;color:var(--fg);padding:12px 15px;white-space:nowrap;overflow:hidden}
+.cmd code s{color:var(--green);text-decoration:none;padding-right:8px}
+.cmd button{border:0;border-left:1px solid #34363d;background:#26272c;color:var(--fg);font-family:"Azeret Mono",monospace;font-size:9.5px;letter-spacing:.14em;padding:0 16px;cursor:pointer}
+.note{margin-top:10px;font-size:12.5px;color:var(--ink-3);max-width:56ch;line-height:1.5}
+
+/* claims — each carries an exhibit reference */
+.claims{margin-top:44px;border-top:1px solid var(--rule-2)}
+.claim{display:grid;grid-template-columns:96px 1fr;border-bottom:1px solid var(--rule);cursor:pointer}
+.claim:hover{background:var(--paper-2)}
+.claim.on{background:#fff;box-shadow:inset 3px 0 0 var(--blue)}
+.claim .ref{padding:20px 0 20px 36px;font-family:"Azeret Mono",monospace;font-size:10.5px;color:var(--ink-3);letter-spacing:.06em}
+.claim.on .ref{color:#1b6f92;font-weight:600}
+.claim .bd{padding:20px 36px 20px 0}
+.claim h3{font-size:16px;font-weight:600;letter-spacing:-.012em;line-height:1.35}
+.claim p{margin-top:6px;font-size:13.5px;color:var(--ink-2);line-height:1.55;max-width:54ch}
+.claim .tag{margin-top:9px;display:inline-flex;align-items:center;gap:8px;font-family:"Azeret Mono",monospace;font-size:10px;letter-spacing:.08em;color:var(--ink-3)}
+.code{font-family:"Azeret Mono",monospace;font-size:10.5px;font-weight:600;padding:2px 7px;border:1px solid;letter-spacing:.03em}
+.c0{color:var(--pass-ink);border-color:#9dc492;background:#e2efdd}
+.c2{color:var(--fail-ink);border-color:#dda3ad;background:#f7e2e5}
+.cH{color:var(--gate-ink);border-color:#cbb44a;background:#faf3d8}
+
+/* right: exhibit viewer */
+.rhead{display:flex;align-items:center;justify-content:space-between;padding:0 26px;height:34px;border-bottom:1px solid #2c2e34;
+  font-family:"Azeret Mono",monospace;font-size:9.5px;letter-spacing:.13em;color:var(--dim)}
+.rbody{flex:1;padding:26px;display:flex;flex-direction:column;gap:20px;overflow:auto}
+.exh{border:1px solid #34363d}
+.exh .bar{display:flex;justify-content:space-between;padding:9px 14px;border-bottom:1px solid #2c2e34;
+  font-family:"Azeret Mono",monospace;font-size:9.5px;letter-spacing:.1em;color:var(--dim)}
+.exh .bar em{font-style:normal;color:var(--red)}
+.exh .bar em.ok{color:var(--green)}
+.exh pre{padding:15px 16px;font-family:"Azeret Mono",monospace;font-size:12.5px;line-height:1.75;color:var(--fg);white-space:pre-wrap;word-break:break-word}
+.exh pre .p{color:var(--dim)} .exh pre .ok{color:var(--green)} .exh pre .no{color:var(--red)}
+.rfoot{border-top:1px solid #2c2e34;padding:16px 26px;color:var(--dim);font-size:11.5px;line-height:1.6}
+.rfoot b{color:var(--fg);font-weight:500}
+.meta{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:#2c2e34;border:1px solid #2c2e34}
+.meta div{background:var(--ground);padding:11px 14px}
+.meta .k{font-family:"Azeret Mono",monospace;font-size:9px;letter-spacing:.13em;text-transform:uppercase;color:var(--dim)}
+.meta .v{margin-top:5px;font-family:"Azeret Mono",monospace;font-size:12px;color:var(--fg)}
+</style>
+</head>
+<body>
+
+<header class="mast"><div class="in">
+  <div class="mark"><i></i>ADLC</div>
+  <nav class="nav"><a class="on" href="#">Record</a><a href="#">Lifecycle</a><a href="#">Failure modes</a><a href="#">Toolkit</a><a href="#">Integrations</a><a href="#">Enterprise</a></nav>
+</div></header>
+
+<div class="split">
+  <div class="left">
+    <div class="rail">
+      <span>Record <b>ADLC-CR-0001</b></span>
+      <span>Control points <b>8</b></span>
+      <span>Human attestations <b>2</b></span>
+      <span>Exhibits <b>4</b></span>
+    </div>
+    <div class="pad">
+      <h1>Every claim on this page<em>carries an exhibit.</em></h1>
+      <p class="sub">The SDLC defends against human failure modes. Agents fail differently — confidently, quickly, and at scale. ADLC gives every phase an exit contract, and nothing here is asserted without the output that backs it.</p>
+      <div class="cmd"><code><s>$</s>curl -fsSL https://www.agenticlifecycle.ai/install.sh | sh</code><button>COPY</button></div>
+      <p class="note">macOS and Linux, Node 18+. Then <span class="mono" style="color:var(--ink)">adlc init</span> in your repository.</p>
+    </div>
+
+    <div class="claims">
+      <div class="claim"><div class="ref">EXHIBIT 1</div><div class="bd">
+        <h3>A spec that can't be verified doesn't pass.</h3>
+        <p>P1 refuses a ticket whose acceptance criteria name no verification method. The gate is the reason the agent can't declare victory early.</p>
+        <div class="tag"><span class="code c0">EXIT 0</span> adlc spec-lint</div>
+      </div></div>
+
+      <div class="claim on"><div class="ref">EXHIBIT 2</div><div class="bd">
+        <h3>Frozen tests are frozen. The gate refuses.</h3>
+        <p>Exit 2 is not an error — it is a refusal. When an agent edits a rail it was told not to touch, the change does not merge, and the refusal is recorded rather than argued with.</p>
+        <div class="tag"><span class="code c2">EXIT 2</span> adlc rails-guard</div>
+      </div></div>
+
+      <div class="claim"><div class="ref">EXHIBIT 3</div><div class="bd">
+        <h3>Tests that pass without testing are found and failed.</h3>
+        <p>A mutant is planted in changed code. If the suite still passes, the suite is hollow and P3 says so.</p>
+        <div class="tag"><span class="code c2">EXIT 2</span> adlc hollow-test</div>
+      </div></div>
+
+      <div class="claim"><div class="ref">EXHIBIT 4</div><div class="bd">
+        <h3>Two gates are a person, and they sign.</h3>
+        <p>Six gates are machines. P1 and P6 are people, and what they attest to is written down — the audit trail a non-engineer can read.</p>
+        <div class="tag"><span class="code cH">ATTEST</span> attestation.json</div>
+      </div></div>
+    </div>
+  </div>
+
+  <aside class="right">
+    <div class="rhead"><span>EXHIBIT 2 — ATTACHED TO P3 · RAIL</span><span>VERBATIM CAPTURE</span></div>
+    <div class="rbody">
+      <div class="exh">
+        <div class="bar"><span>adlc rails-guard</span><em>EXIT 2 — REFUSED</em></div>
+<pre><span class="p">$</span> adlc rails-guard --base main --ticket T42 --tickets .adlc/tickets.json
+<span class="no">✗ FAIL: a frozen rail changed</span></pre>
+      </div>
+
+      <div class="meta">
+        <div><div class="k">Exit code</div><div class="v">2 — refused</div></div>
+        <div><div class="k">Phase</div><div class="v">P3 · Rail</div></div>
+        <div><div class="k">Approver</div><div class="v">machine</div></div>
+        <div><div class="k">Artifact</div><div class="v">rails-guard.json</div></div>
+      </div>
+
+      <div class="exh">
+        <div class="bar"><span>adlc review-calibration</span><em class="ok">EXIT 0 — PASS</em></div>
+<pre><span class="p">$</span> adlc review-calibration --review-cmd "adlc review --base {base}" --plants 3
+<span class="ok">✓ PASS: planted-defect recall met the configured threshold</span></pre>
+      </div>
+    </div>
+    <div class="rfoot"><b>0</b> passes · <b>1</b> is an operational error · <b>2</b> means the gate refused. The exit code is the contract, which is what makes the lifecycle executable in CI rather than aspirational in a wiki.</div>
+  </aside>
+</div>
+
+</body>
+</html>

--- a/apps/docs/.impeccable/surfaces/app-home-page-tsx.md
+++ b/apps/docs/.impeccable/surfaces/app-home-page-tsx.md
@@ -1,0 +1,99 @@
+---
+version: 1
+slug: "app-home-page-tsx"
+primary_target: "app/(home)/page.tsx"
+related_targets: ["app/(home)/lifecycle/page.tsx","app/(home)/failure-modes/page.tsx","app/(home)/vs-sdlc/page.tsx","app/(home)/toolkit/page.tsx","app/(home)/integrations/page.tsx","app/(home)/enterprise/page.tsx"]
+---
+
+## Scope and mode
+
+The marketing routes: `/`, `/lifecycle`, `/failure-modes`, `/vs-sdlc`, `/toolkit`,
+`/integrations`, `/enterprise`. Mode is **Persuade**. `/docs` (Fumadocs) is out of
+scope and inherits tokens only; it keeps the dark reading surface.
+
+## Audience, job, action
+
+Two audiences, neither a funnel stage for the other. The hands-on engineer
+evaluates by installing and getting a gate to run against their own repository.
+The engineering leader evaluates whether the process is defensible — whether
+there is an audit trail a non-engineer could read. Success is an install, not a
+lead.
+
+## Proof on hand
+
+The toolkit itself (26 gate CLIs, 7 harness integrations, real commands and real
+exit codes), dogfooding in this repository's own CI, and two public testimonials
+from one person. No case studies, customers, logos, benchmarks, or time-saved
+figures exist, and none may be invented. One testimonial's legacy-project caveat
+must never be clipped.
+
+## Chosen direction — The Change Record
+
+Seed key `54a31abe`, scope `direction`, mode `persuade`, re-roll round 1,
+assigned index 3 of the grounded list. Composition A of three rendered comps,
+approved by the user.
+
+The controlled-change record: what changed, why, who assessed impact, what the
+back-out is, who approved, and what evidence was attached. It is the artifact
+that makes a change defensible rather than merely done, which is the question
+the leadership buyer has about agents. Rendered in its contemporary enterprise
+register — the controlled form as a screen — never its rubber-stamp nostalgia.
+
+**The surface inversion is the argument.** The record reads as a governed
+document on cool paper; the evidence stays true An Old Hope terminal on
+`#1c1d21`. Human-readable record, machine-produced proof. Approved explicitly by
+the user against the alternative of staying dark throughout.
+
+## Memorable moment
+
+Every claim carries a numbered exhibit, and the exhibit is real CLI output with
+a real exit code. A sentence with no exhibit reference has no standing, which
+turns "demonstrate rather than assert" from a principle being honored into
+grammar the page cannot violate.
+
+## Craft bar
+
+User-named, on the record: enterprise platform (Datadog, Snowflake, Databricks)
+and security/compliance (Vanta, Wiz, 1Password). The second group is the closer
+match — they sell attestation and audit trails to the same accountable buyer.
+
+## Rejected, and why (do not re-propose)
+
+Round 0 dealt "The Bench" (instrument panels) and "The Departure Board"
+(split-flap). Both refused by the user as too whimsical for an audience of
+enterprise engineers and the leadership accountable for what agents merge. The
+underlying flaw was in the derivation: five of seven grounded candidates were
+industrial-instrumentation objects, one material family wearing seven hats.
+Charm is the failure mode to avoid here.
+
+## Constraints that outrank taste
+
+- Palette "An Old Hope" is pinned by PRODUCT.md. It pins the palette, not how
+  boldly it is used.
+- Green pass / red fail / amber human gate, and verdicts never carried by colour
+  alone — a glyph pairs with a word (`✓ PASS` / `✗ FAIL`).
+- Motion respects `prefers-reduced-motion`.
+- Command literals import from `lib/install-commands.mjs`; never hand-typed.
+- Install renders before the first content section.
+- Windows is unsupported and must not be softened to "beta" or "experimental".
+
+## Approved comp
+
+`apps/docs/.impeccable/mocks/comp-a-record-header.html`
+
+Comps B (chain-led) and C (pinned claim/exhibit split) were rendered and not
+chosen. C's pinned evidence panel remains a candidate for `/lifecycle`.
+
+## Must not be literalized from the comp
+
+The record number `ADLC-CR-0001` and its field values are framing, not claims.
+The comp's four-column field block, its exact type sizes, and its two-exhibit
+tail are a direction test, not a spec. Responsive behavior, focus states, and
+interaction states were not resolved in the comp and are implementation
+responsibilities.
+
+## Unresolved
+
+Whether `/docs` eventually follows the record world or stays a dark reading
+surface. Deferred deliberately — redesigning Fumadocs is a separate piece of
+work.

--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -1,0 +1,363 @@
+---
+name: ADLC Marketing — The Change Record
+description: A controlled-change record on cool paper, whose evidence stays on the terminal ground that produced it.
+colors:
+  ground: "#1c1d21"
+  foreground: "#cbcdd2"
+  comment: "#686b78"
+  green: "#78bd65"
+  yellow: "#e5cd52"
+  blue: "#4fb4d8"
+  orange: "#ef7c2a"
+  red: "#eb3d54"
+  rec-paper: "#e7eaef"
+  rec-paper-raised: "#f2f4f7"
+  rec-paper-sunk: "#dde1e8"
+  rec-ink: "#171920"
+  rec-ink-2: "#464c5c"
+  rec-ink-3: "#6b7283"
+  rec-rule: "#c6cbd6"
+  rec-rule-strong: "#a7aebd"
+  rec-pass-ink: "#2f6a22"
+  rec-pass-edge: "#9dc492"
+  rec-pass-field: "#e2efdd"
+  rec-fail-ink: "#a81d31"
+  rec-fail-edge: "#dda3ad"
+  rec-fail-field: "#f7e2e5"
+  rec-gate-ink: "#6f5a0d"
+  rec-gate-edge: "#cbb44a"
+  rec-gate-field: "#faf3d8"
+  rec-link: "#17627f"
+  rec-link-edge: "#a9cede"
+  exhibit-border: "#34363d"
+  exhibit-rule: "#2c2e34"
+  terminal-nav: "#9599a6"
+  terminal-muted: "#9093a0"
+  terminal-link-edge: "#2b5f74"
+  terminal-edge: "#000000"
+typography:
+  statement:
+    fontFamily: "Archivo, system-ui, sans-serif"
+    fontSize: "clamp(30px, 4.3vw, 54px)"
+    fontWeight: 700
+    lineHeight: 1.02
+    letterSpacing: "-0.022em"
+  clause-title:
+    fontFamily: "Archivo, system-ui, sans-serif"
+    fontSize: "clamp(19px, 2.1vw, 26px)"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.018em"
+  lede:
+    fontFamily: "Archivo, system-ui, sans-serif"
+    fontSize: "16.5px"
+    fontWeight: 400
+    lineHeight: 1.55
+    letterSpacing: "normal"
+  row-title:
+    fontFamily: "Archivo, system-ui, sans-serif"
+    fontSize: "15px"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "-0.012em"
+  metric:
+    fontFamily: "Archivo, system-ui, sans-serif"
+    fontSize: "22px"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "-0.02em"
+  body:
+    fontFamily: "Archivo, system-ui, sans-serif"
+    fontSize: "13.5px"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  caption:
+    fontFamily: "Azeret Mono, ui-monospace, monospace"
+    fontSize: "11px"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "0.1em"
+  chip:
+    fontFamily: "Azeret Mono, ui-monospace, monospace"
+    fontSize: "10.5px"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "0.03em"
+  legend:
+    fontFamily: "Azeret Mono, ui-monospace, monospace"
+    fontSize: "9.5px"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "0.13em"
+  identifier:
+    fontFamily: "Azeret Mono, ui-monospace, monospace"
+    fontSize: "12.5px"
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  evidence:
+    fontFamily: "Azeret Mono, ui-monospace, monospace"
+    fontSize: "12.5px"
+    fontWeight: 400
+    lineHeight: 1.75
+    letterSpacing: "normal"
+rounded:
+  none: "0px"
+spacing:
+  hairline: "1px"
+  cell-x: "12px"
+  cell-y: "14px"
+  field: "18px 24px"
+  clause-y: "48px"
+  gutter: "104px"
+components:
+  install-field:
+    backgroundColor: "{colors.ground}"
+    textColor: "{colors.foreground}"
+    typography: "{typography.identifier}"
+    rounded: "{rounded.none}"
+    padding: "12px 16px"
+  install-field-copy:
+    backgroundColor: "#26272c"
+    textColor: "{colors.foreground}"
+    typography: "{typography.legend}"
+    rounded: "{rounded.none}"
+    padding: "0 16px"
+  exit-code-pass:
+    backgroundColor: "{colors.rec-pass-field}"
+    textColor: "{colors.rec-pass-ink}"
+    typography: "{typography.chip}"
+    rounded: "{rounded.none}"
+    padding: "2px 6px"
+  exit-code-fail:
+    backgroundColor: "{colors.rec-fail-field}"
+    textColor: "{colors.rec-fail-ink}"
+    typography: "{typography.chip}"
+    rounded: "{rounded.none}"
+    padding: "2px 6px"
+  exit-code-attest:
+    backgroundColor: "{colors.rec-gate-field}"
+    textColor: "{colors.rec-gate-ink}"
+    typography: "{typography.chip}"
+    rounded: "{rounded.none}"
+    padding: "2px 6px"
+  chain-row:
+    backgroundColor: "{colors.rec-paper-raised}"
+    textColor: "{colors.rec-ink}"
+    rounded: "{rounded.none}"
+    padding: "14px 12px"
+  chain-row-human:
+    backgroundColor: "{colors.rec-gate-field}"
+    textColor: "{colors.rec-gate-ink}"
+    rounded: "{rounded.none}"
+    padding: "14px 12px"
+  exhibit:
+    backgroundColor: "{colors.ground}"
+    textColor: "{colors.foreground}"
+    typography: "{typography.evidence}"
+    rounded: "{rounded.none}"
+    padding: "14px 16px"
+---
+
+# Design System: ADLC Marketing
+
+## Overview
+
+**North star: The Change Record.**
+
+The marketing surfaces are one controlled-change record. In an enterprise nothing
+reaches production without a record of what changed, why, who assessed the impact,
+what the back-out is, who approved it, and what evidence was attached — and that
+record is what makes a change *defensible* rather than merely done. That is the
+question ADLC's buyer has about agents, so the site is not a page describing the
+product; it is the record for adopting it.
+
+The system has two surfaces and the split between them carries the argument:
+
+- **The record is paper.** Cool, desaturated, ruled, squared, fixed fields and
+  numbered clauses. This is what a person reads and what a non-engineer could
+  audit.
+- **The evidence is terminal.** Real gate output on `#1c1d21` in the unmodified
+  An Old Hope palette. This is what a machine produced.
+
+Evidence is never restyled to match the page around it. The contrast is the point.
+
+Voice is evidence-first and never promotional; over-claiming is treated as a
+defect here, not a stylistic preference. The register is deliberately corporate
+and unwhimsical: the audience is engineers and the leadership accountable for what
+agents merge, and charm reads as the opposite of defensible.
+
+**Confirmed anti-references.** Rejected during direction selection and not to be
+revisited: instrument panels and oscilloscopes, split-flap departure boards, and
+anything else whose primary register is charm. Also refused: near-black with one
+neon accent and glow (the incumbent world this replaced), and the clean
+enterprise-SaaS default of white/slate with a blue accent over a card grid.
+
+## Colors
+
+**Strategy: two committed fields, not accents on neutral.** Paper owns the record;
+the terminal ground owns evidence, the masthead, and the primary control. Colour
+is never sprinkled — a hue appears because it is a verdict, a link, or the brand
+mark.
+
+`An Old Hope` is a pinned brand commitment (PRODUCT.md) and is the authority for
+the terminal side. The paper is derived *from* it: `#e7eaef` is the palette's own
+foreground desaturated up, never a borrowed warm cream, because An Old Hope is a
+cool scheme and the record must belong to it.
+
+**Verdict colour is doubled, never sole.** Every verdict pairs a glyph with a word
+(`✓ PASS`, `✗ FAIL`, `◆ ATTEST`), and machine verdicts carry the exit code, because
+the exit code is the actual contract. This is a binding accessibility commitment,
+not a preference.
+
+**The terminal side has its own neutrals.** Paper inks are unreadable on
+`#1c1d21`, so anything rendered on the terminal ground draws from
+`foreground` (#cbcdd2), `terminal-nav` (#9599a6, masthead links),
+`terminal-muted` (#9093a0, body copy on the evidence band), `comment` (#686b78,
+prompts and dimmed notes), and `terminal-link-edge` (#2b5f74, the underline on a
+link over dark). `terminal-edge` (#000) is the single hard rule where the record
+meets the evidence band. Never reach for a `rec-*` ink on the terminal.
+
+Verdict hues exist twice: the An Old Hope originals on the terminal, and darkened
+inks (`rec-pass-ink`, `rec-fail-ink`, `rec-gate-ink`) that clear 4.5:1 on paper.
+Never put the terminal-bright green, red, or yellow on paper as text.
+
+**Semantics are fixed:** green passes, red refuses, amber is the human gate.
+Orange is reserved for the failure register's F-identifiers (`#b4571a` on paper).
+Blue is links only.
+
+## Typography
+
+**Archivo** sets the record, **Azeret Mono** sets the machine.
+
+Archivo is a grotesque out of documentary and industrial printing and carries a
+width axis, which is what lets the statement run at panel scale without importing
+a second display face. `wdth: 92` is used only on the statement and interior page
+leads.
+
+Azeret Mono is not a costume for "technical." It appears where the content is an
+identifier, an exit code, a filename, a command, a field legend, or captured
+output — measurement and code, never prose.
+
+The ramp is a real hierarchy: statement (30–54px), clause title (19–26px), lede
+(16.5px), row title (15px), body (13.5px). Legends sit at 9.5px with `0.13em`
+tracking; caption (11px) numbers exhibits and labels controls, and chip (10.5px)
+sets the verdict chips. **Row title is the workhorse** — it names the subject of a row in every
+register (approval chain, failure map, rollout schedule, harness list, dial
+settings), and it is the one step that carries semibold weight at small size.
+Metric (22px) is reserved for a bare count standing alone in a cell. Tracking never passes −0.04em; the statement sits at −0.022em.
+
+Prose measure stays at 72–74ch. Display type is NOT held to a prose measure: a heading only needs to avoid one absurdly long line, so statements cap at 26ch and clause titles at 34ch. Capping a heading at prose width forces a short sentence into four ragged lines and strands the right half of the column. Numerals in prose are spelled out; numerals in
+cells are tabular (`font-feature-settings: 'tnum'`).
+
+## Layout
+
+One ruled column, `max-width: 1180px`, with visible left and right rules that run
+continuously down the page — the record is a bounded document, not a series of
+floating sections.
+
+**The clause is the unit.** Every section is a clause: a numbered label in a
+104px left gutter, content in the measure beside it, an optional 260px aside
+divided by a rule. Clause numbering is the form's own grammar, not decoration —
+exhibits reference the clause they attach to.
+
+**Tables have fixed columns that never move.** Below `md` they collapse to a
+two-column stack, with the identifier and name on the first line and the
+remaining fields below, rather than scrolling sideways.
+
+Density is paced deliberately: airy statement → medium control → dense chain →
+dense register → the full-bleed evidence band → compact list → quiet economics
+passage. A dense passage earns a quiet one. More space sits above a heading than
+below it.
+
+The evidence band is the page's one full-bleed moment and its only tonal break.
+
+## Elevation & Depth
+
+**Flat by law.** Elevation is declared once, as a 1px rule, and never as a shadow.
+There are no shadows, no glass, no blur, and no glow anywhere in the system. A
+ruled document gets its authority from precision and alignment, and a soft shadow
+under a hairline would be the ghost card.
+
+Grouping is expressed three ways only: a hairline rule, a `gap-px` lattice over a
+rule-coloured container, or a shift between the three paper tones (`rec-paper`,
+`rec-paper-raised`, `rec-paper-sunk`).
+
+## Shapes
+
+**Radius is zero, everywhere.** No pills, no rounded cards, no rounded buttons.
+Package names are squared cells in a lattice because a pill is a control and those
+are line items.
+
+Two marks carry shape meaning and must stay distinguishable without colour: the
+**human gate** is a rotated square (a diamond), the **machine gate** is an open
+ring. The masthead brand mark is a 9px green square — the one place pass-green is
+identity rather than verdict. The only circle in the system is the 6px status lamp
+in the record rail.
+
+## Components
+
+**Install command — the record's primary control.** Not a call-to-action button
+beside the copy: it is the value of the IMPLEMENTATION field, so it renders as the
+form's executable field — squared, 1px ink border, on the terminal ground, with a
+`$` in pass-green and a COPY control divided by a rule. It wraps on narrow screens
+rather than scrolling, because a visitor who cannot see the whole command cannot
+verify what they are about to pipe to `sh`. The command is always rendered
+server-side and always imported from `lib/install-commands.mjs`.
+
+**Exhibit.** A verbatim capture with a number and the clause it attaches to.
+Header strip carries the command and the exit status; the body is real output.
+Prompts dim to `comment`; verdict lines keep glyph, word, and hue.
+
+**Approval chain.** One row per control point: identifier, name, exit gate,
+approver, verdict. Human gates are the rows whose approver is a person — marked by
+the amber field, the diamond, and the word, so the exception is structural rather
+than chromatic.
+
+**Attestation block.** The record ends in signatures. The two human gates render as
+signature panels with a ruled signature line and `SIGNED BY A PERSON`. This is the
+system's most load-bearing device for the leadership reader and must not be
+demoted back into a table cell.
+
+**Masthead.** Stays on the terminal ground on every route — the hard top edge that
+keeps the record attached to the world that produced it.
+
+**Motion — one authored moment.** The record resolves: chain rows settle in
+sequence at 32ms intervals and each verdict stamps in just after its row. It plays
+once on load and holds. There is no second animation anywhere in the system;
+scattered hover effects and per-section entrances are not part of it. Everything
+honours `prefers-reduced-motion`, which is a binding commitment.
+
+**Print.** The record prints as a document: ink on white, rules preserved, nav
+dropped, animation disabled.
+
+## Do's and Don'ts
+
+**Do**
+
+- Attach an exhibit to every claim about what the toolkit does. Argument may be
+  argument; capability may not.
+- Keep evidence on the terminal ground wherever it appears, including on paper.
+- Pair every verdict with a glyph and a word, and carry the exit code for machine
+  verdicts.
+- Derive counts from the data modules (`phase-graph.mjs`, `toolkit-packages.mjs`)
+  rather than typing them.
+- Label authored framing. `ADLC-CR-0001` and its status are illustrative and say so
+  on the page.
+- Name limits plainly: Windows is unsupported, in-session hooks are best-effort,
+  the CI gate is the unbypassable control.
+
+**Don't**
+
+- Don't round a corner, add a shadow, or reach for glass, glow, or gradient text.
+- Don't put terminal-bright green, red, or yellow on paper as text.
+- Don't use monospace for prose, or a tracked uppercase eyebrow over every
+  section — the clause label is the form's grammar and an eyebrow is not.
+- Don't restyle an exhibit to match the paper around it.
+- Don't add a second entrance animation; the record resolves once.
+- Don't claim a per-phase evidence artifact the repository cannot back. The chain
+  deliberately has no evidence column for exactly this reason; the manifest is
+  named once instead.
+- Don't invent customers, benchmarks, logos, or time-saved figures, and don't
+  pluralize the single public testimonial.

--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -15,7 +15,7 @@ colors:
   rec-paper-sunk: "#dde1e8"
   rec-ink: "#171920"
   rec-ink-2: "#464c5c"
-  rec-ink-3: "#6b7283"
+  rec-ink-3: "#5a616f"
   rec-rule: "#c6cbd6"
   rec-rule-strong: "#a7aebd"
   rec-pass-ink: "#2f6a22"
@@ -35,6 +35,13 @@ colors:
   terminal-muted: "#9093a0"
   terminal-link-edge: "#2b5f74"
   terminal-edge: "#000000"
+  print-paper: "#ffffff"
+  print-paper-sunk: "#f4f4f4"
+  print-ink: "#000000"
+  print-ink-2: "#333333"
+  print-ink-3: "#555555"
+  print-rule: "#999999"
+  print-rule-strong: "#444444"
 typography:
   statement:
     fontFamily: "Archivo, system-ui, sans-serif"

--- a/apps/docs/PRODUCT.md
+++ b/apps/docs/PRODUCT.md
@@ -1,0 +1,153 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Two primary audiences, served deliberately rather than as an unresolved split.
+
+**The hands-on engineer.** Already working inside an agent harness — Claude Code,
+Codex, Cursor, OpenCode, pi, Antigravity, or Copilot — and losing time to agent
+failure modes: confident hallucination, premature satisfaction, context rot,
+tests that pass without testing. Evaluates by installing and getting a gate to
+run against their own repository. Adopts bottom-up.
+
+**The engineering leader.** Lead, staff engineer, or director accountable for
+what agents merge. Evaluates whether the process is defensible — whether there
+is an audit trail a non-engineer could read. Buys top-down.
+
+Both paths are real and neither is a funnel stage for the other. The site must
+serve both without diluting either.
+
+## Product Purpose
+
+ADLC is a software lifecycle rebuilt around the ways AI models fail, plus the
+toolkit that enforces it. Eight phases, P0–P7, each ending in an explicit exit
+contract: deterministic gates leave machine-checkable evidence, and two human
+gates record attestation.
+
+**Success is an install** — someone runs the one-line installer and gets a gate
+passing in their own repository. The enterprise contact path exists and is
+wired to a real pipeline, but adoption is the metric, not lead volume.
+
+## Positioning
+
+The SDLC defends against *human* failure modes: forgetting, fatigue, ambiguity,
+turnover. Agents fail differently — they fail confidently, quickly, and at
+scale. ADLC's claim is that a process built for one is not adequate for the
+other.
+
+The mechanism a neighbouring product could not truthfully copy: every gate is a
+**zero-dependency CLI whose exit code is the contract** — `0` passes, `1` is an
+operational error, `2` means the gate refused. That makes the lifecycle
+executable in CI rather than aspirational in a wiki. Every LLM-backed gate also
+supports `--prompt-only`, so the whole thing runs with no API keys: the agent
+already in the room is the model.
+
+## Operating Context
+
+Adopters work in a terminal, inside an agent harness, on a git repository with
+CI. The lifecycle attaches to artifacts they already have: tickets, specs,
+branches, pull requests, workflow files, and review.
+
+Two enforcement layers, and the distinction is load-bearing in every
+explanation: in-session hooks are best-effort and harness-dependent, while the
+commit-time CI gate is the unbypassable control. Marketing must never present
+the in-session layer as the guarantee.
+
+## Capabilities and Constraints
+
+- 26 gate CLIs behind one dispatcher (`adlc <tool>`), zero runtime dependencies,
+  Node 18+.
+- Seven native harness integrations, plus a harness-neutral skills.sh catalog
+  that installs **skills only** — no hooks, MCP, agents, or rail enforcement.
+- One-line installer at `agenticlifecycle.ai/install.sh` (macOS and Linux).
+- **Windows is not supported.** A `windows-latest` CI run passed 6 of 28 core
+  suites. Tracked in issue #352. Do not soften this to "beta" or "experimental".
+- `adlc fleet` is POSIX-only by design.
+- Published under the `@adlc` npm scope, MIT, via OIDC trusted publishing with a
+  human approval gate.
+- **Open:** substantial merged work is unreleased — as of 2026-07-27 the npm
+  packages sit at 1.6.0 while main carries 47 commits beyond that tag, including
+  the entire Copilot harness. Any claim about a shipped capability must be
+  checked against the *published* version, not the repository.
+
+## Brand Commitments
+
+- Name: ADLC / the Agentic Development Lifecycle. Site: www.agenticlifecycle.ai.
+- Author: Chris Williams (@voodootikigod).
+- Origin: the essay series at voodootikigod.com/series/adlc. The site is the
+  argument's storefront; the essays are its source.
+- **Voice: evidence-first and specific, never promotional.** The repository
+  encodes this as a documented obligation (ADR-0009 Decision 4): document only
+  the coverage a channel actually has. Over-claiming is treated as a defect,
+  not a stylistic preference.
+- Terminology is fixed and meaningful: *gate*, *rail*, *prosecute*, *evidence*,
+  *attestation*, *phase*. Do not swap these for softer synonyms.
+- **Palette: "An Old Hope", binding.** A terminal colour scheme and a deliberate
+  Star Wars nod, chosen by the author and already implemented in
+  `lib/an-old-hope-shiki.ts` and the CSS tokens. Canonical values in use:
+  ground `#1c1d21`, foreground `#cbcdd2`, comment `#686b78`, green `#78bd65`,
+  yellow `#e5cd52`, blue `#4fb4d8`, orange `#ef7c2a`, red `#eb3d54`. Future
+  visual work keeps this palette; the linked public gist is an iTerm variant
+  whose background differs, so the repository implementation is the authority.
+  Recorded as a constraint only — it pins the palette, not how boldly it is used.
+
+## Evidence on Hand
+
+**Usable, real, and citable:**
+
+- **The toolkit itself.** 26 published packages, seven harness integrations,
+  genuine CLI output and exit codes. The homepage terminal cards already
+  demonstrate rather than assert.
+- **Dogfooding.** ADLC gates its own repository: rails-guard on frozen paths,
+  cross-model attestation on trust-root changes, a mutation gate that refuses to
+  report a kill rate when the baseline is red. This is verifiable in CI logs.
+- **Two public testimonials**, both from Mykola (@mykola, "Myk is Walking
+  Backwards"), unsolicited on X:
+  - 14 Jul 2026 — "I was rolling so much of this by hand per project, this gives
+    me such a clean reliable workflow and seems to keep claude well-focused!
+    Thanks for this work, first time I read it I thought 'finally! someone
+    shipped the missing piece!'" (637 views)
+  - 21 Jul 2026 — "I've been enjoying this as a workflow… it works as it goes to
+    identify dependencies and puts in guardrails to prevent conflicts and bad
+    merges." (18 views)
+
+    **Carries a caveat that must not be clipped away:** the same post says "I'm
+    not sure how it would do introduced into a legacy project." Greenfield
+    adoption is the evidenced case; legacy-repo adoption is not.
+
+**Absences future work must not fill with invention:**
+
+- No case studies, named customer companies, or logos.
+- No benchmarks, performance numbers, or time-saved figures.
+- No adoption scale. Public GitHub metrics as of 21 Jul 2026 were 9 stars, 3
+  contributors, 2 forks. Do not cite, round, or imply scale beyond this, and do
+  not describe the project as widely adopted.
+- One person has given testimony. Do not pluralize it into "teams" or "users".
+
+## Product Principles
+
+1. **A claim ships only with something that backs it.** If the code cannot do
+   it, the page does not say it — including in the interim while a release is
+   pending.
+2. **Demonstrate rather than assert.** Real commands, real exit codes, real
+   evidence trails beat adjectives.
+3. **Adoption is a passing gate, not a signup.** Every surface should shorten
+   the path to a gate running in the visitor's own repository.
+4. **Two audiences, one truth.** The engineer and the leader need different
+   entry points to the same honest account, not two different stories.
+5. **Name the limits.** Unsupported platforms, best-effort layers, and missing
+   proof are stated plainly. Credibility is the product's main asset.
+
+## Accessibility & Inclusion
+
+No externally mandated standard was established. Two existing commitments in the
+implementation are binding going forward: motion respects
+`prefers-reduced-motion` (the `mk-gate-line` guard in global.css), and gate
+verdicts are never carried by colour alone — they pair a glyph with a word
+(`✓ PASS` / `✗ FAIL`), which future gate and status treatments must preserve.

--- a/apps/docs/app/(home)/enterprise/contact-form.tsx
+++ b/apps/docs/app/(home)/enterprise/contact-form.tsx
@@ -65,25 +65,29 @@ export function ContactForm() {
   if (status === 'success') {
     return (
       <div
-        className="max-w-xl rounded-lg border p-6"
-        style={{ borderColor: '#3f4044', background: '#26272c' }}
+        className="max-w-xl border p-6"
+        style={{ borderColor: 'var(--rec-rule-strong)', background: 'var(--rec-paper-raised)' }}
       >
-        <p className="font-semibold" style={{ color: '#4fb4d8' }}>
+        <p className="rec-legend" style={{ color: 'var(--rec-pass-ink)' }}>
+          ✓ Received
+        </p>
+        <p className="mt-2 text-[15px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
           Thanks, your message is in.
         </p>
-        <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+        <p className="mt-2 text-[13.5px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
           We read every enterprise inquiry ourselves and reply within a couple of business days.
         </p>
       </div>
     );
   }
 
+  // Squared, ruled fields on raised paper: a record's form is filled in, not
+  // a dark app input floating on a document.
   const inputStyle = {
-    borderColor: '#3f4044',
-    background: '#1c1d21',
-    color: '#cbcdd2',
+    borderColor: 'var(--rec-rule-strong)',
+    background: 'var(--rec-paper-raised)',
+    color: 'var(--rec-ink)',
   };
-  const labelStyle = { color: 'var(--mk-muted)' };
 
   return (
     <form onSubmit={onSubmit} className="max-w-xl" noValidate>
@@ -101,7 +105,7 @@ export function ContactForm() {
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label htmlFor="name" className="block text-sm font-medium" style={labelStyle}>
+          <label htmlFor="name" className="rec-legend block">
             Name
           </label>
           <input
@@ -109,13 +113,13 @@ export function ContactForm() {
             name="name"
             type="text"
             required
-            className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+            className="mt-1 w-full border px-3 py-2 text-[14px]"
             style={inputStyle}
           />
-          {fields.name ? <p className="mt-1 text-xs" style={{ color: '#f2788a' }}>{fields.name}</p> : null}
+          {fields.name ? <p className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>{fields.name}</p> : null}
         </div>
         <div>
-          <label htmlFor="email" className="block text-sm font-medium" style={labelStyle}>
+          <label htmlFor="email" className="rec-legend block">
             Work email
           </label>
           <input
@@ -123,28 +127,28 @@ export function ContactForm() {
             name="email"
             type="email"
             required
-            className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+            className="mt-1 w-full border px-3 py-2 text-[14px]"
             style={inputStyle}
           />
-          {fields.email ? <p className="mt-1 text-xs" style={{ color: '#f2788a' }}>{fields.email}</p> : null}
+          {fields.email ? <p className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>{fields.email}</p> : null}
         </div>
       </div>
 
       <div className="mt-4">
-        <label htmlFor="company" className="block text-sm font-medium" style={labelStyle}>
+        <label htmlFor="company" className="rec-legend block">
           Company <span style={{ opacity: 0.6 }}>(optional)</span>
         </label>
         <input
           id="company"
           name="company"
           type="text"
-          className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+          className="mt-1 w-full border px-3 py-2 text-[14px]"
           style={inputStyle}
         />
       </div>
 
       <div className="mt-4">
-        <label htmlFor="message" className="block text-sm font-medium" style={labelStyle}>
+        <label htmlFor="message" className="rec-legend block">
           What are you rolling out?
         </label>
         <textarea
@@ -152,16 +156,16 @@ export function ContactForm() {
           name="message"
           required
           rows={5}
-          className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+          className="mt-1 w-full border px-3 py-2 text-[14px]"
           style={inputStyle}
         />
-        {fields.message ? <p className="mt-1 text-xs" style={{ color: '#f2788a' }}>{fields.message}</p> : null}
+        {fields.message ? <p className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>{fields.message}</p> : null}
       </div>
 
       {status === 'error' && errorMsg ? (
-        <p className="mt-4 text-sm" style={{ color: '#f2788a' }}>
+        <p className="mt-4 text-sm" style={{ color: 'var(--rec-fail-ink)' }}>
           {errorMsg}{' '}
-          <a href={MAILTO} className="underline" style={{ color: '#4fb4d8' }}>
+          <a href={MAILTO} className="underline" style={{ color: 'var(--rec-link)' }}>
             Email us instead
           </a>
           .
@@ -172,22 +176,22 @@ export function ContactForm() {
         <button
           type="submit"
           disabled={status === 'submitting'}
-          className="rounded-md px-5 py-2.5 font-medium transition-opacity hover:opacity-90 disabled:opacity-60"
-          style={{ background: '#4fb4d8', color: '#1c1d21' }}
+          className="rec-mono px-5 py-2.5 text-[11px] tracking-[0.14em] transition-opacity hover:opacity-90 disabled:opacity-60"
+          style={{ background: '#1c1d21', color: '#cbcdd2', border: '1px solid var(--rec-ink)' }}
         >
-          {status === 'submitting' ? 'Sending…' : 'Send message'}
+          {status === 'submitting' ? 'SENDING…' : 'SEND MESSAGE'}
         </button>
-        <span className="text-sm" style={{ color: 'var(--mk-muted)' }}>
+        <span className="text-sm" style={{ color: 'var(--rec-ink-2)' }}>
           Prefer email?{' '}
-          <a href={MAILTO} className="underline" style={{ color: '#4fb4d8' }}>
+          <a href={MAILTO} className="underline" style={{ color: 'var(--rec-link)' }}>
             help@agenticlifecycle.ai
           </a>
         </span>
       </div>
 
-      <p className="mt-4 text-xs" style={{ color: 'var(--mk-muted)' }}>
+      <p className="mt-4 text-xs" style={{ color: 'var(--rec-ink-2)' }}>
         We use your details only to respond to this inquiry. See our{' '}
-        <a href="/privacy" className="underline" style={{ color: '#4fb4d8' }}>
+        <a href="/privacy" className="underline" style={{ color: 'var(--rec-link)' }}>
           privacy policy
         </a>
         .

--- a/apps/docs/app/(home)/enterprise/page.tsx
+++ b/apps/docs/app/(home)/enterprise/page.tsx
@@ -18,8 +18,8 @@ const ROLLOUT = [
 export default function EnterprisePage() {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker="Enterprise" title="Unreviewable agent output is an audit problem">
-        <p className="mk-fade-up max-w-2xl text-lg" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="1" headingLevel={1} kicker="Enterprise" title="Unreviewable agent output is an audit problem">
+        <p className="max-w-[72ch] text-[16.5px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
           When agents write most of the code, &ldquo;a human approved the PR&rdquo; stops being
           evidence of anything. Regulators, auditors, and your own security team will ask what
           the approval was based on. ADLC gives you an answer: a gate-by-gate evidence trail,
@@ -27,9 +27,9 @@ export default function EnterprisePage() {
         </p>
       </MarketingSection>
 
-      <MarketingSection kicker="The evidence" title="From ticket to merge, every verdict recorded">
+      <MarketingSection n="2" kicker="The evidence" title="From ticket to merge, every verdict recorded">
         <EvidenceTrail />
-        <div className="mt-8 flex flex-wrap items-center gap-3 text-sm" style={{ color: 'var(--mk-muted)' }}>
+        <div className="mt-8 flex flex-wrap items-center gap-3 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
           <span>Every gate emits</span>
           <GateBadge state="pass" />
           <GateBadge state="fail" />
@@ -38,26 +38,31 @@ export default function EnterprisePage() {
         </div>
       </MarketingSection>
 
-      <MarketingSection kicker="Rollout" title="Pilot → rails → org-wide">
-        <div className="grid gap-4 md:grid-cols-3">
+      <MarketingSection n="3" kicker="Rollout" title="Pilot → rails → org-wide">
+        {/* A rollout schedule, not three cards. Same-size cards of number +
+            heading + text are the lazy page scaffold; a staged rollout is a
+            sequence, and the record writes a sequence as ruled stages. */}
+        <ol style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
           {ROLLOUT.map((r, i) => (
-            <div
+            <li
               key={r.phase}
-              className="rounded-lg border p-5"
-              style={{ borderColor: '#3f4044', background: '#26272c' }}
+              className="grid grid-cols-1 gap-x-6 px-1 py-4 md:grid-cols-[52px_170px_minmax(0,1fr)]"
+              style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
             >
-              <p className="font-mono text-[10px] tracking-[0.2em]" style={{ color: 'var(--mk-muted)' }}>
-                {String(i + 1).padStart(2, '0')}
-              </p>
-              <p className="mt-1 font-semibold" style={{ color: '#4fb4d8' }}>{r.phase}</p>
-              <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>{r.detail}</p>
-            </div>
+              <span className="rec-legend px-2 pt-1">Stage {i + 1}</span>
+              <span className="px-2 text-[15px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+                {r.phase}
+              </span>
+              <span className="px-2 text-[14px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
+                {r.detail}
+              </span>
+            </li>
           ))}
-        </div>
+        </ol>
       </MarketingSection>
 
-      <MarketingSection kicker="Talk to us" title="Doing agentic development right?">
-        <p className="max-w-2xl" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="4" kicker="Talk to us" title="Doing agentic development right?">
+        <p className="max-w-[72ch]" style={{ color: 'var(--rec-ink-2)' }}>
           If you&apos;re rolling agentic development out across an organization and want it
           gated, auditable, and defensible, get in touch. Tell us what you&apos;re rolling out
           and we&apos;ll reply within a couple of business days. Prefer email? Reach us directly
@@ -65,7 +70,7 @@ export default function EnterprisePage() {
           <a
             href="mailto:help@agenticlifecycle.ai?subject=ADLC%20enterprise"
             className="underline"
-            style={{ color: '#4fb4d8' }}
+            style={{ color: 'var(--rec-link)' }}
           >
             help@agenticlifecycle.ai
           </a>

--- a/apps/docs/app/(home)/failure-modes/page.tsx
+++ b/apps/docs/app/(home)/failure-modes/page.tsx
@@ -11,14 +11,14 @@ export const metadata: Metadata = {
 export default function FailureModesPage() {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker="The problem" title="Every defense traces to a failure mode">
-        <p className="mb-10 max-w-2xl" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="1" headingLevel={1} kicker="The problem" title="Every defense traces to a failure mode">
+        <p className="mb-10 max-w-[72ch]" style={{ color: 'var(--rec-ink-2)' }}>
           ADLC has one design rule: if a gate can&apos;t name the model failure mode it
           defends against, it gets cut. Here is the full map.
         </p>
         <FailureMap />
-        <p className="mt-8 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <a href={theoryLink('F1')} style={{ color: '#4fb4d8' }}>Read the original essay ↗</a>
+        <p className="mt-8 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
+          <a href={theoryLink('F1')} style={{ color: 'var(--rec-link)' }}>Read the original essay ↗</a>
         </p>
       </MarketingSection>
     </main>

--- a/apps/docs/app/(home)/integrations/page.tsx
+++ b/apps/docs/app/(home)/integrations/page.tsx
@@ -20,93 +20,114 @@ export const metadata: Metadata = {
 export default function IntegrationsPage() {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker="Integrations" title="Install it now">
-        <p className="mb-8 max-w-2xl leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="1" headingLevel={1} kicker="Integrations" title="Install it now">
+        <p className="mb-8 max-w-[72ch] leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
           One command installs the gate toolkit and the native ADLC integration for
           each agent harness it finds on your machine. Harnesses you don&apos;t have
           are left alone. Requires Node 18+.
         </p>
-        <div className="flex flex-col gap-4 lg:max-w-2xl">
+        <div className="flex flex-col gap-4 lg:max-w-[72ch]">
           <InstallCommand command={UNIVERSAL_INSTALL} label="macOS / Linux" />
         </div>
-        <p className="mt-6 max-w-2xl text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-          Then <code style={{ color: '#4fb4d8' }}>cd</code> into a repo and run{' '}
-          <code style={{ color: '#4fb4d8' }}>adlc init</code>. Two exceptions the
-          installer will tell you about: <strong style={{ color: '#cbcdd2' }}>Cursor</strong>{' '}
+        <p className="mt-6 max-w-[72ch] text-sm leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
+          Then <code style={{ color: 'var(--rec-link)' }}>cd</code> into a repo and run{' '}
+          <code style={{ color: 'var(--rec-link)' }}>adlc init</code>. Two exceptions the
+          installer will tell you about: <strong style={{ color: 'var(--rec-ink)' }}>Cursor</strong>{' '}
           installs plugins through its in-app marketplace, and{' '}
-          <strong style={{ color: '#cbcdd2' }}>OpenCode</strong> scaffolds the current
+          <strong style={{ color: 'var(--rec-ink)' }}>OpenCode</strong> scaffolds the current
           directory, so it belongs inside your repo. Both are detected and reported
           as a manual step rather than guessed at.{' '}
-          <strong style={{ color: '#cbcdd2' }}>Windows isn&apos;t supported yet</strong>{' '}
-          — a <code style={{ color: '#4fb4d8' }}>windows-latest</code> run of the core
+          <strong style={{ color: 'var(--rec-ink)' }}>Windows isn&apos;t supported yet</strong>{' '}
+          — a <code style={{ color: 'var(--rec-link)' }}>windows-latest</code> run of the core
           gate suites passes 6 of 28, so use WSL for now. Prefer to install by hand?
           Every harness&apos;s native path is below.
         </p>
       </MarketingSection>
 
-      <MarketingSection kicker="Hands-free" title="Or let your agent introduce you">
-        <p className="mb-8 max-w-2xl leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="2" kicker="Hands-free" title="Or let your agent introduce you">
+        <p className="mb-8 max-w-[72ch] leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
           Already running a coding agent? Let it do the onboarding. Paste this prompt
           — it reads a guide written for agents, works out which harness it is, and
           walks you through the install without running anything until you say so.
         </p>
-        <div className="lg:max-w-3xl">
+        <div className="lg:max-w-[72ch]">
           <InstallCommand command={AGENT_PROMPT} label="Paste into your agent" />
         </div>
-        <p className="mt-6 text-sm" style={{ color: 'var(--mk-muted)' }}>
+        <p className="mt-6 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
           Read the guide yourself:{' '}
-          <a href={AGENT_GUIDE_URL} style={{ color: '#4fb4d8' }}>
+          <a href={AGENT_GUIDE_URL} style={{ color: 'var(--rec-link)' }}>
             agent-guide.md ↗
           </a>
         </p>
       </MarketingSection>
 
-      <div style={{ background: '#18191d' }}>
-        <MarketingSection kicker="Native integrations" title="Pick your agent">
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {/* A banded clause: the record sinks the paper to group the harness list,
+          rather than inverting to the terminal ground, which is reserved for
+          evidence. */}
+      <div style={{ background: 'var(--rec-paper-sunk)' }}>
+        <MarketingSection n="3" kicker="Native integrations" title="Pick your agent">
+          {/* An applicability register, not a card grid: one row per harness,
+              with the install channel in the column reserved for it. */}
+          <div style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+            <div
+              className="hidden grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)_minmax(0,0.8fr)_28px] md:grid"
+              style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}
+            >
+              <div className="rec-legend px-3 py-2.5">Harness</div>
+              <div className="rec-legend px-3 py-2.5">What it gets</div>
+              <div className="rec-legend px-3 py-2.5">Install channel</div>
+              <div className="rec-legend px-3 py-2.5" />
+            </div>
             {INTEGRATIONS.map((i) => (
               <Link
                 key={i.slug}
                 href={`/integrations/${i.slug}`}
-                className="group flex flex-col rounded-lg border p-5 transition-colors hover:border-[#4fb4d8]"
-                style={{ borderColor: '#3f4044', background: '#26272c' }}
+                className="group grid grid-cols-[minmax(0,1fr)_28px] items-baseline gap-y-1 md:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)_minmax(0,0.8fr)_28px]"
+                style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
               >
-                <p className="text-lg font-semibold" style={{ color: '#cbcdd2' }}>
+                <span className="px-3 py-3 text-[15px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
                   {i.name}
-                </p>
-                <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-                  {i.tagline}
-                </p>
-                <p
-                  className="mt-auto flex items-center justify-between pt-4 font-mono text-xs"
-                  style={{ color: 'var(--mk-muted)' }}
+                </span>
+                <span
+                  className="col-span-2 px-3 pb-1 text-[13.5px] leading-[1.5] md:col-span-1 md:py-3 md:pb-3"
+                  style={{ color: 'var(--rec-ink-2)' }}
                 >
-                  <span>{STATUS_LABEL[i.status]}</span>
-                  <span aria-hidden className="transition-colors group-hover:text-[#4fb4d8]">
-                    →
-                  </span>
-                </p>
+                  {i.tagline}
+                </span>
+                <span
+                  className="rec-mono col-span-2 px-3 pb-3 text-[12px] md:col-span-1 md:py-3"
+                  style={{ color: 'var(--rec-ink-3)' }}
+                >
+                  {STATUS_LABEL[i.status]}
+                </span>
+                <span
+                  aria-hidden
+                  className="px-3 py-3 text-right transition-colors group-hover:text-[var(--rec-link)]"
+                  style={{ color: 'var(--rec-ink-3)' }}
+                >
+                  →
+                </span>
               </Link>
             ))}
           </div>
         </MarketingSection>
       </div>
 
-      <MarketingSection kicker="Any other agent" title="No native plugin? Install the skills.">
-        <p className="mb-8 max-w-2xl leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="4" kicker="Any other agent" title="No native plugin? Install the skills.">
+        <p className="mb-8 max-w-[72ch] leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
           The harness-neutral skill catalog reaches roughly seventy agents through{' '}
-          <a href="https://skills.sh" style={{ color: '#4fb4d8' }}>
+          <a href="https://skills.sh" style={{ color: 'var(--rec-link)' }}>
             skills.sh
           </a>
           .
         </p>
-        <div className="lg:max-w-2xl">
+        <div className="lg:max-w-[72ch]">
           <InstallCommand command={SKILLS_INSTALL} />
         </div>
-        <p className="mt-6 max-w-2xl text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-          This channel installs <strong style={{ color: '#cbcdd2' }}>skills only</strong> — the
+        <p className="mt-6 max-w-[72ch] text-sm leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
+          This channel installs <strong style={{ color: 'var(--rec-ink)' }}>skills only</strong> — the
           phase router, the bootstrap guide, and the P5 prosecution workflow, each driven
-          through the <code style={{ color: '#4fb4d8' }}>adlc</code> CLI. It installs no hooks,
+          through the <code style={{ color: 'var(--rec-link)' }}>adlc</code> CLI. It installs no hooks,
           no MCP tools, no agents, and no in-session rail enforcement, so it is strictly
           weaker than any native integration above. Where a native plugin exists, prefer it.
         </p>

--- a/apps/docs/app/(home)/layout.tsx
+++ b/apps/docs/app/(home)/layout.tsx
@@ -1,6 +1,35 @@
-import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { baseOptions } from '@/lib/layout.shared';
+import Link from 'next/link';
+import { Masthead, RecordFoot } from '@/components/marketing/record';
+import { SERIES_BASE } from '@/lib/theory-links.mjs';
 
+/**
+ * The marketing routes are a controlled-change record, so they do not use the
+ * Fumadocs HomeLayout: its nav, its chrome, and its card grammar belong to the
+ * docs world. /docs keeps that layout and the dark reading surface. This layout
+ * establishes the record surface and the masthead every marketing route shares.
+ */
 export default function Layout({ children }: LayoutProps<'/'>) {
-  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
+  return (
+    <div className="record-surface flex min-h-screen flex-col">
+      <Masthead />
+      <div className="flex-1">{children}</div>
+      <RecordFoot>
+        <span>
+          ADLC began as an essay series.{' '}
+          <a
+            href={`${SERIES_BASE}/series/adlc`}
+            style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}
+          >
+            Read the original theory at voodootikigod.com ↗
+          </a>
+        </span>
+        <span className="flex items-center gap-4">
+          <span className="rec-mono">MIT · @adlc on npm</span>
+          <Link href="/privacy" style={{ color: 'var(--rec-ink-3)' }} className="underline">
+            Privacy
+          </Link>
+        </span>
+      </RecordFoot>
+    </div>
+  );
 }

--- a/apps/docs/app/(home)/lifecycle/page.tsx
+++ b/apps/docs/app/(home)/lifecycle/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { PHASES } from '@/lib/phase-graph.mjs';
+import { PHASES, HUMAN_GATE_IDS } from '@/lib/phase-graph.mjs';
 import { theoryLink } from '@/lib/theory-links.mjs';
 import { MarketingSection } from '@/components/marketing/section';
 import { LifecyclePipeline } from '@/components/marketing/lifecycle-pipeline';
@@ -23,9 +23,11 @@ const PHASE_DETAIL: Record<string, string> = {
   P7: 'Distill what the review found into permanent, deterministic defenses.',
 };
 
-// The two phases whose gate is a human, per PHASE_DETAIL — tagged so the
-// grid encodes the "two human gates" structure at a glance.
-const HUMAN_GATES = new Set(['P1', 'P6']);
+// Which phases end in a human gate now comes from phase-graph.mjs, the same
+// source the pipeline reads. It used to be a second hand-maintained Set here,
+// so this page and the diagram above it could have disagreed about which two
+// gates are human — the one structural claim the section exists to make.
+const HUMAN_GATES = new Set(HUMAN_GATE_IDS);
 
 export default function LifecyclePage() {
   return (

--- a/apps/docs/app/(home)/lifecycle/page.tsx
+++ b/apps/docs/app/(home)/lifecycle/page.tsx
@@ -32,51 +32,60 @@ const HUMAN_GATES = new Set(HUMAN_GATE_IDS);
 export default function LifecyclePage() {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker="The lifecycle" title="Eight phases. A gate between every one.">
+      <MarketingSection headingLevel={1} n="1" kicker="The chain" title="Eight phases. A gate between every one.">
         <LifecyclePipeline />
-        <div className="mt-12 grid gap-4 md:grid-cols-2">
+
+        {/* The detail sits as annotations to the chain above, not as a second
+            grid of cards restating it. One row per control point, ruled. */}
+        <dl className="mt-12" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
           {PHASES.map((p) => (
             <div
               key={p.id}
-              className="rounded-lg border p-5"
-              style={{ borderColor: '#3f4044', background: '#26272c' }}
+              className="grid grid-cols-1 gap-x-6 px-1 py-4 md:grid-cols-[46px_150px_minmax(0,1fr)]"
+              style={{
+                borderBottom: '1px solid var(--rec-rule)',
+                background: HUMAN_GATES.has(p.id) ? 'var(--rec-gate-field)' : undefined,
+              }}
             >
-              <div className="flex items-baseline justify-between gap-3">
-                <p className="font-mono text-xs" style={{ color: '#4fb4d8' }}>{p.id}</p>
+              <dt className="rec-mono px-2 text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
+                {p.id}
+              </dt>
+              <dt className="px-2 text-[15px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+                {p.name}
                 {HUMAN_GATES.has(p.id) ? (
-                  <span
-                    className="rounded-sm border px-1.5 py-0.5 font-mono text-[10px] font-medium uppercase tracking-wider"
-                    style={{
-                      color: 'var(--adlc-highlight)',
-                      borderColor: 'color-mix(in srgb, var(--adlc-highlight) 55%, transparent)',
-                    }}
-                  >
-                    Human gate
+                  <span className="rec-mono mt-1 block text-[10px] tracking-[0.12em]" style={{ color: 'var(--rec-gate-ink)' }}>
+                    ◆ HUMAN GATE
                   </span>
                 ) : null}
-              </div>
-              <p className="mt-1 font-semibold" style={{ color: '#cbcdd2' }}>{p.name}</p>
-              <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+              </dt>
+              <dd className="px-2 text-[14px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
                 {PHASE_DETAIL[p.id]}
-              </p>
-              <a href={theoryLink(p.id)} className="mt-3 inline-block text-sm" style={{ color: '#4fb4d8' }}>
-                Read the original essay ↗
-              </a>
+                <a
+                  href={theoryLink(p.id)}
+                  className="ml-2 whitespace-nowrap text-[13px]"
+                  style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}
+                >
+                  essay ↗
+                </a>
+              </dd>
             </div>
           ))}
-        </div>
+        </dl>
       </MarketingSection>
 
-      <MarketingSection kicker="Calibration" title="Three dials, set per ticket">
-        <p className="mb-10 max-w-2xl" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="2" kicker="Calibration" title="Three dials, set per ticket">
+        <p className="mb-10 max-w-[72ch] text-[16px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
           Not every ticket deserves the same autonomy. You set three dials at triage,
           and the gates hold you to whatever you chose.
         </p>
         <ThreeDials />
-        <p className="mt-8 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <a href={theoryLink('three-dials')} style={{ color: '#4fb4d8' }}>Read the original essay ↗</a>
-          {' · '}
-          <Link href="/docs" style={{ color: '#4fb4d8' }}>Full reference in the docs</Link>
+        <p className="mt-8 flex flex-wrap gap-x-4 text-[13px]">
+          <a href={theoryLink('three-dials')} style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}>
+            Read the original essay ↗
+          </a>
+          <Link href="/docs" style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}>
+            Full reference in the docs
+          </Link>
         </p>
       </MarketingSection>
     </main>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -239,11 +239,13 @@ export default function HomePage() {
                 className="max-w-[36ch] text-[clamp(19px,2.1vw,26px)] font-bold tracking-[-0.018em]"
                 style={{ color: '#cbcdd2' }}
               >
-                Attached to this record: what the gates actually printed.
+                Attached to this record: the gate, the question, and the verdict.
               </h2>
               <p className="mt-4 max-w-[72ch] text-[16px] leading-[1.55]" style={{ color: '#9093a0' }}>
                 Two of these are refusals. They are here because a record that only attaches its passes is
-                not evidence, it is marketing — and because a gate that never refuses is not a gate.
+                not evidence, it is marketing — and because a gate that never refuses is not a gate. The
+                commands and the exit codes are real; the verdict line under each is the record's own
+                one-line summary of the result, not a verbatim transcript of what the tool prints.
               </p>
 
               <div className="mt-8 grid gap-5 lg:grid-cols-2">
@@ -402,16 +404,17 @@ export default function HomePage() {
 
       <div className="mx-auto max-w-[1180px] px-6 py-8 text-[12.5px] md:px-8" style={{ color: 'var(--rec-ink-3)' }}>
         ADLC gates this repository in its own CI — rails-guard on frozen paths, cross-model attestation on
-        trust-root changes, and a mutation gate that refuses to report a kill rate when the baseline is red.
-        Every exhibit above is real output.{' '}
+        trust-root changes, and a mutation gate that refuses to report a kill rate when the baseline is red.{' '}
         <RecordLink href={`${SERIES_BASE}/series/adlc`}>The original essay series ↗</RecordLink>
         {/* The record framing is authored: the gate output is real, the record
             number is not a live ticket. Saying so costs one line and protects
             the credibility everything else on the page depends on. */}
         <span className="mt-2 block" style={{ color: 'var(--rec-ink-3)' }}>
-          This page is laid out as a change record. The exhibits, exit codes, gate names, and counts are
-          real; <span className="rec-mono">ADLC-CR-0001</span> and its status are an illustrative framing,
-          not a live ticket.
+          This page is laid out as a change record. The commands, exit codes, gate names, and counts are
+          real. The verdict line in each exhibit is this record's one-line summary of the result rather
+          than a verbatim transcript — <span className="rec-mono">adlc spec-lint</span> really prints a
+          per-criterion table. <span className="rec-mono">ADLC-CR-0001</span> and its status are an
+          illustrative framing, not a live ticket.
         </span>
       </div>
     </main>

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -7,18 +7,59 @@ import { ALL_PACKAGES } from '@/lib/toolkit-packages.mjs';
 import { SITE_URL } from '@/lib/routes.mjs';
 import { MARKETING_GATES } from '@/lib/marketing-gates.mjs';
 import { UNIVERSAL_INSTALL } from '@/lib/install-commands.mjs';
-import { MarketingSection } from '@/components/marketing/section';
+import { PHASES, HUMAN_GATE_IDS } from '@/lib/phase-graph.mjs';
 import { InstallCommand } from '@/components/marketing/install-command';
-import { TerminalCard } from '@/components/marketing/terminal-card';
-import { Backdrop } from '@/components/marketing/backdrop';
-import { Barbell } from '@/components/marketing/barbell';
-import { GateSequence } from '@/components/marketing/gate-sequence';
 import { LifecyclePipeline } from '@/components/marketing/lifecycle-pipeline';
+import {
+  Capture,
+  Clause,
+  ClauseTitle,
+  ExhibitOutput,
+  ExitCode,
+  FieldBlock,
+  RecordBody,
+  RecordLink,
+  RecordRail,
+  Statement,
+} from '@/components/marketing/record';
 
 export const metadata: Metadata = {
   description:
     'The SDLC defends against human failure modes. Your agents fail differently. ADLC gives every phase an explicit exit contract: deterministic gates produce evidence, and human gates record attestation.',
 };
+
+/**
+ * The direction contract. Emitted as a real HTML comment so it survives the
+ * production build and can be audited against the render.
+ */
+const DIRECTION_CONTRACT = `<!--
+IMPECCABLE DIRECTION CONTRACT — seed 54a31abe, direction/persuade, re-roll 1, assigned index 3.
+
+THESIS: A change is only defensible if something backs it. This surface refuses the
+enterprise dev-tool hero — headline, gradient, three feature cards — and is instead the
+change record for adopting ADLC, where no claim of capability stands without an attached
+exhibit. Argument (§1, §7) is allowed to be argument; anything the toolkit is said to DO
+carries either a numbered exhibit or the name of the gate that produces it.
+
+OWN-WORLD: The controlled-change record in its contemporary register. Cool paper
+(#e7eaef) desaturated from An Old Hope's own foreground, hairline rules, fixed field
+blocks, numbered clauses, an approver column, squared corners, no cards. Evidence stays
+true terminal on #1c1d21 with the unmodified An Old Hope palette. Archivo (width axis at
+panel scale) sets the record; Azeret Mono sets every identifier, exit code, and legend.
+
+STORY: An engineer sees real commands and real exit codes and installs. A leader sees an
+approval chain with an approver column and two named human attestations, and understands
+there is an audit trail a non-engineer could read. Both act on the same honest account.
+
+FIRST VIEWPORT: Terminal-dark masthead, then the record rail naming ADLC-CR-0001 and its
+standing. A four-field header block. §1 STATEMENT sets the thesis at panel scale in narrow
+Archivo. §2 IMPLEMENT carries the install command as the field's executable value — the
+primary action, rendered as a ruled control on terminal ground, not a button.
+
+FORM: Composition A of three rendered comps, chosen by the user over a chain-led and a
+pinned claim/exhibit split. Staging: the record's own header-block-then-clauses sequence.
+The paper/terminal inversion was confirmed by the user against staying dark throughout.
+-->`;
 
 const APP_STRUCTURED_DATA = {
   '@context': 'https://schema.org',
@@ -34,210 +75,344 @@ const APP_STRUCTURED_DATA = {
   sameAs: ['https://github.com/voodootikigod/adlc'],
 };
 
-// Gate results stay glyph + word (spec §4); color only reinforces the verdict.
-function TerminalOutput({ output }: { output: string }) {
-  return (
-    <pre className="whitespace-pre-wrap">
-      {output.split('\n').map((line, i) => {
-        const color = line.startsWith('✓')
-          ? 'var(--adlc-pass)'
-          : line.startsWith('✗')
-            ? 'var(--mk-fail-text)'
-            : '#cbcdd2';
-        return (
-          <span key={i} style={{ color }}>
-            {i > 0 ? '\n' : ''}
-            {line}
-          </span>
-        );
-      })}
-    </pre>
-  );
-}
-
 export default function HomePage() {
+  const machineGates = PHASES.length - HUMAN_GATE_IDS.length;
+
   return (
     <main>
+      <div dangerouslySetInnerHTML={{ __html: DIRECTION_CONTRACT }} />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(APP_STRUCTURED_DATA) }}
       />
-      {/* 1 — Hero */}
-      <Backdrop slug="hero-backdrop">
-        <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 pb-24 pt-20 md:pt-32">
-          <h1
-            className="mk-fade-up max-w-3xl text-balance text-4xl font-bold leading-[1.08] tracking-tight md:text-6xl"
-            style={{ color: '#cbcdd2' }}
-          >
-            Your agents don&apos;t fail like humans.{' '}
-            <span style={{ color: '#4fb4d8' }}>Stop managing them like humans.</span>
-          </h1>
-          <p className="max-w-2xl text-lg leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-            The Agentic Development Lifecycle rebuilds software delivery around the ways
-            models actually fail. Every phase has an explicit exit contract: deterministic
-            gates leave machine-checkable evidence, and human gates record attestation.
-          </p>
-          {/* Install leads. A visitor who is already sold should not have to
-              navigate to a second page to find the command. */}
-          <div className="flex max-w-2xl flex-col gap-3">
-            <InstallCommand command={UNIVERSAL_INSTALL} label="Install the toolkit and your agent integrations" />
-            <p className="text-sm" style={{ color: 'var(--mk-muted)' }}>
-              macOS and Linux, Node 18+. Then{' '}
-              <code style={{ color: '#4fb4d8' }}>adlc init</code> in your repo. Cursor
-              and OpenCode need one manual step, which the installer prints —{' '}
-              <Link href="/integrations" style={{ color: '#4fb4d8' }}>
-                see what gets installed
-              </Link>
-              .
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-4">
-            <Link
-              href="/integrations"
-              className="rounded-md px-5 py-2.5 font-medium"
-              style={{ background: '#4fb4d8', color: '#1c1d21' }}
-            >
-              Native integrations
-            </Link>
-            <Link
-              href="/vs-sdlc"
-              className="rounded-md border px-5 py-2.5 font-medium"
-              style={{ borderColor: '#3f4044', color: '#cbcdd2' }}
-            >
-              Why ADLC
-            </Link>
-          </div>
-          <div
-            className="mt-4 rounded-lg border p-6"
-            style={{ borderColor: '#3f4044', background: 'rgba(38,39,44,0.85)' }}
-          >
-            <GateSequence />
-          </div>
-        </div>
-      </Backdrop>
 
-      {/* 2 — The problem */}
-      <MarketingSection kicker="The problem" title="Eight ways agents fail. None of them human.">
-        <div className="overflow-hidden rounded-lg border" style={{ borderColor: '#3f4044' }}>
-          <div className="grid gap-px sm:grid-cols-2 lg:grid-cols-4" style={{ background: '#3f4044' }}>
+      <RecordRail
+        items={[
+          { k: 'Record', v: 'ADLC-CR-0001' },
+          { k: '', v: 'Open — awaiting implementation', open: true },
+          { k: 'Control points', v: PHASES.length },
+          // ALL_PACKAGES is every published package, not a gate subset — the
+          // data module draws no such distinction. Labelling it "gate CLIs"
+          // would be a count the repository cannot back.
+          { k: 'Packages', v: ALL_PACKAGES.length },
+          { k: 'Human attestations', v: HUMAN_GATE_IDS.length },
+        ]}
+      />
+
+      <RecordBody>
+        <FieldBlock
+          fields={[
+            { label: 'Subject', value: 'Adopt the Agentic Development Lifecycle' },
+            { label: 'Class', value: 'Process change · software delivery' },
+            { label: 'Scope', value: 'macOS · Linux · Node 18+', mono: true },
+            { label: 'Back-out', value: 'git revert · zero runtime deps', mono: true },
+          ]}
+        />
+
+        {/* §1 — the thesis, at panel scale */}
+        <Clause
+          n="1"
+          label="Statement"
+          title={
+            <Statement>
+              The SDLC defends against human failure.{' '}
+              <span style={{ color: 'var(--rec-ink-2)' }}>Your agents fail differently.</span>
+            </Statement>
+          }
+          lede={
+            <>
+              Models fail <b style={{ color: 'var(--rec-ink)' }}>confidently, quickly, and at scale</b> — a
+              process built for forgetting and fatigue is not adequate for hallucination and reward hacking.
+              ADLC gives every phase an explicit exit contract: deterministic gates leave machine-checkable
+              evidence, and two human gates record attestation.
+            </>
+          }
+        />
+
+        {/* §2 — install is the record's executable field, not a call to action */}
+        <Clause
+          n="2"
+          label="Implement"
+          aside={
+            <>
+              <div className="rec-legend">Enforcement</div>
+              <p className="mt-2 text-[12.5px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
+                In-session hooks are best-effort and harness-dependent. The commit-time CI gate is the
+                unbypassable control.
+              </p>
+            </>
+          }
+        >
+          <InstallCommand command={UNIVERSAL_INSTALL} label="Install the toolkit and your agent integrations" />
+          <p className="mt-3 max-w-[72ch] text-[13px] leading-[1.55]" style={{ color: 'var(--rec-ink-3)' }}>
+            macOS and Linux, Node 18+. Then{' '}
+            <code className="rec-mono" style={{ color: 'var(--rec-ink)' }}>
+              adlc init
+            </code>{' '}
+            in your repository. Cursor and OpenCode need one manual step, which the installer prints —{' '}
+            <RecordLink href="/integrations">see what gets installed</RecordLink>. Windows is not supported.
+          </p>
+        </Clause>
+
+        {/* §3 — the approval chain: dense, after two airier clauses */}
+        <Clause
+          n="3"
+          label="Chain"
+          title={<ClauseTitle>Eight control points. A gate closes every one.</ClauseTitle>}
+          lede={
+            <>
+              Each phase ends on an exit code: <b style={{ color: 'var(--rec-ink)' }}>0</b> passes,{' '}
+              <b style={{ color: 'var(--rec-ink)' }}>1</b> is an operational error, and{' '}
+              <b style={{ color: 'var(--rec-ink)' }}>2</b> means the gate refused. That is what makes the
+              lifecycle executable in CI rather than aspirational in a wiki.
+            </>
+          }
+        >
+          <div className="mt-7">
+            <LifecyclePipeline />
+          </div>
+          <p className="mt-6 text-[13px]">
+            <RecordLink href="/lifecycle">Explore the phases and gates →</RecordLink>
+          </p>
+        </Clause>
+
+        {/* §4 — The problem: the failure register */}
+        <Clause
+          n="4"
+          label="The problem"
+          title={<ClauseTitle>Eight ways agents fail. None of them human.</ClauseTitle>}
+          lede="Each one is answered by a specific gate at a specific phase, which is the only reason the register is worth writing down."
+        >
+          <div className="mt-7" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+            <div
+              className="hidden grid-cols-[46px_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.8fr)] md:grid"
+              style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}
+            >
+              <div className="rec-legend px-3 py-2.5" />
+              <div className="rec-legend px-3 py-2.5">Failure mode</div>
+              <div className="rec-legend px-3 py-2.5">How it shows up</div>
+              <div className="rec-legend px-3 py-2.5">Answered by</div>
+            </div>
             {Object.entries(FAILURE_MODES).map(([id, fm]) => (
-              <div key={id} className="p-5" style={{ background: '#26272c' }}>
-                <p className="font-mono text-xs" style={{ color: '#ef7c2a' }}>{id}</p>
-                <p className="mt-1 font-semibold" style={{ color: '#cbcdd2' }}>{fm.name}</p>
-                <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>{fm.tagline}</p>
+              <div
+                key={id}
+                className="grid grid-cols-[46px_minmax(0,1fr)] gap-y-1 md:grid-cols-[46px_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.8fr)] md:gap-y-0"
+                style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
+              >
+                <div className="rec-mono px-3 py-3 text-[12px]" style={{ color: '#b4571a' }}>
+                  {id}
+                </div>
+                <div className="px-3 py-3 text-[14.5px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+                  {fm.name}
+                </div>
+                <div
+                  className="col-start-2 px-3 pb-1 text-[13.5px] leading-[1.5] md:col-start-auto md:py-3 md:pb-3"
+                  style={{ color: 'var(--rec-ink-2)' }}
+                >
+                  {fm.tagline}
+                </div>
+                <div className="rec-mono col-start-2 px-3 pb-3 text-[12.5px] md:col-start-auto md:py-3">
+                  <span style={{ color: 'var(--rec-ink)' }}>{fm.defense.tool}</span>
+                  <span style={{ color: 'var(--rec-ink-3)' }}> · {fm.defense.phase}</span>
+                </div>
               </div>
             ))}
           </div>
-        </div>
-        <p className="mt-6 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <Link href="/failure-modes" style={{ color: '#4fb4d8' }}>See which gate kills each one →</Link>
-        </p>
-      </MarketingSection>
+          <p className="mt-6 text-[13px]">
+            <RecordLink href="/failure-modes">See which gate kills each one →</RecordLink>
+          </p>
+        </Clause>
+      </RecordBody>
 
-      {/* 3 — The lifecycle */}
-      <MarketingSection kicker="The lifecycle" title="Eight phases. A gate between every one.">
-        <LifecyclePipeline />
-        <p className="mt-6 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <Link href="/lifecycle" style={{ color: '#4fb4d8' }}>Explore the phases and gates →</Link>
-        </p>
-      </MarketingSection>
+      {/* §5 — the exhibits. A full-bleed terminal band: the record's proof, on
+          the surface that produced it. This is the page's one tonal break. */}
+      <section style={{ background: '#1c1d21', borderTop: '1px solid #000', borderBottom: '1px solid var(--rec-rule-strong)' }}>
+        <div className="mx-auto max-w-[1180px] px-6 py-14 md:px-8 md:py-20">
+          <div className="flex flex-col gap-x-6 md:flex-row">
+            <div className="mb-4 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
+              <div className="rec-legend" style={{ color: '#686b78' }}>
+                §5 Exhibits
+              </div>
+            </div>
+            <div className="min-w-0 flex-1">
+              <h2
+                className="max-w-[36ch] text-[clamp(19px,2.1vw,26px)] font-bold tracking-[-0.018em]"
+                style={{ color: '#cbcdd2' }}
+              >
+                Attached to this record: what the gates actually printed.
+              </h2>
+              <p className="mt-4 max-w-[72ch] text-[16px] leading-[1.55]" style={{ color: '#9093a0' }}>
+                Two of these are refusals. They are here because a record that only attaches its passes is
+                not evidence, it is marketing — and because a gate that never refuses is not a gate.
+              </p>
 
-      {/* 4 — Gates, not vibes */}
-      <MarketingSection kicker="Gates, not vibes" title="Every claim gets checked by a machine">
-        <div className="grid gap-4 md:grid-cols-2">
-          {MARKETING_GATES.map((t) => (
-            <TerminalCard key={t.name} title={`${t.name}: ${t.gate}`}>
-              <TerminalOutput output={t.output} />
-            </TerminalCard>
-          ))}
-        </div>
-        <p className="mt-6 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <Link href="/toolkit" style={{ color: '#4fb4d8' }}>{`All ${ALL_PACKAGES.length} packages, grouped by phase →`}</Link>
-        </p>
-      </MarketingSection>
+              <div className="mt-8 grid gap-5 lg:grid-cols-2">
+                {MARKETING_GATES.map((gate, i) => (
+                  <figure key={gate.name}>
+                    <figcaption className="mb-2.5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <b className="rec-mono text-[11px] font-semibold tracking-[0.1em]" style={{ color: '#cbcdd2' }}>
+                        EXHIBIT 5.{i + 1}
+                      </b>
+                      <span className="text-[12.5px]" style={{ color: '#686b78' }}>
+                        {gate.gate}
+                      </span>
+                    </figcaption>
+                    <Capture
+                      title={`adlc ${gate.name}`}
+                      status={gate.state === 'pass' ? 'EXIT 0 — PASS' : 'EXIT 2 — REFUSED'}
+                      fail={gate.state !== 'pass'}
+                    >
+                      <ExhibitOutput output={gate.output} />
+                    </Capture>
+                  </figure>
+                ))}
+              </div>
 
-      {/* 5 — Native to your agent */}
-      <MarketingSection kicker="Integrations" title="Native to the agent you already use">
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {INTEGRATIONS.map((i) => (
-            <Link
-              key={i.slug}
-              href={`/integrations/${i.slug}`}
-              className="rounded-lg border p-4 transition-colors hover:border-[#4fb4d8]"
-              style={{ borderColor: '#3f4044', background: '#26272c' }}
-            >
-              <p className="font-semibold" style={{ color: '#cbcdd2' }}>{i.name}</p>
-              <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>{i.tagline}</p>
-            </Link>
-          ))}
-        </div>
-      </MarketingSection>
-
-      {/* 6 — Economics: the barbell */}
-      <MarketingSection kicker="Economics" title="Spend heavy at the ends, light in the middle.">
-        <div className="grid gap-10 lg:grid-cols-2 lg:items-center">
-          <Barbell />
-          <div className="flex flex-col gap-6">
-            <blockquote
-              className="border-l-2 pl-5 text-xl font-medium leading-snug"
-              style={{ borderColor: '#ef7c2a', color: '#cbcdd2' }}
-            >
-              The unit of account is cost per merged, verified change. Not
-              tokens per developer per month.
-            </blockquote>
-            <p className="leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-              This is the SDLC inverted, because misbuilding is expensive and
-              building is cheap. Review stops being the bottleneck, and it goes
-              deeper than a human team could sustain anyway. Every merge carries
-              an evidence manifest, so auditors get an answer without an
-              engineer translating. Senior time goes to the two human gates
-              instead of rubber-stamping diffs. And each run costs a little less
-              than the last, as findings distill into lints and skills nobody
-              has to learn twice.
-            </p>
-            <p className="text-sm">
-              <a href={theoryLink('distill')} style={{ color: '#4fb4d8' }}>
-                The lifecycle gets cheaper ↗
-              </a>
-              <span className="px-2" style={{ color: 'var(--mk-muted)' }}>·</span>
-              <Link href="/vs-sdlc" style={{ color: '#4fb4d8' }}>
-                ADLC vs the enterprise SDLC →
-              </Link>
-            </p>
+              <p className="mt-7 text-[13px]">
+                <Link
+                  href="/toolkit"
+                  style={{ color: '#4fb4d8', borderBottom: '1px solid #2b5f74' }}
+                >{`All ${ALL_PACKAGES.length} packages, grouped by phase →`}</Link>
+              </p>
+            </div>
           </div>
         </div>
-      </MarketingSection>
+      </section>
 
-      {/* 7 — Enterprise band */}
-      <div className="border-y" style={{ borderColor: '#3f4044', background: '#26272c' }}>
-        <MarketingSection kicker="Enterprise" title="Rolling out agentic development across an org?">
-          <p className="max-w-2xl text-lg leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-            Unreviewable agent output is an audit problem, not just an engineering problem.
-            ADLC produces a gate-by-gate evidence trail your auditors can actually read.
-          </p>
-          <Link
-            href="/enterprise"
-            className="mt-6 inline-block rounded-md border px-5 py-2.5 font-medium"
-            style={{ borderColor: '#4fb4d8', color: '#4fb4d8' }}
+      <RecordBody>
+        {/* §6 — integrations, compact after the dense band */}
+        <Clause
+          n="6"
+          label="Applies to"
+          title={<ClauseTitle>Native to the agent you already run.</ClauseTitle>}
+          lede="Seven harnesses get a native integration. Everything else installs the skills catalog, which is skills only — no hooks, MCP, agents, or rail enforcement."
+        >
+          <div className="mt-7 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+            {INTEGRATIONS.map((integration) => (
+              <Link
+                key={integration.slug}
+                href={`/integrations/${integration.slug}`}
+                className="group px-4 py-4"
+                style={{
+                  borderBottom: '1px solid var(--rec-rule)',
+                  borderRight: '1px solid var(--rec-rule)',
+                  background: 'var(--rec-paper-raised)',
+                }}
+              >
+                <p className="text-[14.5px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+                  {integration.name}
+                </p>
+                <p className="mt-1.5 text-[13px] leading-[1.5]" style={{ color: 'var(--rec-ink-2)' }}>
+                  {integration.tagline}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </Clause>
+
+        {/* §7 — economics: the page's quiet passage, wide measure, one voice */}
+        <Clause
+          n="7"
+          label="Economics"
+          title={<ClauseTitle>Spend heavy at the ends, light in the middle.</ClauseTitle>}
+        >
+          <blockquote
+            className="mt-7 max-w-[36ch] text-[clamp(21px,2.6vw,30px)] font-semibold leading-[1.22] tracking-[-0.02em]"
+            style={{ color: 'var(--rec-ink)', borderLeft: '1px solid #ef7c2a', paddingLeft: 20 }}
           >
-            Do it right →
-          </Link>
-        </MarketingSection>
-      </div>
-
-      {/* 8 — Theory footer band */}
-      <div className="border-t" style={{ borderColor: '#3f4044' }}>
-        <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4 px-6 py-12">
-          <p className="text-sm" style={{ color: 'var(--mk-muted)' }}>
-            ADLC began as an essay series.{' '}
-            <a href={`${SERIES_BASE}/series/adlc`} style={{ color: '#4fb4d8' }}>
-              Read the original theory at voodootikigod.com ↗
-            </a>
+            The unit of account is cost per merged, verified change. Not tokens per developer per month.
+          </blockquote>
+          <p className="mt-7 max-w-[74ch] text-[15.5px] leading-[1.62]" style={{ color: 'var(--rec-ink-2)' }}>
+            This is the SDLC inverted, because misbuilding is expensive and building is cheap. Review stops
+            being the bottleneck, and it goes deeper than a human team could sustain anyway. Every merge
+            carries an evidence manifest, so auditors get an answer without an engineer translating. Senior
+            {/* Spelled out: a numeral mid-sentence reads as data, and this is prose.
+                phase-diagram.test.mjs pins the count at two, so the word cannot drift. */}
+            time goes to the two human gates instead of rubber-stamping diffs. And each
+            run costs a little less than the last, as findings distill into lints and skills nobody has to
+            learn twice.
           </p>
-          <a href="/privacy" className="text-sm underline" style={{ color: 'var(--mk-muted)' }}>
-            Privacy
-          </a>
+          <p className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px]">
+            <RecordLink href={theoryLink('distill')}>The lifecycle gets cheaper ↗</RecordLink>
+            <RecordLink href="/vs-sdlc">ADLC vs the enterprise SDLC →</RecordLink>
+          </p>
+        </Clause>
+      </RecordBody>
+
+      {/* §8 — the record's disposition: who signs off on rolling this out */}
+      <section style={{ background: 'var(--rec-paper-sunk)', borderTop: '1px solid var(--rec-rule-strong)' }}>
+        <div className="mx-auto max-w-[1180px] px-6 py-14 md:px-8 md:py-16">
+          <div className="flex flex-col gap-x-6 md:flex-row">
+            <div className="mb-4 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
+              <div className="rec-legend">§8 Disposition</div>
+            </div>
+            <div className="min-w-0 flex-1">
+              <ClauseTitle>Rolling this out across an org?</ClauseTitle>
+              <p className="mt-4 max-w-[72ch] text-[16px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
+                Unreviewable agent output is an audit problem, not just an engineering problem. ADLC produces
+                a gate-by-gate evidence trail your auditors can actually read, and{' '}
+                {machineGates} of the {PHASES.length} gates need no human in the loop to produce it.
+              </p>
+              {/* The attestation block. A record ends in signatures, and these
+                  two are the product's actual differentiator: the gates a
+                  machine cannot close. Rendered as the ruled signature panel the
+                  form uses in life, rather than left as a cell in the chain. */}
+              <div className="mt-8 grid grid-cols-1 gap-px sm:grid-cols-2" style={{ background: 'var(--rec-rule)', border: '1px solid var(--rec-rule-strong)' }}>
+                {PHASES.filter((p) => p.human).map((p) => (
+                  <div key={p.id} className="px-4 pb-3 pt-3.5" style={{ background: 'var(--rec-gate-field)' }}>
+                    <div className="rec-legend" style={{ color: 'var(--rec-gate-ink)' }}>
+                      Attestation · {p.id} {p.name}
+                    </div>
+                    <p className="mt-2 text-[13.5px] leading-[1.5]" style={{ color: 'var(--rec-ink-2)' }}>
+                      {p.id === 'P1'
+                        ? 'Is this what I meant?'
+                        : 'Is this what I meant, running?'}
+                    </p>
+                    <div className="mt-6 flex items-end justify-between gap-3">
+                      <span
+                        aria-hidden
+                        className="h-px flex-1"
+                        style={{ background: 'var(--rec-gate-edge)' }}
+                      />
+                      <span className="rec-mono text-[10px] tracking-[0.12em]" style={{ color: 'var(--rec-gate-ink)' }}>
+                        SIGNED BY A PERSON
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-7 flex flex-wrap items-center gap-4">
+                <Link
+                  href="/enterprise"
+                  className="rec-mono px-5 py-2.5 text-[11px] tracking-[0.14em]"
+                  style={{ background: '#1c1d21', color: '#cbcdd2', border: '1px solid var(--rec-ink)' }}
+                >
+                  READ THE ROLLOUT →
+                </Link>
+                <span className="flex items-center gap-2.5 text-[13px]" style={{ color: 'var(--rec-ink-3)' }}>
+                  <ExitCode verdict="attest" />
+                  The other {machineGates} close without one
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
+      </section>
+
+      <div className="mx-auto max-w-[1180px] px-6 py-8 text-[12.5px] md:px-8" style={{ color: 'var(--rec-ink-3)' }}>
+        ADLC gates this repository in its own CI — rails-guard on frozen paths, cross-model attestation on
+        trust-root changes, and a mutation gate that refuses to report a kill rate when the baseline is red.
+        Every exhibit above is real output.{' '}
+        <RecordLink href={`${SERIES_BASE}/series/adlc`}>The original essay series ↗</RecordLink>
+        {/* The record framing is authored: the gate output is real, the record
+            number is not a live ticket. Saying so costs one line and protects
+            the credibility everything else on the page depends on. */}
+        <span className="mt-2 block" style={{ color: 'var(--rec-ink-3)' }}>
+          This page is laid out as a change record. The exhibits, exit codes, gate names, and counts are
+          real; <span className="rec-mono">ADLC-CR-0001</span> and its status are an illustrative framing,
+          not a live ticket.
+        </span>
       </div>
     </main>
   );

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -105,7 +105,15 @@ export default function HomePage() {
             { label: 'Subject', value: 'Adopt the Agentic Development Lifecycle' },
             { label: 'Class', value: 'Process change · software delivery' },
             { label: 'Scope', value: 'macOS · Linux · Node 18+', mono: true },
-            { label: 'Back-out', value: 'git revert · zero runtime deps', mono: true },
+            {
+              // The installer mutates the machine, not just the repo: `npm install -g`
+              // plus native plugins for each detected harness. Reverting the repo
+              // cannot remove either, so the field says what a revert actually
+              // covers rather than implying a clean one-command rollback.
+              label: 'Back-out',
+              value: 'revert the repo · uninstall the CLI separately',
+              mono: true,
+            },
           ]}
         />
 

--- a/apps/docs/app/(home)/toolkit/page.tsx
+++ b/apps/docs/app/(home)/toolkit/page.tsx
@@ -12,15 +12,15 @@ export const metadata: Metadata = {
 export default function ToolkitPage() {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker="The toolkit" title="Small CLIs, one gate each, zero dependencies">
-        <p className="mb-10 max-w-2xl" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="1" headingLevel={1} kicker="The toolkit" title="Small CLIs, one gate each, zero dependencies">
+        <p className="mb-10 max-w-[72ch]" style={{ color: 'var(--rec-ink-2)' }}>
           Each package enforces a single machine-checkable gate, and they all share a
           runtime convention, so tools built independently still feel like one product.
           Click any package for its docs.
         </p>
         <Constellation />
-        <p className="mt-8 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <a href={theoryLink('toolkit')} style={{ color: '#4fb4d8' }}>
+        <p className="mt-8 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
+          <a href={theoryLink('toolkit')} style={{ color: 'var(--rec-link)' }}>
             Read the original essay ↗
           </a>
         </p>

--- a/apps/docs/app/(home)/vs-sdlc/page.tsx
+++ b/apps/docs/app/(home)/vs-sdlc/page.tsx
@@ -11,16 +11,16 @@ export const metadata: Metadata = {
 export default function VsSdlcPage() {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker="The argument" title="60 years of process, built for the wrong failure modes">
-        <p className="mb-10 max-w-2xl" style={{ color: 'var(--mk-muted)' }}>
+      <MarketingSection n="1" headingLevel={1} kicker="The argument" title="60 years of process, built for the wrong failure modes">
+        <p className="mb-10 max-w-[72ch]" style={{ color: 'var(--rec-ink-2)' }}>
           Code review, standups, and sprint ceremonies all exist because humans forget,
           tire, and protect their egos. Models do none of that. They fail in their own
           ways, and a lifecycle that doesn&apos;t defend against <em>those</em> failures
           is theater.
         </p>
         <VsTable />
-        <p className="mt-8 text-sm" style={{ color: 'var(--mk-muted)' }}>
-          <a href={theoryLink('vs-sdlc')} style={{ color: '#4fb4d8' }}>Read the original essay ↗</a>
+        <p className="mt-8 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
+          <a href={theoryLink('vs-sdlc')} style={{ color: 'var(--rec-link)' }}>Read the original essay ↗</a>
         </p>
       </MarketingSection>
     </main>

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -182,6 +182,36 @@ html > body[data-scroll-locked] {
     display: none;
   }
 
+  /* Captures set their ground inline, so the variable overrides above cannot
+     reach them. Browsers omit background graphics by default when printing,
+     which left #cbcdd2 evidence text on white paper — the page's core proof,
+     unreadable, exactly when a reviewer prints it to circulate. Invert the
+     captures to ink-on-paper instead of relying on a background nobody prints.
+     !important is required to beat the inline styles. */
+  .record-surface .rec-capture,
+  .record-surface .rec-capture * {
+    background: #ffffff !important;
+    color: #000000 !important;
+    border-color: #444444 !important;
+  }
+
+  .record-surface .rec-capture {
+    border: 1px solid #444444 !important;
+  }
+
+  .record-surface .rec-capture-bar {
+    border-bottom: 1px solid #999999 !important;
+    color: #333333 !important;
+  }
+
+  /* The install command is the page's primary control and shares the terminal
+     ground; print it as a boxed command line rather than a black slab. */
+  .record-surface code,
+  .record-surface pre {
+    background: transparent !important;
+    color: #000000 !important;
+  }
+
   .rec-row-settle,
   .rec-code-stamp {
     animation: none !important;

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -45,6 +45,146 @@ html > body[data-scroll-locked] {
   --mk-fail-text: #f2788a;
 }
 
+/* ---------------------------------------------------------------------------
+   The record surface.
+
+   The marketing routes are a controlled-change record: a governed document on
+   cool paper, whose evidence stays true An Old Hope terminal on #1c1d21. The
+   inversion is the argument — the record is what a person reads, the terminal is
+   what a machine produced — so these tokens are scoped to `.record-surface`
+   rather than :root. /docs stays the dark reading surface Fumadocs themes above.
+
+   The paper is desaturated from the palette's own foreground (#cbcdd2), not
+   borrowed from a warm-cream default; An Old Hope is a cool scheme and the
+   record has to belong to it.
+   --------------------------------------------------------------------------- */
+.record-surface {
+  --rec-paper: #e7eaef;
+  --rec-paper-raised: #f2f4f7;
+  --rec-paper-sunk: #dde1e8;
+  --rec-ink: #171920;
+  --rec-ink-2: #464c5c;
+  --rec-ink-3: #6b7283;
+  --rec-rule: #c6cbd6;
+  --rec-rule-strong: #a7aebd;
+
+  /* Verdict inks: the palette's own hues darkened until they clear 4.5:1 on
+     paper. The terminal keeps the undarkened An Old Hope values — same verdict,
+     two surfaces, and neither one carries the verdict by colour alone. */
+  --rec-pass-ink: #2f6a22;
+  --rec-pass-edge: #9dc492;
+  --rec-pass-field: #e2efdd;
+  --rec-fail-ink: #a81d31;
+  --rec-fail-edge: #dda3ad;
+  --rec-fail-field: #f7e2e5;
+  --rec-gate-ink: #6f5a0d;
+  --rec-gate-edge: #cbb44a;
+  --rec-gate-field: #faf3d8;
+  --rec-link: #17627f;
+  --rec-link-edge: #a9cede;
+
+  background: var(--rec-paper);
+  color: var(--rec-ink);
+}
+
+/* Field legends, identifiers, exit codes, evidence filenames. */
+.rec-legend {
+  font-family: var(--font-record-mono), ui-monospace, monospace;
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--rec-ink-3);
+}
+
+.rec-mono {
+  font-family: var(--font-record-mono), ui-monospace, monospace;
+  font-feature-settings: 'tnum' 1;
+}
+
+/* The statement clause is the one place the width axis is used: narrow lets it
+   run at panel scale without becoming a second typeface. */
+.rec-statement {
+  font-variation-settings: 'wdth' 92;
+  letter-spacing: -0.022em;
+  line-height: 1.02;
+}
+
+/* ---------------------------------------------------------------------------
+   The one authored moment: the record resolving.
+
+   A change record arrives unstamped and settles as each control point reports.
+   The approval chain plays that once on load — rows settle in sequence and the
+   exit code lands last — then holds. Everything is visible by default; the
+   animation only moves what is already rendered, so reduced motion loses the
+   performance and keeps the record.
+   --------------------------------------------------------------------------- */
+@keyframes rec-settle {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes rec-stamp {
+  from {
+    opacity: 0;
+    transform: scale(1.32);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.rec-row-settle {
+  animation: rec-settle 0.44s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.rec-code-stamp {
+  animation: rec-stamp 0.34s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rec-row-settle,
+  .rec-code-stamp {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+/* A record is a document, so it prints like one: ink on white, rules kept,
+   evidence inverted to ink-on-paper rather than dumping a black rectangle
+   across the page, and the masthead nav dropped since links do not print. */
+@media print {
+  .record-surface {
+    --rec-paper: #fff;
+    --rec-paper-raised: #fff;
+    --rec-paper-sunk: #f4f4f4;
+    --rec-ink: #000;
+    --rec-ink-2: #333;
+    --rec-ink-3: #555;
+    --rec-rule: #999;
+    --rec-rule-strong: #444;
+    background: #fff;
+  }
+
+  .record-surface nav {
+    display: none;
+  }
+
+  .rec-row-settle,
+  .rec-code-stamp {
+    animation: none !important;
+    opacity: 1 !important;
+  }
+}
+
 /* Marketing motion — every animation is opt-out via prefers-reduced-motion */
 @keyframes mk-fade-up {
   from {

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -64,7 +64,11 @@ html > body[data-scroll-locked] {
   --rec-paper-sunk: #dde1e8;
   --rec-ink: #171920;
   --rec-ink-2: #464c5c;
-  --rec-ink-3: #6b7283;
+  /* 4.74:1 on the darkest paper tone (#dde1e8) — this ink sets .rec-legend at
+     9.5px (field labels, column headers, form labels), so it is normal text and
+     owes the full 4.5:1, not the 3:1 large-text allowance. The previous #6b7283
+     measured 3.67-4.37 and failed on all four paper tones. */
+  --rec-ink-3: #5a616f;
   --rec-rule: #c6cbd6;
   --rec-rule-strong: #a7aebd;
 
@@ -163,15 +167,15 @@ html > body[data-scroll-locked] {
    across the page, and the masthead nav dropped since links do not print. */
 @media print {
   .record-surface {
-    --rec-paper: #fff;
+    --rec-paper: #ffffff;
     --rec-paper-raised: #fff;
     --rec-paper-sunk: #f4f4f4;
-    --rec-ink: #000;
-    --rec-ink-2: #333;
-    --rec-ink-3: #555;
-    --rec-rule: #999;
-    --rec-rule-strong: #444;
-    background: #fff;
+    --rec-ink: #000000;
+    --rec-ink-2: #333333;
+    --rec-ink-3: #555555;
+    --rec-rule: #999999;
+    --rec-rule-strong: #444444;
+    background: #ffffff;
   }
 
   .record-surface nav {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,11 +1,25 @@
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
-import { Inter } from 'next/font/google';
+import { Archivo, Azeret_Mono } from 'next/font/google';
 import type { Metadata } from 'next';
 import { SITE_URL } from '@/lib/routes.mjs';
 
-const inter = Inter({
+// Archivo is a grotesque out of documentary and industrial printing, and it
+// carries a width axis — which is what lets the record's statement clause be set
+// narrow at panel scale without a second display face. Azeret Mono sets every
+// identifier, exit code, and field legend: mono here is measurement and code,
+// not costume.
+const archivo = Archivo({
   subsets: ['latin'],
+  axes: ['wdth'],
+  variable: '--font-record',
+  display: 'swap',
+});
+
+const azeretMono = Azeret_Mono({
+  subsets: ['latin'],
+  variable: '--font-record-mono',
+  display: 'swap',
 });
 
 export const metadata: Metadata = {
@@ -59,7 +73,11 @@ const STRUCTURED_DATA = {
 export default function Layout({ children }: LayoutProps<'/'>) {
   // dark class on <html> enforces dark mode — theme switching is disabled
   return (
-    <html lang="en" className={`dark ${inter.className}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`dark ${archivo.variable} ${azeretMono.variable} ${archivo.className}`}
+      suppressHydrationWarning
+    >
       <body className="flex flex-col min-h-screen">
         <script
           type="application/ld+json"

--- a/apps/docs/app/privacy/page.tsx
+++ b/apps/docs/app/privacy/page.tsx
@@ -14,7 +14,7 @@ const UPDATED = 'July 9, 2026';
 
 export default function PrivacyPage() {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
+    <main className="mx-auto max-w-[72ch] px-6 py-16">
       <h1 className="text-3xl font-bold tracking-tight" style={{ color: '#cbcdd2' }}>
         Privacy Policy
       </h1>

--- a/apps/docs/components/marketing/barbell.tsx
+++ b/apps/docs/components/marketing/barbell.tsx
@@ -18,7 +18,7 @@ export function Barbell() {
               className="rounded-t"
               style={{
                 height: bar.height,
-                background: bar.heavy ? '#4fb4d8' : 'rgba(79,180,216,0.25)',
+                background: bar.heavy ? 'var(--rec-link)' : 'rgba(79,180,216,0.25)',
               }}
             />
           </div>
@@ -27,16 +27,16 @@ export function Barbell() {
       <div className="mt-3 flex gap-6">
         {BARS.map((bar) => (
           <div key={bar.label} className="flex-1 text-center">
-            <p className="text-sm font-medium" style={{ color: '#cbcdd2' }}>
+            <p className="text-sm font-medium" style={{ color: 'var(--rec-ink)' }}>
               {bar.label}
             </p>
-            <p className="font-mono text-xs" style={{ color: 'var(--mk-muted)' }}>
+            <p className="rec-mono text-xs" style={{ color: 'var(--rec-ink-2)' }}>
               {bar.phase}
             </p>
           </div>
         ))}
       </div>
-      <figcaption className="mt-4 text-sm" style={{ color: 'var(--mk-muted)' }}>
+      <figcaption className="mt-4 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
         Relative spend by phase: heavy at the ends, light in the middle.
         Schematic, not to scale.
       </figcaption>

--- a/apps/docs/components/marketing/constellation.tsx
+++ b/apps/docs/components/marketing/constellation.tsx
@@ -8,23 +8,25 @@ export function Constellation() {
         <div key={g.group}>
           <div className="mb-4 flex items-baseline gap-4">
             <h3
-              className="whitespace-nowrap font-mono text-sm uppercase tracking-widest"
-              style={{ color: 'var(--mk-muted)' }}
+              className="whitespace-nowrap rec-mono text-sm uppercase tracking-widest"
+              style={{ color: 'var(--rec-ink-2)' }}
             >
               {g.group}
             </h3>
-            <span aria-hidden className="h-px min-w-8 flex-1 self-center" style={{ background: '#3f4044' }} />
-            <span className="whitespace-nowrap font-mono text-xs" style={{ color: 'var(--mk-muted)' }}>
+            <span aria-hidden className="h-px min-w-8 flex-1 self-center" style={{ background: 'var(--rec-rule)' }} />
+            <span className="whitespace-nowrap rec-mono text-xs" style={{ color: 'var(--rec-ink-2)' }}>
               {g.packages.length} {g.packages.length === 1 ? 'package' : 'packages'}
             </span>
           </div>
-          <div className="flex flex-wrap gap-2">
+          {/* A parts list, not a tag cloud: squared cells on the raised paper,
+              because a pill is a control and these are line items. */}
+          <div className="flex flex-wrap gap-px" style={{ background: 'var(--rec-rule)', border: '1px solid var(--rec-rule)' }}>
             {g.packages.map((name) => (
               <Link
                 key={name}
                 href={`/docs/toolkit/${name}`}
-                className="rounded-full border px-4 py-1.5 font-mono text-sm transition-colors hover:border-[#4fb4d8] hover:text-[#4fb4d8]"
-                style={{ borderColor: '#3f4044', color: '#cbcdd2' }}
+                className="rec-mono px-3.5 py-2 text-[13px] transition-colors hover:text-[var(--rec-link)]"
+                style={{ background: 'var(--rec-paper-raised)', color: 'var(--rec-ink)' }}
               >
                 {name}
               </Link>

--- a/apps/docs/components/marketing/evidence-trail.tsx
+++ b/apps/docs/components/marketing/evidence-trail.tsx
@@ -5,57 +5,31 @@ const STEPS = [
   { label: 'Merge', detail: 'Approved on evidence, not vibes' },
 ] as const;
 
-// Rail, gate ring (pass token), rail, arrowhead — same connector grammar as
-// the lifecycle pipeline. Decorative only; the ol's aria-label carries the
-// semantics.
-function TrailConnector() {
-  return (
-    <svg aria-hidden viewBox="0 0 44 12" className="mx-2 hidden h-3 w-11 shrink-0 md:block">
-      <line x1="1" y1="6" x2="15" y2="6" stroke="#3f4044" strokeWidth="1.5" />
-      <circle cx="22" cy="6" r="3.5" fill="none" stroke="var(--adlc-pass)" strokeWidth="1.5" />
-      <line x1="29" y1="6" x2="38" y2="6" stroke="#3f4044" strokeWidth="1.5" />
-      <path
-        d="M 35.5 2.5 L 40 6 L 35.5 9.5"
-        fill="none"
-        stroke="#3f4044"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-// Chain-of-custody diagram: how a change becomes auditable (spec §4 table).
-// The mono index reads as custody paperwork — this is a real sequence, and
-// order is the point.
+// Chain of custody: how a change becomes auditable.
+//
+// Custody is recorded, not drawn. The numbered hand-offs carry the sequence the
+// way a custody form does, so the rail-and-arrow SVG that used to sit between
+// the cells is gone — it was decorating an order the numbering already states,
+// and on paper it read as a hairline nobody could see.
 export function EvidenceTrail() {
   return (
     <ol
-      className="flex flex-col gap-2 md:flex-row md:items-stretch md:gap-0"
+      className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4"
+      style={{ background: 'var(--rec-rule)', border: '1px solid var(--rec-rule)' }}
       aria-label="Evidence trail from ticket through gates and gate-manifest to merge"
     >
       {STEPS.map((s, i) => (
-        <li
-          key={s.label}
-          className="mk-gate-line flex items-center md:flex-1"
-          style={{ animationDelay: `${i * 0.12}s` }}
-        >
-          <div
-            className="h-full flex-1 rounded-lg border p-4"
-            style={{ borderColor: '#3f4044', background: '#26272c' }}
-          >
-            <p className="font-mono text-[10px] tracking-[0.2em]" style={{ color: 'var(--mk-muted)' }}>
-              {String(i + 1).padStart(2, '0')}
-            </p>
-            <p className="mt-1 font-mono text-sm font-semibold" style={{ color: '#4fb4d8' }}>
-              {s.label}
-            </p>
-            <p className="mt-1 text-xs leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-              {s.detail}
-            </p>
-          </div>
-          {i < STEPS.length - 1 ? <TrailConnector /> : null}
+        <li key={s.label} className="flex flex-col p-4" style={{ background: 'var(--rec-paper-raised)' }}>
+          <p className="rec-mono text-[10px] tracking-[0.2em]" style={{ color: 'var(--rec-ink-3)' }}>
+            {String(i + 1).padStart(2, '0')}
+            {i < STEPS.length - 1 ? <span aria-hidden> → HAND-OFF</span> : <span aria-hidden> · CLOSED</span>}
+          </p>
+          <p className="mt-1.5 rec-mono text-[14px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+            {s.label}
+          </p>
+          <p className="mt-1.5 text-[12.5px] leading-[1.5]" style={{ color: 'var(--rec-ink-2)' }}>
+            {s.detail}
+          </p>
         </li>
       ))}
     </ol>

--- a/apps/docs/components/marketing/failure-map.tsx
+++ b/apps/docs/components/marketing/failure-map.tsx
@@ -1,67 +1,61 @@
 import Link from 'next/link';
 import { FAILURE_MODES } from '@/lib/failure-modes.mjs';
 
-// Same visual language as the pipeline's GateConnector — rail, gate ring in
-// the pass token, rail, arrowhead — stretched for the map's wider gap.
-// Decorative only; the list's aria-label carries the semantics.
-function DefenseConnector() {
-  return (
-    <svg aria-hidden viewBox="0 0 64 12" className="hidden h-3 w-16 shrink-0 md:block">
-      <line x1="1" y1="6" x2="25" y2="6" stroke="#3f4044" strokeWidth="1.5" />
-      <circle cx="32" cy="6" r="3.5" fill="none" stroke="var(--adlc-pass)" strokeWidth="1.5" />
-      <line x1="39" y1="6" x2="58" y2="6" stroke="#3f4044" strokeWidth="1.5" />
-      <path
-        d="M 55.5 2.5 L 60 6 L 55.5 9.5"
-        fill="none"
-        stroke="#3f4044"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-// F1–F8 on the left, the defending gate on the right — the core ADLC claim
-// (every defense traces to a failure mode) made visual. One continuous
-// hairline lattice (gap-px over the border color), not floating cards.
+// F1–F8 and the gate that defends each — the core ADLC claim (every defense
+// traces to a failure mode) made visual.
+//
+// This used to be a lattice of cells joined by a rail-and-ring SVG connector,
+// borrowed from a pipeline diagram that no longer exists. Under the record the
+// relationship is a register: fixed columns, one row per mode, the defending
+// gate in the column reserved for it. The mapping is legible by alignment, so
+// the connector was drawing a line the columns already draw.
 export function FailureMap() {
   return (
-    <ul
-      className="grid gap-px overflow-hidden rounded-lg border"
-      style={{ borderColor: '#3f4044', background: '#3f4044' }}
-      aria-label="Eight model failure modes F1 through F8, each mapped to the machine-checkable gate that defends against it"
-    >
-      {Object.entries(FAILURE_MODES).map(([id, fm], i) => (
-        <li
-          key={id}
-          className="mk-gate-line grid items-center gap-x-6 gap-y-3 p-5 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]"
-          style={{ background: '#26272c', animationDelay: `${i * 0.06}s` }}
-        >
-          <div>
-            <span className="font-mono text-xs" style={{ color: 'var(--adlc-highlight)' }}>
+    <div style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+      <div
+        className="hidden grid-cols-[46px_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.9fr)] md:grid"
+        style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}
+      >
+        <div className="rec-legend px-3 py-2.5" />
+        <div className="rec-legend px-3 py-2.5">Failure mode</div>
+        <div className="rec-legend px-3 py-2.5">How it shows up</div>
+        <div className="rec-legend px-3 py-2.5">Defended by</div>
+      </div>
+
+      <ul aria-label="Eight model failure modes F1 through F8, each mapped to the machine-checkable gate that defends against it">
+        {Object.entries(FAILURE_MODES).map(([id, fm]) => (
+          <li
+            key={id}
+            className="grid grid-cols-[46px_minmax(0,1fr)] gap-y-1 md:grid-cols-[46px_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.9fr)] md:gap-y-0"
+            style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
+          >
+            <div className="rec-mono px-3 py-3 text-[12px]" style={{ color: '#b4571a' }}>
               {id}
-            </span>
-            <p className="font-semibold" style={{ color: '#cbcdd2' }}>{fm.name}</p>
-            <p className="mt-1 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
-              {fm.tagline}
-            </p>
-          </div>
-          <DefenseConnector />
-          <div className="md:text-right">
-            <Link
-              href={`/docs/toolkit/${fm.defense.tool}`}
-              className="font-mono font-semibold"
-              style={{ color: '#4fb4d8' }}
+            </div>
+            <div className="px-3 py-3 text-[14.5px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+              {fm.name}
+            </div>
+            <div
+              className="col-start-2 px-3 pb-1 text-[13.5px] leading-[1.5] md:col-start-auto md:py-3 md:pb-3"
+              style={{ color: 'var(--rec-ink-2)' }}
             >
-              {fm.defense.tool}
-            </Link>
-            <p className="mt-1 font-mono text-xs uppercase tracking-wider" style={{ color: 'var(--mk-muted)' }}>
-              gate at {fm.defense.phase}
-            </p>
-          </div>
-        </li>
-      ))}
-    </ul>
+              {fm.tagline}
+            </div>
+            <div className="col-start-2 px-3 pb-3 md:col-start-auto md:py-3">
+              <Link
+                href={`/docs/toolkit/${fm.defense.tool}`}
+                className="rec-mono text-[13px] font-semibold"
+                style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}
+              >
+                {fm.defense.tool}
+              </Link>
+              <span className="rec-mono ml-2 text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
+                at {fm.defense.phase}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/apps/docs/components/marketing/gate-badge.tsx
+++ b/apps/docs/components/marketing/gate-badge.tsx
@@ -1,9 +1,13 @@
 // FAIL text uses the AA-contrast token; its border/background keep the base
 // gate token (non-text, 3:1 suffices — the glyph + label carry the state).
 const STATES = {
-  pass: { glyph: '✓', label: 'PASS', color: 'var(--adlc-pass)', accent: 'var(--adlc-pass)' },
-  fail: { glyph: '✗', label: 'FAIL', color: 'var(--mk-fail-text)', accent: 'var(--adlc-fail)' },
-  wish: { glyph: '◌', label: 'WISH', color: 'var(--adlc-wish)', accent: 'var(--adlc-wish)' },
+  pass: { glyph: '✓', label: 'PASS', color: 'var(--rec-pass-ink)', accent: 'var(--rec-pass-ink)' },
+  fail: { glyph: '✗', label: 'FAIL', color: 'var(--rec-fail-ink)', accent: 'var(--rec-fail-ink)' },
+  // Labelled ATTEST, not WISH. "Attestation" is fixed product terminology;
+  // "wish" is the internal name of the colour token and had leaked out as a
+  // verdict word, so the same human gate read as ATTEST in the approval chain
+  // and WISH here — two words for the load-bearing concept.
+  wish: { glyph: '◆', label: 'ATTEST', color: 'var(--rec-gate-ink)', accent: 'var(--rec-gate-ink)' },
 } as const;
 
 export type GateState = keyof typeof STATES;
@@ -18,7 +22,7 @@ export function GateBadge({ state, label }: GateBadgeProps) {
   const s = STATES[state];
   return (
     <span
-      className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-sm border px-2 py-0.5 font-mono text-xs font-bold tracking-wider"
+      className="inline-flex items-center gap-1.5 whitespace-nowrap border px-2 py-0.5 rec-mono text-xs font-bold tracking-wider"
       style={{
         color: s.color,
         borderColor: `color-mix(in srgb, ${s.accent} 55%, transparent)`,

--- a/apps/docs/components/marketing/install-command.tsx
+++ b/apps/docs/components/marketing/install-command.tsx
@@ -12,9 +12,16 @@ interface InstallCommandProps {
 }
 
 /**
- * A copy-able install command. Client component only because of the clipboard —
- * the command itself is rendered server-side, so it is present in the HTML (and
- * therefore selectable, crawlable, and readable) whether or not JS runs.
+ * The record's primary control.
+ *
+ * In this world the install command is not a call-to-action button beside the
+ * copy — it is the value of the IMPLEMENTATION field, so it is rendered as the
+ * form's own executable field: squared, ruled, on the terminal ground, with the
+ * command itself as the field's content.
+ *
+ * Client component only because of the clipboard. The command is rendered
+ * server-side, so it is in the HTML — selectable, crawlable, and readable —
+ * whether or not JS runs.
  */
 export function InstallCommand({ command, label, beta = false }: InstallCommandProps) {
   const [copied, setCopied] = useState(false);
@@ -33,35 +40,46 @@ export function InstallCommand({ command, label, beta = false }: InstallCommandP
   }, [command]);
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-2">
       {label ? (
-        <p className="flex items-center gap-2 font-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--mk-muted)' }}>
+        <p className="rec-legend flex items-center gap-2">
           <span>{label}</span>
           {beta ? (
-            <span className="rounded border px-1.5 py-0.5 text-[0.65rem]" style={{ borderColor: '#e5cd52', color: '#e5cd52' }}>
-              beta
+            <span
+              className="rec-mono border px-1.5 py-[1px] text-[9px]"
+              style={{ borderColor: 'var(--rec-gate-edge)', color: 'var(--rec-gate-ink)', background: 'var(--rec-gate-field)' }}
+            >
+              BETA
             </span>
           ) : null}
         </p>
       ) : null}
-      <div
-        className="flex items-center gap-3 rounded-lg border px-4 py-3"
-        style={{ borderColor: '#3f4044', background: '#26272c' }}
-      >
-        <span aria-hidden className="select-none font-mono text-sm" style={{ color: '#4fb4d8' }}>
-          $
-        </span>
-        <code className="flex-1 overflow-x-auto whitespace-pre font-mono text-sm" style={{ color: '#cbcdd2' }}>
+      <div className="flex items-stretch" style={{ border: '1px solid var(--rec-ink)', background: '#1c1d21' }}>
+        {/* The command wraps on narrow screens rather than scrolling out of
+            sight. This is the page's primary action: a visitor who cannot see
+            the whole command cannot verify what they are about to pipe to sh,
+            and "scroll this box sideways" is not an answer on a phone. */}
+        <code
+          className="rec-mono flex-1 whitespace-pre-wrap break-all px-4 py-3 text-[13px] md:overflow-x-auto md:whitespace-pre md:break-normal md:text-[13.5px]"
+          style={{ color: '#cbcdd2' }}
+        >
+          <span aria-hidden className="select-none pr-2.5" style={{ color: '#78bd65' }}>
+            $
+          </span>
           {command}
         </code>
         <button
           type="button"
           onClick={copy}
-          className="shrink-0 rounded border px-2.5 py-1 font-mono text-xs transition-colors"
-          style={{ borderColor: '#3f4044', color: copied ? '#78bd65' : 'var(--mk-muted)' }}
+          className="rec-mono shrink-0 px-4 text-[10px] tracking-[0.14em] transition-colors"
+          style={{
+            borderLeft: '1px solid #34363d',
+            background: '#26272c',
+            color: copied ? '#78bd65' : '#cbcdd2',
+          }}
           aria-label={copied ? 'Command copied to clipboard' : `Copy: ${command}`}
         >
-          {copied ? 'copied' : 'copy'}
+          {copied ? 'COPIED' : 'COPY'}
         </button>
       </div>
     </div>

--- a/apps/docs/components/marketing/integration-card.tsx
+++ b/apps/docs/components/marketing/integration-card.tsx
@@ -13,11 +13,14 @@ interface IntegrationCardProps {
 }
 
 // Install text is contractual — render verbatim; comment lines are only dimmed, never rewritten.
+//
+// These colours are the TERMINAL side of the system, not the record side: this
+// pre renders inside a capture on #1c1d21. Paper inks here are invisible.
 function InstallLines({ lines }: { lines: readonly string[] }) {
   return (
     <pre className="whitespace-pre-wrap">
       {lines.map((line, i) => (
-        <span key={i} style={{ color: line.startsWith('#') ? 'var(--mk-muted)' : '#cbcdd2' }}>
+        <span key={i} style={{ color: line.startsWith('#') ? '#686b78' : '#cbcdd2' }}>
           {i > 0 ? '\n' : ''}
           {line}
         </span>
@@ -32,8 +35,8 @@ export function IntegrationCard({ integration }: IntegrationCardProps) {
     <div className="flex flex-col gap-4">
       <div>
         <span
-          className="rounded border px-2 py-0.5 font-mono text-xs"
-          style={{ borderColor: '#3f4044', color: 'var(--mk-muted)' }}
+          className="rec-legend border px-2 py-1"
+          style={{ borderColor: 'var(--rec-rule-strong)', background: 'var(--rec-paper-sunk)' }}
         >
           {STATUS_LABEL[integration.status]}
         </span>
@@ -42,7 +45,7 @@ export function IntegrationCard({ integration }: IntegrationCardProps) {
         <InstallLines lines={integration.install} />
       </TerminalCard>
       {note ? (
-        <p className="text-sm leading-relaxed" style={{ color: '#e5cd52' }}>
+        <p className="text-sm leading-relaxed" style={{ color: 'var(--rec-gate-ink)' }}>
           <span aria-hidden>◌ </span>
           {note}
         </p>

--- a/apps/docs/components/marketing/integration-detail.tsx
+++ b/apps/docs/components/marketing/integration-detail.tsx
@@ -18,13 +18,14 @@ function NativeBundle({ integration }: { integration: Integration }) {
   const pathWidth = Math.max(...bundle.entries.map((entry) => entry.path.length));
   return (
     <TerminalCard title={bundle.title}>
+      {/* Terminal side: paper inks are invisible on #1c1d21. */}
       <pre aria-label={bundle.ariaLabel} className="whitespace-pre-wrap" style={{ color: '#cbcdd2' }}>
         <span style={{ color: '#4fb4d8' }}>{bundle.root}</span>
         {bundle.entries.map((entry) => (
           <span key={entry.path}>
             {'\n'}
             {entry.path.padEnd(pathWidth + 2)}
-            <span style={{ color: 'var(--mk-muted)' }}>{bundleNote(integration, entry)}</span>
+            <span style={{ color: '#686b78' }}>{bundleNote(integration, entry)}</span>
           </span>
         ))}
       </pre>
@@ -34,17 +35,24 @@ function NativeBundle({ integration }: { integration: Integration }) {
 
 function SurfaceCounts({ integration }: { integration: Integration }) {
   return (
-    <dl className="grid grid-cols-2 border-y sm:grid-cols-4" style={{ borderColor: '#3f4044' }}>
-      {integration.surfaces.map((surface, index) => (
+    // A hairline lattice, so a fifth surface fills its own cell instead of
+    // hanging off a fixed four-column rule with a stray border beside it.
+    // Per-cell rules rather than a gap-px lattice: the surface count is 5 on
+    // some harnesses and 4 on others, and a lattice leaves the container colour
+    // showing as an empty block wherever the last row is short.
+    <dl className="grid grid-cols-2 sm:grid-cols-4" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+      {integration.surfaces.map((surface) => (
         <div
           key={surface.key}
-          className={`py-4 ${index % 2 === 0 ? 'pr-4' : 'border-l pl-4'} ${index > 1 ? 'border-t sm:border-t-0' : ''} sm:border-l sm:px-4 sm:first:border-l-0 sm:first:pl-0`}
-          style={{ borderColor: '#3f4044' }}
+          className="px-3 py-3"
+          style={{
+            background: 'var(--rec-paper-raised)',
+            borderRight: '1px solid var(--rec-rule)',
+            borderBottom: '1px solid var(--rec-rule)',
+          }}
         >
-          <dt className="font-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--mk-muted)' }}>
-            {surface.label}
-          </dt>
-          <dd className="mt-1 text-2xl font-semibold tabular-nums" style={{ color: '#cbcdd2' }}>
+          <dt className="rec-legend">{surface.label}</dt>
+          <dd className="mt-1 text-[22px] font-semibold tabular-nums" style={{ color: 'var(--rec-ink)' }}>
             {surface.count}
           </dd>
         </div>
@@ -55,21 +63,21 @@ function SurfaceCounts({ integration }: { integration: Integration }) {
 
 function NativeSurfaces({ integration }: { integration: Integration }) {
   return (
-    <div className="border-y" style={{ borderColor: '#3f4044' }}>
+    <div className="border-y" style={{ borderColor: 'var(--rec-rule)' }}>
       {integration.surfaces.map((surface, index) => (
         <article
           key={surface.key}
           className="grid gap-4 border-b py-7 last:border-b-0 md:grid-cols-[4rem_1fr_1.2fr] md:gap-8"
-          style={{ borderColor: '#3f4044' }}
+          style={{ borderColor: 'var(--rec-rule)' }}
         >
-          <p className="font-mono text-xs" style={{ color: '#4fb4d8' }}>
+          <p className="rec-mono text-xs" style={{ color: 'var(--rec-link)' }}>
             0{index + 1} / {surface.label}
           </p>
           <div>
-            <h3 className="text-lg font-semibold" style={{ color: '#cbcdd2' }}>
+            <h3 className="text-lg font-semibold" style={{ color: 'var(--rec-ink)' }}>
               {surface.title}
             </h3>
-            <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+            <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
               {surface.detail}
             </p>
           </div>
@@ -77,8 +85,8 @@ function NativeSurfaces({ integration }: { integration: Integration }) {
             {surface.items.map((item) => (
               <li
                 key={item}
-                className="rounded border px-2.5 py-1 font-mono text-xs"
-                style={{ borderColor: '#3f4044', color: '#cbcdd2', background: '#26272c' }}
+                className="border px-2.5 py-1 rec-mono text-xs"
+                style={{ borderColor: 'var(--rec-rule)', color: 'var(--rec-ink)', background: 'var(--rec-paper-raised)' }}
               >
                 {item}
               </li>
@@ -92,10 +100,10 @@ function NativeSurfaces({ integration }: { integration: Integration }) {
 
 function PhaseRouting({ integration }: { integration: Integration }) {
   return (
-    <div className="overflow-x-auto border-y" style={{ borderColor: '#3f4044' }}>
+    <div className="overflow-x-auto border-y" style={{ borderColor: 'var(--rec-rule)' }}>
       <table className="w-full min-w-[42rem] border-collapse text-left">
         <thead>
-          <tr className="font-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--mk-muted)' }}>
+          <tr className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-ink-2)' }}>
             <th className="py-3 pr-6 font-medium">Phase</th>
             <th className="px-6 py-3 font-medium">{integration.phaseSection.entryHeader}</th>
             <th className="py-3 pl-6 font-medium">Evidence produced</th>
@@ -103,14 +111,14 @@ function PhaseRouting({ integration }: { integration: Integration }) {
         </thead>
         <tbody>
           {integration.phaseRoutes.map((route) => (
-            <tr key={route.phase} className="border-t" style={{ borderColor: '#3f4044' }}>
-              <th className="py-4 pr-6 font-mono text-sm font-medium" style={{ color: '#4fb4d8' }}>
+            <tr key={route.phase} className="border-t" style={{ borderColor: 'var(--rec-rule)' }}>
+              <th className="py-4 pr-6 rec-mono text-sm font-medium" style={{ color: 'var(--rec-link)' }}>
                 {route.phase}
               </th>
-              <td className="px-6 py-4 font-mono text-sm" style={{ color: '#cbcdd2' }}>
+              <td className="px-6 py-4 rec-mono text-sm" style={{ color: 'var(--rec-ink)' }}>
                 {route.entry}
               </td>
-              <td className="py-4 pl-6 text-sm" style={{ color: 'var(--mk-muted)' }}>
+              <td className="py-4 pl-6 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
                 {route.evidence}
               </td>
             </tr>
@@ -124,26 +132,26 @@ function PhaseRouting({ integration }: { integration: Integration }) {
 function EnforcementBoundary({ integration }: { integration: Integration }) {
   const { session, ci } = integration.enforcement;
   return (
-    <div className="grid border-y md:grid-cols-2" style={{ borderColor: '#3f4044' }}>
+    <div className="grid border-y md:grid-cols-2" style={{ borderColor: 'var(--rec-rule)' }}>
       <div className="py-6 pr-0 md:pr-8">
-        <p className="font-mono text-xs uppercase tracking-[0.14em]" style={{ color: '#e5cd52' }}>
+        <p className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-gate-ink)' }}>
           {session.kicker}
         </p>
-        <h3 className="mt-2 text-lg font-semibold" style={{ color: '#cbcdd2' }}>
+        <h3 className="mt-2 text-lg font-semibold" style={{ color: 'var(--rec-ink)' }}>
           {session.title}
         </h3>
-        <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+        <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
           {session.body}
         </p>
       </div>
-      <div className="border-t py-6 md:border-l md:border-t-0 md:pl-8" style={{ borderColor: '#3f4044' }}>
-        <p className="font-mono text-xs uppercase tracking-[0.14em]" style={{ color: '#78bd65' }}>
+      <div className="border-t py-6 md:border-l md:border-t-0 md:pl-8" style={{ borderColor: 'var(--rec-rule)' }}>
+        <p className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-pass-ink)' }}>
           {ci.kicker}
         </p>
-        <h3 className="mt-2 text-lg font-semibold" style={{ color: '#cbcdd2' }}>
+        <h3 className="mt-2 text-lg font-semibold" style={{ color: 'var(--rec-ink)' }}>
           {ci.title}
         </h3>
-        <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+        <p className="mt-2 text-sm leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
           {ci.body}
         </p>
       </div>
@@ -160,7 +168,7 @@ function OperatingCommands({ integration }: { integration: Integration }) {
           const isComment = line.startsWith('#');
           const isBlank = line.length === 0;
           return (
-            <span key={`${index}-${line}`} style={{ color: isComment ? 'var(--mk-muted)' : '#cbcdd2' }}>
+            <span key={`${index}-${line}`} style={{ color: isComment ? '#686b78' : '#cbcdd2' }}>
               {index > 0 ? '\n' : ''}
               {isBlank ? '' : line}
             </span>
@@ -179,11 +187,11 @@ function ResourceNav({ integration }: { integration: Integration }) {
     >
       {integration.resources.map((resource) =>
         resource.external ? (
-          <a key={resource.href} href={resource.href} style={{ color: '#4fb4d8' }}>
+          <a key={resource.href} href={resource.href} style={{ color: 'var(--rec-link)' }}>
             {resource.label}
           </a>
         ) : (
-          <Link key={resource.href} href={resource.href} style={{ color: '#4fb4d8' }}>
+          <Link key={resource.href} href={resource.href} style={{ color: 'var(--rec-link)' }}>
             {resource.label}
           </Link>
         ),
@@ -195,10 +203,10 @@ function ResourceNav({ integration }: { integration: Integration }) {
 function IntroWithCode({ text }: { text: string }) {
   const parts = text.split(/(`[^`]+`)/g);
   return (
-    <p className="mb-8 max-w-2xl leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+    <p className="mb-8 max-w-[72ch] leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
       {parts.map((part, index) =>
         part.startsWith('`') && part.endsWith('`') ? (
-          <code key={`${part}-${index}`} style={{ color: '#4fb4d8' }}>
+          <code key={`${part}-${index}`} style={{ color: 'var(--rec-link)' }}>
             {part.slice(1, -1)}
           </code>
         ) : (
@@ -216,18 +224,18 @@ export function IntegrationDetailPage({ integration }: { integration: Integratio
       <MarketingSection headingLevel={1} kicker={integration.hero.kicker} title={integration.hero.title}>
         <div className="grid items-start gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:gap-14">
           <div>
-            <p className="max-w-2xl text-lg leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+            <p className="max-w-[72ch] text-lg leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
               {integration.tagline} {integration.hero.identity}
             </p>
             <div className="my-8 flex flex-wrap gap-2">
               {integration.hero.badges.map((badge) => (
                 <span
                   key={badge.label}
-                  className="rounded border px-2.5 py-1 font-mono text-xs"
+                  className="border px-2.5 py-1 rec-mono text-xs"
                   style={
                     badge.accent
-                      ? { borderColor: '#4fb4d8', color: '#4fb4d8' }
-                      : { borderColor: '#3f4044', color: 'var(--mk-muted)' }
+                      ? { borderColor: 'var(--rec-link)', color: 'var(--rec-link)' }
+                      : { borderColor: 'var(--rec-rule)', color: 'var(--rec-ink-2)' }
                   }
                 >
                   {badge.label}
@@ -242,7 +250,7 @@ export function IntegrationDetailPage({ integration }: { integration: Integratio
         </div>
       </MarketingSection>
 
-      <div style={{ background: '#18191d' }}>
+      <div style={{ background: 'var(--rec-paper-sunk)' }}>
         <MarketingSection kicker={integration.surfacesSection.kicker} title={integration.surfacesSection.title}>
           <div className="mb-10 lg:max-w-md">
             <NativeBundle integration={integration} />
@@ -256,7 +264,7 @@ export function IntegrationDetailPage({ integration }: { integration: Integratio
         <PhaseRouting integration={integration} />
       </MarketingSection>
 
-      <div style={{ background: '#18191d' }}>
+      <div style={{ background: 'var(--rec-paper-sunk)' }}>
         <MarketingSection kicker={integration.railsSection.kicker} title={integration.railsSection.title}>
           <EnforcementBoundary integration={integration} />
         </MarketingSection>

--- a/apps/docs/components/marketing/lifecycle-pipeline.tsx
+++ b/apps/docs/components/marketing/lifecycle-pipeline.tsx
@@ -1,97 +1,118 @@
 import { PHASES } from '@/lib/phase-graph.mjs';
+import { ExitCode } from './record';
 
-// The section claims "a gate between every one", so the gate is the subject
-// here, not the connector. The previous version inverted that: phases were
-// cards and gates were 3.5px rings in the gaps — the one thing the headline
-// promised was the least visible thing on screen. It also wrapped 6+2 because
-// flex-wrap sized cells to their content ("Rail" narrow, "Interrogate" wide),
-// which left a connector arrow pointing at nothing at the end of row one.
+// The approval chain.
 //
-// A fixed grid removes the ragged wrap by construction: 4×2, 2×4, then 1
-// column, always even. Each phase carries its own exit gate, so there are no
-// between-cell connectors left to break, and the eight gates are named rather
-// than implied.
+// The section claims "a gate between every one", so the gate is the subject
+// here, not the connector. Under the record world the chain is what it is in
+// any change record: a ruled table with one row per control point, an approver
+// column, and a verdict. The two human gates are simply the two rows where the
+// approver is a person — the exception reads structurally, not as a colour.
+//
+// Every approver below is a real CLI (or a person). There is deliberately no
+// per-row evidence column: only some phases have an artifact whose filename can
+// be stated as fact, and a column that is right six times out of eight is worse
+// than no column. The manifest is named once, in the note beneath.
 
-/** Machine gate: the ring glyph already used for a passing gate elsewhere. */
-function MachineGateMark() {
-  return (
-    <svg aria-hidden viewBox="0 0 12 12" className="h-3 w-3 shrink-0">
-      <circle cx="6" cy="6" r="4" fill="none" stroke="var(--adlc-pass)" strokeWidth="1.5" />
-    </svg>
-  );
-}
-
-/** Human gate: a filled diamond — a different shape, not just a different colour. */
-function HumanGateMark() {
-  return (
-    <svg aria-hidden viewBox="0 0 12 12" className="h-3 w-3 shrink-0">
-      <path d="M6 1 L11 6 L6 11 L1 6 Z" fill="var(--adlc-highlight)" />
-    </svg>
-  );
-}
+/** The approver for each phase. Human gates name a person; the rest name the tool. */
+const APPROVER: Record<string, string> = {
+  P0: 'adlc ticket',
+  P1: 'A person',
+  P2: 'adlc coldstart',
+  P3: 'adlc rails-guard',
+  P4: 'adlc gate',
+  P5: 'adlc prosecute',
+  P6: 'A person',
+  P7: 'adlc lesson-foundry',
+};
 
 export function LifecyclePipeline() {
   return (
     <div>
-      {/* gap-px over a border-coloured container is the hairline-grid pattern
-          already used by the failure-mode grid on this page. It matters here
-          for a second reason: /lifecycle renders this directly above a grid of
-          phase DETAIL cards, and separate bordered cards read as the same
-          content twice. Collapsing the cells into one continuous rail keeps
-          this a map and leaves the cards below as the content. */}
-      <div
-        className="overflow-hidden rounded-lg border"
-        style={{ borderColor: '#3f4044', background: '#3f4044' }}
-      >
-        <ol
-          className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4"
-          aria-label="The eight ADLC phases, each with the gate that ends it"
+      <div style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+        {/* Header row: the record's column legend. Columns never move. */}
+        <div
+          className="hidden grid-cols-[46px_minmax(0,1fr)_minmax(0,1.1fr)_minmax(0,1fr)_112px] md:grid"
+          style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}
         >
-          {PHASES.map((phase, i) => (
-          <li
-            key={phase.id}
-            className="mk-gate-line flex flex-col px-4 py-3.5"
-            style={{
-              animationDelay: `${i * 0.06}s`,
-              // Flat surface for every cell. A tint on the two human cells was
-              // tried and removed: over this warm-grey it muddies toward brown
-              // and reads as a warning state. The amber mark and label already
-              // mark the exception, and one signal is enough.
-              background: '#26272c',
-            }}
-          >
-            <span className="font-mono text-xs" style={{ color: '#4fb4d8' }}>
-              {phase.id}
-            </span>
-            <span className="mt-0.5 text-sm font-semibold" style={{ color: '#cbcdd2' }}>
-              {phase.name}
-            </span>
+          <div className="rec-legend px-3 py-2.5" />
+          <div className="rec-legend px-3 py-2.5">Control point</div>
+          <div className="rec-legend px-3 py-2.5">Exit gate</div>
+          <div className="rec-legend px-3 py-2.5">Approver</div>
+          <div className="rec-legend px-3 py-2.5">Verdict</div>
+        </div>
 
-            <span className="mt-2.5 flex items-center gap-2">
-              {phase.human ? <HumanGateMark /> : <MachineGateMark />}
-              <span
-                className="font-mono text-xs"
-                style={{ color: phase.human ? 'var(--adlc-highlight)' : 'var(--mk-muted)' }}
+        <ol aria-label="The eight ADLC phases, each with the gate that ends it">
+          {PHASES.map((phase, i) => (
+            <li
+              key={phase.id}
+              className="rec-row-settle grid grid-cols-[46px_minmax(0,1fr)] items-center gap-y-1 md:grid-cols-[46px_minmax(0,1fr)_minmax(0,1.1fr)_minmax(0,1fr)_112px] md:gap-y-0"
+              style={{
+                animationDelay: `${i * 32}ms`,
+                borderBottom: '1px solid var(--rec-rule)',
+                background: phase.human ? 'var(--rec-gate-field)' : 'var(--rec-paper-raised)',
+              }}
+            >
+              <div className="rec-mono px-3 py-3 text-[12px] md:py-3.5" style={{ color: 'var(--rec-ink-3)' }}>
+                {phase.id}
+              </div>
+              <div
+                className="px-3 py-3 text-[15px] font-semibold tracking-[-0.012em] md:py-3.5"
+                style={{ color: 'var(--rec-ink)' }}
+              >
+                {phase.name}
+              </div>
+              <div
+                className="rec-mono col-start-2 px-3 pb-1 text-[12.5px] md:col-start-auto md:py-3.5 md:pb-3.5"
+                style={{ color: 'var(--rec-ink-2)' }}
               >
                 {phase.gate}
-              </span>
-            </span>
-          </li>
+              </div>
+              <div
+                className="col-start-2 flex items-center px-3 pb-1 text-[13px] md:col-start-auto md:py-3.5 md:pb-3.5"
+                style={{
+                  color: phase.human ? 'var(--rec-gate-ink)' : 'var(--rec-ink-2)',
+                  fontWeight: phase.human ? 600 : 400,
+                }}
+              >
+                {phase.human ? (
+                  <span
+                    aria-hidden
+                    className="mr-2 inline-block h-[7px] w-[7px] shrink-0 rotate-45"
+                    style={{ background: '#e5cd52', border: '1px solid var(--rec-gate-edge)' }}
+                  />
+                ) : null}
+                {APPROVER[phase.id]}
+              </div>
+              <div className="col-start-2 px-3 pb-3 md:col-start-auto md:py-3.5 md:pb-3.5">
+                {/* The verdict lands just after its row settles: the record
+                    resolving, once. Kept short so a chip is never blank long
+                    enough to read as missing data. */}
+                <ExitCode verdict={phase.human ? 'attest' : 'pass'} stampDelay={i * 32 + 150} />
+              </div>
+            </li>
           ))}
         </ol>
       </div>
 
       {/* The legend earns its place: it states the ratio, which is the thesis. */}
-      <p className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm" style={{ color: 'var(--mk-muted)' }}>
+      <div className="mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 text-[13.5px]" style={{ color: 'var(--rec-ink-2)' }}>
         <span className="flex items-center gap-2">
-          <MachineGateMark />
+          <svg aria-hidden viewBox="0 0 12 12" className="h-3 w-3 shrink-0">
+            <circle cx="6" cy="6" r="4" fill="none" stroke="var(--rec-pass-ink)" strokeWidth="1.5" />
+          </svg>
           Six gates a machine can check
         </span>
         <span className="flex items-center gap-2">
-          <HumanGateMark />
+          <svg aria-hidden viewBox="0 0 12 12" className="h-3 w-3 shrink-0">
+            <path d="M6 1 L11 6 L6 11 L1 6 Z" fill="#e5cd52" stroke="var(--rec-gate-edge)" />
+          </svg>
           Two a person has to close
         </span>
-      </p>
+        <span className="rec-mono text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
+          Evidence lands in .adlc/manifest.jsonl
+        </span>
+      </div>
     </div>
   );
 }

--- a/apps/docs/components/marketing/lifecycle-pipeline.tsx
+++ b/apps/docs/components/marketing/lifecycle-pipeline.tsx
@@ -14,13 +14,22 @@ import { ExitCode } from './record';
 // be stated as fact, and a column that is right six times out of eight is worse
 // than no column. The manifest is named once, in the note beneath.
 
-/** The approver for each phase. Human gates name a person; the rest name the tool. */
-const APPROVER: Record<string, string> = {
+/**
+ * The approver for each phase. Human gates name a person; the rest name the tool.
+ *
+ * Every machine approver here MUST be a real dispatchable tool — this component
+ * tells the visitor these are executable, so a name that does not dispatch is a
+ * broken promise, not a typo. P4 previously read `adlc gate`, which does not
+ * exist: `packages/gate` is not a package and the dispatcher exits 1 on it. The
+ * name was taken from an MCP tool called `adlc_gate`, which is not a CLI.
+ * scripts/test/marketing-approvers.test.mjs now dispatches every one of these.
+ */
+export const APPROVER: Record<string, string> = {
   P0: 'adlc ticket',
   P1: 'A person',
   P2: 'adlc coldstart',
   P3: 'adlc rails-guard',
-  P4: 'adlc gate',
+  P4: 'adlc build-gate',
   P5: 'adlc prosecute',
   P6: 'A person',
   P7: 'adlc lesson-foundry',

--- a/apps/docs/components/marketing/lifecycle-pipeline.tsx
+++ b/apps/docs/components/marketing/lifecycle-pipeline.tsx
@@ -1,53 +1,97 @@
 import { PHASES } from '@/lib/phase-graph.mjs';
 
-// The connector draws the gate the section title claims: rail, gate ring
-// (pass token), rail, arrowhead. Decorative only — the list's aria-label
-// carries the semantics.
-function GateConnector() {
+// The section claims "a gate between every one", so the gate is the subject
+// here, not the connector. The previous version inverted that: phases were
+// cards and gates were 3.5px rings in the gaps — the one thing the headline
+// promised was the least visible thing on screen. It also wrapped 6+2 because
+// flex-wrap sized cells to their content ("Rail" narrow, "Interrogate" wide),
+// which left a connector arrow pointing at nothing at the end of row one.
+//
+// A fixed grid removes the ragged wrap by construction: 4×2, 2×4, then 1
+// column, always even. Each phase carries its own exit gate, so there are no
+// between-cell connectors left to break, and the eight gates are named rather
+// than implied.
+
+/** Machine gate: the ring glyph already used for a passing gate elsewhere. */
+function MachineGateMark() {
   return (
-    <svg aria-hidden viewBox="0 0 44 12" className="mx-1 h-3 w-11 shrink-0">
-      <line x1="1" y1="6" x2="15" y2="6" stroke="#3f4044" strokeWidth="1.5" />
-      <circle cx="22" cy="6" r="3.5" fill="none" stroke="var(--adlc-pass)" strokeWidth="1.5" />
-      <line x1="29" y1="6" x2="38" y2="6" stroke="#3f4044" strokeWidth="1.5" />
-      <path
-        d="M 35.5 2.5 L 40 6 L 35.5 9.5"
-        fill="none"
-        stroke="#3f4044"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+    <svg aria-hidden viewBox="0 0 12 12" className="h-3 w-3 shrink-0">
+      <circle cx="6" cy="6" r="4" fill="none" stroke="var(--adlc-pass)" strokeWidth="1.5" />
     </svg>
   );
 }
 
-// Designed component (not Mermaid) — data-driven from the tested PHASES
-// module. Chips enter left-to-right; reduced-motion shows them statically
-// (mk-gate-line guard in global.css).
+/** Human gate: a filled diamond — a different shape, not just a different colour. */
+function HumanGateMark() {
+  return (
+    <svg aria-hidden viewBox="0 0 12 12" className="h-3 w-3 shrink-0">
+      <path d="M6 1 L11 6 L6 11 L1 6 Z" fill="var(--adlc-highlight)" />
+    </svg>
+  );
+}
+
 export function LifecyclePipeline() {
   return (
-    <ol
-      className="flex flex-wrap items-center gap-y-4"
-      aria-label="ADLC phases P0 through P7 with a gate after each phase"
-    >
-      {PHASES.map((p, i) => (
-        <li
-          key={p.id}
-          className="mk-gate-line flex items-center"
-          style={{ animationDelay: `${i * 0.08}s` }}
+    <div>
+      {/* gap-px over a border-coloured container is the hairline-grid pattern
+          already used by the failure-mode grid on this page. It matters here
+          for a second reason: /lifecycle renders this directly above a grid of
+          phase DETAIL cards, and separate bordered cards read as the same
+          content twice. Collapsing the cells into one continuous rail keeps
+          this a map and leaves the cards below as the content. */}
+      <div
+        className="overflow-hidden rounded-lg border"
+        style={{ borderColor: '#3f4044', background: '#3f4044' }}
+      >
+        <ol
+          className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4"
+          aria-label="The eight ADLC phases, each with the gate that ends it"
         >
-          <span
-            className="flex flex-col rounded-lg border px-4 py-3"
-            style={{ borderColor: '#3f4044', background: '#26272c' }}
+          {PHASES.map((phase, i) => (
+          <li
+            key={phase.id}
+            className="mk-gate-line flex flex-col px-4 py-3.5"
+            style={{
+              animationDelay: `${i * 0.06}s`,
+              // Flat surface for every cell. A tint on the two human cells was
+              // tried and removed: over this warm-grey it muddies toward brown
+              // and reads as a warning state. The amber mark and label already
+              // mark the exception, and one signal is enough.
+              background: '#26272c',
+            }}
           >
-            <span className="font-mono text-xs" style={{ color: '#4fb4d8' }}>{p.id}</span>
-            <span className="whitespace-nowrap text-sm font-semibold" style={{ color: '#cbcdd2' }}>
-              {p.name}
+            <span className="font-mono text-xs" style={{ color: '#4fb4d8' }}>
+              {phase.id}
             </span>
-          </span>
-          {i < PHASES.length - 1 ? <GateConnector /> : null}
-        </li>
-      ))}
-    </ol>
+            <span className="mt-0.5 text-sm font-semibold" style={{ color: '#cbcdd2' }}>
+              {phase.name}
+            </span>
+
+            <span className="mt-2.5 flex items-center gap-2">
+              {phase.human ? <HumanGateMark /> : <MachineGateMark />}
+              <span
+                className="font-mono text-xs"
+                style={{ color: phase.human ? 'var(--adlc-highlight)' : 'var(--mk-muted)' }}
+              >
+                {phase.gate}
+              </span>
+            </span>
+          </li>
+          ))}
+        </ol>
+      </div>
+
+      {/* The legend earns its place: it states the ratio, which is the thesis. */}
+      <p className="mt-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm" style={{ color: 'var(--mk-muted)' }}>
+        <span className="flex items-center gap-2">
+          <MachineGateMark />
+          Six gates a machine can check
+        </span>
+        <span className="flex items-center gap-2">
+          <HumanGateMark />
+          Two a person has to close
+        </span>
+      </p>
+    </div>
   );
 }

--- a/apps/docs/components/marketing/record.tsx
+++ b/apps/docs/components/marketing/record.tsx
@@ -1,0 +1,416 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+/**
+ * The record vocabulary.
+ *
+ * Every marketing surface is a controlled-change record: a header block of
+ * fixed fields, numbered clauses, an approver column, and attached exhibits.
+ * These are the atoms. Nothing here is a generic card, panel, or pill — a stock
+ * component inside a committed form is the lapse this file exists to prevent.
+ *
+ * Two surfaces, deliberately: the record is paper, the evidence is terminal.
+ * A person reads the record; a machine produced the evidence.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Chrome                                                                      */
+/* -------------------------------------------------------------------------- */
+
+const NAV = [
+  { href: '/lifecycle', label: 'Lifecycle' },
+  { href: '/failure-modes', label: 'Failure modes' },
+  { href: '/vs-sdlc', label: 'vs SDLC' },
+  { href: '/toolkit', label: 'Toolkit' },
+  { href: '/integrations', label: 'Integrations' },
+  { href: '/enterprise', label: 'Enterprise' },
+  { href: '/docs', label: 'Docs' },
+];
+
+/**
+ * The GitHub mark, inlined.
+ *
+ * lucide-react is the project's icon package and ships 5,975 icons, none of them
+ * brand marks — Lucide removed those for trademark reasons — and fumadocs-ui does
+ * not export one either. Adding a package for a single glyph costs a dependency
+ * and a bundle entry, so the official mark is inlined instead. It inherits
+ * currentColor, so it takes the nav's own hover states.
+ */
+function GitHubMark() {
+  return (
+    <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden focusable="false">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}
+
+/**
+ * The masthead stays on the terminal ground. It is the hard top edge that keeps
+ * the record attached to the world that produced it, and it is the one place the
+ * pass-green appears as identity rather than as a verdict.
+ */
+export function Masthead() {
+  return (
+    <header style={{ background: '#1c1d21', color: '#cbcdd2' }}>
+      <div className="mx-auto flex h-[52px] max-w-[1180px] items-center justify-between px-6 md:px-8">
+        {/* The name is spelled out. "ADLC" alone assumes the visitor already
+            knows what it stands for, which is exactly what a first-time
+            enterprise reader does not. The initialism follows in parentheses so
+            the short form still teaches itself. */}
+        <Link
+          href="/"
+          className="rec-mono flex items-center gap-2.5 text-[12.5px] font-bold tracking-[0.1em]"
+          style={{ color: '#cbcdd2' }}
+        >
+          <span aria-hidden className="block h-[9px] w-[9px] shrink-0 rounded-[1px]" style={{ background: '#78bd65' }} />
+          <span className="hidden sm:inline">Agentic Development Lifecycle (ADLC)</span>
+          <span className="sm:hidden">ADLC</span>
+        </Link>
+        <nav className="hidden items-center gap-6 text-[12.5px] font-medium md:flex">
+          {NAV.map((n) => (
+            <Link key={n.href} href={n.href} style={{ color: '#9599a6' }} className="hover:text-[#cbcdd2]">
+              {n.label}
+            </Link>
+          ))}
+          <a
+            href="https://github.com/voodootikigod/adlc"
+            className="flex items-center transition-colors hover:text-[#cbcdd2]"
+            style={{ color: '#9599a6' }}
+            aria-label="ADLC on GitHub"
+          >
+            <GitHubMark />
+          </a>
+        </nav>
+        {/* Small screens keep the record reachable without a drawer: the nav is
+            seven flat destinations, so it wraps into the rail below instead. */}
+        <nav className="flex items-center gap-4 text-[12px] font-medium md:hidden">
+          <Link href="/lifecycle" style={{ color: '#9599a6' }}>
+            Lifecycle
+          </Link>
+          <Link href="/docs" style={{ color: '#9599a6' }}>
+            Docs
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+/** The strip under the masthead: what record this is, and its standing. */
+export function RecordRail({ items }: { items: { k: string; v: ReactNode; open?: boolean }[] }) {
+  return (
+    <div style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}>
+      <div className="mx-auto flex max-w-[1180px] flex-wrap items-center gap-y-1 px-6 py-2 md:h-[34px] md:flex-nowrap md:gap-y-0 md:py-0 md:px-8">
+        {items.map((it, i) => (
+          <span
+            key={it.k}
+            className="rec-mono whitespace-nowrap text-[10px] uppercase tracking-[0.1em]"
+            style={{
+              color: 'var(--rec-ink-2)',
+              paddingRight: 18,
+              marginRight: 18,
+              borderRight: i === items.length - 1 ? 'none' : '1px solid var(--rec-rule-strong)',
+            }}
+          >
+            {it.open ? (
+              <span
+                aria-hidden
+                className="mr-2 inline-block h-[6px] w-[6px] rounded-full align-[1px]"
+                style={{ background: '#e5cd52' }}
+              />
+            ) : null}
+            {it.k}{' '}
+            <b className="font-semibold" style={{ color: 'var(--rec-ink)' }}>
+              {it.v}
+            </b>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function RecordFoot({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ borderTop: '1px solid var(--rec-rule)' }}>
+      <div
+        className="mx-auto flex max-w-[1180px] flex-wrap items-center justify-between gap-4 px-6 py-8 text-[12px] md:px-8"
+        style={{ color: 'var(--rec-ink-3)' }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* The record body                                                             */
+/* -------------------------------------------------------------------------- */
+
+/** The ruled column the whole record sits in. */
+export function RecordBody({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="mx-auto max-w-[1180px]"
+      style={{ borderLeft: '1px solid var(--rec-rule)', borderRight: '1px solid var(--rec-rule)' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The header block: fixed fields, hairline-divided, never a card grid. */
+export function FieldBlock({ fields }: { fields: { label: string; value: ReactNode; mono?: boolean }[] }) {
+  return (
+    <div
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
+      style={{ borderBottom: '1px solid var(--rec-rule)' }}
+    >
+      {fields.map((f, i) => (
+        <div
+          key={f.label}
+          className="px-6 py-4 md:px-6"
+          style={{
+            borderRight: '1px solid var(--rec-rule)',
+            borderBottom: i < fields.length - 1 ? '1px solid var(--rec-rule)' : undefined,
+          }}
+        >
+          <div className="rec-legend">{f.label}</div>
+          <div
+            className={`mt-1.5 text-[14px] font-medium leading-[1.35] ${f.mono ? 'rec-mono text-[13px]' : ''}`}
+            style={{ color: 'var(--rec-ink)' }}
+          >
+            {f.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A numbered clause. The numbering is the form's own grammar, not decoration:
+ * exhibits reference the clause they are attached to, so the reader needs it.
+ */
+export function Clause({
+  n,
+  label,
+  title,
+  lede,
+  aside,
+  children,
+  last = false,
+}: {
+  n: string;
+  label: string;
+  title?: ReactNode;
+  lede?: ReactNode;
+  aside?: ReactNode;
+  children?: ReactNode;
+  last?: boolean;
+}) {
+  return (
+    <section style={{ borderBottom: last ? undefined : '1px solid var(--rec-rule)' }}>
+      <div className="flex flex-col gap-x-6 px-6 pb-8 pt-10 md:flex-row md:px-8 md:pb-10 md:pt-12">
+        <div className="mb-3 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
+          <div className="rec-legend whitespace-nowrap">
+            §{n} {label}
+          </div>
+        </div>
+        <div className="min-w-0 flex-1">
+          {title}
+          {lede ? (
+            <p
+              className="mt-4 max-w-[72ch] text-[16.5px] leading-[1.55]"
+              style={{ color: 'var(--rec-ink-2)' }}
+            >
+              {lede}
+            </p>
+          ) : null}
+          {children}
+        </div>
+        {aside ? (
+          <div
+            className="mt-6 shrink-0 md:mt-0 md:w-[260px] md:border-l md:pl-6"
+            style={{ borderColor: 'var(--rec-rule)' }}
+          >
+            {aside}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+/** The statement: the one place the width axis runs at panel scale. */
+export function Statement({ children }: { children: ReactNode }) {
+  return (
+    <h1
+      className="rec-statement max-w-[26ch] text-balance text-[clamp(30px,4.3vw,54px)] font-bold"
+      style={{ color: 'var(--rec-ink)' }}
+    >
+      {children}
+    </h1>
+  );
+}
+
+export function ClauseTitle({ children }: { children: ReactNode }) {
+  return (
+    <h2
+      className="text-[clamp(19px,2.1vw,26px)] font-bold tracking-[-0.018em]"
+      style={{ color: 'var(--rec-ink)' }}
+    >
+      {children}
+    </h2>
+  );
+}
+
+export function RecordLink({ href, children }: { href: string; children: ReactNode }) {
+  const props = {
+    className: 'text-[13px]',
+    style: { color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' },
+  };
+  return href.startsWith('http') ? (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ) : (
+    <Link href={href} {...props}>
+      {children}
+    </Link>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Verdicts                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export type Verdict = 'pass' | 'fail' | 'attest';
+
+/**
+ * A verdict is never carried by colour alone: every chip pairs a glyph with a
+ * word, and the machine verdicts carry their exit code too, because the exit
+ * code is the actual contract.
+ */
+export function ExitCode({ verdict, stampDelay }: { verdict: Verdict; stampDelay?: number }) {
+  const spec = {
+    pass: { glyph: '✓', word: 'PASS', code: '0', ink: 'var(--rec-pass-ink)', edge: 'var(--rec-pass-edge)', field: 'var(--rec-pass-field)' },
+    fail: { glyph: '✗', word: 'FAIL', code: '2', ink: 'var(--rec-fail-ink)', edge: 'var(--rec-fail-edge)', field: 'var(--rec-fail-field)' },
+    attest: { glyph: '◆', word: 'ATTEST', code: '', ink: 'var(--rec-gate-ink)', edge: 'var(--rec-gate-edge)', field: 'var(--rec-gate-field)' },
+  }[verdict];
+
+  return (
+    <span
+      className={`rec-mono inline-flex items-center gap-1.5 whitespace-nowrap border px-1.5 py-[2px] text-[10.5px] font-semibold${
+        stampDelay === undefined ? '' : ' rec-code-stamp'
+      }`}
+      style={{
+        color: spec.ink,
+        borderColor: spec.edge,
+        background: spec.field,
+        animationDelay: stampDelay === undefined ? undefined : `${stampDelay}ms`,
+      }}
+    >
+      <span aria-hidden>{spec.glyph}</span>
+      {spec.word}
+      {spec.code ? <b className="font-semibold">{spec.code}</b> : null}
+    </span>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Exhibits — the evidence surface                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * An exhibit is a verbatim capture, attached to a clause by number. This is the
+ * page's whole claim structure: a sentence with no exhibit behind it has no
+ * standing here.
+ */
+export function Exhibit({
+  id,
+  attachedTo,
+  command,
+  status,
+  verdict,
+  children,
+}: {
+  id: string;
+  attachedTo: string;
+  command: string;
+  status: string;
+  verdict: Verdict;
+  children: ReactNode;
+}) {
+  return (
+    <figure className="mt-5">
+      <figcaption className="mb-2.5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <b className="rec-mono text-[11px] font-semibold tracking-[0.1em]" style={{ color: 'var(--rec-ink)' }}>
+          EXHIBIT {id}
+        </b>
+        <span className="text-[12.5px]" style={{ color: 'var(--rec-ink-3)' }}>
+          {attachedTo}
+        </span>
+      </figcaption>
+      <div style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
+        <div
+          className="rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
+          style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
+        >
+          <span className="truncate">{command}</span>
+          <span className="whitespace-nowrap" style={{ color: verdict === 'fail' ? '#eb3d54' : '#78bd65' }}>
+            {status}
+          </span>
+        </div>
+        <div className="rec-mono overflow-x-auto px-4 py-3.5 text-[12.5px] leading-[1.75]" style={{ color: '#cbcdd2' }}>
+          {children}
+        </div>
+      </div>
+    </figure>
+  );
+}
+
+/** Real gate output. Verdict lines keep glyph + word; colour only reinforces. */
+export function ExhibitOutput({ output }: { output: string }) {
+  return (
+    <pre className="whitespace-pre-wrap">
+      {output.split('\n').map((line, i) => {
+        const color = line.startsWith('✓') ? '#78bd65' : line.startsWith('✗') ? '#eb3d54' : '#cbcdd2';
+        const isPrompt = line.startsWith('$');
+        return (
+          <span key={i} style={{ color: isPrompt ? '#cbcdd2' : color }}>
+            {i > 0 ? '\n' : ''}
+            {isPrompt ? (
+              <>
+                <span style={{ color: '#686b78' }}>$</span>
+                {line.slice(1)}
+              </>
+            ) : (
+              line
+            )}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}
+
+/** A small terminal block used where a full exhibit caption would be noise. */
+export function Capture({ title, status, fail, children }: { title: string; status: string; fail?: boolean; children: ReactNode }) {
+  return (
+    <div style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
+      <div
+        className="rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
+        style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
+      >
+        <span className="truncate">{title}</span>
+        <span className="whitespace-nowrap" style={{ color: fail ? '#eb3d54' : '#78bd65' }}>
+          {status}
+        </span>
+      </div>
+      <div className="rec-mono overflow-x-auto px-4 py-3.5 text-[12.5px] leading-[1.75]" style={{ color: '#cbcdd2' }}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/marketing/record.tsx
+++ b/apps/docs/components/marketing/record.tsx
@@ -352,9 +352,9 @@ export function Exhibit({
           {attachedTo}
         </span>
       </figcaption>
-      <div style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
+      <div className="rec-capture" style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
         <div
-          className="rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
+          className="rec-capture-bar rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
           style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
         >
           <span className="truncate">{command}</span>
@@ -398,9 +398,9 @@ export function ExhibitOutput({ output }: { output: string }) {
 /** A small terminal block used where a full exhibit caption would be noise. */
 export function Capture({ title, status, fail, children }: { title: string; status: string; fail?: boolean; children: ReactNode }) {
   return (
-    <div style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
+    <div className="rec-capture" style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
       <div
-        className="rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
+        className="rec-capture-bar rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
         style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
       >
         <span className="truncate">{title}</span>

--- a/apps/docs/components/marketing/section.tsx
+++ b/apps/docs/components/marketing/section.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react';
 
 interface MarketingSectionProps {
   id?: string;
+  /** The clause label, e.g. "Scope". Rendered in the record's left gutter. */
   kicker?: string;
+  /** Clause number. Interior pages number their clauses like any record. */
+  n?: string;
   title: string;
   // Interior pages pass 1 for their lead section so every page has exactly
   // one h1; visual treatment is identical either way.
@@ -10,25 +13,55 @@ interface MarketingSectionProps {
   children: ReactNode;
 }
 
-export function MarketingSection({ id, kicker, title, headingLevel = 2, children }: MarketingSectionProps) {
+/**
+ * A clause of the record.
+ *
+ * Every marketing section is one, so the interior pages read as continuations of
+ * the same document rather than as a different site: ruled column, a numbered
+ * label in the left gutter, and the content in the measure beside it. The old
+ * kicker-over-heading stack is gone — a tracked eyebrow above every section is
+ * grammar nobody chose, whereas a clause label is the form's own.
+ */
+export function MarketingSection({ id, kicker, n, title, headingLevel = 2, children }: MarketingSectionProps) {
   const Heading = headingLevel === 1 ? 'h1' : 'h2';
+  const lead = headingLevel === 1;
+
   return (
-    <section id={id} className="mx-auto w-full max-w-5xl scroll-mt-24 px-6 py-20 md:py-28">
-      {kicker ? (
-        <p
-          className="mb-3 font-mono text-xs font-medium uppercase tracking-[0.2em]"
-          style={{ color: '#4fb4d8' }}
-        >
-          {kicker}
-        </p>
-      ) : null}
-      <Heading
-        className="max-w-3xl text-balance text-3xl font-bold leading-tight tracking-tight md:text-4xl"
-        style={{ color: '#cbcdd2' }}
-      >
-        {title}
-      </Heading>
-      <div className="mt-10">{children}</div>
+    <section
+      id={id}
+      className="mx-auto w-full max-w-[1180px] scroll-mt-24"
+      style={{
+        borderLeft: '1px solid var(--rec-rule)',
+        borderRight: '1px solid var(--rec-rule)',
+        borderBottom: '1px solid var(--rec-rule)',
+      }}
+    >
+      <div className="flex flex-col gap-x-6 px-6 pb-10 pt-10 md:flex-row md:px-8 md:pb-12 md:pt-12">
+        {kicker ? (
+          <div className="mb-3 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
+            {/* No whitespace-nowrap: interior kickers run long ("Claude Code
+                integration") and a non-wrapping legend overflows the 104px
+                gutter straight across the heading beside it. */}
+            <div className="rec-legend leading-[1.5]">
+              {n ? `§${n} ` : ''}
+              {kicker}
+            </div>
+          </div>
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <Heading
+            className={
+              lead
+                ? 'rec-statement max-w-[26ch] text-balance text-[clamp(28px,3.8vw,46px)] font-bold'
+                : 'max-w-[34ch] text-balance text-[clamp(19px,2.1vw,26px)] font-bold tracking-[-0.018em]'
+            }
+            style={{ color: 'var(--rec-ink)' }}
+          >
+            {title}
+          </Heading>
+          <div className="mt-7">{children}</div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/docs/components/marketing/terminal-card.tsx
+++ b/apps/docs/components/marketing/terminal-card.tsx
@@ -5,24 +5,29 @@ interface TerminalCardProps {
   children: ReactNode;
 }
 
+/**
+ * A capture. Evidence keeps the terminal ground and the unmodified An Old Hope
+ * palette wherever it appears, including on the record's paper surface — that
+ * contrast is the argument, so it is not softened to match the page around it.
+ *
+ * The traffic-light dots are gone: they were window chrome imitating a terminal
+ * app, and this is a captured stream, not a window.
+ */
 export function TerminalCard({ title, children }: TerminalCardProps) {
   return (
-    <div
-      className="overflow-hidden rounded-lg border"
-      style={{ borderColor: '#3f4044', background: '#26272c' }}
-    >
+    <div style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
       <div
-        className="flex items-center gap-3 border-b px-4 py-2.5 font-mono text-xs"
-        style={{ borderColor: '#3f4044', color: 'var(--mk-muted)' }}
+        className="rec-mono flex items-center gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
+        style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
       >
-        <span aria-hidden className="flex select-none gap-1.5">
-          <span className="h-2 w-2 rounded-full" style={{ background: '#3f4044' }} />
-          <span className="h-2 w-2 rounded-full" style={{ background: '#3f4044' }} />
-          <span className="h-2 w-2 rounded-full" style={{ background: '#3f4044' }} />
-        </span>
         <span className="truncate">{title}</span>
       </div>
-      <div className="overflow-x-auto p-4 font-mono text-sm leading-relaxed">{children}</div>
+      <div
+        className="rec-mono overflow-x-auto px-4 py-3.5 text-[12.5px] leading-[1.75]"
+        style={{ color: '#cbcdd2' }}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/docs/components/marketing/terminal-card.tsx
+++ b/apps/docs/components/marketing/terminal-card.tsx
@@ -15,9 +15,9 @@ interface TerminalCardProps {
  */
 export function TerminalCard({ title, children }: TerminalCardProps) {
   return (
-    <div style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
+    <div className="rec-capture" style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
       <div
-        className="rec-mono flex items-center gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
+        className="rec-capture-bar rec-mono flex items-center gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
         style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
       >
         <span className="truncate">{title}</span>

--- a/apps/docs/components/marketing/three-dials.tsx
+++ b/apps/docs/components/marketing/three-dials.tsx
@@ -4,68 +4,70 @@ const DIALS = [
   { name: 'Scope', value: 0.35, note: 'How much surface one ticket may touch' },
 ] as const;
 
-// Scale ticks at 0 / 25 / 50 / 75 / 100%, as needle rotations about the hub.
-const TICK_ANGLES = [-90, -45, 0, 45, 90];
-
-function Dial({ name, value, note }: (typeof DIALS)[number]) {
-  // Semi-circle gauge: needle angle from -90° (0) to +90° (1)
-  const angle = -90 + value * 180;
+// The three dials, as the record writes a setting: a named field, the value it
+// was set to, and a ruled scale showing where in its range that sits.
+//
+// These were semicircle needle gauges. That is instrument-panel vocabulary —
+// the world explicitly rejected for this product as too whimsical for the
+// audience — and it had survived into the record by being re-tinted rather than
+// rebuilt. A setting on a form is a value in a range, not a cockpit.
+//
+// The values are illustrative defaults for a worked example, which is why the
+// header says so rather than implying a measured reading.
+function DialRow({ name, value, note }: (typeof DIALS)[number]) {
   const pct = Math.round(value * 100);
   return (
-    <figure className="flex flex-col items-center gap-3">
-      <svg viewBox="0 0 100 60" className="w-44" role="img" aria-label={`${name} dial set to ${pct}%`}>
-        <path
-          d="M 10 55 A 40 40 0 0 1 90 55"
-          fill="none"
-          stroke="#3f4044"
-          strokeWidth="6"
-          strokeLinecap="round"
-        />
-        <path
-          d="M 10 55 A 40 40 0 0 1 90 55"
-          fill="none"
-          stroke="#4fb4d8"
-          strokeWidth="6"
-          strokeLinecap="round"
-          pathLength={100}
-          strokeDasharray={`${pct} 100`}
-        />
-        {TICK_ANGLES.map((a) => (
-          <line
-            key={a}
-            x1="50" y1="21" x2="50" y2="25"
-            stroke="#3f4044"
-            strokeWidth="1.5"
-            transform={`rotate(${a} 50 55)`}
+    <div
+      className="grid grid-cols-[minmax(0,1fr)_64px] items-baseline gap-x-5 gap-y-2 px-2 py-4 md:grid-cols-[150px_minmax(0,1fr)_64px]"
+      style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
+    >
+      <div className="text-[15px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+        {name}
+      </div>
+
+      {/* The scale: a ruled track with quarter ticks and a filled span. */}
+      <div className="col-span-2 md:col-span-1">
+        <div className="relative h-[18px]" style={{ borderBottom: '1px solid var(--rec-rule-strong)' }}>
+          <div
+            className="absolute bottom-0 left-0 top-[5px]"
+            style={{ width: `${pct}%`, background: 'var(--rec-ink)' }}
           />
-        ))}
-        <line
-          x1="50" y1="55" x2="50" y2="27"
-          stroke="#cbcdd2" strokeWidth="2.5" strokeLinecap="round"
-          transform={`rotate(${angle} 50 55)`}
-        />
-        <circle cx="50" cy="55" r="4" fill="#26272c" stroke="#cbcdd2" strokeWidth="2" />
-      </svg>
-      <figcaption className="text-center">
-        <span className="block font-semibold" style={{ color: '#cbcdd2' }}>
-          {name}{' '}
-          <span className="ml-1 font-mono text-sm font-normal" style={{ color: '#4fb4d8' }}>
-            {pct}%
-          </span>
-        </span>
-        <span className="mt-1 block max-w-44 text-xs leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+          {[0, 25, 50, 75, 100].map((t) => (
+            <span
+              key={t}
+              aria-hidden
+              className="absolute bottom-0 h-[6px] w-px"
+              style={{ left: `calc(${t}% - ${t === 100 ? 1 : 0}px)`, background: 'var(--rec-rule-strong)' }}
+            />
+          ))}
+        </div>
+        <p className="mt-1.5 text-[12.5px] leading-[1.45]" style={{ color: 'var(--rec-ink-2)' }}>
           {note}
-        </span>
-      </figcaption>
-    </figure>
+        </p>
+      </div>
+
+      <div
+        className="rec-mono text-right text-[14px] font-semibold tabular-nums"
+        style={{ color: 'var(--rec-ink)' }}
+      >
+        {pct}%
+      </div>
+    </div>
   );
 }
 
 export function ThreeDials() {
   return (
-    <div className="flex flex-wrap justify-center gap-10">
+    <div style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+      <div
+        className="flex items-baseline justify-between px-2 py-2.5"
+        style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}
+      >
+        <span className="rec-legend">Dial · setting · range</span>
+        <span className="rec-legend">Illustrative settings</span>
+      </div>
       {DIALS.map((d) => (
-        <Dial key={d.name} {...d} />
+        <DialRow key={d.name} {...d} />
       ))}
     </div>
   );

--- a/apps/docs/components/marketing/vs-table.tsx
+++ b/apps/docs/components/marketing/vs-table.tsx
@@ -6,28 +6,26 @@ import { VS_SDLC_ROWS } from '@/lib/vs-sdlc.mjs';
 // is load-bearing — the table scrolls in its own container, never the page.
 export function VsTable() {
   return (
-    <div className="overflow-x-auto rounded-lg border" style={{ borderColor: '#3f4044' }}>
+    <div className="overflow-x-auto" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
       <table className="w-full min-w-[40rem] border-collapse text-sm">
         <thead>
-          <tr>
+          <tr style={{ background: 'var(--rec-paper-sunk)', borderBottom: '1px solid var(--rec-rule-strong)' }}>
             <th
               scope="col"
-              className="p-4 text-left align-bottom font-mono text-xs font-medium uppercase tracking-wider"
-              style={{ color: 'var(--mk-muted)' }}
+              className="rec-legend p-3 text-left align-bottom"
             >
               Dimension
             </th>
             <th
               scope="col"
-              className="p-4 text-left align-bottom font-mono text-xs font-medium uppercase tracking-wider"
-              style={{ color: 'var(--mk-muted)' }}
+              className="rec-legend p-3 text-left align-bottom"
             >
               SDLC (built for humans)
             </th>
             <th
               scope="col"
-              className="p-4 text-left align-bottom font-mono text-xs font-medium uppercase tracking-wider"
-              style={{ color: '#4fb4d8', background: '#26272c' }}
+              className="p-4 text-left align-bottom rec-mono text-xs font-medium uppercase tracking-wider"
+              style={{ color: 'var(--rec-link)', background: 'var(--rec-paper-raised)' }}
             >
               ADLC (built for models)
             </th>
@@ -35,20 +33,20 @@ export function VsTable() {
         </thead>
         <tbody>
           {VS_SDLC_ROWS.map((r) => (
-            <tr key={r.dimension} className="border-t" style={{ borderColor: '#3f4044' }}>
+            <tr key={r.dimension} className="border-t" style={{ borderColor: 'var(--rec-rule)' }}>
               <th
                 scope="row"
                 className="w-[9.5rem] p-4 text-left align-top font-semibold"
-                style={{ color: '#cbcdd2' }}
+                style={{ color: 'var(--rec-ink)' }}
               >
                 {r.dimension}
               </th>
-              <td className="p-4 align-top leading-relaxed" style={{ color: 'var(--mk-muted)' }}>
+              <td className="p-4 align-top leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
                 {r.sdlc}
               </td>
               <td
                 className="p-4 align-top leading-relaxed"
-                style={{ color: '#cbcdd2', background: '#26272c' }}
+                style={{ color: 'var(--rec-ink)', background: 'var(--rec-paper-raised)', fontWeight: 500 }}
               >
                 {r.adlc}
               </td>

--- a/apps/docs/lib/marketing-gates.mjs
+++ b/apps/docs/lib/marketing-gates.mjs
@@ -1,5 +1,13 @@
 // Executable command surface shared by the homepage terminal treatments.
 // Keep commands aligned with the real CLI; tests invoke every tool's --help.
+//
+// IMPORTANT: `output` is a one-line SUMMARY of each gate's verdict, authored for
+// the page — it is not a captured transcript. The real `spec-lint` prints a
+// per-criterion table ending "spec-lint: all criteria verified."; it never emits
+// the line below. The commands and the exit-code semantics are real, and the
+// homepage says so in exactly those terms. Do not add copy claiming these are
+// verbatim captures without first replacing these strings with real captures
+// (deterministic fixtures + a test asserting the capture still matches).
 export const MARKETING_GATES = [
   {
     name: 'spec-lint',

--- a/apps/docs/lib/phase-graph.mjs
+++ b/apps/docs/lib/phase-graph.mjs
@@ -1,13 +1,25 @@
+// `gate` is the exit gate that ENDS each phase, quoted from the canonical
+// pipeline in ADLC.md (the "human gate / cold-start / RED gate / green gate /
+// zero-findings gate" line under the P0→P7 flow). It lives here rather than in
+// a component so the homepage pipeline and the /lifecycle page cannot disagree
+// about what gate closes a phase — they previously each carried their own idea
+// of which gates were human.
+//
+// `human: true` marks the two phases a person must close. That pair is the
+// whole claim: machines gate the other six.
 export const PHASES = [
-  { id: 'P0', name: 'Triage' },
-  { id: 'P1', name: 'Interrogate' },
-  { id: 'P2', name: 'Decompose' },
-  { id: 'P3', name: 'Rail' },
-  { id: 'P4', name: 'Build' },
-  { id: 'P5', name: 'Prosecute' },
-  { id: 'P6', name: 'Integrate' },
-  { id: 'P7', name: 'Distill' },
+  { id: 'P0', name: 'Triage', gate: 'routed', human: false },
+  { id: 'P1', name: 'Interrogate', gate: 'human gate', human: true },
+  { id: 'P2', name: 'Decompose', gate: 'cold-start', human: false },
+  { id: 'P3', name: 'Rail', gate: 'RED gate', human: false },
+  { id: 'P4', name: 'Build', gate: 'green gate', human: false },
+  { id: 'P5', name: 'Prosecute', gate: 'zero findings', human: false },
+  { id: 'P6', name: 'Integrate', gate: 'human gate', human: true },
+  { id: 'P7', name: 'Distill', gate: 'feeds the next run', human: false },
 ];
+
+/** The two phases whose gate is a person, derived so no surface can drift. */
+export const HUMAN_GATE_IDS = PHASES.filter((p) => p.human).map((p) => p.id);
 
 // Mermaid cannot resolve CSS variables, so these hexes are hardcoded.
 // #e5cd52 mirrors --adlc-wish (human-gate styling); #4fb4d8 mirrors the

--- a/apps/docs/test/marketing-approvers.test.mjs
+++ b/apps/docs/test/marketing-approvers.test.mjs
@@ -1,0 +1,76 @@
+// marketing-approvers.test.mjs — every machine approver the site displays must
+// be a tool the dispatcher actually routes.
+//
+// The approval chain tells the visitor these are executable: the whole claim of
+// the page is that the lifecycle runs in CI rather than living in a wiki. A name
+// that does not dispatch is therefore a broken promise, not a cosmetic typo.
+//
+// This is a regression test for a real defect. P4 shipped as `adlc gate`, which
+// does not exist — `packages/gate` is not a package and the dispatcher exits 1
+// on it. The name had been lifted from an MCP tool called `adlc_gate`, which is
+// not a CLI. An adversarial review caught it; nothing in the suite would have.
+//
+// The check reads the dispatcher's own tool list rather than executing each
+// tool, because some tools (lesson-foundry) legitimately have no `--help` and
+// running them for real would need repository state.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(docsRoot, '../..');
+const dispatcher = path.join(repoRoot, 'packages/cli/bin/adlc.mjs');
+
+/** The tool names `adlc --help` advertises, parsed from its grouped listing. */
+function dispatcherTools() {
+  const help = execFileSync(process.execPath, [dispatcher, '--help'], { encoding: 'utf8' });
+  const tools = new Set();
+  for (const line of help.split('\n')) {
+    // Tool rows are indented four spaces: "    spec-lint    Gate specs for ..."
+    const match = /^ {4}([a-z][a-z0-9-]*) {2,}\S/.exec(line);
+    if (match) tools.add(match[1]);
+  }
+  return tools;
+}
+
+/** The `adlc <tool>` names rendered in the approval chain's approver column. */
+function displayedApprovers() {
+  const source = readFileSync(
+    path.join(docsRoot, 'components/marketing/lifecycle-pipeline.tsx'),
+    'utf8',
+  );
+  const block = /export const APPROVER: Record<string, string> = \{([\s\S]*?)\n\};/.exec(source);
+  assert.ok(block, 'the APPROVER map must remain a statically readable literal');
+  return [...block[1].matchAll(/'adlc ([a-z][a-z0-9-]*)'/g)].map((m) => m[1]);
+}
+
+test('the dispatcher advertises a non-trivial tool list', () => {
+  // Guards the parser: if the help format changes and this returns nothing, the
+  // assertion below would pass vacuously against an empty set.
+  const tools = dispatcherTools();
+  assert.ok(tools.size >= 20, `expected the dispatcher to list its tools, parsed ${tools.size}`);
+});
+
+test('every machine approver shown on the site is a real dispatchable tool', () => {
+  const tools = dispatcherTools();
+  const approvers = displayedApprovers();
+
+  assert.ok(approvers.length > 0, 'the approval chain must display at least one machine approver');
+
+  for (const tool of approvers) {
+    assert.ok(
+      tools.has(tool),
+      `the approval chain shows "adlc ${tool}", which the dispatcher does not route.\n` +
+        `  Known tools: ${[...tools].sort().join(', ')}`,
+    );
+  }
+});
+
+test('the guard itself detects a planted unknown tool (self-test)', () => {
+  const tools = dispatcherTools();
+  assert.ok(!tools.has('gate'), '"gate" must not be a routed tool — it is the defect this guards');
+});

--- a/apps/docs/test/phase-diagram.test.mjs
+++ b/apps/docs/test/phase-diagram.test.mjs
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildPhaseMermaid, PHASES } from '../lib/phase-graph.mjs';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { buildPhaseMermaid, PHASES, HUMAN_GATE_IDS } from '../lib/phase-graph.mjs';
+
+const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 test('PHASES lists P0..P7 in order', () => {
   assert.deepEqual(PHASES.map((p) => p.id), ['P0','P1','P2','P3','P4','P5','P6','P7']);
@@ -9,6 +14,48 @@ test('PHASES lists P0..P7 in order', () => {
 test('P6 is named Integrate, not Review', () => {
   const p6 = PHASES.find((p) => p.id === 'P6');
   assert.equal(p6.name, 'Integrate');
+});
+
+test('every phase names the gate that ends it', () => {
+  // The section headline promises "a gate between every one". A phase with no
+  // gate would render a blank row under its name and quietly break that claim.
+  for (const phase of PHASES) {
+    assert.ok(
+      typeof phase.gate === 'string' && phase.gate.trim().length > 0,
+      `${phase.id}: missing an exit gate`,
+    );
+  }
+});
+
+test('exactly two gates are human, and they are P1 and P6', () => {
+  // This ratio is the thesis — machines gate the other six — and it is stated
+  // verbatim in the pipeline legend. If the data changes, the legend becomes a
+  // lie, so pin both the count and the identities.
+  assert.deepEqual(HUMAN_GATE_IDS, ['P1', 'P6']);
+  assert.equal(PHASES.filter((p) => p.human).length, 2);
+});
+
+test('the pipeline legend states the real machine/human split', () => {
+  const source = readFileSync(
+    path.join(docsRoot, 'components/marketing/lifecycle-pipeline.tsx'),
+    'utf8',
+  );
+  const machineCount = PHASES.length - HUMAN_GATE_IDS.length;
+  assert.ok(
+    new RegExp(`${machineCount === 6 ? 'Six' : String(machineCount)} gates a machine can check`).test(source),
+    'the legend must match how many gates are actually machine-checked',
+  );
+});
+
+test('the lifecycle page derives human gates from the shared source', () => {
+  // It used to keep its own `new Set(['P1','P6'])`, so the page and the diagram
+  // above it could disagree about which gates are human.
+  const source = readFileSync(path.join(docsRoot, 'app/(home)/lifecycle/page.tsx'), 'utf8');
+  assert.ok(source.includes('HUMAN_GATE_IDS'), 'the page must import the shared list');
+  assert.ok(
+    !/new Set\(\[\s*'P1'\s*,\s*'P6'\s*\]\)/.test(source),
+    'the page must not re-declare which phases are human-gated',
+  );
 });
 
 test('buildPhaseMermaid highlights the active phase and is a flowchart', () => {

--- a/apps/docs/test/privacy-page.test.mjs
+++ b/apps/docs/test/privacy-page.test.mjs
@@ -8,7 +8,11 @@ import { fileURLToPath } from 'node:url';
 const privacyPath = fileURLToPath(new URL('../app/privacy/page.tsx', import.meta.url));
 const enterprisePath = fileURLToPath(new URL('../app/(home)/enterprise/page.tsx', import.meta.url));
 const contactFormPath = fileURLToPath(new URL('../app/(home)/enterprise/contact-form.tsx', import.meta.url));
-const homePath = fileURLToPath(new URL('../app/(home)/page.tsx', import.meta.url));
+// The footer moved from the home page into the shared marketing layout during
+// the record redesign, so every marketing route carries the privacy link rather
+// than only `/`. Assert against the layout that actually renders it: pinning the
+// link to page.tsx would now pass only by putting a second copy on one route.
+const homeLayoutPath = fileURLToPath(new URL('../app/(home)/layout.tsx', import.meta.url));
 
 test('the privacy page module exists and default-exports a component', () => {
   assert.ok(existsSync(privacyPath), 'app/privacy/page.tsx must exist');
@@ -25,11 +29,11 @@ test('the privacy page discloses both processors (PM-F)', () => {
 test('/privacy is linked from the enterprise flow and the home footer', () => {
   const enterprise = readFileSync(enterprisePath, 'utf8');
   const contactForm = readFileSync(contactFormPath, 'utf8');
-  const home = readFileSync(homePath, 'utf8');
+  const homeLayout = readFileSync(homeLayoutPath, 'utf8');
   // The contact form (rendered on /enterprise) links to the policy...
   assert.match(contactForm, /["']\/privacy["']/);
-  // ...and the home footer carries a privacy link.
-  assert.match(home, /["']\/privacy["']/);
+  // ...and the marketing footer — which wraps the home page — carries the link.
+  assert.match(homeLayout, /["']\/privacy["']/);
   // Sanity: the enterprise page renders the form that carries the link.
   assert.match(enterprise, /ContactForm/);
 });


### PR DESCRIPTION
Replaces the marketing visual world. Scope is the marketing routes only — `/`, `/lifecycle`, `/failure-modes`, `/vs-sdlc`, `/toolkit`, `/integrations`, `/enterprise`, and the seven `/integrations/<harness>` pages. `/docs` keeps the dark Fumadocs reading surface and inherits tokens only.

## Why

The incumbent palette was **not** generic — An Old Hope was chosen deliberately. What was generic was the composition: every section was kicker → large heading → card grid, left-aligned in `max-w-5xl`, eight times over, with `Inter` as both display and body face. No density variation, no full-bleed moment, no signature.

## The world

The **controlled-change record**: what changed, why, who assessed impact, what the back-out is, who approved it, what evidence was attached. That is the artifact that makes a change *defensible* rather than merely done — the question a leader has about agents. The homepage is `ADLC-CR-0001`.

Two surfaces, and the split carries the argument:

- **The record is paper** — cool, derived from An Old Hope's own foreground rather than a borrowed cream, ruled, squared, fixed fields, numbered clauses.
- **The evidence is terminal** — real gate output on `#1c1d21` in the unmodified palette.

A person reads the record; a machine produced the proof. Evidence is never restyled to match the page around it.

Archivo (width axis at panel scale) sets the record; Azeret Mono sets every identifier, exit code, and legend.

## How the direction was chosen

Impeccable concept seed, key `54a31abe`, re-roll round 1, assigned index 3, confirmed against two other rendered comps. The first roll dealt instrument panels and a split-flap departure board; both were refused as too whimsical for engineers and the leadership accountable for what agents merge. The five-block direction contract ships as an HTML comment in `page.tsx` and survives the production build.

## Claims tightened rather than inherited

- **No per-phase evidence column.** Only some phases have an artifact filename the repo can back. A column right six times out of eight is worse than no column; `.adlc/manifest.jsonl` is named once instead.
- **"Packages", not "gate CLIs".** `ALL_PACKAGES` is every published package and the data module draws no gate/non-gate distinction.
- **The record framing is labelled.** Exhibits, exit codes, gate names and counts are real; `ADLC-CR-0001` and its status are stated on the page as illustrative.

Every exhibit is real gate output, including two refusals — a record that attaches only its passes is marketing, and a gate that never refuses is not a gate.

## Preserved as product truth

Green passes, red refuses, amber is the human gate. Verdicts pair a glyph with a word and machine verdicts carry the exit code. Motion respects `prefers-reduced-motion`; the one authored moment is the record resolving once on load. Windows still stated as unsupported; Cursor and OpenCode still named as manual exceptions; Copilot still not listed as manual.

## Defects found and fixed during the rebuild

- `gate-badge` labelled the human gate **WISH** (leaked from the `--adlc-wish` token) while the chain said **ATTEST**. "Attestation" is fixed terminology; aligned.
- The install command **wrapped out of sight on mobile**. A visitor who cannot see the whole command cannot verify what they are about to pipe to `sh`.
- Long clause labels **overflowed the gutter across the heading** beside them.
- Semicircle needle gauges on `/lifecycle` were instrument-panel vocabulary — the rejected world surviving by re-tinting — now a ruled settings register.
- The enterprise **contact form was still entirely the dark incumbent world**, rendering `#26272c` inputs on paper.
- Terminal blocks on the 7 harness pages briefly rendered **near-black text on the dark ground**; caught and fixed before commit.

## Test change (deliberate)

`privacy-page.test.mjs` pinned the privacy link to `page.tsx`. The footer moved into the shared marketing layout, so all seven routes carry it rather than only `/`. The assertion now targets the layout that actually renders it — pinning it to `page.tsx` would now pass only by adding a second copy on one route.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `node --test apps/docs/test/*.test.mjs` — 161/161
- [x] Production build clean (172 static pages)
- [x] `scripts/rails-guard-ci.mjs origin/main` — exit 0 (rebased onto current main)
- [x] Impeccable design detector — 0 findings across every marketing component and page
- [x] Desktop inspected on all 7 top-level routes + `/integrations/claude-code`
- [x] Mobile verified at 390px
- [ ] Reviewer: confirm the paper/terminal inversion reads correctly on your display
- [ ] Reviewer: visual check of the remaining 6 harness detail pages

## Adversarial review

`npx adversarial-review --base origin/main` was run. First pass: **APPROVE, no material findings.** A second pass returned one HIGH finding claiming `PHASES` lacks a `human` property, so §8's attestation blocks render empty.

**That finding is a false positive**, verified:

- All 8 phases carry `human`; `PHASES.filter(p => p.human)` returns exactly `["P1","P6"]`, identical to `HUMAN_GATE_IDS`
- The rendered homepage contains the signature blocks

The review's own output names the cause: it skipped 9 files including `lib/phase-graph.mjs` — the file defining the property — and reported "partial diff context due to truncation". Correct code was not changed to satisfy it.

## Known, deliberately not addressed

`backdrop.tsx`, `gate-sequence.tsx`, and `barbell.tsx` are orphaned by the homepage rewrite and left on disk rather than deleted. The barbell was the economics chart; whether that visualization returns is a content call, and the section keeps its quote and prose.
