### PR TITLE
fix(marketing): head the chain column "At this phase", not "Approver"

### DIFF
--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -317,10 +317,17 @@ server-side and always imported from `lib/install-commands.mjs`.
 Header strip carries the command and the exit status; the body is real output.
 Prompts dim to `comment`; verdict lines keep glyph, word, and hue.
 
-**Approval chain.** One row per control point: identifier, name, exit gate,
-approver, verdict. Human gates are the rows whose approver is a person — marked by
-the amber field, the diamond, and the word, so the exception is structural rather
-than chromatic.
+**Approval chain.** One row per control point: identifier, name, exit gate, what
+acts at that phase, verdict. Human gates are the rows where that is a person —
+marked by the amber field, the diamond, and the word, so the exception is
+structural rather than chromatic.
+
+The column is headed "At this phase", never "Approver". Naming a tool that runs
+at a phase is true; naming it as the thing that closes the gate is a claim the
+toolkit does not back for every phase — `rails-guard` enforces frozen rails
+rather than proving a suite is RED, and `build-gate` guards entry to a build
+rather than validating one. Every name shown must still dispatch through `adlc`,
+which `marketing-approvers.test.mjs` enforces.
 
 **Attestation block.** The record ends in signatures. The two human gates render as
 signature panels with a ruled signature line and `SIGNED BY A PERSON`. This is the

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -43,13 +43,13 @@ carries either a numbered exhibit or the name of the gate that produces it.
 
 OWN-WORLD: The controlled-change record in its contemporary register. Cool paper
 (#e7eaef) desaturated from An Old Hope's own foreground, hairline rules, fixed field
-blocks, numbered clauses, an approver column, squared corners, no cards. Evidence stays
+blocks, numbered clauses, an at-this-phase column, squared corners, no cards. Evidence stays
 true terminal on #1c1d21 with the unmodified An Old Hope palette. Archivo (width axis at
 panel scale) sets the record; Azeret Mono sets every identifier, exit code, and legend.
 
 STORY: An engineer sees real commands and real exit codes and installs. A leader sees an
-approval chain with an approver column and two named human attestations, and understands
-there is an audit trail a non-engineer could read. Both act on the same honest account.
+approval chain naming what acts at each phase, and two named human attestations, and
+understands there is an audit trail a non-engineer could read. Both act on the same honest account.
 
 FIRST VIEWPORT: Terminal-dark masthead, then the record rail naming ADLC-CR-0001 and its
 standing. A four-field header block. §1 STATEMENT sets the thesis at panel scale in narrow

--- a/apps/docs/components/marketing/lifecycle-pipeline.tsx
+++ b/apps/docs/components/marketing/lifecycle-pipeline.tsx
@@ -5,25 +5,29 @@ import { ExitCode } from './record';
 //
 // The section claims "a gate between every one", so the gate is the subject
 // here, not the connector. Under the record world the chain is what it is in
-// any change record: a ruled table with one row per control point, an approver
-// column, and a verdict. The two human gates are simply the two rows where the
-// approver is a person — the exception reads structurally, not as a colour.
+// any change record: a ruled table with one row per control point, and a column
+// naming what acts at that phase. The two human gates are simply the two rows
+// where that is a person — the exception reads structurally, not as a colour.
 //
-// Every approver below is a real CLI (or a person). There is deliberately no
-// per-row evidence column: only some phases have an artifact whose filename can
-// be stated as fact, and a column that is right six times out of eight is worse
-// than no column. The manifest is named once, in the note beneath.
+// The column is deliberately headed "At this phase", not "Approver". An earlier
+// version claimed the named CLI *enforced* that phase's exit gate, and for two
+// rows that was not true: rails-guard enforces frozen rails rather than proving
+// the suite is RED, and build-gate denies starting a build in a degraded session
+// rather than validating the P4 build. Naming a tool that runs at a phase is
+// true; naming it as the thing that closes the gate was a claim the toolkit does
+// not back. The machine/person split is unaffected and remains the real thesis.
+//
+// Every name here must still dispatch — the page renders them as commands, and
+// marketing-approvers.test.mjs asserts the dispatcher routes each one. That test
+// checks the names are real, not that they enforce a gate; the weakened column
+// header is what makes that the right assertion.
+//
+// There is deliberately no per-row evidence column: only some phases have an
+// artifact whose filename can be stated as fact, and a column that is right six
+// times out of eight is worse than no column. The manifest is named once, in the
+// note beneath.
 
-/**
- * The approver for each phase. Human gates name a person; the rest name the tool.
- *
- * Every machine approver here MUST be a real dispatchable tool — this component
- * tells the visitor these are executable, so a name that does not dispatch is a
- * broken promise, not a typo. P4 previously read `adlc gate`, which does not
- * exist: `packages/gate` is not a package and the dispatcher exits 1 on it. The
- * name was taken from an MCP tool called `adlc_gate`, which is not a CLI.
- * scripts/test/marketing-approvers.test.mjs now dispatches every one of these.
- */
+/** What acts at each phase. Human gates name a person; the rest name the tool. */
 export const APPROVER: Record<string, string> = {
   P0: 'adlc ticket',
   P1: 'A person',
@@ -47,7 +51,7 @@ export function LifecyclePipeline() {
           <div className="rec-legend px-3 py-2.5" />
           <div className="rec-legend px-3 py-2.5">Control point</div>
           <div className="rec-legend px-3 py-2.5">Exit gate</div>
-          <div className="rec-legend px-3 py-2.5">Approver</div>
+          <div className="rec-legend px-3 py-2.5">At this phase</div>
           <div className="rec-legend px-3 py-2.5">Verdict</div>
         </div>
 

--- a/apps/docs/components/marketing/record.tsx
+++ b/apps/docs/components/marketing/record.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
  * The record vocabulary.
  *
  * Every marketing surface is a controlled-change record: a header block of
- * fixed fields, numbered clauses, an approver column, and attached exhibits.
+ * fixed fields, numbered clauses, a column naming what acts, and attached exhibits.
  * These are the atoms. Nothing here is a generic card, panel, or pill — a stock
  * component inside a committed form is the lapse this file exists to prevent.
  *


### PR DESCRIPTION
Follow-up to #371, found by a second adversarial-review pass run against a different provider.

## The defect

The approval chain claimed a specific CLI **enforced** each phase's exit gate. For two rows that is not true, and the toolkit's own dispatcher descriptions say so:

| Row | Displayed gate | What the tool actually does (`adlc --help`) |
|---|---|---|
| P3 Rail | RED gate | `rails-guard` — "Enforce frozen rails, declared suppressions, and manifest recording" |
| P4 Build | green gate | `build-gate` — "Deny starting a high-risk ticket build in a degraded (context-rot) session unless audited" |

`rails-guard` does not establish that the P3 suite is RED for the right reasons. `build-gate` is a P3→P4 entry check for context fitness and can exit 0 purely because a ticket is not high risk — it does not run or validate the P4 build, tests, or lint.

Naming a tool that **runs at** a phase is true. Naming it as the thing that **closes the gate** was a claim the toolkit does not back everywhere — on the one surface whose entire thesis is that no capability claim ships without an exhibit.

## The fix

The column keeps every tool name and is now headed **"At this phase"**.

The machine/person split is untouched: it is accurate, and it is the actual thesis — six gates a machine can check, two a person has to close.

## On the test

`marketing-approvers.test.mjs` (added in #371) still asserts every displayed name dispatches through `adlc`. That test proves the names are **real**, not that they enforce a gate. The review correctly pointed out that under the old header, the test positively validated a semantically wrong mapping. The weakened header is what makes the existing assertion the right one.

Fixing the semantics instead — remapping P3/P4 to tools that genuinely prove those contracts — was considered and rejected for now: there is no single CLI that proves the P4 green gate, and inventing one mapping to fill the column would repeat the original error. Left as a product decision.

The direction contract in `page.tsx`, the `record.tsx` header comment, and `DESIGN.md` are updated to describe the column the page actually renders, so the recorded system matches the build.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `node --test apps/docs/test/*.test.mjs` — 164/164
- [x] `scripts/rails-guard-ci.mjs origin/main` — exit 0
- [x] Production build clean
- [x] Impeccable design detector — 0 findings
- [ ] Reviewer: confirm "At this phase" is the claim you want the column to make
