### PR TITLE
docs(antigravity): recommend npm global install & npx adlc-agy install

### DIFF
--- a/apps/docs/content/docs/integrations/antigravity.mdx
+++ b/apps/docs/content/docs/integrations/antigravity.mdx
@@ -15,22 +15,30 @@ Native ADLC integration for the Antigravity CLI. Two layers:
 
 ## Install
 
-**Local checkout (recommended/verified).** Currently, the most reliable way to install the plugin is directly from a local checkout:
+**Global npm install (recommended).** Install `@adlc/antigravity` globally via npm, then point `agy` at the globally installed package path:
 
 ```sh
-agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
+npm install -g @adlc/antigravity
+agy plugin install $(npm root -g)/@adlc/antigravity
 ```
 
-Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
+**One-liner via npx.** Alternatively, run the helper CLI directly via `npx` to install and register:
 
-**npm-assisted install.** `agy` has no native `agy install npm:X` command, and `agy
-plugin install` always takes a filesystem path. But `@adlc/antigravity` is now
-published on npm, so you can install it as a normal dependency and point `agy` at
-`node_modules`:
+```sh
+npx adlc-agy install
+```
+
+**Local project install.** If you prefer to install `@adlc/antigravity` inside a project's `node_modules`:
 
 ```sh
 npm install @adlc/antigravity
 agy plugin install ./node_modules/@adlc/antigravity
+```
+
+**Local checkout (from source).** For local development or installing directly from a local `adlc` source checkout:
+
+```sh
+agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
 ```
 
 **Universal installer (planned, not yet supported).** Support for Google Antigravity inside the vendor-neutral `plugins` installer is currently in development and **not yet present**. Once implemented, you will be able to install it via:
@@ -39,9 +47,9 @@ agy plugin install ./node_modules/@adlc/antigravity
 npx plugins add voodootikigod/adlc
 ```
 
-**Note on native marketplace:** the native `.agents` marketplace registration command (`agy plugin install adlc-antigravity@adlc`) is currently subject to a CLI limitation where the CLI rejects unregistered third-party marketplaces with `unknown marketplace: adlc`. Local installation is the recommended path.
+**Note on native marketplace:** the native `.agents` marketplace registration command (`agy plugin install adlc-antigravity@adlc`) is currently subject to a CLI limitation where the CLI rejects unregistered third-party marketplaces with `unknown marketplace: adlc`. Global npm or local installation is the recommended path.
 
-Then `/adlc-init` (or manual bootstrap). Enforcement: `export ADLC_P4_ENFORCEMENT=1` with an active ticket.
+Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository). Enforcement: `export ADLC_P4_ENFORCEMENT=1` with an active ticket.
 
 ## Formal ADLC coverage
 

--- a/apps/docs/lib/integration-facts.mjs
+++ b/apps/docs/lib/integration-facts.mjs
@@ -716,16 +716,18 @@ export const ANTIGRAVITY_INTEGRATION = {
   status: 'local',
   tagline: 'Advisory PreToolUse rails-guard for agy, plus skills and a prosecutor agent. The unbypassable CI rail-freeze gate is the real control.',
   install: [
-    'agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity',
+    'npm install -g @adlc/antigravity',
+    'agy plugin install $(npm root -g)/@adlc/antigravity',
+    'npx adlc-agy install',
   ],
-  note: 'agy plugin install only takes a filesystem path. npm-assisted path: npm install @adlc/antigravity then agy plugin install ./node_modules/@adlc/antigravity. Marketplace and universal-installer support are still planned. Export ADLC_P4_ENFORCEMENT=1 with an active ticket.',
+  note: 'Recommended: install globally via npm (npm install -g @adlc/antigravity) and register with agy, or run npx adlc-agy install. Export ADLC_P4_ENFORCEMENT=1 with an active ticket.',
   pluginDir: 'plugins/adlc-antigravity',
   hero: {
     kicker: 'Antigravity integration',
     title: 'ADLC for Google Antigravity',
     identity: 'In-session rails are advisory. agy fails open on hook failure, so CI is the guarantee, not an optional extra.',
     badges: [
-      { label: 'Local plugin install', accent: true },
+      { label: 'Global npm & npx install', accent: true },
       { label: 'CI is the backstop' },
     ],
   },
@@ -810,14 +812,17 @@ export const ANTIGRAVITY_INTEGRATION = {
   },
   installSection: {
     kicker: 'Install',
-    title: 'Install from a local checkout path',
+    title: 'Install via global npm or npx',
   },
   operate: {
     title: 'operate: Antigravity plugin',
     lines: [
-      '# npm-assisted path (still a filesystem install)',
-      'npm install @adlc/antigravity',
-      'agy plugin install ./node_modules/@adlc/antigravity',
+      '# Recommended global npm install',
+      'npm install -g @adlc/antigravity',
+      'agy plugin install $(npm root -g)/@adlc/antigravity',
+      '',
+      '# Or one-liner via npx',
+      'npx adlc-agy install',
       '',
       '# Arm enforcement for an active ticket',
       'export ADLC_P4_ENFORCEMENT=1',

--- a/apps/docs/test/integration-facts.test.mjs
+++ b/apps/docs/test/integration-facts.test.mjs
@@ -273,6 +273,8 @@ test('Antigravity marketing facts keep CI as the real backstop', () => {
   assert.equal(ag?.status, 'local');
   assert.match(ag?.enforcement.session.body ?? '', /fail-open|Advisory/i);
   assert.match(ag?.enforcement.ci.body ?? '', /unbypassable|rails-guard-ci/i);
+  assert.match(ag?.note ?? '', /ADLC_P4_ENFORCEMENT=1/);
+  assert.match(ag?.note ?? '', /npm install -g @adlc\/antigravity/);
 });
 
 test('Pi marketing publication claim matches a non-private @adlc/pi package', () => {

--- a/docs/integrations/antigravity.md
+++ b/docs/integrations/antigravity.md
@@ -21,22 +21,30 @@ Native ADLC integration for the Antigravity CLI. Two layers:
 > [`docs/ci/rails-guard.yml`](../ci/rails-guard.yml)) — **make it a required
 > check** before relying on this integration for enforcement.
 
-**Local Checkout (Recommended/Verified).** Currently, the most reliable way to install the plugin is directly from a local checkout:
+**Global npm Install (Recommended).** Install `@adlc/antigravity` globally via npm, then point `agy` at the global package location:
 
 ```sh
-agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
+npm install -g @adlc/antigravity
+agy plugin install $(npm root -g)/@adlc/antigravity
 ```
 
-Then run `/adlc-init` inside your agent session (or execute the steps manually to bootstrap `.adlc/` in your repository).
+**One-liner via npx.** Alternatively, run the helper CLI directly via `npx` to install and register:
 
-**npm-assisted install.** `agy` has no native `agy install npm:X` command — `agy
-plugin install` always takes a filesystem path — but `@adlc/antigravity` is now
-published on npm, so you can install it as a normal dependency and point `agy` at
-`node_modules`:
+```sh
+npx adlc-agy install
+```
+
+**Local Project Install.** Install `@adlc/antigravity` into your project's `node_modules` and register with `agy`:
 
 ```sh
 npm install @adlc/antigravity
 agy plugin install ./node_modules/@adlc/antigravity
+```
+
+**Local Checkout (from Source).** For local development or installing directly from an `adlc` source checkout:
+
+```sh
+agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
 ```
 
 **Universal Installer (Planned — Not yet supported).** Support for Google Antigravity inside the vendor-neutral `plugins` installer is currently in development and **not yet present**. Once implemented, you will be able to install it via:
@@ -45,8 +53,7 @@ agy plugin install ./node_modules/@adlc/antigravity
 npx plugins add voodootikigod/adlc
 ```
 
-
-**Note on native marketplace:** The native `.agents` marketplace registration command (`agy plugin install adlc-antigravity@adlc`) is currently subject to a CLI limitation where the CLI rejects unregistered third-party marketplaces with `unknown marketplace: adlc`. Local installation is the recommended path.
+**Note on native marketplace:** The native `.agents` marketplace registration command (`agy plugin install adlc-antigravity@adlc`) is currently subject to a CLI limitation where the CLI rejects unregistered third-party marketplaces with `unknown marketplace: adlc`. Global npm or local installation is the recommended path.
 
 Then `/adlc-init` (or manual bootstrap). Enforcement: `export ADLC_P4_ENFORCEMENT=1` with an active ticket.
 

--- a/plugins/adlc-antigravity/README.md
+++ b/plugins/adlc-antigravity/README.md
@@ -4,6 +4,34 @@ Embrace the ADLC inside Google Antigravity (`agy`): a phase-router plus doctrine
 skills and a `PreToolUse` rails-guard that freezes ADLC rails. Requires the
 `@adlc/cli` gate toolkit (`npm i -g @adlc/cli`).
 
+## Install
+
+**Global npm install (recommended):**
+
+```sh
+npm install -g @adlc/antigravity
+agy plugin install $(npm root -g)/@adlc/antigravity
+```
+
+**One-liner via npx:**
+
+```sh
+npx adlc-agy install
+```
+
+**Local project install:**
+
+```sh
+npm install @adlc/antigravity
+agy plugin install ./node_modules/@adlc/antigravity
+```
+
+**From local checkout:**
+
+```sh
+agy plugin install /abs/path/to/adlc/plugins/adlc-antigravity
+```
+
 ## Manifest: `version` and `adlcContract`
 
 `plugin.json` is the authoritative manifest. `agy plugin install` copies the whole

--- a/plugins/adlc-antigravity/bin/cli.mjs
+++ b/plugins/adlc-antigravity/bin/cli.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, cpSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const command = args[0] || 'install';
+
+if (command === '--help' || command === '-h' || command === 'help') {
+  console.log(`
+ADLC Google Antigravity Plugin Helper
+
+Usage:
+  npx adlc-agy install             Install and register the ADLC plugin with agy
+  npx @adlc/antigravity install    Alternative package name invocation
+  adlc-agy install                 Install when @adlc/antigravity is installed globally
+  adlc-agy --help                  Display this help message
+
+Description:
+  Registers the @adlc/antigravity plugin with Google Antigravity (agy).
+  First attempts to run \`agy plugin install <path>\`. If agy is not found,
+  copies the plugin to ~/.gemini/config/plugins/adlc-antigravity.
+`);
+  process.exit(0);
+}
+
+if (command === 'install' || command === '--install') {
+  console.log(`Installing @adlc/antigravity plugin from: ${packageRoot}`);
+
+  let agyInstalled = false;
+  try {
+    const res = spawnSync('agy', ['--version'], { encoding: 'utf8' });
+    if (res.status === 0) {
+      agyInstalled = true;
+    }
+  } catch {
+    agyInstalled = false;
+  }
+
+  if (agyInstalled) {
+    console.log('Google Antigravity (agy) detected. Running agy plugin install...');
+    const result = spawnSync('agy', ['plugin', 'install', packageRoot], {
+      stdio: 'inherit',
+    });
+    if (result.status === 0) {
+      console.log('✓ Successfully installed @adlc/antigravity plugin via agy!');
+      process.exit(0);
+    } else {
+      console.error('⚠️ `agy plugin install` returned non-zero status.');
+    }
+  }
+
+  // Fallback / manual placement into plugin dir
+  const targetDir = join(homedir(), '.gemini', 'config', 'plugins', 'adlc-antigravity');
+  console.log(`Copying plugin files directly to ${targetDir}...`);
+  try {
+    mkdirSync(targetDir, { recursive: true });
+    cpSync(packageRoot, targetDir, { recursive: true });
+    console.log(`✓ Plugin copied to ${targetDir}`);
+    console.log('Note: Run `/adlc-init` inside your agent session to complete setup.');
+    process.exit(0);
+  } catch (err) {
+    console.error(`Failed to copy plugin files to ${targetDir}:`, err.message);
+    process.exit(1);
+  }
+} else {
+  console.error(`Unknown command: ${command}`);
+  console.error('Run `npx adlc-agy --help` for available commands.');
+  process.exit(1);
+}

--- a/plugins/adlc-antigravity/package.json
+++ b/plugins/adlc-antigravity/package.json
@@ -27,6 +27,10 @@
   "scripts": {
     "test": "node --test test/*.test.mjs"
   },
+  "bin": {
+    "adlc-agy": "bin/cli.mjs",
+    "adlc-antigravity": "bin/cli.mjs"
+  },
   "dependencies": {},
   "agy": {
     "hooks": "./hooks.json",
@@ -35,6 +39,7 @@
   },
   "files": [
     "agents/",
+    "bin/",
     "build-gate-inline.mjs",
     "commands/",
     "constants.mjs",

--- a/plugins/adlc-antigravity/test/packaging.test.mjs
+++ b/plugins/adlc-antigravity/test/packaging.test.mjs
@@ -85,7 +85,7 @@ test('AC3: no @adlc/* runtime dependency (agy copies without node_modules)', () 
 
 test('AC2: files allowlist ships the runtime surface, plugin.json, and never test/', () => {
   const files = pkg.files ?? [];
-  for (const entry of ['agents/', 'build-gate-inline.mjs', 'commands/', 'constants.mjs', 'core-inline.mjs', 'flail-inline.mjs', 'hooks/', 'hooks.json', 'rails-checker.mjs', 'skills/', 'plugin.json', 'README.md', 'LICENSE']) {
+  for (const entry of ['agents/', 'bin/', 'build-gate-inline.mjs', 'commands/', 'constants.mjs', 'core-inline.mjs', 'flail-inline.mjs', 'hooks/', 'hooks.json', 'rails-checker.mjs', 'skills/', 'plugin.json', 'README.md', 'LICENSE']) {
     assert.ok(files.includes(entry), `files must include ${entry}`);
   }
   assert.ok(!files.some((f) => f.replace(/^\.\//, '').startsWith('test')), 'files must not include test/');
@@ -97,10 +97,10 @@ test('AC2: npm pack --dry-run ships the runtime surface, plugin.json, and NO tes
   const manifest = JSON.parse(res.stdout);
   const paths = manifest[0].files.map((f) => f.path.replace(/^\.\//, ''));
 
-  for (const dir of ['agents/', 'commands/', 'hooks/', 'skills/']) {
+  for (const dir of ['agents/', 'bin/', 'commands/', 'hooks/', 'skills/']) {
     assert.ok(paths.some((p) => p.startsWith(dir)), `pack must include ${dir}`);
   }
-  for (const file of ['build-gate-inline.mjs', 'constants.mjs', 'core-inline.mjs', 'flail-inline.mjs', 'hooks.json', 'rails-checker.mjs', 'plugin.json', 'README.md', 'LICENSE']) {
+  for (const file of ['bin/cli.mjs', 'build-gate-inline.mjs', 'constants.mjs', 'core-inline.mjs', 'flail-inline.mjs', 'hooks.json', 'rails-checker.mjs', 'plugin.json', 'README.md', 'LICENSE']) {
     assert.ok(paths.includes(file), `pack must include ${file}`);
   }
   assert.ok(!paths.some((p) => p.startsWith('test/')), `pack must NOT include test/: ${paths.filter((p) => p.startsWith('test/')).join(', ')}`);
@@ -168,3 +168,10 @@ test('AC4: packed tarball extracted outside the repo imports rails-checker with 
     rmSync(work, { recursive: true, force: true });
   }
 });
+
+test('AC4: bin/cli.mjs executable displays help output on --help', () => {
+  const res = spawnSync('node', [join(pkgDir, 'bin', 'cli.mjs'), '--help'], { encoding: 'utf8', timeout: 10_000 });
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /adlc-agy install/);
+});
+

--- a/plugins/adlc-antigravity/test/packaging.test.mjs
+++ b/plugins/adlc-antigravity/test/packaging.test.mjs
@@ -173,5 +173,12 @@ test('AC4: bin/cli.mjs executable displays help output on --help', () => {
   const res = spawnSync('node', [join(pkgDir, 'bin', 'cli.mjs'), '--help'], { encoding: 'utf8', timeout: 10_000 });
   assert.equal(res.status, 0);
   assert.match(res.stdout, /adlc-agy install/);
+  assert.match(res.stdout, /agy plugin install <path>/);
+});
+
+test('AC4: bin/cli.mjs runs install command and does not trigger help mode', () => {
+  const res = spawnSync('node', [join(pkgDir, 'bin', 'cli.mjs'), 'install'], { encoding: 'utf8', timeout: 10_000 });
+  assert.match(res.stdout, /Installing @adlc\/antigravity plugin from:/);
+  assert.doesNotMatch(res.stdout, /ADLC Google Antigravity Plugin Helper/);
 });
 


### PR DESCRIPTION
## Summary

- **Primary Install Path Updated**: Standardized documentation across the marketing site (`apps/docs`), integration facts (`apps/docs/lib/integration-facts.mjs`), repo docs (`docs/integrations/antigravity.md`), and package README (`plugins/adlc-antigravity/README.md`) to recommend installing `@adlc/antigravity` globally via npm (`npm install -g @adlc/antigravity` + `agy plugin install $(npm root -g)/@adlc/antigravity`).
- **New `npx adlc-agy install` Helper**: Added `bin/cli.mjs` to `@adlc/antigravity` package providing `adlc-agy` and `adlc-antigravity` CLI commands for one-liner install and registration.
- **Verification**: Packaging tests added in `plugins/adlc-antigravity/test/packaging.test.mjs` and integration-facts assertions added in `apps/docs/test/integration-facts.test.mjs`. Passed all 5 PR-blocking gates via `npm run preflight`.