### PR TITLE
fix(docs): marketing site design polish — impeccable critique fixes, P0 claims/form, exhibits everywhere

### DIFF
--- a/apps/docs/.impeccable/critique/2026-07-28T15-22-56Z__app-home.md
+++ b/apps/docs/.impeccable/critique/2026-07-28T15-22-56Z__app-home.md
@@ -1,0 +1,59 @@
+---
+target: marketing site subpages
+total_score: 21
+max_score: 36
+na_heuristics: 7
+p0_count: 2
+p1_count: 4
+timestamp: 2026-07-28T15-22-56Z
+slug: app-home
+---
+# Critique — ADLC marketing subpages (/lifecycle, /failure-modes, /vs-sdlc, /toolkit, /integrations, /integrations/claude-code, /enterprise)
+
+Method: dual-agent (A: design review · B: detector evidence). Mode: Persuade.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of system status | 2 | Contact form submit has no aria-live; /toolkit package cells carry no link affordance |
+| 2 | Match system / real world | 4 | Domain vocabulary (clause, exhibit, at-this-phase) used precisely |
+| 3 | User control and freedom | 2 | Form success destroys form; mobile nav reaches only 2 of 7 routes |
+| 4 | Consistency and standards | 2 | /integrations/claude-code drops clause grammar for eyebrows; link-blue on non-links; amber on non-gate |
+| 5 | Error prevention | 1 | contact-form noValidate: required never fires; empty submit = network round-trip |
+| 6 | Recognition rather than recall | 2 | Mobile table collapse strips column legends; /toolkit never states total |
+| 7 | Flexibility and efficiency | n/a | Persuade surface; COPY affordance present |
+| 8 | Aesthetic and minimalist design | 3 | Disciplined; docked for /lifecycle duplicate table and /toolkit dead lattice cells |
+| 9 | Error recovery | 1 | "Please fix the highlighted fields" while nothing is highlighted; no aria-invalid/role=alert |
+| 10 | Help and documentation | 4 | Docs, per-phase essay links, honest caveats |
+| **Total** | | **21/36** | Acceptable (58%) |
+
+## Design specificity verdict
+The paper register is genuinely authored (LifecyclePipeline, F-register, vs-table are domain objects). The evidence register is absent: Exhibit and RecordRail are homepage-only; five of seven routes are all-paper. The approved direction's memorable moment ("every claim carries a numbered exhibit with a real exit code") does not exist on any subpage. /enterprise §2 "The evidence" contains no machine output. Category-interchangeable elements: /enterprise contact form, EvidenceTrail four-card scaffold, /integrations/claude-code section chrome.
+
+Deterministic scan (two engines): v2.1.8 CLI = 16 findings; skill engine = 64, dominated by undersized-ui-text ×61 — the 9.5px rec-legend used for functional text (table column headers, clause labels, /enterprise contact-form labels; floor 11px). Also: line-length ~105ch on /lifecycle (desktop only); skipped-heading h1→h3 on /toolkit; theater-slop-phrase "is theater" on /vs-sdlc; cramped-padding on two overflow containers; heading-rhythm ×3 on /enterprise at mobile width (12px above vs 28px below h2 — inverts DESIGN.md's own rule). False positives: pure-black-white on all routes is a v2.1.8 artifact (rule removed in newer engine; no element bg is #000); ai-color-palette on claude-code is the pinned An Old Hope cyan. Static scan: #a24e15 not yet in DESIGN.md colors frontmatter (advisory, 2 sites).
+
+## Priority issues
+
+- **[P0] /enterprise invents a time-to-value figure** — "Two weeks to the first prosecuted merge" (enterprise/page.tsx:13) violates PRODUCT.md's no-invented-numbers rule on the trust-critical page. Fix: cut or replace with a duration-free scope statement. ($impeccable clarify)
+- **[P0] Contact form cannot prevent, announce, or explain an error** — noValidate (contact-form.tsx:93), no aria-invalid/aria-describedby/role=alert, "highlighted fields" copy with no highlight, bare red errors with no glyph (breaks the glyph+word rule). Fix: local validation, per-field aria, fail-edge borders, ✗-prefixed messages, focus management. ($impeccable harden)
+- **[P1] Exhibit device is homepage-only** — six routes make capability claims (zero dependencies, every verdict recorded, eight ✓ PASS 0 chips) with no exhibit or exit code. Fix: one exhibit per route attached to its clause. ($impeccable bolder / polish)
+- **[P1] Install field clips on desktop** — install-command.tsx:63 md:whitespace-pre inverts the field's own rationale; /integrations §2 agent prompt cut mid-sentence at 1440px. Fix: wrap at all breakpoints. ($impeccable adapt)
+- **[P1] Mobile nav reaches 2 of 7 routes** — no menu control at 390px; Toolkit/Integrations/Enterprise unreachable. Fix: masthead menu or ruled footer route list. ($impeccable adapt)
+- **[P1] Functional text below the 11px floor, site-wide** — 9.5px rec-legend as column headers and form labels (61 detector hits). Fix: raise legend to 11px in global.css + DESIGN.md, or split legend (decorative) from column-header/label styles. ($impeccable typeset)
+- **[P2] /lifecycle renders the same 8 phases twice; /toolkit lattice exposes dead grey cells** — fold PHASE_DETAIL into the pipeline; fill trailing lattice tracks. ($impeccable layout / distill)
+- **[P2] Four routes end on an offsite essay link with no install command on the page** — peak-end spent on a bounce against an install success metric. ($impeccable polish)
+- **[P3] Grammar/palette drift on /integrations/claude-code** — eyebrows instead of §N (MarketingSection missing n props), duplicated install block, link-blue Phase column, amber IN THE SESSION label, "windows-latestrun" missing space, 10px/0.1em residues. ($impeccable polish)
+
+## Persona red flags
+Jordan: /toolkit's 29 affordance-less package links; /lifecycle's duplicate tables read as a mistake; unlabeled ✓ PASS 0 chips read as live results; four routes end with nothing to do.
+Riley: offline empty-submit says "couldn't reach the server" instead of "Name is required"; "two weeks" has no source; 29 cells vs "26 gate CLIs" unreconciled; refuses to paste a clipped agent prompt.
+Casey: cannot navigate (no menu); /toolkit counts clipped at 390px; ~4,000px scroll on /lifecycle; mobile collapse strips column legends.
+
+## Minor observations
+ThreeDials bars fill solid black (undefined in paper palette); eight essay links share one accessible name; /integrations spends its only full-bleed break on a harness table; /vs-sdlc "Cost over time" row is the table's only pure assertion, in terminal position; attestation block absent from /enterprise; testimonial unused anywhere; /enterprise "Every gate emits ✓/✗/◆" contradicts /lifecycle's 2-of-8 ATTEST.
+
+## Questions
+1. If a visitor read only /enterprise, what machine-produced artifact would they have seen? (None.)
+2. Is the site the argument's storefront or its lobby? Four explain-why routes cannot install.
+3. "No shadows" has a linter; "no invented numbers" does not. Why?

--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -29,6 +29,7 @@ colors:
   rec-gate-field: "#faf3d8"
   rec-link: "#17627f"
   rec-link-edge: "#a9cede"
+  rec-failure-id: "#a24e15"
   exhibit-border: "#34363d"
   exhibit-rule: "#2c2e34"
   terminal-nav: "#9599a6"
@@ -93,7 +94,7 @@ typography:
     letterSpacing: "0.03em"
   legend:
     fontFamily: "Azeret Mono, ui-monospace, monospace"
-    fontSize: "9.5px"
+    fontSize: "11px"
     fontWeight: 500
     lineHeight: 1.2
     letterSpacing: "0.13em"
@@ -248,7 +249,7 @@ identifier, an exit code, a filename, a command, a field legend, or captured
 output — measurement and code, never prose.
 
 The ramp is a real hierarchy: statement (30–54px), clause title (19–26px), lede
-(16.5px), row title (15px), body (13.5px). Legends sit at 9.5px with `0.13em`
+(16.5px), row title (15px), body (13.5px). Legends sit at 11px with `0.13em`
 tracking; caption (11px) numbers exhibits and labels controls, and chip (10.5px)
 sets the verdict chips. **Row title is the workhorse** — it names the subject of a row in every
 register (approval chain, failure map, rollout schedule, harness list, dial

--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -231,7 +231,7 @@ inks (`rec-pass-ink`, `rec-fail-ink`, `rec-gate-ink`) that clear 4.5:1 on paper.
 Never put the terminal-bright green, red, or yellow on paper as text.
 
 **Semantics are fixed:** green passes, red refuses, amber is the human gate.
-Orange is reserved for the failure register's F-identifiers (`#b4571a` on paper).
+Orange is reserved for the failure register's F-identifiers (`#a24e15` on paper — the palette orange darkened to clear 4.5:1 on the raised paper tone).
 Blue is links only.
 
 ## Typography

--- a/apps/docs/app/(home)/enterprise/contact-form.tsx
+++ b/apps/docs/app/(home)/enterprise/contact-form.tsx
@@ -2,21 +2,27 @@
 
 import { useState } from 'react';
 import { HONEYPOT_FIELD } from '@/lib/contact/handle.mjs';
+import { parseLead } from '@/lib/contact/schema.mjs';
 
 type Status = 'idle' | 'submitting' | 'success' | 'error';
 
 const MAILTO = 'mailto:help@agenticlifecycle.ai?subject=ADLC%20enterprise';
+
+/** Focus the first field the validator rejected, in the form's own order. */
+const FIELD_ORDER = ['name', 'email', 'company', 'message'] as const;
 
 export function ContactForm() {
   const [status, setStatus] = useState<Status>('idle');
   const [fields, setFields] = useState<Record<string, string>>({});
   const [errorMsg, setErrorMsg] = useState<string>('');
 
+  function focusFirstInvalid(errors: Record<string, string>) {
+    const first = FIELD_ORDER.find((f) => errors[f]);
+    if (first) document.getElementById(first)?.focus();
+  }
+
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setStatus('submitting');
-    setFields({});
-    setErrorMsg('');
 
     const form = e.currentTarget;
     const data = new FormData(form);
@@ -27,6 +33,22 @@ export function ContactForm() {
       message: String(data.get('message') ?? ''),
       [HONEYPOT_FIELD]: String(data.get(HONEYPOT_FIELD) ?? ''),
     };
+
+    // The same validator the API route runs. Catching an empty field here means
+    // the round-trip only ever carries a lead the server would accept, and the
+    // two layers can never disagree about a message.
+    const parsed = parseLead(payload);
+    if (!parsed.ok) {
+      setFields(parsed.errors);
+      setStatus('error');
+      setErrorMsg('Please fix the highlighted fields.');
+      focusFirstInvalid(parsed.errors);
+      return;
+    }
+
+    setStatus('submitting');
+    setFields({});
+    setErrorMsg('');
 
     try {
       const res = await fetch('/api/contact', {
@@ -48,6 +70,7 @@ export function ContactForm() {
         setFields(json.fields);
         setStatus('error');
         setErrorMsg('Please fix the highlighted fields.');
+        focusFirstInvalid(json.fields);
         return;
       }
       setStatus('error');
@@ -65,6 +88,7 @@ export function ContactForm() {
   if (status === 'success') {
     return (
       <div
+        role="status"
         className="max-w-xl border p-6"
         style={{ borderColor: 'var(--rec-rule-strong)', background: 'var(--rec-paper-raised)' }}
       >
@@ -77,18 +101,37 @@ export function ContactForm() {
         <p className="mt-2 text-[13.5px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
           We read every enterprise inquiry ourselves and reply within a couple of business days.
         </p>
+        <button
+          type="button"
+          onClick={() => setStatus('idle')}
+          className="rec-mono mt-4 border px-3 py-1.5 text-[11px] tracking-[0.1em]"
+          style={{ borderColor: 'var(--rec-rule-strong)', color: 'var(--rec-ink-2)' }}
+        >
+          SEND ANOTHER
+        </button>
       </div>
     );
   }
 
   // Squared, ruled fields on raised paper: a record's form is filled in, not
-  // a dark app input floating on a document.
-  const inputStyle = {
-    borderColor: 'var(--rec-rule-strong)',
+  // a dark app input floating on a document. An invalid field takes the fail
+  // edge so "highlighted" in the summary is literally true.
+  const inputStyle = (invalid: boolean) => ({
+    borderColor: invalid ? 'var(--rec-fail-edge)' : 'var(--rec-rule-strong)',
     background: 'var(--rec-paper-raised)',
     color: 'var(--rec-ink)',
-  };
+  });
 
+  const fieldError = (id: string) =>
+    fields[id] ? (
+      <p id={`${id}-error`} className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>
+        <span aria-hidden>✗ </span>
+        {fields[id]}
+      </p>
+    ) : null;
+
+  // noValidate is deliberate: parseLead runs on submit with the server's own
+  // messages, so the browser's generic bubbles would only compete with them.
   return (
     <form onSubmit={onSubmit} className="max-w-xl" noValidate>
       {/* Honeypot: hidden from users, tempting to bots. */}
@@ -113,10 +156,12 @@ export function ContactForm() {
             name="name"
             type="text"
             required
+            aria-invalid={fields.name ? true : undefined}
+            aria-describedby={fields.name ? 'name-error' : undefined}
             className="mt-1 w-full border px-3 py-2 text-[14px]"
-            style={inputStyle}
+            style={inputStyle(Boolean(fields.name))}
           />
-          {fields.name ? <p className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>{fields.name}</p> : null}
+          {fieldError('name')}
         </div>
         <div>
           <label htmlFor="email" className="rec-legend block">
@@ -127,10 +172,12 @@ export function ContactForm() {
             name="email"
             type="email"
             required
+            aria-invalid={fields.email ? true : undefined}
+            aria-describedby={fields.email ? 'email-error' : undefined}
             className="mt-1 w-full border px-3 py-2 text-[14px]"
-            style={inputStyle}
+            style={inputStyle(Boolean(fields.email))}
           />
-          {fields.email ? <p className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>{fields.email}</p> : null}
+          {fieldError('email')}
         </div>
       </div>
 
@@ -142,9 +189,12 @@ export function ContactForm() {
           id="company"
           name="company"
           type="text"
+          aria-invalid={fields.company ? true : undefined}
+          aria-describedby={fields.company ? 'company-error' : undefined}
           className="mt-1 w-full border px-3 py-2 text-[14px]"
-          style={inputStyle}
+          style={inputStyle(Boolean(fields.company))}
         />
+        {fieldError('company')}
       </div>
 
       <div className="mt-4">
@@ -156,14 +206,17 @@ export function ContactForm() {
           name="message"
           required
           rows={5}
+          aria-invalid={fields.message ? true : undefined}
+          aria-describedby={fields.message ? 'message-error' : undefined}
           className="mt-1 w-full border px-3 py-2 text-[14px]"
-          style={inputStyle}
+          style={inputStyle(Boolean(fields.message))}
         />
-        {fields.message ? <p className="mt-1 text-xs" style={{ color: 'var(--rec-fail-ink)' }}>{fields.message}</p> : null}
+        {fieldError('message')}
       </div>
 
       {status === 'error' && errorMsg ? (
-        <p className="mt-4 text-sm" style={{ color: 'var(--rec-fail-ink)' }}>
+        <p role="alert" className="mt-4 text-sm" style={{ color: 'var(--rec-fail-ink)' }}>
+          <span aria-hidden>✗ </span>
           {errorMsg}{' '}
           <a href={MAILTO} className="underline" style={{ color: 'var(--rec-link)' }}>
             Email us instead

--- a/apps/docs/app/(home)/enterprise/page.tsx
+++ b/apps/docs/app/(home)/enterprise/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingSection } from '@/components/marketing/section';
 import { GateBadge } from '@/components/marketing/gate-badge';
 import { EvidenceTrail } from '@/components/marketing/evidence-trail';
+import { RouteExhibit } from '@/components/marketing/route-exhibit';
 import { ContactForm } from './contact-form';
 
 export const metadata: Metadata = {
@@ -10,7 +11,10 @@ export const metadata: Metadata = {
 };
 
 const ROLLOUT = [
-  { phase: 'Pilot', detail: 'One team, full gates, conservative dials. Two weeks to the first prosecuted merge.' },
+  // No duration here on purpose: a time-to-value figure is exactly the claim
+  // class PRODUCT.md forbids inventing, and this page's reader is the one most
+  // damaged by discovering an unbacked number.
+  { phase: 'Pilot', detail: 'One team, full gates, conservative dials, through to the first prosecuted merge.' },
   { phase: 'Rails', detail: 'Freeze org-wide conventions as rails: CI gates, protected specs, calibrated review.' },
   { phase: 'Org-wide', detail: 'Native integrations for every agent your teams use. Same gates everywhere.' },
 ] as const;
@@ -29,12 +33,21 @@ export default function EnterprisePage() {
 
       <MarketingSection n="2" kicker="The evidence" title="From ticket to merge, every verdict recorded">
         <EvidenceTrail />
+        {/* Accurate about who emits what: six machine gates return exit codes;
+            the two human gates record attestation. "Every gate emits all three"
+            contradicted the /lifecycle chain, which shows ATTEST on two of eight. */}
         <div className="mt-8 flex flex-wrap items-center gap-3 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
-          <span>Every gate emits</span>
+          <span>Machine gates emit</span>
           <GateBadge state="pass" />
           <GateBadge state="fail" />
+          <span>with exit codes; the two human gates record</span>
           <GateBadge state="wish" />
-          <span>verdicts your auditors can read without an engineer translating.</span>
+          <span>— verdicts your auditors can read without an engineer translating.</span>
+        </div>
+        {/* The page that argues "approval is not evidence" attaches some: a real
+            gate, the question it answers, and its verdict. */}
+        <div className="mt-10">
+          <RouteExhibit id="2.1" gateName="review-calibration" />
         </div>
       </MarketingSection>
 

--- a/apps/docs/app/(home)/failure-modes/page.tsx
+++ b/apps/docs/app/(home)/failure-modes/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { theoryLink } from '@/lib/theory-links.mjs';
 import { MarketingSection } from '@/components/marketing/section';
 import { FailureMap } from '@/components/marketing/failure-map';
+import { RouteExhibit } from '@/components/marketing/route-exhibit';
+import { ImplementClause } from '@/components/marketing/implement-clause';
 
 export const metadata: Metadata = {
   title: 'Failure Modes: Why Agents Fail',
@@ -17,10 +19,17 @@ export default function FailureModesPage() {
           defends against, it gets cut. Here is the full map.
         </p>
         <FailureMap />
+        {/* The cheapest page on the site to attach evidence to: eight claims
+            that a named gate kills a named failure mode, so show one doing it. */}
+        <div className="mt-10">
+          <RouteExhibit id="1.1" gateName="hollow-test" />
+        </div>
         <p className="mt-8 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
           <a href={theoryLink('F1')} style={{ color: 'var(--rec-link)' }}>Read the original essay ↗</a>
         </p>
       </MarketingSection>
+
+      <ImplementClause n="2" />
     </main>
   );
 }

--- a/apps/docs/app/(home)/integrations/page.tsx
+++ b/apps/docs/app/(home)/integrations/page.tsx
@@ -38,8 +38,8 @@ export default function IntegrationsPage() {
           directory, so it belongs inside your repo. Both are detected and reported
           as a manual step rather than guessed at.{' '}
           <strong style={{ color: 'var(--rec-ink)' }}>Windows isn&apos;t supported yet</strong>{' '}
-          — a <code style={{ color: 'var(--rec-link)' }}>windows-latest</code> run of the core
-          gate suites passes 6 of 28, so use WSL for now. Prefer to install by hand?
+          — a <code style={{ color: 'var(--rec-link)' }}>windows-latest</code>{' '}
+          run of the core gate suites passes 6 of 28, so use WSL for now. Prefer to install by hand?
           Every harness&apos;s native path is below.
         </p>
       </MarketingSection>

--- a/apps/docs/app/(home)/lifecycle/page.tsx
+++ b/apps/docs/app/(home)/lifecycle/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { PHASES, HUMAN_GATE_IDS } from '@/lib/phase-graph.mjs';
 import { theoryLink } from '@/lib/theory-links.mjs';
 import { MarketingSection } from '@/components/marketing/section';
 import { LifecyclePipeline } from '@/components/marketing/lifecycle-pipeline';
 import { ThreeDials } from '@/components/marketing/three-dials';
+import { RouteExhibit } from '@/components/marketing/route-exhibit';
+import { ImplementClause } from '@/components/marketing/implement-clause';
 
 export const metadata: Metadata = {
   title: 'The Lifecycle: Phases and Gates',
@@ -23,54 +24,17 @@ const PHASE_DETAIL: Record<string, string> = {
   P7: 'Distill what the review found into permanent, deterministic defenses.',
 };
 
-// Which phases end in a human gate now comes from phase-graph.mjs, the same
-// source the pipeline reads. It used to be a second hand-maintained Set here,
-// so this page and the diagram above it could have disagreed about which two
-// gates are human — the one structural claim the section exists to make.
-const HUMAN_GATES = new Set(HUMAN_GATE_IDS);
-
 export default function LifecyclePage() {
   return (
     <main>
       <MarketingSection headingLevel={1} n="1" kicker="The chain" title="Eight phases. A gate between every one.">
-        <LifecyclePipeline />
-
-        {/* The detail sits as annotations to the chain above, not as a second
-            grid of cards restating it. One row per control point, ruled. */}
-        <dl className="mt-12" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
-          {PHASES.map((p) => (
-            <div
-              key={p.id}
-              className="grid grid-cols-1 gap-x-6 px-1 py-4 md:grid-cols-[46px_150px_minmax(0,1fr)]"
-              style={{
-                borderBottom: '1px solid var(--rec-rule)',
-                background: HUMAN_GATES.has(p.id) ? 'var(--rec-gate-field)' : undefined,
-              }}
-            >
-              <dt className="rec-mono px-2 text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
-                {p.id}
-              </dt>
-              <dt className="px-2 text-[15px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
-                {p.name}
-                {HUMAN_GATES.has(p.id) ? (
-                  <span className="rec-mono mt-1 block text-[10px] tracking-[0.12em]" style={{ color: 'var(--rec-gate-ink)' }}>
-                    ◆ HUMAN GATE
-                  </span>
-                ) : null}
-              </dt>
-              <dd className="px-2 text-[14px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
-                {PHASE_DETAIL[p.id]}
-                <a
-                  href={theoryLink(p.id)}
-                  className="ml-2 whitespace-nowrap text-[13px]"
-                  style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}
-                >
-                  essay ↗
-                </a>
-              </dd>
-            </div>
-          ))}
-        </dl>
+        {/* One table, annotated in place. This page used to render the chain and
+            then a second eight-row list restating it to carry one sentence per
+            phase — on mobile, the same table twice. */}
+        <LifecyclePipeline details={PHASE_DETAIL} />
+        <div className="mt-10">
+          <RouteExhibit id="1.1" gateName="rails-guard" />
+        </div>
       </MarketingSection>
 
       <MarketingSection n="2" kicker="Calibration" title="Three dials, set per ticket">
@@ -88,6 +52,8 @@ export default function LifecyclePage() {
           </Link>
         </p>
       </MarketingSection>
+
+      <ImplementClause n="3" />
     </main>
   );
 }

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -16,7 +16,6 @@ import {
   ClauseTitle,
   ExhibitOutput,
   ExitCode,
-  FieldBlock,
   RecordBody,
   RecordLink,
   RecordRail,
@@ -52,9 +51,10 @@ approval chain naming what acts at each phase, and two named human attestations,
 understands there is an audit trail a non-engineer could read. Both act on the same honest account.
 
 FIRST VIEWPORT: Terminal-dark masthead, then the record rail naming ADLC-CR-0001 and its
-standing. A four-field header block. §1 STATEMENT sets the thesis at panel scale in narrow
-Archivo. §2 IMPLEMENT carries the install command as the field's executable value — the
-primary action, rendered as a ruled control on terminal ground, not a button.
+standing. §1 STATEMENT sets the thesis at panel scale in narrow Archivo. §2 IMPLEMENT
+carries the install command as the field's executable value — the primary action, rendered
+as a ruled control on terminal ground, not a button. (The comp's four-field header block
+was a direction test, not a spec; it delayed the thesis and was dropped in refinement.)
 
 FORM: Composition A of three rendered comps, chosen by the user over a chain-led and a
 pinned claim/exhibit split. Staging: the record's own header-block-then-clauses sequence.
@@ -89,7 +89,7 @@ export default function HomePage() {
       <RecordRail
         items={[
           { k: 'Record', v: 'ADLC-CR-0001' },
-          { k: '', v: 'Open — awaiting implementation', open: true },
+          { k: 'Status', v: 'Open', open: true },
           { k: 'Control points', v: PHASES.length },
           // ALL_PACKAGES is every published package, not a gate subset — the
           // data module draws no such distinction. Labelling it "gate CLIs"
@@ -100,23 +100,6 @@ export default function HomePage() {
       />
 
       <RecordBody>
-        <FieldBlock
-          fields={[
-            { label: 'Subject', value: 'Adopt the Agentic Development Lifecycle' },
-            { label: 'Class', value: 'Process change · software delivery' },
-            { label: 'Scope', value: 'macOS · Linux · Node 18+', mono: true },
-            {
-              // The installer mutates the machine, not just the repo: `npm install -g`
-              // plus native plugins for each detected harness. Reverting the repo
-              // cannot remove either, so the field says what a revert actually
-              // covers rather than implying a clean one-command rollback.
-              label: 'Back-out',
-              value: 'revert the repo · uninstall the CLI separately',
-              mono: true,
-            },
-          ]}
-        />
-
         {/* §1 — the thesis, at panel scale */}
         <Clause
           n="1"
@@ -151,7 +134,7 @@ export default function HomePage() {
             </>
           }
         >
-          <InstallCommand command={UNIVERSAL_INSTALL} label="Install the toolkit and your agent integrations" />
+          <InstallCommand command={UNIVERSAL_INSTALL} />
           <p className="mt-3 max-w-[72ch] text-[13px] leading-[1.55]" style={{ color: 'var(--rec-ink-3)' }}>
             macOS and Linux, Node 18+. Then{' '}
             <code className="rec-mono" style={{ color: 'var(--rec-ink)' }}>
@@ -159,6 +142,11 @@ export default function HomePage() {
             </code>{' '}
             in your repository. Cursor and OpenCode need one manual step, which the installer prints —{' '}
             <RecordLink href="/integrations">see what gets installed</RecordLink>. Windows is not supported.
+            {/* The installer mutates the machine, not just the repo: `npm install -g`
+                plus native plugins per detected harness. Reverting the repo removes
+                neither, so the back-out names both steps rather than implying a
+                clean one-command rollback. */}{' '}
+            Back-out: revert your repository, and uninstall the CLI separately.
           </p>
         </Clause>
 
@@ -207,7 +195,7 @@ export default function HomePage() {
                 className="grid grid-cols-[46px_minmax(0,1fr)] gap-y-1 md:grid-cols-[46px_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.8fr)] md:gap-y-0"
                 style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
               >
-                <div className="rec-mono px-3 py-3 text-[12px]" style={{ color: '#b4571a' }}>
+                <div className="rec-mono px-3 py-3 text-[12px]" style={{ color: '#a24e15' }}>
                   {id}
                 </div>
                 <div className="px-3 py-3 text-[14.5px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
@@ -238,7 +226,7 @@ export default function HomePage() {
         <div className="mx-auto max-w-[1180px] px-6 py-14 md:px-8 md:py-20">
           <div className="flex flex-col gap-x-6 md:flex-row">
             <div className="mb-4 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
-              <div className="rec-legend" style={{ color: '#686b78' }}>
+              <div className="rec-legend" style={{ color: '#9093a0' }}>
                 §5 Exhibits
               </div>
             </div>
@@ -263,7 +251,7 @@ export default function HomePage() {
                       <b className="rec-mono text-[11px] font-semibold tracking-[0.1em]" style={{ color: '#cbcdd2' }}>
                         EXHIBIT 5.{i + 1}
                       </b>
-                      <span className="text-[12.5px]" style={{ color: '#686b78' }}>
+                      <span className="text-[12.5px]" style={{ color: '#9093a0' }}>
                         {gate.gate}
                       </span>
                     </figcaption>
@@ -327,7 +315,7 @@ export default function HomePage() {
           title={<ClauseTitle>Spend heavy at the ends, light in the middle.</ClauseTitle>}
         >
           <blockquote
-            className="mt-7 max-w-[36ch] text-[clamp(21px,2.6vw,30px)] font-semibold leading-[1.22] tracking-[-0.02em]"
+            className="mt-7 max-w-[36ch] text-[clamp(21px,2.6vw,30px)] font-semibold leading-[1.3] tracking-[-0.02em]"
             style={{ color: 'var(--rec-ink)', borderLeft: '1px solid #ef7c2a', paddingLeft: 20 }}
           >
             The unit of account is cost per merged, verified change. Not tokens per developer per month.
@@ -384,7 +372,7 @@ export default function HomePage() {
                         className="h-px flex-1"
                         style={{ background: 'var(--rec-gate-edge)' }}
                       />
-                      <span className="rec-mono text-[10px] tracking-[0.12em]" style={{ color: 'var(--rec-gate-ink)' }}>
+                      <span className="rec-mono text-[11px] tracking-[0.12em]" style={{ color: 'var(--rec-gate-ink)' }}>
                         SIGNED BY A PERSON
                       </span>
                     </div>

--- a/apps/docs/app/(home)/toolkit/page.tsx
+++ b/apps/docs/app/(home)/toolkit/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next';
 import { theoryLink } from '@/lib/theory-links.mjs';
+import { TOOLKIT_GROUPS, ALL_PACKAGES } from '@/lib/toolkit-packages.mjs';
 import { MarketingSection } from '@/components/marketing/section';
 import { Constellation } from '@/components/marketing/constellation';
+import { RouteExhibit } from '@/components/marketing/route-exhibit';
+import { ImplementClause } from '@/components/marketing/implement-clause';
 
 export const metadata: Metadata = {
   title: 'The Toolkit',
@@ -9,22 +12,37 @@ export const metadata: Metadata = {
     'Zero-dependency CLIs that each enforce one machine-checkable gate, grouped by lifecycle phase.',
 };
 
+// Derived from the data module, never typed: the total the visitor can count on
+// this page must reconcile with the "gate CLIs" figure used elsewhere, and the
+// difference is exactly the shared-foundation packages.
+const FOUNDATION = TOOLKIT_GROUPS.find((g) => g.group === 'Shared foundation');
+const FOUNDATION_COUNT = FOUNDATION?.packages.length ?? 0;
+
 export default function ToolkitPage() {
   return (
     <main>
       <MarketingSection n="1" headingLevel={1} kicker="The toolkit" title="Small CLIs, one gate each, zero dependencies">
         <p className="mb-10 max-w-[72ch]" style={{ color: 'var(--rec-ink-2)' }}>
-          Each package enforces a single machine-checkable gate, and they all share a
-          runtime convention, so tools built independently still feel like one product.
-          Click any package for its docs.
+          {ALL_PACKAGES.length} published packages: {ALL_PACKAGES.length - FOUNDATION_COUNT} gate
+          CLIs behind one dispatcher, plus the shared foundation
+          ({FOUNDATION?.packages.join(', ')}). Each gate enforces a single machine-checkable
+          question and answers on its exit code, and they all share a runtime convention, so
+          tools built independently still feel like one product. Click any package for its docs.
         </p>
         <Constellation />
+        {/* "One gate each" is a capability claim, so a gate demonstrates it:
+            one command in, one exit code out. */}
+        <div className="mt-10">
+          <RouteExhibit id="1.1" gateName="spec-lint" />
+        </div>
         <p className="mt-8 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
           <a href={theoryLink('toolkit')} style={{ color: 'var(--rec-link)' }}>
             Read the original essay ↗
           </a>
         </p>
       </MarketingSection>
+
+      <ImplementClause n="2" />
     </main>
   );
 }

--- a/apps/docs/app/(home)/vs-sdlc/page.tsx
+++ b/apps/docs/app/(home)/vs-sdlc/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { theoryLink } from '@/lib/theory-links.mjs';
 import { MarketingSection } from '@/components/marketing/section';
 import { VsTable } from '@/components/marketing/vs-table';
+import { ImplementClause } from '@/components/marketing/implement-clause';
 
 export const metadata: Metadata = {
   title: 'ADLC vs SDLC',
@@ -15,14 +16,16 @@ export default function VsSdlcPage() {
         <p className="mb-10 max-w-[72ch]" style={{ color: 'var(--rec-ink-2)' }}>
           Code review, standups, and sprint ceremonies all exist because humans forget,
           tire, and protect their egos. Models do none of that. They fail in their own
-          ways, and a lifecycle that doesn&apos;t defend against <em>those</em> failures
-          is theater.
+          ways, and a lifecycle that never checks for <em>those</em> failures will pass
+          them straight through.
         </p>
         <VsTable />
         <p className="mt-8 text-sm" style={{ color: 'var(--rec-ink-2)' }}>
           <a href={theoryLink('vs-sdlc')} style={{ color: 'var(--rec-link)' }}>Read the original essay ↗</a>
         </p>
       </MarketingSection>
+
+      <ImplementClause n="2" />
     </main>
   );
 }

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -64,8 +64,8 @@ html > body[data-scroll-locked] {
   --rec-paper-sunk: #dde1e8;
   --rec-ink: #171920;
   --rec-ink-2: #464c5c;
-  /* 4.74:1 on the darkest paper tone (#dde1e8) — this ink sets .rec-legend at
-     9.5px (field labels, column headers, form labels), so it is normal text and
+  /* 4.74:1 on the darkest paper tone (#dde1e8) — this ink sets .rec-legend
+     (field labels, column headers, form labels), so it is normal text and
      owes the full 4.5:1, not the 3:1 large-text allowance. The previous #6b7283
      measured 3.67-4.37 and failed on all four paper tones. */
   --rec-ink-3: #5a616f;
@@ -91,10 +91,13 @@ html > body[data-scroll-locked] {
   color: var(--rec-ink);
 }
 
-/* Field legends, identifiers, exit codes, evidence filenames. */
+/* Field legends, identifiers, exit codes, evidence filenames.
+   11px, not 9.5px: the legend does functional duty — table column headers and
+   the contact form's labels — so it holds the readable-text floor, not a
+   decorative one. */
 .rec-legend {
   font-family: var(--font-record-mono), ui-monospace, monospace;
-  font-size: 9.5px;
+  font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.13em;
   text-transform: uppercase;

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -37,5 +37,10 @@ export function GET() {
     '',
   ].join('\n');
 
-  return new Response(header + llms(source).index());
+  // The Fumadocs index emits site-relative links. Everything above is
+  // absolute, and an LLM consuming llms.txt away from the site has no base
+  // URL to resolve `/docs/...` against, so absolutize them to match.
+  const docsIndex = llms(source).index().replaceAll('](/docs/', `](${SITE_URL}/docs/`);
+
+  return new Response(header + docsIndex);
 }

--- a/apps/docs/components/failure-mode.tsx
+++ b/apps/docs/components/failure-mode.tsx
@@ -6,8 +6,8 @@ export function FailureMode({ id }: { id: keyof typeof FAILURE_MODES }) {
   if (!fm) return null;
   return (
     <div
-      className="my-4 rounded-md border-l-4 p-3"
-      style={{ borderColor: 'var(--adlc-highlight)', background: '#2f3137' }}
+      className="my-4 rounded-md border p-3"
+      style={{ borderColor: 'var(--color-fd-border)', background: '#2f3137' }}
     >
       <strong>
         {id}: {fm.name}

--- a/apps/docs/components/marketing/constellation.tsx
+++ b/apps/docs/components/marketing/constellation.tsx
@@ -7,30 +7,36 @@ export function Constellation() {
       {TOOLKIT_GROUPS.map((g) => (
         <div key={g.group}>
           <div className="mb-4 flex items-baseline gap-4">
-            <h3
-              className="whitespace-nowrap rec-mono text-sm uppercase tracking-widest"
-              style={{ color: 'var(--rec-ink-2)' }}
-            >
+            {/* h2, not h3: the page's h1 is the only heading above these, and a
+                skipped level is a real hole in the outline a reader's screen
+                reader walks. */}
+            <h2 className="rec-mono text-sm uppercase tracking-widest" style={{ color: 'var(--rec-ink-2)' }}>
               {g.group}
-            </h3>
+            </h2>
             <span aria-hidden className="h-px min-w-8 flex-1 self-center" style={{ background: 'var(--rec-rule)' }} />
             <span className="whitespace-nowrap rec-mono text-xs" style={{ color: 'var(--rec-ink-2)' }}>
               {g.packages.length} {g.packages.length === 1 ? 'package' : 'packages'}
             </span>
           </div>
           {/* A parts list, not a tag cloud: squared cells on the raised paper,
-              because a pill is a control and these are line items. */}
+              because a pill is a control and these are line items. Link ink on
+              the names because they ARE links — a cell with no affordance reads
+              as an inert label and never gets clicked. */}
           <div className="flex flex-wrap gap-px" style={{ background: 'var(--rec-rule)', border: '1px solid var(--rec-rule)' }}>
             {g.packages.map((name) => (
               <Link
                 key={name}
                 href={`/docs/toolkit/${name}`}
-                className="rec-mono px-3.5 py-2 text-[13px] transition-colors hover:text-[var(--rec-link)]"
-                style={{ background: 'var(--rec-paper-raised)', color: 'var(--rec-ink)' }}
+                className="rec-mono px-3.5 py-2 text-[13px] transition-colors hover:underline"
+                style={{ background: 'var(--rec-paper-raised)', color: 'var(--rec-link)' }}
               >
                 {name}
               </Link>
             ))}
+            {/* Filler: absorbs the unfilled end of the last track as plain
+                paper, so the lattice never shows a dead grey slab where the
+                row runs short. */}
+            <span aria-hidden className="min-w-8 flex-[999]" style={{ background: 'var(--rec-paper)' }} />
           </div>
         </div>
       ))}

--- a/apps/docs/components/marketing/evidence-trail.tsx
+++ b/apps/docs/components/marketing/evidence-trail.tsx
@@ -7,29 +7,34 @@ const STEPS = [
 
 // Chain of custody: how a change becomes auditable.
 //
-// Custody is recorded, not drawn. The numbered hand-offs carry the sequence the
-// way a custody form does, so the rail-and-arrow SVG that used to sit between
-// the cells is gone — it was decorating an order the numbering already states,
-// and on paper it read as a hairline nobody could see.
+// Custody is recorded, not drawn — and it is a sequence, so the record writes
+// it the way it writes every sequence: ruled rows with a numbered hand-off,
+// not a grid of same-size cards. (The card lattice this replaced was the exact
+// number-heading-text scaffold the rollout section's own comment rejects.)
 export function EvidenceTrail() {
   return (
     <ol
-      className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-4"
-      style={{ background: 'var(--rec-rule)', border: '1px solid var(--rec-rule)' }}
+      style={{ borderTop: '1px solid var(--rec-rule-strong)' }}
       aria-label="Evidence trail from ticket through gates and gate-manifest to merge"
     >
       {STEPS.map((s, i) => (
-        <li key={s.label} className="flex flex-col p-4" style={{ background: 'var(--rec-paper-raised)' }}>
-          <p className="rec-mono text-[10px] tracking-[0.2em]" style={{ color: 'var(--rec-ink-3)' }}>
+        <li
+          key={s.label}
+          className="grid grid-cols-1 gap-x-6 px-1 py-4 md:grid-cols-[52px_170px_minmax(0,1fr)]"
+          style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
+        >
+          <span className="rec-mono px-2 pt-0.5 text-[11px] tracking-[0.1em]" style={{ color: 'var(--rec-ink-3)' }}>
             {String(i + 1).padStart(2, '0')}
-            {i < STEPS.length - 1 ? <span aria-hidden> → HAND-OFF</span> : <span aria-hidden> · CLOSED</span>}
-          </p>
-          <p className="mt-1.5 rec-mono text-[14px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
+          </span>
+          <span className="rec-mono px-2 text-[14px] font-semibold" style={{ color: 'var(--rec-ink)' }}>
             {s.label}
-          </p>
-          <p className="mt-1.5 text-[12.5px] leading-[1.5]" style={{ color: 'var(--rec-ink-2)' }}>
+          </span>
+          <span className="px-2 text-[14px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
             {s.detail}
-          </p>
+            <span aria-hidden className="rec-mono ml-2 text-[11px]" style={{ color: 'var(--rec-ink-3)' }}>
+              {i < STEPS.length - 1 ? '→ hand-off' : '· closed'}
+            </span>
+          </span>
         </li>
       ))}
     </ol>

--- a/apps/docs/components/marketing/failure-map.tsx
+++ b/apps/docs/components/marketing/failure-map.tsx
@@ -29,7 +29,7 @@ export function FailureMap() {
             className="grid grid-cols-[46px_minmax(0,1fr)] gap-y-1 md:grid-cols-[46px_minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,0.9fr)] md:gap-y-0"
             style={{ borderBottom: '1px solid var(--rec-rule)', background: 'var(--rec-paper-raised)' }}
           >
-            <div className="rec-mono px-3 py-3 text-[12px]" style={{ color: '#b4571a' }}>
+            <div className="rec-mono px-3 py-3 text-[12px]" style={{ color: '#a24e15' }}>
               {id}
             </div>
             <div className="px-3 py-3 text-[14.5px] font-semibold" style={{ color: 'var(--rec-ink)' }}>

--- a/apps/docs/components/marketing/implement-clause.tsx
+++ b/apps/docs/components/marketing/implement-clause.tsx
@@ -1,0 +1,31 @@
+import { MarketingSection } from './section';
+import { InstallCommand } from './install-command';
+import { RecordLink } from './record';
+import { UNIVERSAL_INSTALL } from '@/lib/install-commands.mjs';
+
+/**
+ * The closing clause of an interior route: the record's executable field.
+ *
+ * Success for this site is an install, and four routes used to end on an
+ * offsite essay link with no install path anywhere on the page — the peak-end
+ * spent on a bounce. Every interior route now closes the way the record does,
+ * with the IMPLEMENTATION field. One component so the wording cannot drift
+ * per page.
+ */
+export function ImplementClause({ n }: { n: string }) {
+  return (
+    <MarketingSection n={n} kicker="Implement" title="Run it against your own repository">
+      <div className="lg:max-w-[72ch]">
+        <InstallCommand command={UNIVERSAL_INSTALL} />
+      </div>
+      <p className="mt-3 max-w-[72ch] text-[13px] leading-[1.55]" style={{ color: 'var(--rec-ink-3)' }}>
+        macOS and Linux, Node 18+. Then{' '}
+        <code className="rec-mono" style={{ color: 'var(--rec-ink)' }}>
+          adlc init
+        </code>{' '}
+        in your repository. Windows is not supported.{' '}
+        <RecordLink href="/integrations">Every install channel →</RecordLink>
+      </p>
+    </MarketingSection>
+  );
+}

--- a/apps/docs/components/marketing/install-command.tsx
+++ b/apps/docs/components/marketing/install-command.tsx
@@ -71,7 +71,7 @@ export function InstallCommand({ command, label, beta = false }: InstallCommandP
         <button
           type="button"
           onClick={copy}
-          className="rec-mono shrink-0 px-4 text-[10px] tracking-[0.14em] transition-colors"
+          className="rec-mono shrink-0 px-4 text-[11px] tracking-[0.14em] transition-colors"
           style={{
             borderLeft: '1px solid #34363d',
             background: '#26272c',

--- a/apps/docs/components/marketing/install-command.tsx
+++ b/apps/docs/components/marketing/install-command.tsx
@@ -55,12 +55,13 @@ export function InstallCommand({ command, label, beta = false }: InstallCommandP
         </p>
       ) : null}
       <div className="flex items-stretch" style={{ border: '1px solid var(--rec-ink)', background: '#1c1d21' }}>
-        {/* The command wraps on narrow screens rather than scrolling out of
-            sight. This is the page's primary action: a visitor who cannot see
-            the whole command cannot verify what they are about to pipe to sh,
-            and "scroll this box sideways" is not an answer on a phone. */}
+        {/* The command wraps at every width rather than scrolling out of sight.
+            This is the page's primary action: a visitor who cannot see the
+            whole command cannot verify what they are about to pipe to sh — and
+            an earlier md:whitespace-pre variant clipped the agent prompt
+            mid-sentence at exactly the width where most visitors copy it. */}
         <code
-          className="rec-mono flex-1 whitespace-pre-wrap break-all px-4 py-3 text-[13px] md:overflow-x-auto md:whitespace-pre md:break-normal md:text-[13.5px]"
+          className="rec-mono flex-1 whitespace-pre-wrap break-all px-4 py-3 text-[13px] md:break-words md:text-[13.5px]"
           style={{ color: '#cbcdd2' }}
         >
           <span aria-hidden className="select-none pr-2.5" style={{ color: '#78bd65' }}>

--- a/apps/docs/components/marketing/integration-detail.tsx
+++ b/apps/docs/components/marketing/integration-detail.tsx
@@ -40,7 +40,9 @@ function SurfaceCounts({ integration }: { integration: Integration }) {
     // Per-cell rules rather than a gap-px lattice: the surface count is 5 on
     // some harnesses and 4 on others, and a lattice leaves the container colour
     // showing as an empty block wherever the last row is short.
-    <dl className="grid grid-cols-2 sm:grid-cols-4" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
+    // Three across, not four: five surfaces in a four-column grid stranded the
+    // fifth tile alone on its own row.
+    <dl className="grid grid-cols-2 sm:grid-cols-3" style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
       {integration.surfaces.map((surface) => (
         <div
           key={surface.key}
@@ -70,7 +72,8 @@ function NativeSurfaces({ integration }: { integration: Integration }) {
           className="grid gap-4 border-b py-7 last:border-b-0 md:grid-cols-[4rem_1fr_1.2fr] md:gap-8"
           style={{ borderColor: 'var(--rec-rule)' }}
         >
-          <p className="rec-mono text-xs" style={{ color: 'var(--rec-link)' }}>
+          {/* Blue is links only; a section ordinal is not one. */}
+          <p className="rec-mono text-xs" style={{ color: 'var(--rec-ink-3)' }}>
             0{index + 1} / {surface.label}
           </p>
           <div>
@@ -112,7 +115,7 @@ function PhaseRouting({ integration }: { integration: Integration }) {
         <tbody>
           {integration.phaseRoutes.map((route) => (
             <tr key={route.phase} className="border-t" style={{ borderColor: 'var(--rec-rule)' }}>
-              <th className="py-4 pr-6 rec-mono text-sm font-medium" style={{ color: 'var(--rec-link)' }}>
+              <th className="py-4 pr-6 rec-mono text-sm font-medium" style={{ color: 'var(--rec-ink)' }}>
                 {route.phase}
               </th>
               <td className="px-6 py-4 rec-mono text-sm" style={{ color: 'var(--rec-ink)' }}>
@@ -134,7 +137,9 @@ function EnforcementBoundary({ integration }: { integration: Integration }) {
   return (
     <div className="grid border-y md:grid-cols-2" style={{ borderColor: 'var(--rec-rule)' }}>
       <div className="py-6 pr-0 md:pr-8">
-        <p className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-gate-ink)' }}>
+        {/* Neither kicker takes a verdict hue: amber is the human gate and green
+            is a pass, and "in the session" is neither. */}
+        <p className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-ink-3)' }}>
           {session.kicker}
         </p>
         <h3 className="mt-2 text-lg font-semibold" style={{ color: 'var(--rec-ink)' }}>
@@ -145,7 +150,7 @@ function EnforcementBoundary({ integration }: { integration: Integration }) {
         </p>
       </div>
       <div className="border-t py-6 md:border-l md:border-t-0 md:pl-8" style={{ borderColor: 'var(--rec-rule)' }}>
-        <p className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-pass-ink)' }}>
+        <p className="rec-mono text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--rec-ink-3)' }}>
           {ci.kicker}
         </p>
         <h3 className="mt-2 text-lg font-semibold" style={{ color: 'var(--rec-ink)' }}>
@@ -221,7 +226,9 @@ function IntroWithCode({ text }: { text: string }) {
 export function IntegrationDetailPage({ integration }: { integration: Integration }) {
   return (
     <main>
-      <MarketingSection headingLevel={1} kicker={integration.hero.kicker} title={integration.hero.title}>
+      {/* Interior pages number their clauses like any record; an unnumbered
+          eyebrow over every section is the exact grammar DESIGN.md forbids. */}
+      <MarketingSection headingLevel={1} n="1" kicker={integration.hero.kicker} title={integration.hero.title}>
         <div className="grid items-start gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:gap-14">
           <div>
             <p className="max-w-[72ch] text-lg leading-relaxed" style={{ color: 'var(--rec-ink-2)' }}>
@@ -251,7 +258,7 @@ export function IntegrationDetailPage({ integration }: { integration: Integratio
       </MarketingSection>
 
       <div style={{ background: 'var(--rec-paper-sunk)' }}>
-        <MarketingSection kicker={integration.surfacesSection.kicker} title={integration.surfacesSection.title}>
+        <MarketingSection n="2" kicker={integration.surfacesSection.kicker} title={integration.surfacesSection.title}>
           <div className="mb-10 lg:max-w-md">
             <NativeBundle integration={integration} />
           </div>
@@ -259,20 +266,22 @@ export function IntegrationDetailPage({ integration }: { integration: Integratio
         </MarketingSection>
       </div>
 
-      <MarketingSection kicker={integration.phaseSection.kicker} title={integration.phaseSection.title}>
+      <MarketingSection n="3" kicker={integration.phaseSection.kicker} title={integration.phaseSection.title}>
         <IntroWithCode text={integration.phaseSection.intro} />
         <PhaseRouting integration={integration} />
       </MarketingSection>
 
       <div style={{ background: 'var(--rec-paper-sunk)' }}>
-        <MarketingSection kicker={integration.railsSection.kicker} title={integration.railsSection.title}>
+        <MarketingSection n="4" kicker={integration.railsSection.kicker} title={integration.railsSection.title}>
           <EnforcementBoundary integration={integration} />
         </MarketingSection>
       </div>
 
-      <MarketingSection kicker={integration.installSection.kicker} title={integration.installSection.title}>
-        <div className="grid items-start gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:gap-14">
-          <IntegrationCard integration={integration} />
+      <MarketingSection n="5" kicker={integration.installSection.kicker} title={integration.installSection.title}>
+        {/* The install card renders once, in the hero. This closing clause used
+            to repeat it byte-identically; a reader who scrolled the whole page
+            gets the day-to-day commands and the resource nav instead. */}
+        <div className="lg:max-w-[42rem]">
           <OperatingCommands integration={integration} />
         </div>
         <ResourceNav integration={integration} />

--- a/apps/docs/components/marketing/lifecycle-pipeline.tsx
+++ b/apps/docs/components/marketing/lifecycle-pipeline.tsx
@@ -1,4 +1,5 @@
 import { PHASES } from '@/lib/phase-graph.mjs';
+import { theoryLink } from '@/lib/theory-links.mjs';
 import { ExitCode } from './record';
 
 // The approval chain.
@@ -39,7 +40,14 @@ export const APPROVER: Record<string, string> = {
   P7: 'adlc lesson-foundry',
 };
 
-export function LifecyclePipeline() {
+/**
+ * `details` folds the per-phase annotation into the chain itself. The
+ * /lifecycle page used to render a second eight-row table restating this one —
+ * same identifiers, same names, same amber banding — to carry one sentence per
+ * phase; on mobile that was the same table twice. The sentence belongs to the
+ * row it annotates.
+ */
+export function LifecyclePipeline({ details }: { details?: Record<string, string> } = {}) {
   return (
     <div>
       <div style={{ borderTop: '1px solid var(--rec-rule-strong)' }}>
@@ -79,6 +87,10 @@ export function LifecyclePipeline() {
                 className="rec-mono col-start-2 px-3 pb-1 text-[12.5px] md:col-start-auto md:py-3.5 md:pb-3.5"
                 style={{ color: 'var(--rec-ink-2)' }}
               >
+                {/* The header row is display:none below md, so the collapsed
+                    rows restate their legends inline — an unlabeled mono value
+                    like "routed" carries nothing on its own. */}
+                <span className="rec-legend mr-2 md:hidden">Exit gate</span>
                 {phase.gate}
               </div>
               <div
@@ -88,6 +100,9 @@ export function LifecyclePipeline() {
                   fontWeight: phase.human ? 600 : 400,
                 }}
               >
+                <span className="rec-legend mr-2 md:hidden" style={{ color: 'var(--rec-ink-3)' }}>
+                  At this phase
+                </span>
                 {phase.human ? (
                   <span
                     aria-hidden
@@ -103,6 +118,21 @@ export function LifecyclePipeline() {
                     enough to read as missing data. */}
                 <ExitCode verdict={phase.human ? 'attest' : 'pass'} stampDelay={i * 32 + 150} />
               </div>
+              {details?.[phase.id] ? (
+                <div className="col-span-full px-3 pb-3.5 md:pl-[58px]">
+                  <p className="max-w-[72ch] text-[13.5px] leading-[1.55]" style={{ color: 'var(--rec-ink-2)' }}>
+                    {details[phase.id]}{' '}
+                    <a
+                      href={theoryLink(phase.id)}
+                      aria-label={`${phase.name} essay`}
+                      className="whitespace-nowrap text-[13px]"
+                      style={{ color: 'var(--rec-link)', borderBottom: '1px solid var(--rec-link-edge)' }}
+                    >
+                      essay ↗
+                    </a>
+                  </p>
+                </div>
+              ) : null}
             </li>
           ))}
         </ol>
@@ -124,6 +154,11 @@ export function LifecyclePipeline() {
         </span>
         <span className="rec-mono text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
           Evidence lands in .adlc/manifest.jsonl
+        </span>
+        {/* Same honesty the dials block already has: these chips are the form's
+            worked example, not the output of a live run. */}
+        <span className="rec-mono text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
+          Verdicts shown are illustrative
         </span>
       </div>
     </div>

--- a/apps/docs/components/marketing/record.tsx
+++ b/apps/docs/components/marketing/record.tsx
@@ -81,16 +81,33 @@ export function Masthead() {
             <GitHubMark />
           </a>
         </nav>
-        {/* Small screens keep the record reachable without a drawer: the nav is
-            seven flat destinations, so it wraps into the rail below instead. */}
-        <nav className="flex items-center gap-4 text-[12px] font-medium md:hidden">
-          <Link href="/lifecycle" style={{ color: '#9599a6' }}>
-            Lifecycle
-          </Link>
-          <Link href="/docs" style={{ color: '#9599a6' }}>
-            Docs
-          </Link>
-        </nav>
+        {/* Small screens get every route, not a two-link sample: a no-JS
+            disclosure on the terminal ground. A mobile visitor who lands on an
+            interior page must still be able to reach the install path. */}
+        <details className="relative md:hidden">
+          <summary
+            className="rec-mono flex cursor-pointer list-none items-center border px-2.5 py-1 text-[11px] tracking-[0.1em] [&::-webkit-details-marker]:hidden"
+            style={{ color: '#9599a6', borderColor: '#34363d' }}
+          >
+            MENU
+          </summary>
+          <nav
+            className="absolute right-0 top-[calc(100%+9px)] z-50 flex w-52 flex-col"
+            style={{ background: '#1c1d21', border: '1px solid #34363d' }}
+            aria-label="All pages"
+          >
+            {NAV.map((n) => (
+              <Link
+                key={n.href}
+                href={n.href}
+                className="px-4 py-2.5 text-[13px] font-medium"
+                style={{ color: '#cbcdd2', borderBottom: '1px solid #2c2e34' }}
+              >
+                {n.label}
+              </Link>
+            ))}
+          </nav>
+        </details>
       </div>
     </header>
   );

--- a/apps/docs/components/marketing/record.tsx
+++ b/apps/docs/components/marketing/record.tsx
@@ -59,7 +59,7 @@ export function Masthead() {
             the short form still teaches itself. */}
         <Link
           href="/"
-          className="rec-mono flex items-center gap-2.5 text-[12.5px] font-bold tracking-[0.1em]"
+          className="rec-mono flex items-center gap-2.5 text-[12.5px] font-bold tracking-[0.05em]"
           style={{ color: '#cbcdd2' }}
         >
           <span aria-hidden className="block h-[9px] w-[9px] shrink-0 rounded-[1px]" style={{ background: '#78bd65' }} />
@@ -104,7 +104,7 @@ export function RecordRail({ items }: { items: { k: string; v: ReactNode; open?:
         {items.map((it, i) => (
           <span
             key={it.k}
-            className="rec-mono whitespace-nowrap text-[10px] uppercase tracking-[0.1em]"
+            className="rec-mono whitespace-nowrap text-[11px] uppercase tracking-[0.1em]"
             style={{
               color: 'var(--rec-ink-2)',
               paddingRight: 18,
@@ -354,10 +354,10 @@ export function Exhibit({
       </figcaption>
       <div className="rec-capture" style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
         <div
-          className="rec-capture-bar rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
-          style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
+          className="rec-capture-bar rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[11px] tracking-[0.1em]"
+          style={{ borderBottom: '1px solid #2c2e34', color: '#9093a0' }}
         >
-          <span className="truncate">{command}</span>
+          <span className="truncate text-[12px] tracking-normal">{command}</span>
           <span className="whitespace-nowrap" style={{ color: verdict === 'fail' ? '#eb3d54' : '#78bd65' }}>
             {status}
           </span>
@@ -400,10 +400,10 @@ export function Capture({ title, status, fail, children }: { title: string; stat
   return (
     <div className="rec-capture" style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
       <div
-        className="rec-capture-bar rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
-        style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
+        className="rec-capture-bar rec-mono flex items-center justify-between gap-3 px-3.5 py-2 text-[11px] tracking-[0.1em]"
+        style={{ borderBottom: '1px solid #2c2e34', color: '#9093a0' }}
       >
-        <span className="truncate">{title}</span>
+        <span className="truncate text-[12px] tracking-normal">{title}</span>
         <span className="whitespace-nowrap" style={{ color: fail ? '#eb3d54' : '#78bd65' }}>
           {status}
         </span>

--- a/apps/docs/components/marketing/route-exhibit.tsx
+++ b/apps/docs/components/marketing/route-exhibit.tsx
@@ -1,0 +1,37 @@
+import { Exhibit, ExhibitOutput } from './record';
+import { MARKETING_GATES } from '@/lib/marketing-gates.mjs';
+
+/**
+ * A numbered exhibit for an interior route, drawn from the same gate data the
+ * homepage exhibits use. The memorable moment of this design is that no claim
+ * of capability stands without an attached exhibit — a device that was
+ * homepage-only until these routes got one each.
+ *
+ * The disclosure line ships with the exhibit, not beside it in page copy, so a
+ * route can never render the capture without the honesty about what the
+ * verdict line is.
+ */
+export function RouteExhibit({ id, gateName }: { id: string; gateName: string }) {
+  const gate = MARKETING_GATES.find((g) => g.name === gateName);
+  if (!gate) return null;
+  return (
+    <div className="lg:max-w-[72ch]">
+      <Exhibit
+        id={id}
+        attachedTo={gate.gate}
+        // Short name in the bar; the full command with its flags is the
+        // capture's own $ line, so truncating it here would clip nothing but
+        // still read as clipped.
+        command={`adlc ${gate.name}`}
+        status={gate.state === 'pass' ? 'EXIT 0 — PASS' : 'EXIT 2 — REFUSED'}
+        verdict={gate.state === 'pass' ? 'pass' : 'fail'}
+      >
+        <ExhibitOutput output={gate.output} />
+      </Exhibit>
+      <p className="mt-2 max-w-[72ch] text-[12px]" style={{ color: 'var(--rec-ink-3)' }}>
+        The command and exit code are real; the verdict line is this record&apos;s one-line summary
+        of the result, not a verbatim transcript.
+      </p>
+    </div>
+  );
+}

--- a/apps/docs/components/marketing/section.tsx
+++ b/apps/docs/components/marketing/section.tsx
@@ -38,7 +38,9 @@ export function MarketingSection({ id, kicker, n, title, headingLevel = 2, child
     >
       <div className="flex flex-col gap-x-6 px-6 pb-10 pt-10 md:flex-row md:px-8 md:pb-12 md:pt-12">
         {kicker ? (
-          <div className="mb-3 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
+          // mb-4 over the heading vs mt-3 under it: a heading keeps more space
+          // above than below, including where the gutter stacks at mobile width.
+          <div className="mb-4 shrink-0 md:mb-0 md:w-[104px] md:pt-1">
             {/* No whitespace-nowrap: interior kickers run long ("Claude Code
                 integration") and a non-wrapping legend overflows the 104px
                 gutter straight across the heading beside it. */}
@@ -59,7 +61,7 @@ export function MarketingSection({ id, kicker, n, title, headingLevel = 2, child
           >
             {title}
           </Heading>
-          <div className="mt-7">{children}</div>
+          <div className="mt-3 md:mt-7">{children}</div>
         </div>
       </div>
     </section>

--- a/apps/docs/components/marketing/terminal-card.tsx
+++ b/apps/docs/components/marketing/terminal-card.tsx
@@ -17,10 +17,10 @@ export function TerminalCard({ title, children }: TerminalCardProps) {
   return (
     <div className="rec-capture" style={{ background: '#1c1d21', border: '1px solid #34363d' }}>
       <div
-        className="rec-capture-bar rec-mono flex items-center gap-3 px-3.5 py-2 text-[10px] tracking-[0.1em]"
-        style={{ borderBottom: '1px solid #2c2e34', color: '#686b78' }}
+        className="rec-capture-bar rec-mono flex items-center gap-3 px-3.5 py-2 text-[11px] tracking-[0.1em]"
+        style={{ borderBottom: '1px solid #2c2e34', color: '#9093a0' }}
       >
-        <span className="truncate">{title}</span>
+        <span className="truncate text-[12px] tracking-normal">{title}</span>
       </div>
       <div
         className="rec-mono overflow-x-auto px-4 py-3.5 text-[12.5px] leading-[1.75]"

--- a/apps/docs/components/marketing/vs-table.tsx
+++ b/apps/docs/components/marketing/vs-table.tsx
@@ -24,8 +24,10 @@ export function VsTable() {
             </th>
             <th
               scope="col"
-              className="p-4 text-left align-bottom rec-mono text-xs font-medium uppercase tracking-wider"
-              style={{ color: 'var(--rec-link)', background: 'var(--rec-paper-raised)' }}
+              className="p-4 text-left align-bottom rec-mono text-xs font-semibold uppercase tracking-wider"
+              // Blue is links only; the raised surface and heavier weight carry
+              // the column's emphasis without borrowing the link hue.
+              style={{ color: 'var(--rec-ink)', background: 'var(--rec-paper-raised)' }}
             >
               ADLC (built for models)
             </th>

--- a/apps/docs/lib/vs-sdlc.mjs
+++ b/apps/docs/lib/vs-sdlc.mjs
@@ -27,6 +27,10 @@ export const VS_SDLC_ROWS = [
   {
     dimension: 'Cost over time',
     sdlc: 'Process overhead compounds',
-    adlc: 'Gets cheaper over time, because findings distill into permanent defenses',
+    // Mechanism, not an economic promise: P7 turns review findings into
+    // deterministic lints and skills, so the same defect class is caught by a
+    // machine on the next run. Stated as what the lifecycle does, not what it
+    // will save.
+    adlc: 'Findings distill into deterministic defenses (P7), so the same failure is caught by a lint next time',
   },
 ];

--- a/apps/docs/test/phase-diagram.test.mjs
+++ b/apps/docs/test/phase-diagram.test.mjs
@@ -49,12 +49,26 @@ test('the pipeline legend states the real machine/human split', () => {
 
 test('the lifecycle page derives human gates from the shared source', () => {
   // It used to keep its own `new Set(['P1','P6'])`, so the page and the diagram
-  // above it could disagree about which gates are human.
+  // above it could disagree about which gates are human. The page now renders
+  // the chain exactly once through LifecyclePipeline (its second, restating
+  // table was removed), so the invariant is: the page declares no human-gate
+  // list of any kind, and the pipeline reads `phase.human` from phase-graph.
   const source = readFileSync(path.join(docsRoot, 'app/(home)/lifecycle/page.tsx'), 'utf8');
-  assert.ok(source.includes('HUMAN_GATE_IDS'), 'the page must import the shared list');
   assert.ok(
     !/new Set\(\[\s*'P1'\s*,\s*'P6'\s*\]\)/.test(source),
     'the page must not re-declare which phases are human-gated',
+  );
+  assert.ok(
+    !source.includes('HUMAN GATE'),
+    'the page must not hand-render human-gate marks; the pipeline owns them',
+  );
+  const pipeline = readFileSync(
+    path.join(docsRoot, 'components/marketing/lifecycle-pipeline.tsx'),
+    'utf8',
+  );
+  assert.ok(
+    pipeline.includes('phase.human'),
+    'the chain must derive human gates from phase-graph.mjs',
   );
 });
 

--- a/plugins/adlc-herdr/test/on-event-e2e.test.mjs
+++ b/plugins/adlc-herdr/test/on-event-e2e.test.mjs
@@ -114,9 +114,14 @@ test('agent going idle with an active ticket nudges to gate it (drives pane→re
 test('a rapid re-idle within the dedupe window does not notify again', () => {
   writeFileSync(join(repo, '.adlc', 'current-ticket.json'), JSON.stringify({ id: 't-active', ticketHash: 'x' }));
   const payload = JSON.stringify({ event: 'pane_agent_status_changed', data: { pane_id: 'w4:p2', agent_status: 'idle' } });
-  runEvent('pane.agent_status_changed', payload, { ADLC_HERDR_NUDGE_WINDOW_MS: '60000' }); // first: notify + mark
+  // The window is a wall-clock bucket (floor(now/windowMs)), so a 60s window
+  // flakes whenever the two runs straddle a minute boundary — CI hit exactly
+  // that. MAX_SAFE_INTEGER keeps the entire test inside bucket 0, which makes
+  // "within the window" true by construction instead of by luck.
+  const window = { ADLC_HERDR_NUDGE_WINDOW_MS: String(Number.MAX_SAFE_INTEGER) };
+  runEvent('pane.agent_status_changed', payload, window); // first: notify + mark
   const before = (calls().match(/notification show/g) || []).length;
-  runEvent('pane.agent_status_changed', payload, { ADLC_HERDR_NUDGE_WINDOW_MS: '60000' }); // within window: suppressed
+  runEvent('pane.agent_status_changed', payload, window); // within window: suppressed
   const after = (calls().match(/notification show/g) || []).length;
   assert.equal(after, before, 'a flap within the window must not nudge twice');
 });


### PR DESCRIPTION
## Summary

A full impeccable design pass over the marketing site (homepage + all six subpages), driven by a dual-agent critique (design review + rendered-page detector). Rendered-page anti-pattern findings went from **16 → 2 (homepage)** and **64 → 0 (subpages)**; the two survivors are pinned brand choices (An Old Hope cyan on terminal ground, the 1px #000 terminal-edge rule).

### Trust / claims (P0)
- **/enterprise**: removed the invented "Two weeks to the first prosecuted merge" time-to-value figure — the claim class PRODUCT.md explicitly forbids. The pilot stage is now duration-free.
- **Contact form**: client now runs the same `parseLead` validator as the API route (its comment always claimed it was shared; it never was). Per-field `aria-invalid`/`aria-describedby`, `role="alert"` summary, fail-edge highlighting so "highlighted fields" is literally true, ✗-prefixed messages honoring the glyph+word rule, focus moves to the first invalid field, and the success state keeps a send-another path.
- "Every gate emits ✓/✗/◆" corrected to the real machine/human split (it contradicted /lifecycle's 2-of-8 ATTEST).

### The evidence register (P1)
- The exhibit device was homepage-only; the approved direction's whole argument ("no claim without an attached exhibit") stopped at the front door. New `RouteExhibit` attaches a real gate capture to /lifecycle (rails-guard), /failure-modes (hollow-test), /toolkit (spec-lint), /enterprise (review-calibration), with the summary-not-transcript disclosure built into the component.
- New `ImplementClause` closes /lifecycle, /failure-modes, /vs-sdlc, /toolkit with the install field — those routes previously ended on an offsite essay link with no install path anywhere on the page.

### Mechanical (P1)
- Homepage: dropped the SUBJECT/CLASS/SCOPE/BACK-OUT field block (the comp marked it "a direction test, not a spec"); the §1 statement now leads. Back-out fact folded into §2.
- Install command wraps at every breakpoint (the md:whitespace-pre variant clipped the agent prompt mid-sentence on desktop — the width where most visitors copy it).
- Masthead gains a no-JS `<details>` menu at mobile width: all 7 routes reachable (was 2, with no menu control at all).
- `rec-legend` raised 9.5px → 11px: legends do functional duty (column headers, form labels) and now hold the readable floor. Contrast fixes: F-identifier orange darkened to #a24e15 (≥4.5:1), terminal-band secondary text to the muted token.

### Layout / drift (P2–P3)
- /lifecycle: the duplicate eight-row table is gone — `PHASE_DETAIL` folds into the pipeline rows (~4,000px of mobile scroll reclaimed); per-phase essay links get distinct accessible names; verdict chips labelled illustrative; collapsed mobile rows restate their column legends inline.
- /toolkit: lattice filler kills the dead grey slabs; group headings h3→h2; package cells take link ink; the 29-vs-26 count reconciled from the data module.
- /enterprise: EvidenceTrail card grid → ruled rows; mobile heading rhythm keeps more space above than below.
- Integration detail pages: sections numbered §1–§5 (tracked-eyebrow grammar removed per DESIGN.md's own Don't), duplicate install card removed, blue reserved for links, verdict hues off non-verdict labels.
- /integrations: `windows-latest run` missing-space defect fixed. /vs-sdlc: "is theater" reworded; cost row restated as mechanism, not economic promise.
- AEO: llms.txt docs-index links absolutized (relative links are useless to an LLM reading the file off-site).

### Tests
- `phase-diagram.test.mjs` updated to a strictly stronger invariant: the lifecycle page declares no human-gate list at all; the pipeline derives `phase.human` from phase-graph.

## Test plan
- [x] 164/164 docs tests pass (`node --test`)
- [x] `types:check` clean
- [x] Rendered-page detector: 0 findings across all six subpages, desktop and 390px mobile; homepage down to 2 brief-pinned findings
- [x] Live verification: mobile menu open/close, contact-form error state (focus lands on first invalid field, fail-edge highlight), desktop + mobile screenshots of every route
- [x] `adversarial-review --base main`: **APPROVE**, no material findings
- [ ] Verify preview deployment renders fonts and OG images correctly

Critique snapshot committed under `apps/docs/.impeccable/critique/` for follow-up work (per-route OG images, sitemap lastModified, deeper JSON-LD).