### PR TITLE
feat(test-runner): scrub ambient trust-root env from spawned segments (T1)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -17,7 +17,7 @@
 // looks the same as before.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, realpathSync } from 'node:fs';
 import { join, delimiter, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -29,10 +29,41 @@ import { fileURLToPath } from 'node:url';
 // PATH and those spawns fail with ENOENT on a runner without a global adlc — a
 // silent false red. Prepending it here makes the runner self-sufficient either way.
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const SEGMENT_ENV = {
-  ...process.env,
-  PATH: `${join(REPO_ROOT, 'node_modules', '.bin')}${delimiter}${process.env.PATH ?? ''}`,
-};
+
+// Ambient trust-root variables the OPERATOR's shell may carry that must not decide
+// test outcomes (spec: .adlc/specs/manifest-key-hermeticity.md, Layer 1):
+//   ADLC_MANIFEST_KEY — flips key-present/key-absent branches deep in library code
+//     (measured: gate-manifest + tickets segments 0/2 with it exported, 2/2 without);
+//   RAILS_BASE / BASE_REF — retarget rails-guard base resolution at branches the
+//     tests' scratch repos don't contain (75/80 bootstrap tests failed).
+// Tests that NEED one of these set their own value inline and are unaffected.
+export const SCRUBBED_ENV_VARS = ['ADLC_MANIFEST_KEY', 'RAILS_BASE', 'BASE_REF'];
+
+/**
+ * Build the env every segment is spawned with: the caller's env with the repo's
+ * node_modules/.bin prepended to PATH, and each SCRUBBED_ENV_VARS member DELETED when
+ * its value is non-empty. An explicitly-empty value ('') is PRESERVED: presence beats
+ * truthiness for these variables — an empty ADLC_MANIFEST_KEY is a deliberate
+ * fail-closed that blocks the .env.local file loader (load-env-local.mjs rule 2), and
+ * deleting it would re-enable file fallback inside spawned bins. Unset stays absent.
+ *
+ * @param {NodeJS.ProcessEnv} [baseEnv]
+ * @returns {{env: NodeJS.ProcessEnv, scrubbed: string[]}} scrubbed lists what was deleted
+ */
+export function buildSegmentEnv(baseEnv = process.env) {
+  const env = {
+    ...baseEnv,
+    PATH: `${join(REPO_ROOT, 'node_modules', '.bin')}${delimiter}${baseEnv.PATH ?? ''}`,
+  };
+  const scrubbed = [];
+  for (const name of SCRUBBED_ENV_VARS) {
+    if (Object.hasOwn(env, name) && env[name] !== '') {
+      delete env[name];
+      scrubbed.push(name);
+    }
+  }
+  return { env, scrubbed };
+}
 
 const TSC_FLAGS = '--noEmit --allowJs --target es2022 --module nodenext --moduleResolution nodenext --skipLibCheck true';
 
@@ -70,24 +101,39 @@ const SEGMENTS = [
   ['docs app', 'node --test apps/docs/test/*.test.mjs'],
 ];
 
-const only = process.argv.slice(2).filter((a) => !a.startsWith('-'));
-const segments = only.length ? SEGMENTS.filter(([name]) => only.some((o) => name.includes(o))) : SEGMENTS;
-if (only.length && segments.length === 0) {
-  console.error(`no test segment matches ${JSON.stringify(only)}. Known: ${SEGMENTS.map(([n]) => n).join(', ')}`);
-  process.exit(1);
+function main() {
+  const { env: segmentEnv, scrubbed } = buildSegmentEnv(process.env);
+  if (scrubbed.length) {
+    console.log(`note: ${scrubbed.join(', ')} set in your shell — scrubbed for test segments`);
+  }
+
+  const only = process.argv.slice(2).filter((a) => !a.startsWith('-'));
+  const segments = only.length ? SEGMENTS.filter(([name]) => only.some((o) => name.includes(o))) : SEGMENTS;
+  if (only.length && segments.length === 0) {
+    console.error(`no test segment matches ${JSON.stringify(only)}. Known: ${SEGMENTS.map(([n]) => n).join(', ')}`);
+    process.exit(1);
+  }
+
+  const failed = [];
+  for (const [name, command] of segments) {
+    console.log(`\n─── ${name}`);
+    const result = spawnSync(command, { shell: true, stdio: 'inherit', env: segmentEnv });
+    // A signal (status null) is a failure too — never let a killed segment read as a pass.
+    if (result.status !== 0) failed.push({ name, status: result.status, signal: result.signal });
+  }
+
+  console.log(`\n═══ ${segments.length - failed.length}/${segments.length} segments passed`);
+  if (failed.length) {
+    for (const f of failed) console.log(`  FAILED  ${f.name}${f.signal ? ` (${f.signal})` : ` (exit ${f.status})`}`);
+    process.exit(1);
+  }
+  console.log('  all green');
 }
 
-const failed = [];
-for (const [name, command] of segments) {
-  console.log(`\n─── ${name}`);
-  const result = spawnSync(command, { shell: true, stdio: 'inherit', env: SEGMENT_ENV });
-  // A signal (status null) is a failure too — never let a killed segment read as a pass.
-  if (result.status !== 0) failed.push({ name, status: result.status, signal: result.signal });
-}
-
-console.log(`\n═══ ${segments.length - failed.length}/${segments.length} segments passed`);
-if (failed.length) {
-  for (const f of failed) console.log(`  FAILED  ${f.name}${f.signal ? ` (${f.signal})` : ` (exit ${f.status})`}`);
-  process.exit(1);
-}
-console.log('  all green');
+// Only run the suite when executed directly — the hermeticity test imports this module
+// for buildSegmentEnv, and an import must never launch every test segment. realpathSync
+// on BOTH sides: macOS /tmp is a symlink, so a path-string comparison can disagree
+// locally while agreeing on Linux CI (or vice versa).
+const invokedDirectly = process.argv[1]
+  && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+if (invokedDirectly) main();

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -50,17 +50,30 @@ export const SCRUBBED_ENV_VARS = ['ADLC_MANIFEST_KEY', 'RAILS_BASE', 'BASE_REF']
  * @param {NodeJS.ProcessEnv} [baseEnv]
  * @returns {{env: NodeJS.ProcessEnv, scrubbed: string[]}} scrubbed lists what was deleted
  */
-export function buildSegmentEnv(baseEnv = process.env) {
+export function buildSegmentEnv(baseEnv = process.env, { platform = process.platform } = {}) {
   const env = {
     ...baseEnv,
     PATH: `${join(REPO_ROOT, 'node_modules', '.bin')}${delimiter}${baseEnv.PATH ?? ''}`,
   };
   const scrubbed = [];
+  // Windows environment names are case-insensitive: a child process resolves
+  // `adlc_manifest_key` as ADLC_MANIFEST_KEY, so an uppercase-only check would let a
+  // mixed-case export defeat the scrub there. On POSIX, casing is significant and a
+  // lowercase variant is a DIFFERENT variable nothing reads — scrubbing it would be
+  // overreach — so the fold applies on win32 only. Reported names are canonical.
+  const caseInsensitive = platform === 'win32';
   for (const name of SCRUBBED_ENV_VARS) {
-    if (Object.hasOwn(env, name) && env[name] !== '') {
-      delete env[name];
-      scrubbed.push(name);
+    const matches = caseInsensitive
+      ? Object.keys(env).filter((k) => k.toUpperCase() === name)
+      : (Object.hasOwn(env, name) ? [name] : []);
+    let removed = false;
+    for (const match of matches) {
+      if (env[match] !== '') {
+        delete env[match];
+        removed = true;
+      }
     }
+    if (removed) scrubbed.push(name);
   }
   return { env, scrubbed };
 }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -42,6 +42,7 @@ const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 //   ADLC_GATE_MOCK_RESPONSE — a test seam that, exported ambiently, makes LLM-backed
 //     gates return canned verdicts instead of exercising the real path.
 // Tests that NEED one of these set their own value inline and are unaffected.
+export const PRESERVE_EMPTY = new Set(['ADLC_MANIFEST_KEY']);
 export const SCRUBBED_ENV_VARS = [
   'ADLC_MANIFEST_KEY',
   'RAILS_BASE',
@@ -80,10 +81,14 @@ export function buildSegmentEnv(baseEnv = process.env, { platform = process.plat
       : (Object.hasOwn(env, name) ? [name] : []);
     let removed = false;
     for (const match of matches) {
-      if (env[match] !== '') {
-        delete env[match];
-        removed = true;
-      }
+      // The explicit-'' carve-out applies ONLY to the key: its presence (even empty)
+      // is a deliberate fail-closed that blocks the .env.local loader. The other
+      // variables have PRESENCE-checked consumers (e.g. ADLC_GATE_MOCK_RESPONSE
+      // present-but-empty can still select a mock path), so for them any present
+      // value — empty included — is scrubbed (codex review finding).
+      if (env[match] === '' && PRESERVE_EMPTY.has(name)) continue;
+      delete env[match];
+      removed = true;
     }
     if (removed) scrubbed.push(name);
   }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -35,9 +35,21 @@ const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 //   ADLC_MANIFEST_KEY — flips key-present/key-absent branches deep in library code
 //     (measured: gate-manifest + tickets segments 0/2 with it exported, 2/2 without);
 //   RAILS_BASE / BASE_REF — retarget rails-guard base resolution at branches the
-//     tests' scratch repos don't contain (75/80 bootstrap tests failed).
+//     tests' scratch repos don't contain (75/80 bootstrap tests failed);
+//   ADLC_RAILS_BYPASS / ADLC_BUILD_GATE_BYPASS — documented operator overrides that
+//     flip gate outcomes: a bypass exported for legitimate maintenance would make a
+//     test expecting exit 2 see a recorded override and exit 0 (codex review finding);
+//   ADLC_GATE_MOCK_RESPONSE — a test seam that, exported ambiently, makes LLM-backed
+//     gates return canned verdicts instead of exercising the real path.
 // Tests that NEED one of these set their own value inline and are unaffected.
-export const SCRUBBED_ENV_VARS = ['ADLC_MANIFEST_KEY', 'RAILS_BASE', 'BASE_REF'];
+export const SCRUBBED_ENV_VARS = [
+  'ADLC_MANIFEST_KEY',
+  'RAILS_BASE',
+  'BASE_REF',
+  'ADLC_RAILS_BYPASS',
+  'ADLC_BUILD_GATE_BYPASS',
+  'ADLC_GATE_MOCK_RESPONSE',
+];
 
 /**
  * Build the env every segment is spawned with: the caller's env with the repo's

--- a/scripts/test/run-tests-hermetic.test.mjs
+++ b/scripts/test/run-tests-hermetic.test.mjs
@@ -1,0 +1,91 @@
+// run-tests-hermetic.test.mjs — the test runner must scrub ambient trust-root env
+// (T-01KYQMPBEKCDCZ60FZKDC1WNF7, spec .adlc/specs/manifest-key-hermeticity.md Layer 1).
+//
+// Why: an exported ADLC_MANIFEST_KEY flips key-present/key-absent branches deep in
+// library code (measured 2026-07-29: gate-manifest + tickets segments 0/2 with the key
+// exported, 2/2 without), and an exported RAILS_BASE retargets rails-guard tests at
+// branches the scratch repos don't contain (75/80 bootstrap tests failed). The failure
+// names a package, not a variable — so the runner deletes non-empty values of the
+// sensitive set from every segment's env and says so once.
+//
+// Presence-vs-emptiness is load-bearing: an explicitly-empty ADLC_MANIFEST_KEY='' is a
+// deliberate fail-closed that beats the .env.local file loader
+// (packages/prosecute/lib/load-env-local.mjs rule 2). DELETING it would convert
+// "never fall back to a file key" into absence and re-enable file fallback in spawned
+// bins — so '' is PRESERVED, and only non-empty values are deleted.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { join, dirname, delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildSegmentEnv, SCRUBBED_ENV_VARS } from '../run-tests.mjs';
+
+const REPO_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+test('the sensitive set is exactly the three ambient trust-root variables', () => {
+  assert.deepEqual([...SCRUBBED_ENV_VARS].sort(), ['ADLC_MANIFEST_KEY', 'BASE_REF', 'RAILS_BASE']);
+});
+
+test('non-empty sensitive values are ABSENT from the segment env and reported', () => {
+  const { env, scrubbed } = buildSegmentEnv({
+    HOME: '/h',
+    ADLC_MANIFEST_KEY: 'leaked-key',
+    RAILS_BASE: 'chore/somewhere',
+    BASE_REF: 'main',
+  });
+  for (const name of SCRUBBED_ENV_VARS) {
+    assert.equal(Object.hasOwn(env, name), false, `${name} must be deleted, not emptied`);
+  }
+  assert.deepEqual([...scrubbed].sort(), ['ADLC_MANIFEST_KEY', 'BASE_REF', 'RAILS_BASE']);
+  assert.equal(env.HOME, '/h', 'unrelated vars pass through');
+});
+
+test("an explicitly-empty value ('') is PRESERVED as the deliberate fail-closed state", () => {
+  const { env, scrubbed } = buildSegmentEnv({ ADLC_MANIFEST_KEY: '', RAILS_BASE: '' });
+  assert.equal(env.ADLC_MANIFEST_KEY, '', "'' must survive: it blocks .env.local fallback by PRESENCE");
+  assert.equal(env.RAILS_BASE, '');
+  assert.deepEqual(scrubbed, [], 'preserving is not scrubbing — no notice for empty values');
+});
+
+test('unset variables stay absent and produce no notice', () => {
+  const { env, scrubbed } = buildSegmentEnv({ HOME: '/h' });
+  for (const name of SCRUBBED_ENV_VARS) assert.equal(Object.hasOwn(env, name), false);
+  assert.deepEqual(scrubbed, []);
+});
+
+test('mixed input: only the non-empty members are scrubbed', () => {
+  const { env, scrubbed } = buildSegmentEnv({ ADLC_MANIFEST_KEY: 'k', RAILS_BASE: '' });
+  assert.equal(Object.hasOwn(env, 'ADLC_MANIFEST_KEY'), false);
+  assert.equal(env.RAILS_BASE, '');
+  assert.deepEqual(scrubbed, ['ADLC_MANIFEST_KEY']);
+});
+
+test('the runner PATH prepend is preserved by the helper', () => {
+  const { env } = buildSegmentEnv({ PATH: '/usr/bin' });
+  assert.ok(env.PATH.startsWith(join(REPO_ROOT, 'node_modules', '.bin') + delimiter),
+    'node_modules/.bin must stay first on PATH (mutation-gate baseline runs the runner directly)');
+});
+
+// Behavioral, process-boundary: the notice appears exactly once when a non-empty key is
+// exported, and never when the environment is clean. Uses the cheapest real segment.
+// The assertion greps for the variable name plus the word "scrub" rather than pinning
+// the full sentence — the notice is prose, and prose must stay reword-able.
+function runRunner(extraEnv) {
+  const env = { ...process.env, ...extraEnv };
+  delete env.ADLC_MANIFEST_KEY; delete env.RAILS_BASE; delete env.BASE_REF;
+  Object.assign(env, extraEnv);
+  return execFileSync(process.execPath, ['scripts/run-tests.mjs', 'generated-reader'], {
+    cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env,
+  });
+}
+
+test('spawned runner prints the scrub notice exactly once with a leaked key', () => {
+  const out = runRunner({ ADLC_MANIFEST_KEY: 'leak-test' });
+  const notices = out.split('\n').filter((l) => /ADLC_MANIFEST_KEY/.test(l) && /scrub/i.test(l));
+  assert.equal(notices.length, 1, `expected exactly one notice line, got:\n${out}`);
+});
+
+test('spawned runner prints no notice when the environment is clean', () => {
+  const out = runRunner({});
+  assert.ok(!/scrub/i.test(out), `expected no scrub notice, got:\n${out}`);
+});

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -103,3 +103,35 @@ test('an unknown segment filter is an OPERATIONAL error: exit 1, never the gate-
   assert.equal(status, 1);
   assert.match(stderr, /no test segment matches/);
 });
+
+test('win32: differently-cased spellings are scrubbed too (env names are case-insensitive there)', () => {
+  const { env, scrubbed } = buildSegmentEnv(
+    { adlc_manifest_key: 'k', Rails_Base: 'b', BASE_REF: 'main', HOME: '/h' },
+    { platform: 'win32' },
+  );
+  assert.equal(Object.hasOwn(env, 'adlc_manifest_key'), false);
+  assert.equal(Object.hasOwn(env, 'Rails_Base'), false);
+  assert.equal(Object.hasOwn(env, 'BASE_REF'), false);
+  assert.deepEqual([...scrubbed].sort(), ['ADLC_MANIFEST_KEY', 'BASE_REF', 'RAILS_BASE'], 'reported names are canonical');
+  assert.equal(env.HOME, '/h');
+});
+
+test('posix: a differently-cased spelling is a DIFFERENT variable and is preserved', () => {
+  const { env, scrubbed } = buildSegmentEnv(
+    { adlc_manifest_key: 'unrelated', ADLC_MANIFEST_KEY: 'k' },
+    { platform: 'linux' },
+  );
+  assert.equal(env.adlc_manifest_key, 'unrelated', 'lowercase variant is untouched on POSIX');
+  assert.equal(Object.hasOwn(env, 'ADLC_MANIFEST_KEY'), false);
+  assert.deepEqual(scrubbed, ['ADLC_MANIFEST_KEY']);
+});
+
+test("win32: an explicitly-empty canonical value still blocks scrubbing of ITSELF but a non-empty variant is removed", () => {
+  const { env, scrubbed } = buildSegmentEnv(
+    { ADLC_MANIFEST_KEY: '', adlc_manifest_key: 'k' },
+    { platform: 'win32' },
+  );
+  assert.equal(env.ADLC_MANIFEST_KEY, '', "explicit '' preserved");
+  assert.equal(Object.hasOwn(env, 'adlc_manifest_key'), false, 'the non-empty variant is scrubbed');
+  assert.deepEqual(scrubbed, ['ADLC_MANIFEST_KEY']);
+});

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -1,4 +1,4 @@
-// run-tests-hermetic.test.mjs — the test runner must scrub ambient trust-root env
+// run-tests.test.mjs — the test runner must scrub ambient trust-root env
 // (T-01KYQMPBEKCDCZ60FZKDC1WNF7, spec .adlc/specs/manifest-key-hermeticity.md Layer 1).
 //
 // Why: an exported ADLC_MANIFEST_KEY flips key-present/key-absent branches deep in

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -77,8 +77,15 @@ test('the runner PATH prepend is preserved by the helper', () => {
 function runRunner(extraEnv) {
   const env = { ...process.env, ...extraEnv };
   // Start from a clean slate for EVERY scrubbed variable — this test file itself may
-  // be running under a deliberately leaked env (that is T1's whole premise).
-  for (const name of SCRUBBED_ENV_VARS) delete env[name];
+  // be running under a deliberately leaked env (that is T1's whole premise). Case-fold
+  // on win32 for the same reason buildSegmentEnv does: an ambient mixed-case spelling
+  // would survive a canonical-only delete there and trip the no-notice assertion.
+  const fold = process.platform === 'win32';
+  for (const name of SCRUBBED_ENV_VARS) {
+    for (const k of Object.keys(env)) {
+      if (k === name || (fold && k.toUpperCase() === name)) delete env[k];
+    }
+  }
   Object.assign(env, extraEnv);
   return execFileSync(process.execPath, ['scripts/run-tests.mjs', 'generated-reader'], {
     cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env,

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -22,8 +22,8 @@ import { buildSegmentEnv, SCRUBBED_ENV_VARS } from '../run-tests.mjs';
 
 const REPO_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 
-test('the sensitive set is exactly the three ambient trust-root variables', () => {
-  assert.deepEqual([...SCRUBBED_ENV_VARS].sort(), ['ADLC_MANIFEST_KEY', 'BASE_REF', 'RAILS_BASE']);
+test('the sensitive set is exactly the six ambient trust-root/override variables', () => {
+  assert.deepEqual([...SCRUBBED_ENV_VARS].sort(), ['ADLC_BUILD_GATE_BYPASS', 'ADLC_GATE_MOCK_RESPONSE', 'ADLC_MANIFEST_KEY', 'ADLC_RAILS_BYPASS', 'BASE_REF', 'RAILS_BASE']);
 });
 
 test('non-empty sensitive values are ABSENT from the segment env and reported', () => {
@@ -134,4 +134,16 @@ test("win32: an explicitly-empty canonical value still blocks scrubbing of ITSEL
   assert.equal(env.ADLC_MANIFEST_KEY, '', "explicit '' preserved");
   assert.equal(Object.hasOwn(env, 'adlc_manifest_key'), false, 'the non-empty variant is scrubbed');
   assert.deepEqual(scrubbed, ['ADLC_MANIFEST_KEY']);
+});
+
+test('gate-bypass and mock-seam variables are scrubbed like the key', () => {
+  const { env, scrubbed } = buildSegmentEnv({
+    ADLC_RAILS_BYPASS: '1',
+    ADLC_BUILD_GATE_BYPASS: '1',
+    ADLC_GATE_MOCK_RESPONSE: '{"verdict":"pass"}',
+  });
+  for (const name of ['ADLC_RAILS_BYPASS', 'ADLC_BUILD_GATE_BYPASS', 'ADLC_GATE_MOCK_RESPONSE']) {
+    assert.equal(Object.hasOwn(env, name), false, `${name} must not reach test segments ambiently`);
+  }
+  assert.equal(scrubbed.length, 3);
 });

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -89,3 +89,17 @@ test('spawned runner prints no notice when the environment is clean', () => {
   const out = runRunner({});
   assert.ok(!/scrub/i.test(out), `expected no scrub notice, got:\n${out}`);
 });
+
+test('an unknown segment filter is an OPERATIONAL error: exit 1, never the gate-fail code 2', () => {
+  // Exit codes are load-bearing across ADLC: 1 = operational error, 2 = a gate
+  // failed. A runner that exits 2 for a typo'd segment name would read as a real
+  // test failure to any caller that distinguishes the two.
+  let status = 0, stderr = '';
+  try {
+    execFileSync(process.execPath, ['scripts/run-tests.mjs', 'no-such-segment-xyz'], {
+      cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) { status = err.status; stderr = String(err.stderr); }
+  assert.equal(status, 1);
+  assert.match(stderr, /no test segment matches/);
+});

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -72,7 +72,9 @@ test('the runner PATH prepend is preserved by the helper', () => {
 // the full sentence — the notice is prose, and prose must stay reword-able.
 function runRunner(extraEnv) {
   const env = { ...process.env, ...extraEnv };
-  delete env.ADLC_MANIFEST_KEY; delete env.RAILS_BASE; delete env.BASE_REF;
+  // Start from a clean slate for EVERY scrubbed variable — this test file itself may
+  // be running under a deliberately leaked env (that is T1's whole premise).
+  for (const name of SCRUBBED_ENV_VARS) delete env[name];
   Object.assign(env, extraEnv);
   return execFileSync(process.execPath, ['scripts/run-tests.mjs', 'generated-reader'], {
     cwd: REPO_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env,

--- a/scripts/test/run-tests.test.mjs
+++ b/scripts/test/run-tests.test.mjs
@@ -40,11 +40,15 @@ test('non-empty sensitive values are ABSENT from the segment env and reported', 
   assert.equal(env.HOME, '/h', 'unrelated vars pass through');
 });
 
-test("an explicitly-empty value ('') is PRESERVED as the deliberate fail-closed state", () => {
-  const { env, scrubbed } = buildSegmentEnv({ ADLC_MANIFEST_KEY: '', RAILS_BASE: '' });
-  assert.equal(env.ADLC_MANIFEST_KEY, '', "'' must survive: it blocks .env.local fallback by PRESENCE");
-  assert.equal(env.RAILS_BASE, '');
-  assert.deepEqual(scrubbed, [], 'preserving is not scrubbing — no notice for empty values');
+test("an explicitly-empty KEY is PRESERVED; empty OTHER variables are scrubbed", () => {
+  // '' preservation is a key-specific contract (presence blocks the .env.local
+  // loader). The rest have presence-checked consumers — ADLC_GATE_MOCK_RESPONSE=''
+  // could still select a mock path — so present-but-empty is scrubbed for them.
+  const { env, scrubbed } = buildSegmentEnv({ ADLC_MANIFEST_KEY: '', RAILS_BASE: '', ADLC_GATE_MOCK_RESPONSE: '' });
+  assert.equal(env.ADLC_MANIFEST_KEY, '', "'' key must survive: it blocks .env.local fallback by PRESENCE");
+  assert.equal(Object.hasOwn(env, 'RAILS_BASE'), false);
+  assert.equal(Object.hasOwn(env, 'ADLC_GATE_MOCK_RESPONSE'), false, "an empty mock seam must not reach segments");
+  assert.deepEqual([...scrubbed].sort(), ['ADLC_GATE_MOCK_RESPONSE', 'RAILS_BASE']);
 });
 
 test('unset variables stay absent and produce no notice', () => {
@@ -53,11 +57,11 @@ test('unset variables stay absent and produce no notice', () => {
   assert.deepEqual(scrubbed, []);
 });
 
-test('mixed input: only the non-empty members are scrubbed', () => {
+test('mixed input: a set key is scrubbed while an EMPTY key is the only preserved form', () => {
   const { env, scrubbed } = buildSegmentEnv({ ADLC_MANIFEST_KEY: 'k', RAILS_BASE: '' });
   assert.equal(Object.hasOwn(env, 'ADLC_MANIFEST_KEY'), false);
-  assert.equal(env.RAILS_BASE, '');
-  assert.deepEqual(scrubbed, ['ADLC_MANIFEST_KEY']);
+  assert.equal(Object.hasOwn(env, 'RAILS_BASE'), false, 'empty non-key variables are scrubbed too');
+  assert.deepEqual([...scrubbed].sort(), ['ADLC_MANIFEST_KEY', 'RAILS_BASE']);
 });
 
 test('the runner PATH prepend is preserved by the helper', () => {


### PR DESCRIPTION
Builds ticket `T-01KYQMPBEKCDCZ60FZKDC1WNF7` — Layer 1 of `.adlc/specs/manifest-key-hermeticity.md` (#403). Closes the runner half of #398.

## What

`scripts/run-tests.mjs` deletes six ambient trust-root/override variables from every spawned segment's env, printing one notice line when it does: `ADLC_MANIFEST_KEY`, `RAILS_BASE`, `BASE_REF`, `ADLC_RAILS_BYPASS`, `ADLC_BUILD_GATE_BYPASS`, `ADLC_GATE_MOCK_RESPONSE` (the last three added by codex review — documented operator overrides and the mock seam flip gate tests exactly like the key does).

Contract details, each pinned by a test:
- explicit `ADLC_MANIFEST_KEY=''` is **preserved** — key-specific: presence blocks the `.env.local` loader; for the other five, present-but-empty is scrubbed (they have presence-checked consumers).
- **win32 case-folds** (env names are case-insensitive there); POSIX does not (a lowercase variant is a different variable).
- runner body is main-guarded — importing the module for the helper cannot launch the suite.
- unknown-segment filter exits 1, never the gate-fail code 2.

## Deviation from the ticket text

The AC names `scripts/test/run-tests-hermetic.test.mjs`; the file is `scripts/test/run-tests.test.mjs` so mutation-gate's `scripts/<name>.mjs → scripts/test/<name>.test.mjs` fast-target mapping engages (the -hermetic name forced 4 full-suite runs per gate execution). Assertions match the AC; the ticket text gets corrected at completion.

## Verification

- **AC1.1 both arms**: 53/53 segments green with the key exported (notice exactly once); 53/53 green with the vars absent (no top-level notice).
- **AC1.2**: 13 unit/spawn cases in `run-tests.test.mjs`.
- **Preflight**: all 5 PR-blocking gates pass with the key **and** a build-gate bypass both exported.
- **mutation-gate**: all mutants killed (fast path; one off-by-one exit-code mutant initially survived and is now pinned).
- **codex adversarial review, 4 rounds**: win32 case-insensitivity, the bypass-variable class, key-specific empty semantics, and the test-helper fold — all found by review, all fixed and re-verified.
- tier-check: NOT trust-root tier.

## Note for the operating-stack carrier team

T2 (separate PR) changes `writeEvidence(type, data, dir, key)` and `runProsecution({ key, … })` in `packages/prosecute/lib/run.mjs` — a parked carrier adding a `writeEvidence` call site will need to thread `key` on rebase; the throw message is self-explanatory.
