### PR TITLE
docs(quartermaster): correct the reference registry's model IDs to real gateway IDs

### DIFF
--- a/apps/docs/content/docs/toolkit/quartermaster.mdx
+++ b/apps/docs/content/docs/toolkit/quartermaster.mdx
@@ -108,10 +108,10 @@ adlc fleet run --dry-run
 
 ```
   quartermaster registry: /Users/you/.config/adlc/quartermaster.json
-  T900     job=build.critical-path channel=frontier adapter=opencode model=operator/frontier-model transport=subscription:anthropic-max
-           argv: opencode ["run","-m","operator/frontier-model","<prompt>"]
-  T901     job=build.ladder-start channel=mid adapter=opencode model=zai/glm-5.2 transport=gateway:opencode-go
-           argv: opencode ["run","-m","zai/glm-5.2","<prompt>"]
+  T900     job=build.critical-path channel=frontier adapter=claude-code model=claude-opus-5 transport=subscription:anthropic-max
+           argv: claude ["-p","<prompt>","--permission-mode","acceptEdits","--output-format","text","--model","claude-opus-5"]
+  T901     job=build.ladder-start channel=mid adapter=opencode model=opencode-go/glm-5.2 transport=gateway:opencode-go
+           argv: opencode ["run","-m","opencode-go/glm-5.2","<prompt>"]
 ```
 
 Notices — an ignored in-repo registry, a disabled path — go to stderr. Adding

--- a/docs/integrations/quartermaster-registry.md
+++ b/docs/integrations/quartermaster-registry.md
@@ -118,8 +118,8 @@ a guarantee about which credential paid for the call.
 
     // `rateWindow` is optional and observed-only (spec §11 q2): a coarse hint
     // about the gateway's quota window, never a pre-flight probe.
-    "mid":              { "adapter": "opencode",    "model": "zai/glm-5.2",       "transport": "gateway:opencode-go",        "provider": "zai",      "rateWindow": "5h" },
-    "cheap":            { "adapter": "opencode",    "model": "deepseek/v4-flash", "transport": "gateway:opencode-go",        "provider": "deepseek", "rateWindow": "5h" }
+    "mid":              { "adapter": "opencode",    "model": "opencode-go/glm-5.2",          "transport": "gateway:opencode-go",        "provider": "zai",      "rateWindow": "5h" },
+    "cheap":            { "adapter": "opencode",    "model": "opencode-go/deepseek-v4-flash","transport": "gateway:opencode-go",        "provider": "deepseek", "rateWindow": "5h" }
   },
 
   // Reviewer groups (§6). Members carry CONCRETE model IDs — never an alias.
@@ -127,7 +127,7 @@ a guarantee about which credential paid for the call.
     "cross-model-routine": {
       "quorum": 1,
       "members": [
-        { "adapter": "opencode", "model": "qwen/qwen3.7-coder", "transport": "gateway:opencode-go", "provider": "alibaba" }
+        { "adapter": "opencode", "model": "opencode-go/qwen3.7-plus", "transport": "gateway:opencode-go", "provider": "alibaba" }
       ]
     },
     "cross-model-trust-root": {
@@ -136,7 +136,7 @@ a guarantee about which credential paid for the call.
       // itself `directAuth`.
       "quorum": 2,
       "members": [
-        { "adapter": "opencode", "model": "moonshot/kimi-k3", "transport": "gateway:opencode-go",       "provider": "moonshot" },
+        { "adapter": "opencode", "model": "opencode-go/kimi-k3",    "transport": "gateway:opencode-go",       "provider": "moonshot" },
         { "adapter": "codex",    "model": "gpt-5.3-codex",    "transport": "subscription:chatgpt-plus", "provider": "openai", "directAuth": true }
       ]
     }
@@ -147,7 +147,7 @@ a guarantee about which credential paid for the call.
   "modelProviders": {
     "claude-code": { "claude-opus-5": "anthropic", "claude-sonnet-5": "anthropic", "claude-haiku-4-5": "anthropic" },
     "codex":       { "gpt-5.3-codex": "openai" },
-    "opencode":    { "zai/glm-5.2": "zai", "deepseek/v4-flash": "deepseek", "qwen/qwen3.7-coder": "alibaba", "moonshot/kimi-k3": "moonshot" }
+    "opencode":    { "opencode-go/glm-5.2": "zai", "opencode-go/deepseek-v4-flash": "deepseek", "opencode-go/qwen3.7-plus": "alibaba", "opencode-go/kimi-k3": "moonshot" }
   }
 }
 ```
@@ -238,6 +238,47 @@ alternative applies — use a concrete model ID. The reference registry above do
 When §9.3 lands and adapters surface `resolvedModel`, alias channels become
 available again for attesting adapters, and rule 7's alias-coverage requirement
 starts doing real work.
+
+### Model IDs are the HARNESS's names, not the vendor's
+
+A `model` must be spelled exactly as the harness spells it, because §4c forces it
+onto the command line verbatim. For a gateway transport that means the
+**gateway's** namespace, which is usually *not* the upstream vendor's name.
+
+OpenCode Go namespaces every model it brokers under `opencode-go/`:
+
+| Upstream family | What you might write | What the harness accepts |
+| --- | --- | --- |
+| Z.ai GLM | ~~`zai/glm-5.2`~~ | `opencode-go/glm-5.2` |
+| DeepSeek | ~~`deepseek/v4-flash`~~ | `opencode-go/deepseek-v4-flash` |
+| Moonshot Kimi | ~~`moonshot/kimi-k3`~~ | `opencode-go/kimi-k3` |
+| Alibaba Qwen | ~~`qwen/qwen3.7-coder`~~ | `opencode-go/qwen3.7-plus` |
+
+A vendor-style ID validates fine at load — nothing here can know which strings a
+remote gateway accepts — and then fails at dispatch. List the real ones with:
+
+```sh
+opencode models
+```
+
+Note also that OpenCode Go and OpenCode Zen are **separate** products with
+separate credentials, billing, and namespaces (`opencode-go/*` vs `opencode/*`).
+A model ID from one is not valid on the other, and an empty balance on one does
+not affect the other.
+
+### `provider` is an operator assertion, and a gateway cannot confirm it
+
+Because the gateway flattens everything into its own namespace,
+`opencode-go/glm-5.2` does not reveal that the upstream family is Z.ai. So the
+`provider` field — and the `modelProviders` mapping — are things **you** assert;
+nothing validates them against the gateway.
+
+This is not a gap so much as the reason §6 exists in the shape it does: all
+members sharing a `gateway:*` transport collapse to a single family for quorum,
+*precisely* because a mediated channel cannot prove the diversity it declares.
+Keep the vendor family in `provider` (it is the honest intent, and phase-2
+author binding needs it), but do not read a passing load as confirmation that
+the gateway agrees.
 
 ### The alias contract is adapter-owned
 


### PR DESCRIPTION
The reference registry documented four models that **do not exist**. Verified against the live gateway (`opencode models`, 143 models):

| Documented | Real |
| --- | --- |
| `zai/glm-5.2` | `opencode-go/glm-5.2` |
| `deepseek/v4-flash` | `opencode-go/deepseek-v4-flash` |
| `moonshot/kimi-k3` | `opencode-go/kimi-k3` |
| `qwen/qwen3.7-coder` | `opencode-go/qwen3.7-plus` — no `*-coder` variant exists |

They were **vendor-style names where the gateway uses its own namespace**. That is newly load-bearing: §4c now forces the model onto the command line verbatim, so a vendor-style ID validates at load — nothing in the loader can know which strings a remote gateway accepts — and then fails at dispatch. An operator copying the documented example would have hit exactly that.

Confirmed by live smoke:

```
$ opencode run -m opencode-go/glm-5.2 "Reply with the single word: ok" < /dev/null
ok                                        # EXIT=0

$ opencode run -m zai/glm-5.2 "..." < /dev/null
Error: ...                                # EXIT=1
```

(The failure is fail-closed, which is the good news — a bad registry ID aborts rather than silently running something else.)

## Two sections added, not just corrected strings

**Model IDs are the harness's names, not the vendor's** — the mapping table above, `opencode models` to list them, and the fact that **OpenCode Go and OpenCode Zen are separate products** with separate credentials, billing, and namespaces (`opencode-go/*` vs `opencode/*`). An ID from one is invalid on the other, and an empty balance on one does not affect the other. Both facts were discovered the hard way here.

**`provider` is an operator assertion a gateway cannot confirm** — the gateway flattens every upstream family into its own namespace, so `opencode-go/glm-5.2` does not reveal that the family is Z.ai. `provider` and `modelProviders` are therefore asserted, never validated. This is not a new gap: it is *why* §6 collapses all members behind one `gateway:*` transport into a single quorum family. The doc now says so, so a passing load is not misread as the gateway agreeing.

The toolkit page's dry-run example is corrected too, and now shows the real `claude-code` argv instead of a placeholder model on the wrong adapter.

## Deliberately out of scope

- **`docs/specs/operating-stack.md` carries the same error** but is a declared rail of T151/T152 — it needs a spec revision, not an edit from here.
- **`packages/**` references** are a code comment and synthetic validation fixtures. They are correct as-is (validation never checks model existence), and editing them would make this diff trust-root tier, requiring a signed attestation and therefore a ledger append — which must not happen while the `ADLC_MANIFEST_KEY` hermeticity branches (#403's T1/T2) are in flight, since concurrent evidence-appending forks the manifest hash chain.

## Verification

- Full suite **53/53 segments**
- `rails-guard-ci origin/main` — pass
- `tier-check` — **NOT trust-root tier**, no cross-model review required
- `.adlc/` untouched — **no ledger append**, so this is safe to land alongside the hermeticity work
- Spec rail untouched

Related: #395, #396, #401 (quartermaster follow-ups), #407, #408 (usage-telemetry follow-ups found during the same verification).
