### PR TITLE
fix(tests): stop copying live .adlc/, and probe .gitignore in a temp repo (#416)

### DIFF
--- a/scripts/test/claude-code-plugin-smoke.test.mjs
+++ b/scripts/test/claude-code-plugin-smoke.test.mjs
@@ -9,6 +9,24 @@ import { tmpdir } from 'node:os';
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'claude-code-plugin-smoke.mjs');
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
+// What a throwaway copy of this repo must NOT include.
+//
+// `.adlc/` is LIVE, CONCURRENTLY MUTATING state, and copying it is what made
+// these tests fail only under a full suite run (#416): the `scripts` segment runs
+// its files in parallel, and gitignore-negations-effective.test.mjs creates
+// `.adlc/manifest.d/` in the real repo root for the duration of a `git
+// check-ignore` probe, then removes it. A cpSync racing that window has the entry
+// returned by readdir and gone by the time cp lstat's it — ENOENT, mid-copy.
+// Nothing under `.adlc/` is read by the smoke script; it checks plugin sources,
+// docs and manifests. Excluding it removes the race rather than narrowing it.
+//
+// Matched by PATH PREFIX, not substring: `.claude` must not also exclude
+// `.claude-plugin/`, which carries the plugin and marketplace manifests the smoke
+// script exists to validate. `.worktrees/` and `.claude/worktrees/` hold nested
+// checkouts, so copying them turns each case into minutes of I/O.
+const COPY_SKIP = ['.git', 'node_modules', '.worktrees', '.claude', '.adlc'].map((d) => resolve(REPO, d));
+const copyFilter = (src) => !COPY_SKIP.some((skip) => src === skip || src.startsWith(`${skip}/`));
+
 test('claude-code-plugin-smoke passes against the repo', () => {
   const result = spawnSync(process.execPath, [SCRIPT, REPO], { encoding: 'utf8' });
   assert.strictEqual(result.status, 0, `smoke test failed:\n${result.stderr}`);
@@ -26,7 +44,7 @@ test('claude-code-plugin-smoke fails on a bare, non-namespaced command recommend
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     const skillPath = join(tmpRepo, 'plugins/adlc-claude-code/skills/adlc/SKILL.md');
@@ -57,7 +75,7 @@ test('claude-code-plugin-smoke fails on a bare command recommendation in the hom
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     const docPath = join(tmpRepo, 'docs/integrations/claude-code.md');
@@ -84,7 +102,7 @@ test('claude-code-plugin-smoke fails on a bare command recommendation in README.
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     const readmePath = join(tmpRepo, 'README.md');
@@ -111,7 +129,7 @@ test('claude-code-plugin-smoke fails on a bare command recommendation in the des
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     const adrPath = join(tmpRepo, 'docs/adr/0003-adlc-claude-code-plugin.md');
@@ -140,7 +158,7 @@ test('claude-code-plugin-smoke fails on a bare command recommendation in an arbi
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     // A brand-new doc, nested two levels deep, never listed in any allowlist.
@@ -170,7 +188,7 @@ test('claude-code-plugin-smoke fails on a bare reference to a newly-added comman
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     // Add a brand-new command file the guard has never been told about by name.
@@ -221,7 +239,7 @@ test('claude-code-plugin-smoke escapes regex metacharacters in derived command n
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     // A command name containing a literal "." — if spliced unescaped into the
@@ -256,7 +274,7 @@ test('claude-code-plugin-smoke fails cleanly (not an uncaught crash) on a comman
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     // An unescaped "(" in the alternation would throw "Unterminated group" from
@@ -286,7 +304,7 @@ test('claude-code-plugin-smoke does not let a degenerate empty-name command file
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     // A degenerate command filename that derives an empty name.
@@ -322,7 +340,7 @@ test('claude-code-plugin-smoke follows a symlinked directory under docs/ instead
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     // A real directory OUTSIDE docs/, containing a bare-command doc, linked
@@ -365,7 +383,7 @@ test('claude-code-plugin-smoke follows a symlinked directory under the plugin gu
   try {
     cpSync(REPO, tmpRepo, {
       recursive: true,
-      filter: (src) => !src.includes(`${resolve(REPO, '.git')}`) && !src.includes(`${resolve(REPO, 'node_modules')}`),
+      filter: copyFilter,
     });
 
     const externalDir = join(tmpRepo, '..', 'adlc-cc-smoke-external-commands');
@@ -400,15 +418,11 @@ test('claude-code-plugin-smoke follows a symlinked directory under the plugin gu
 // this lockstep from day one and never drifted. These four tests are the ones
 // whose absence let the bug ship.
 //
-// The repo copy filters .worktrees/ and .claude/ as well as .git/node_modules:
-// this repo carries 8 worktrees, and copying them makes each case take minutes.
+// Uses the same exclusion set as every other copy here (see COPY_SKIP): nested
+// checkouts and live .adlc/ state are never what a throwaway copy needs.
 function copyRepoFast() {
   const tmpRepo = mkdtempSync(join(tmpdir(), 'adlc-cc-lockstep-'));
-  const skip = ['.git', 'node_modules', '.worktrees', '.claude'].map((d) => resolve(REPO, d));
-  cpSync(REPO, tmpRepo, {
-    recursive: true,
-    filter: (src) => !skip.some((s) => src === s || src.startsWith(s + '/')),
-  });
+  cpSync(REPO, tmpRepo, { recursive: true, filter: copyFilter });
   return tmpRepo;
 }
 

--- a/scripts/test/gitignore-negations-effective.test.mjs
+++ b/scripts/test/gitignore-negations-effective.test.mjs
@@ -65,6 +65,31 @@ const isIgnored = (path) => isIgnoredIn(REPO_ROOT, path);
 // by anything actually wrong with the pattern. Make the directory genuinely
 // exist for the duration of the probe instead, removing exactly what this
 // created (deepest first) so a pre-existing directory is never touched.
+// Probe in a THROWAWAY repo carrying this repo's .gitignore, never in the live
+// checkout (#416).
+//
+// withDirEnsured below has to materialise the directory for the probe to be
+// meaningful, and doing that at REPO_ROOT mutates the working tree other tests
+// are concurrently reading: the `scripts` segment runs its files in parallel, and
+// claude-code-plugin-smoke.test.mjs cpSync's the repo, so it saw `.adlc/manifest.d`
+// returned by readdir and gone by lstat — an ENOENT that looked like a bug in the
+// forest writer and was only ever this probe's cleanup.
+//
+// Verdicts are unchanged: every negation under test is declared in the ROOT
+// .gitignore and names a repo-relative path, and check-ignore resolves patterns
+// against the repo it is run in, so a temp repo holding the same file answers
+// identically — while being immune to local .git/info/exclude entries.
+function withProbeRepo(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'adlc-gitignore-probe-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: dir, stdio: 'ignore' });
+    writeFileSync(join(dir, '.gitignore'), readFileSync(join(REPO_ROOT, '.gitignore'), 'utf8'));
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 function withDirEnsured(repoRoot, relDir, fn) {
   const parts = relDir.split('/').filter(Boolean);
   const created = [];
@@ -88,13 +113,15 @@ const negations = readFileSync(join(REPO_ROOT, '.gitignore'), 'utf8')
 
 test('every .gitignore negation is effective, not shadowed by a later blanket rule', () => {
   assert.ok(negations.length > 0, 'expected .gitignore to declare negations — otherwise this guard is vacuous');
-  const dead = negations.filter((pattern) => {
-    const sample = samplePath(pattern);
-    const body = pattern.slice(1);
-    return body.endsWith('/')
-      ? withDirEnsured(REPO_ROOT, body.slice(0, -1), () => isIgnored(sample))
-      : isIgnored(sample);
-  });
+  const dead = withProbeRepo((probeRoot) =>
+    negations.filter((pattern) => {
+      const sample = samplePath(pattern);
+      const body = pattern.slice(1);
+      return body.endsWith('/')
+        ? withDirEnsured(probeRoot, body.slice(0, -1), () => isIgnoredIn(probeRoot, sample))
+        : isIgnoredIn(probeRoot, sample);
+    }),
+  );
   assert.deepEqual(
     dead,
     [],


### PR DESCRIPTION
Fixes #416.

## Root cause — not what the issue suspected

The issue suspected the T-MANIFEST-FOREST slice-3 segment writer (#411) leaking a
default `dir = ADLC_DIR`. It is not. Every in-repo caller passes `dir` explicitly.

The writer is **`scripts/test/gitignore-negations-effective.test.mjs`**.
`git check-ignore --no-index` has no stat info for a path that does not exist, so it
cannot tell a bare path is a directory — and a `!dir/` negation for a directory this
checkout does not carry is therefore reported *dead*. To avoid that false verdict the
test creates `.adlc/manifest.d/` **in the real repo root** for the duration of the
probe and removes it afterwards.

`claude-code-plugin-smoke.test.mjs` `cpSync`s the whole repo. Both files live in the
`scripts` segment, whose test files node runs **in parallel** — so the copy walked
`.adlc/` exactly while the probe was creating and removing `manifest.d`. `readdir`
returned the entry, `lstat` found it gone: `ENOENT`, mid-copy. That is precisely why
it only ever failed under a full suite run and never standalone.

## Both sides fixed, as the issue asked

**Reader** — one shared copy filter that excludes `.adlc/`, live and concurrently
mutating state the smoke script never reads. Matched by **path prefix**, not
substring, so `.claude` cannot also exclude `.claude-plugin/` — which carries the
plugin and marketplace manifests the smoke script exists to validate. This replaces
eleven duplicated `includes()` filters that were also copying the repo's nested
worktrees.

**Writer** — the probe now runs in a throwaway git repo holding a copy of the root
`.gitignore`, so it never touches the working tree. `withDirEnsured` is **kept**:
probing with a trailing slash instead returns the *wrong* verdict for
`!.omo/evidence/` (reports IGNORED where the bare-path-plus-real-directory form
correctly reports not-ignored), so materialising the directory is load-bearing — it
just needed a temp dir rather than the live one.

Verdicts are unchanged: every negation under test is declared in the root `.gitignore`
and names a repo-relative path, and `check-ignore` resolves patterns against the repo
it runs in. The nested `.gitignore`s (`apps/docs/`, `.pi/npm/`) govern none of these
paths.

## Test plan

- [x] Under a loop churning `.adlc/manifest.d` in the live tree, the **old** smoke
      test reproduces `ENOENT` **3/3**; the **fixed** one is clean **3/3** (18 ok).
- [x] The probe no longer creates `.adlc/manifest.d` in the live tree (watched during
      a full run of the file).
- [x] Still load-bearing: appending a blanket rule that shadows a negation fails the
      guard with the dead-negation assertion.
- [x] `scripts` segment: 717 tests, 0 fail (and now ~65s, since eleven copies no
      longer walk the nested worktrees).
- [x] Full suite: **53/53 segments green**.

No trust-root path is touched, so no cross-model attestation is required and this
cannot fork the ledger.