### PR TITLE
fix(antigravity): scope staging-leak assertions to a private TMPDIR (#417)

### DIFF
--- a/plugins/adlc-antigravity/test/packaging.test.mjs
+++ b/plugins/adlc-antigravity/test/packaging.test.mjs
@@ -552,15 +552,27 @@ test('bin/cli.mjs forwards Ctrl-C to the detached agy group and cleans staging',
     );
     chmodSync(join(binDir, 'agy'), 0o755);
 
-    // Snapshot BEFORE, and compare only the delta. Scanning all of TMPDIR for the
-    // staging prefix would fail on litter from unrelated earlier runs — this test
-    // owns what THIS invocation leaves behind, nothing else.
-    const stagingBefore = new Set(
-      readdirSync(tmpdir()).filter((entry) => /^adlc-agy-[A-Za-z0-9]{6}$/.test(entry)),
-    );
+    // GIVE THE CHILD ITS OWN TMPDIR, so "was staging left behind" is a question
+    // about THIS cli.mjs and nothing else.
+    //
+    // cli.mjs stages under os.tmpdir(), which is shared machine-wide. A
+    // before/after delta over the shared directory attributes to this test every
+    // adlc-agy-XXXXXX that appears during its window — including ones created by a
+    // cli.mjs running in another worktree, another agent session, or a second CI
+    // job on the same host. That is what made this flake load-dependent: the
+    // assertion failed on a directory this test never created, while the CLI's own
+    // cleanup was correct (it rmSync's staging before process.exit, on every path).
+    // Isolating TMPDIR makes the observation exact instead of probabilistic, so the
+    // guarantee below is asserted immediately and strictly — no polling, no grace.
+    const stagingRoot = join(work, 'staging');
+    mkdirSync(stagingRoot, { recursive: true });
 
     const child = spawn(process.execPath, [join(pkgDir, 'bin', 'cli.mjs'), 'install'], {
-      env: { ...sealedEnv(home, `${binDir}:/usr/bin:/bin`), ADLC_AGY_TIMEOUT_MS: '60000' },
+      env: {
+        ...sealedEnv(home, `${binDir}:/usr/bin:/bin`),
+        TMPDIR: stagingRoot,
+        ADLC_AGY_TIMEOUT_MS: '60000',
+      },
       stdio: 'ignore',
     });
 
@@ -589,9 +601,7 @@ test('bin/cli.mjs forwards Ctrl-C to the detached agy group and cleans staging',
     );
     // Staging must not survive a cancelled install either — the `finally` cannot
     // run once a signal terminates us, so the interrupt handler has to do it.
-    const leaked = readdirSync(tmpdir())
-      .filter((entry) => /^adlc-agy-[A-Za-z0-9]{6}$/.test(entry))
-      .filter((entry) => !stagingBefore.has(entry));
+    const leaked = readdirSync(stagingRoot).filter((entry) => /^adlc-agy-[A-Za-z0-9]{6}$/.test(entry));
     assert.deepEqual(leaked, [], `cancelled install left staging behind: ${leaked.join(', ')}`);
   } finally {
     if (leaderPidValue) reap(leaderPidValue);
@@ -675,12 +685,17 @@ test('bin/cli.mjs Ctrl-C during the VERSION PROBE reaps the worker and reports c
     );
     chmodSync(join(binDir, 'agy'), 0o755);
 
-    const stagingBefore = new Set(
-      readdirSync(tmpdir()).filter((entry) => /^adlc-agy-[A-Za-z0-9]{6}$/.test(entry)),
-    );
+    // Own TMPDIR for the same reason as the Ctrl-C test above: a shared-tmpdir
+    // delta blames this test for staging created by any other concurrent cli.mjs.
+    const stagingRoot = join(work, 'staging');
+    mkdirSync(stagingRoot, { recursive: true });
 
     const child = spawn(process.execPath, [join(pkgDir, 'bin', 'cli.mjs'), 'install'], {
-      env: { ...sealedEnv(home, `${binDir}:/usr/bin:/bin`), ADLC_AGY_TIMEOUT_MS: '60000' },
+      env: {
+        ...sealedEnv(home, `${binDir}:/usr/bin:/bin`),
+        TMPDIR: stagingRoot,
+        ADLC_AGY_TIMEOUT_MS: '60000',
+      },
       stdio: 'ignore',
     });
     const exited = new Promise((resolveExit) => child.on('exit', (code) => resolveExit(code)));
@@ -697,9 +712,7 @@ test('bin/cli.mjs Ctrl-C during the VERSION PROBE reaps the worker and reports c
       `a probe worker outlived cancellation (pid ${workerPidValue})`,
     );
     // Cancelling the probe must not go on to start an install.
-    const created = readdirSync(tmpdir())
-      .filter((entry) => /^adlc-agy-[A-Za-z0-9]{6}$/.test(entry))
-      .filter((entry) => !stagingBefore.has(entry));
+    const created = readdirSync(stagingRoot).filter((entry) => /^adlc-agy-[A-Za-z0-9]{6}$/.test(entry));
     assert.deepEqual(created, [], `an install was staged after cancellation: ${created.join(', ')}`);
   } finally {
     if (workerPidValue) reap(workerPidValue);


### PR DESCRIPTION
Fixes #417.

## The CLI was never at fault

The issue read this as a timing flake — the interrupt handler's cleanup not having
finished when the assertion ran — and suggested a bounded poll. Measurement says
otherwise.

From a **quiescent** tmpdir under full CPU saturation, the cancel path leaked nothing
in **6/6** runs. The ordering is correct by construction: `onInterrupt` SIGKILLs the
snapshotted groups, `rmSync`s every entry in `activeStages`, resolves
`cancellationDone`, and only then exits — and every exit path routes through
`exitAfterCancellation`, which awaits it. `agyInstallFromStagedCopy`'s `finally`
removes staging as well.

## The actual defect is in the test

Both cancellation tests asserted "no staging survived" by diffing a before/after
listing of the **machine-wide `os.tmpdir()`**. That attributes to the test every
`adlc-agy-XXXXXX` created during its window by **any** other `cli.mjs` — one running
in a second worktree, another agent session, or a parallel CI job on the same host.

That is what made it load-dependent, and it explains the report's "both the
`antigravity` and `antigravity install smoke` segments failed in the same run": the
version-probe test at the same file carried the identical shared-tmpdir delta, and
both failed together in a reproduction here.

## Fix

Give each spawned `cli.mjs` its own `TMPDIR` inside the test's work directory, so the
observation is exact rather than probabilistic. `sealedEnv` already exists to seal the
child off from the developer's machine; this extends that containment to staging.

**No bounded poll.** The guarantee holds strictly, so the assertion stays immediate —
a poll would have traded a false failure for a window in which a *real* leak passes,
which is the failure mode the issue explicitly warned against.

## Proof the guard is still load-bearing

Hand-applied mutants against `bin/cli.mjs`:

| Mutant | Result |
|---|---|
| `onInterrupt` staging cleanup removed | **caught** — `cancelled install left staging behind` |
| both cleanup sites removed | **caught** |
| only the `finally` cleanup removed | survives these two tests, **caught** by the existing `@`-free staging tests (28, 29) |

So no coverage was lost; the interrupt-path guarantee these tests exist for still
fails when it is broken.

## Test plan

- [x] 6/6 loaded iterations of both cancellation tests green (previously reproduced a
      failure on the first iteration under the same load).
- [x] `packaging.test.mjs`: 29/29.
- [x] `antigravity` + `antigravity install smoke`: 2/2 segments green.
- [x] Full suite: **53/53 segments green**.

Test-only change; no trust-root path touched, so no cross-model attestation is
required and this cannot fork the ledger.