### PR TITLE
docs(contributing): sync preflight gate table, add gate usage line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,14 +121,17 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
 
 1. Fork the repo and create a branch (`feat/<name>`, `fix/<name>`, …).
 2. Make your change with tests, then run `npm run preflight` — **not just
-   `npm test`**. CI blocks a PR on three gates and the suite is only one of
-   them; preflight runs all three locally, in CI's order:
+   `npm test`**. CI blocks a PR on several gates and the suite is only one of
+   them; preflight runs all of them locally, in CI's order:
 
    | gate | what it checks |
    | --- | --- |
    | tests | the full workspace suite |
    | rail-freeze | no frozen rail edited, and no *existing* ticket changed in `.adlc/tickets.json` |
    | mutation-gate | changed code has tests that notice it being broken |
+   | findings-ledger | the committed findings ledger carries no secret or raw dump (git-boundary backstop, ADR 0014) |
+   | findings-append-only | the durable findings ledger is only extended, never deleted/truncated/rewritten (ADR 0014) |
+   | reviewer-directed-comments | no added comment instructs a future reviewer how to classify a finding (round-reference + classification phrase) |
 
    Note `adlc rails-guard` is **not** the CI check — `scripts/rails-guard-ci.mjs`
    is stricter, and a clean `adlc rails-guard` has already been mistaken for

--- a/scripts/check-reviewer-directed-comments.mjs
+++ b/scripts/check-reviewer-directed-comments.mjs
@@ -42,6 +42,7 @@
  * scripts/block-secret-exposure.mjs) is to accept the rare false positive
  * over the risk of a silent bypass.
  *
+ * Usage: node scripts/check-reviewer-directed-comments.mjs <base-ref>
  * Exit codes: 0 = clean, 2 = a violation was found, 1 = could not compute the diff.
  */
 

--- a/scripts/check-reviewer-directed-comments.mjs
+++ b/scripts/check-reviewer-directed-comments.mjs
@@ -42,7 +42,6 @@
  * scripts/block-secret-exposure.mjs) is to accept the rare false positive
  * over the risk of a silent bypass.
  *
- * Usage: node scripts/check-reviewer-directed-comments.mjs <base-ref>
  * Exit codes: 0 = clean, 2 = a violation was found, 1 = could not compute the diff.
  */
 


### PR DESCRIPTION
## Summary

Doc-only follow-up from #432. Two gaps:

1. CONTRIBUTING.md's pre-push checklist said preflight runs "three gates" and only listed `tests` / `rail-freeze` / `mutation-gate`. `scripts/preflight.mjs`'s `buildGates()` actually runs **six**: those three plus `findings-ledger` and `findings-append-only` (pre-existing, already undocumented before #432) and now `reviewer-directed-comments` (new in #432). Updated the table to match all six and fixed the "three gates" wording.
2. `scripts/check-reviewer-directed-comments.mjs`'s header documented exit codes but not invocation syntax. Added a `Usage:` line matching the convention already used in `scripts/guard-findings-ledger-append-only.mjs`.

No behavior change — comment/doc only.

## Test plan

- [x] `node --test scripts/test/check-reviewer-directed-comments.test.mjs` — 77/77 still green (comment-only change)