### PR TITLE
chore: record the GitHub Release step in the release profile

### DIFF
--- a/.claude/release-profile.md
+++ b/.claude/release-profile.md
@@ -11,6 +11,7 @@ landing: pr
 publishTrigger: tag
 publishEnvironment: npm-publish
 publishWorkflow: .github/workflows/publish.yml
+releaseNotes: awk '/^## \[{{version}}\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md
 tokenException: |
   Applies to: any @adlc/* package being published for the FIRST time in this release.
   Reason: npm trusted publishing is configured against an existing package, so it cannot
@@ -55,6 +56,16 @@ checks run, and let a human merge.
 environment with required reviewers. Pushing the tag starts the run *waiting*, not running — the
 maintainer must approve the deployment. Hand over the run URL and STOP (R1). The retired release
 command never mentioned the gate and told the operator the workflow publishes automatically.
+
+**The GitHub Release is a separate step here, and it was missed twice.** `publishTrigger` is
+`tag`, so nothing about publishing needs a Release — and so v1.6.0 and v1.7.0 shipped to npm
+while the Releases page still showed v1.5.1 as latest. The skill now creates it in Step 12, after
+`verify` passes. `releaseNotes` above extracts this version's `CHANGELOG.md` section so the
+Release body matches the changelog, which is what v1.5.1's body is; `--generate-notes` would
+replace a written entry with a commit list. `publish.yml` triggers on `push.tags` only, so
+creating the Release does not fire a second publish run — confirmed when the two missing
+Releases were backfilled from their changelog sections on 2026-08-04, which added no run to
+the publish workflow.
 
 All packages are lockstep, so any package's version is authoritative; `packages/core` is the
 convention.


### PR DESCRIPTION
## Why

`publishTrigger: tag` means nothing about publishing needs a GitHub Release, so the release skill never created one — its only `gh release create` lived in the branch that exists to *trigger* a publish. v1.6.0 and v1.7.0 shipped to npm while the Releases page still advertised v1.5.1 as latest.

Both have been backfilled from their `CHANGELOG.md` sections:

- https://github.com/voodootikigod/adlc/releases/tag/v1.6.0
- https://github.com/voodootikigod/adlc/releases/tag/v1.7.0

## What changed

Profile only — no code, no workflow.

- `releaseNotes` extracts this version's `CHANGELOG.md` section so the Release body matches the changelog the way v1.5.1's does, instead of a generated commit list.
- Prose records the incident, and that `publish.yml` triggers on `push.tags` only — so creating a Release cannot fire a duplicate publish run against an already-published version.

The skill-side fix (rail R11 + a new Step 12 that creates the Release after `verify` passes) is in `voodootikigod/release@4c2bfa6`.

## Test plan

- [x] Frontmatter parses under the vendored js-yaml the skill uses
- [x] `awk` extraction returns the 1.6.0 (63 line) and 1.7.0 (40 line) sections
- [x] Both Releases exist, are not drafts, and their tag SHAs match local and remote refs
- [x] `gh run list --workflow=publish.yml` shows no run added by the backfill — newest is still the v1.7.0 tag push from 2026-07-29