### PR TITLE
fix(release): publish in true dependency order (T-01KZGT27XA)

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -58,29 +58,88 @@ export function packagePublishOrder(names) {
 }
 
 /**
- * Every directory `--publish` must publish, in dependency order: packages/* in
- * the core-first/cli-last order, THEN each non-private plugin package (plugins
- * consume the packages, so they publish after them). Skipping publishable
- * plugins is exactly how @adlc/opencode ended up registered in user
- * opencode.json files while not existing on npm (T30).
+ * Topologically sort publish targets so every runtime dependency publishes
+ * before its dependents. `deps` maps each target name to its internal
+ * dependency names; ties break alphabetically so the order is stable across
+ * machines and enumeration orders. A cycle throws: npm publish does not
+ * validate dependencies, so an arbitrary order on a cycle would be a coin
+ * flip whose losing side is a stranded, uninstallable partial release.
+ */
+function topologicalOrder(targets, deps) {
+  const remaining = new Map(targets.map((t) => [t.name, t]));
+  const ordered = [];
+  while (remaining.size > 0) {
+    const ready = [...remaining.keys()]
+      .filter((name) => [...(deps.get(name) ?? [])].every((d) => !remaining.has(d)))
+      .sort();
+    if (ready.length === 0) {
+      const stuck = [...remaining.keys()].sort().join(', ');
+      throw new Error(`publish order: dependency cycle among ${stuck} — refusing to guess an order`);
+    }
+    for (const name of ready) {
+      ordered.push(remaining.get(name));
+      remaining.delete(name);
+    }
+  }
+  return ordered;
+}
+
+/** The internal @adlc/* RUNTIME dependencies of one manifest. devDependencies
+ *  are deliberately excluded: they are not needed to install the published
+ *  artifact, and treating them as edges manufactures cycles that do not exist
+ *  at install time. */
+function internalRuntimeDeps(pkg) {
+  const deps = new Set();
+  for (const kind of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+    for (const name of Object.keys(pkg[kind] ?? {})) {
+      if (name.startsWith('@adlc/')) deps.add(name);
+    }
+  }
+  return deps;
+}
+
+/**
+ * Every directory `--publish` must publish, in TRUE dependency order: each
+ * group (packages/*, then non-private plugins) is topologically sorted over
+ * its internal @adlc/* runtime dependencies, so a dependency always publishes
+ * before its dependents. This is load-bearing precisely when a run FAILS
+ * part-way: npm never validates dependencies at publish time, so a dependent
+ * published before its exact-pinned dependency is live and uninstallable the
+ * moment the run dies between them (the v1.4.0 incident shape; the earlier
+ * core-first/cli-last directory order had 17 such inversions, including core
+ * itself pinning tickets 29 slots later). Plugins consume the packages, so
+ * they still publish after all of packages/* — skipping publishable plugins
+ * is exactly how @adlc/opencode ended up registered in user opencode.json
+ * files while not existing on npm (T30).
  * Returns [{ dir, name, private }].
  */
 export function publishTargets({ packagesDir = PKGS, pluginsDir = PLUGINS } = {}) {
-  const targets = [];
-  for (const name of packagePublishOrder(workspacePackageNames(packagesDir))) {
-    const dir = join(packagesDir, name);
+  const load = (dir) => {
     const pkg = readJson(join(dir, 'package.json'));
-    targets.push({ dir, name: pkg.name, private: pkg.private === true });
-  }
+    return { dir, name: pkg.name, private: pkg.private === true, deps: internalRuntimeDeps(pkg) };
+  };
+  const packages = workspacePackageNames(packagesDir)
+    .map((name) => load(join(packagesDir, name)))
+    .filter((t) => !t.private);
+  const plugins = [];
   if (existsSync(pluginsDir)) {
     for (const name of readdirSync(pluginsDir).sort()) {
-      const pj = join(pluginsDir, name, 'package.json');
-      if (!existsSync(pj)) continue;
-      const pkg = readJson(pj);
-      targets.push({ dir: join(pluginsDir, name), name: pkg.name, private: pkg.private === true });
+      if (!existsSync(join(pluginsDir, name, 'package.json'))) continue;
+      const t = load(join(pluginsDir, name));
+      if (!t.private) plugins.push(t);
     }
   }
-  return targets.filter((t) => !t.private);
+  // Each group only orders against members of the SAME group: a plugin's
+  // package dependencies are all satisfied by the time its group starts, and
+  // no package depends on a plugin, so the group boundary never fights the
+  // graph.
+  const order = [];
+  for (const group of [packages, plugins]) {
+    const names = new Set(group.map((t) => t.name));
+    const deps = new Map(group.map((t) => [t.name, [...t.deps].filter((d) => names.has(d))]));
+    order.push(...topologicalOrder(group, deps));
+  }
+  return order.map(({ dir, name, private: priv }) => ({ dir, name, private: priv }));
 }
 
 export function repinInternalDependencies(pkg, version) {
@@ -779,7 +838,8 @@ export function releaseMain(
     return 1;
   }
 
-  // core publishes first; cli publishes last because it depends on every routed tool.
+  // Order here only sequences the version WRITES (cosmetic); the publish loop
+  // gets its own dependency-ordered list from publishTargets().
   const order = packagePublishOrder(workspacePackageNames(packagesDir));
 
   // 1. Set version everywhere and repin every internal @adlc/* dependency to match.

--- a/scripts/test/release.test.mjs
+++ b/scripts/test/release.test.mjs
@@ -394,6 +394,22 @@ test('publishTargets: a dependency cycle fails closed, naming the packages', () 
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('publishTargets: an optionalDependencies edge constrains order like a runtime dep', () => {
+  // optionalDependencies install by default, so a dependent published before
+  // its optional dep is just as stranded as with a hard dep. This fixture's
+  // ONLY edge is optional, and the names are chosen so alphabetical order
+  // gets it wrong — dropping 'optionalDependencies' from the kind list
+  // reverts to alphabetical and fails here.
+  const { root, packagesDir, pluginsDir } = depsRepo({
+    aopt: { name: '@adlc/aopt', version: '1.0.0', optionalDependencies: { '@adlc/zopt': '1.0.0' } },
+    zopt: { name: '@adlc/zopt', version: '1.0.0' },
+  });
+  try {
+    const names = publishTargets({ packagesDir, pluginsDir }).map((t) => t.name);
+    assert.deepEqual(names, ['@adlc/zopt', '@adlc/aopt']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('publishTargets: devDependencies do not constrain order — a dev-only cycle is not a cycle', () => {
   const { root, packagesDir, pluginsDir } = depsRepo({
     app: { name: '@adlc/app', version: '1.0.0', dependencies: { '@adlc/lib': '1.0.0' } },

--- a/scripts/test/release.test.mjs
+++ b/scripts/test/release.test.mjs
@@ -308,3 +308,113 @@ test('releaseMain --publish fails closed and publishes NOTHING when a target lac
     assert.equal(published.length, 0, `nothing should publish; got: ${published}`);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+// ---- T-01KZGT27XA: publish order must be DEPENDENCY order --------------------
+// publishTargets documented "dependency order" while implementing directory
+// order. npm publish does not validate dependencies, so a complete run hides
+// it — the defect fires on a PARTIAL failure, stranding an already-published
+// dependent whose exact-pinned dependency never shipped (the v1.4.0 shape).
+// Found at 17 violations on the real tree, including core (slot 0) pinning
+// tickets (slot 29).
+
+import { fileURLToPath } from 'node:url';
+const REAL_REPO = fileURLToPath(new URL('../../', import.meta.url));
+
+/** Bare fixture: a packages/ tree with exactly the given manifests. */
+function depsRepo(packages, plugins = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'adlc-order-'));
+  const packagesDir = join(root, 'packages');
+  const pluginsDir = join(root, 'plugins');
+  mkdirSync(packagesDir, { recursive: true });
+  mkdirSync(pluginsDir, { recursive: true });
+  for (const [dir, pkg] of Object.entries(packages)) {
+    mkdirSync(join(packagesDir, dir));
+    writeFileSync(join(packagesDir, dir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
+  }
+  for (const [dir, pkg] of Object.entries(plugins)) {
+    mkdirSync(join(pluginsDir, dir));
+    writeFileSync(join(pluginsDir, dir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
+  }
+  return { root, packagesDir, pluginsDir };
+}
+
+test('publishTargets: the REAL tree publishes every runtime dependency before its dependents', () => {
+  const targets = publishTargets({
+    packagesDir: join(REAL_REPO, 'packages'),
+    pluginsDir: join(REAL_REPO, 'plugins'),
+  });
+  const idx = new Map(targets.map((t, i) => [t.name, i]));
+  for (const [i, t] of targets.entries()) {
+    const pkg = JSON.parse(readFileSync(join(t.dir, 'package.json'), 'utf8'));
+    const deps = { ...pkg.dependencies, ...pkg.peerDependencies, ...pkg.optionalDependencies };
+    for (const name of Object.keys(deps)) {
+      if (!idx.has(name)) continue;
+      assert.ok(idx.get(name) < i, `${t.name} (slot ${i}) publishes before its dependency ${name} (slot ${idx.get(name)})`);
+    }
+  }
+});
+
+test('publishTargets: quartermaster precedes fleet — the 1.8.0 near-miss, pinned', () => {
+  const names = publishTargets({
+    packagesDir: join(REAL_REPO, 'packages'),
+    pluginsDir: join(REAL_REPO, 'plugins'),
+  }).map((t) => t.name);
+  assert.ok(
+    names.indexOf('@adlc/quartermaster') < names.indexOf('@adlc/fleet'),
+    'fleet exact-pins quartermaster; a partial run publishing fleet first strands it uninstallable'
+  );
+});
+
+test('publishTargets: order does not follow directory names — a dependency later in the alphabet still goes first', () => {
+  const { root, packagesDir, pluginsDir } = depsRepo({
+    aa: { name: '@adlc/aa', version: '1.0.0', dependencies: { '@adlc/zz': '1.0.0' } },
+    mm: { name: '@adlc/mm', version: '1.0.0', dependencies: { '@adlc/aa': '1.0.0' } },
+    zz: { name: '@adlc/zz', version: '1.0.0' },
+  });
+  try {
+    const first = publishTargets({ packagesDir, pluginsDir }).map((t) => t.name);
+    assert.deepEqual(first, ['@adlc/zz', '@adlc/aa', '@adlc/mm']);
+    // Determinism: a second call yields the identical order.
+    const second = publishTargets({ packagesDir, pluginsDir }).map((t) => t.name);
+    assert.deepEqual(second, first);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('publishTargets: a dependency cycle fails closed, naming the packages', () => {
+  const { root, packagesDir, pluginsDir } = depsRepo({
+    ping: { name: '@adlc/ping', version: '1.0.0', dependencies: { '@adlc/pong': '1.0.0' } },
+    pong: { name: '@adlc/pong', version: '1.0.0', dependencies: { '@adlc/ping': '1.0.0' } },
+  });
+  try {
+    assert.throws(
+      () => publishTargets({ packagesDir, pluginsDir }),
+      (err) => /@adlc\/ping/.test(err.message) && /@adlc\/pong/.test(err.message),
+      'an arbitrary order on a cycle is a coin flip; the release must stop instead'
+    );
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('publishTargets: devDependencies do not constrain order — a dev-only cycle is not a cycle', () => {
+  const { root, packagesDir, pluginsDir } = depsRepo({
+    app: { name: '@adlc/app', version: '1.0.0', dependencies: { '@adlc/lib': '1.0.0' } },
+    lib: { name: '@adlc/lib', version: '1.0.0', devDependencies: { '@adlc/app': '1.0.0' } },
+  });
+  try {
+    const names = publishTargets({ packagesDir, pluginsDir }).map((t) => t.name);
+    assert.deepEqual(names, ['@adlc/lib', '@adlc/app'], 'runtime edge app→lib holds; the dev back-edge must not create a cycle');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('publishTargets: plugins still publish after all packages, in dependency order among themselves', () => {
+  const { root, packagesDir, pluginsDir } = depsRepo(
+    { core: { name: '@adlc/core', version: '1.0.0' } },
+    {
+      'adlc-early': { name: '@adlc/early', version: '1.0.0', dependencies: { '@adlc/late': '1.0.0' } },
+      'adlc-late': { name: '@adlc/late', version: '1.0.0', dependencies: { '@adlc/core': '1.0.0' } },
+    }
+  );
+  try {
+    const names = publishTargets({ packagesDir, pluginsDir }).map((t) => t.name);
+    assert.deepEqual(names, ['@adlc/core', '@adlc/late', '@adlc/early']);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Implements `T-01KZGT27XA` (filed in #464 after the 1.8.0 release; severity re-verified during the 1.9.0 attempt, where cross-model review of the *bump diff* flagged it as no-ship).

## The defect

`publishTargets()` documented "dependency order" while implementing core-first/cli-last with directory order between. On the real tree that was **17 inversions**, including `@adlc/core` (slot 0) exact-pinning `@adlc/tickets` (slot 29). npm doesn't validate dependencies at publish time, so a complete run hides it — a run dying between a dependent and its exact-pinned dependency strands the dependent live, `latest`-tagged, and uninstallable, with no resume path (the v1.4.0 incident shape). 1.8.0 shipped through this window and happened not to fail.

## The fix

Per-group topological sort (packages/*, then non-private plugins) over internal `@adlc/*` **runtime** deps:

- `devDependencies` excluded — not needed to install the artifact, and treating them as edges manufactures cycles that don't exist at install time
- alphabetical tie-break → deterministic across machines and enumeration orders
- a real cycle **throws naming its members** — an arbitrary order on a cycle is a coin flip whose losing side is a stranded release
- `packagePublishOrder` stays for the version-*write* loop, where order is cosmetic (comment now says so)

One correction to the ticket itself, recorded rather than papered over: its premise "core sorts first naturally" was wrong — core depends on tickets, so core-first was never a correct invariant. cli-last still falls out naturally.

## Verification

- Six new tests, **all RED first** against the old implementation (including the devDependencies one, after renaming fixtures so alphabetical order couldn't mask it)
- Real tree: 17 violations → **0** (checked by a standalone scan, not just the new tests)
- New real order: `context-handoff`/`quartermaster` (dep-free) first, `core` after `tickets`, `fleet` at 29 behind its four pins, `cli` last
- `release.test.mjs` 21/21 · `release-artifact.test.mjs` 37/37 · full suite **54/54**

## Sequencing

Blocks the paused release PR #467: once this lands, #467 rebases onto it so the 1.9.0 tag publishes through a correct order.