### PR TITLE
fix(release-profile): verify re-polls npm propagation before failing (T-01KZGT282PR1YQ7N31JB199B99)

### DIFF
--- a/.claude/release-profile.md
+++ b/.claude/release-profile.md
@@ -25,23 +25,54 @@ verify:
     # it. Asserting dist-tags for only @adlc/core and @adlc/cli was not enough: a phase CLI
     # published under some other tag still satisfies an existence check while `npm install`
     # resolves the previous release for that package. Fail closed on both.
-    fail=0
+    #
+    # Bounded re-poll (v1.8.0): run immediately after publish, a single-shot check races npm
+    # propagation — brand-new package documents 404 for up to ~60s, indistinguishable from
+    # "never published". Each target that fails is re-polled for 180s from ITS OWN first
+    # failure (per-target budget, so a slow serialized round cannot shortchange a target
+    # first observed failing late) before being declared missing/stale; a target still
+    # failing after its budget still exits non-zero (the retry raises the evidence bar,
+    # it never lowers it). Serialized `npm view` only — 38 rapid raw-HTTP requests during
+    # v1.8.0 rate-limited into a response that read as "all 38 missing". No parallelism;
+    # no raw HTTP.
+    names=""
     for f in $(find packages plugins -maxdepth 2 -name package.json -not -path '*/node_modules/*'); do
       name=$(node -p "require('$PWD/$f').name || ''" 2>/dev/null)
       priv=$(node -p "require('$PWD/$f').private === true" 2>/dev/null)
       [ "$priv" = "true" ] && continue
       [ -z "$name" ] && continue
-      if ! npm view "$name@{{version}}" version >/dev/null 2>&1; then
-        echo "MISSING: $name@{{version}}"; fail=1; continue
-      fi
-      latest=$(npm view "$name" dist-tags.latest 2>/dev/null)
-      if [ "$latest" = "{{version}}" ]; then
-        echo "ok: $name@{{version}} (latest)"
-      else
-        echo "STALE TAG: $name latest=$latest expected {{version}}"; fail=1
-      fi
+      names="$names $name:"
     done
-    exit $fail
+    pending="$names"
+    fail=0
+    while :; do
+      next=""
+      for item in $pending; do
+        name=${item%%:*}
+        d=${item#*:}
+        if ! npm view "$name@{{version}}" version >/dev/null 2>&1; then
+          msg="MISSING: $name@{{version}}"
+        else
+          latest=$(npm view "$name" dist-tags.latest 2>/dev/null)
+          if [ "$latest" = "{{version}}" ]; then
+            echo "ok: $name@{{version}} (latest)"
+            continue
+          fi
+          msg="STALE TAG: $name latest=$latest expected {{version}}"
+        fi
+        now=$(date +%s)
+        [ -z "$d" ] && d=$(( now + 180 ))
+        if [ "$now" -ge "$d" ]; then
+          echo "$msg"; fail=1
+        else
+          echo "re-poll: $msg (propagation can lag ~60s for new package names)"
+          next="$next $name:$d"
+        fi
+      done
+      [ -z "$next" ] && exit $fail
+      pending="$next"
+      sleep 20
+    done
 ---
 
 **The bump lands via PR, never directly.** `main` carries an active ruleset requiring pull
@@ -99,6 +130,19 @@ the partial-publish failure mode did not recur. Checking only `@adlc/core` and `
 cannot detect a missing phase CLI: the umbrella resolving does not prove its dependencies were
 published at that version.
 
+**A `verify` miss immediately after publish is not yet a failure.** During v1.8.0, all 38
+targets published successfully — the publish log showed `+ <name>@1.8.0` for every one — yet
+the then-single-shot `verify` reported three MISSING: one existing package whose new version
+had not propagated, and two brand-new package names whose entire package documents returned
+`Not found` at t+20s and t+40s before appearing at t+60s. New package names are the worst
+case: the whole document 404s, indistinguishable from "never published." The publish log's
+`+ <name>@<version>` line is the authoritative signal that a publish succeeded; a `verify`
+miss right after publish must be re-polled before it is treated as a failure. The `verify`
+block now does this itself (bounded 180s re-poll, then fail closed) — do not "fix" it back
+to a single shot, and do not swap its serialized `npm view` calls for raw HTTP: 38 rapid
+`curl` requests during the same release self-inflicted rate limiting that parsed as "all 38
+missing," which looks exactly like a catastrophic release failure.
+
 Publish order is `@adlc/core` first, then the phase CLIs, then the `@adlc/cli` umbrella last
 (it depends on every other CLI), each with `--provenance --access public`.
 
@@ -126,6 +170,15 @@ gate downstream is untouched by it. R1 still forbids bypassing the *approval* ga
 
 **Conformant, with one declared exception.** `npm-publish` has a required reviewer, the publish
 job is bound to it, `id-token: write` is requested, and there is no repo- or org-scoped token.
+
+**Trusted publishing is configured — confirmed, not proven.** The conformance checker's caveat
+that it "cannot prove the npm trusted publisher is configured" stands as a statement about what
+an in-repo check can see. For the record: on 2026-08-08 (during the v1.8.0 release) the
+maintainer confirmed directly that trusted publishing IS configured on npmjs.com for the
+existing `@adlc/*` packages, and that the environment-scoped `NPM_TOKEN` remains solely to
+bootstrap first-time publishes of new package names. That is the maintainer's dated statement
+about npmjs.com settings, not something any in-repo check verified; npm-side settings are
+mutable, so it answers the question as of that date rather than settling it forever.
 
 **The `NPM_TOKEN` environment secret is deliberate and stays.** npm trusted publishing cannot
 create a package that does not exist yet — a brand-new package's *first* publish needs a token.


### PR DESCRIPTION
Builds store ticket `T-01KZGT282PR1YQ7N31JB199B99`. Closes #484.

## What

During v1.8.0 all 38 targets published successfully, yet the single-shot `verify` block reported three MISSING — two brand-new package documents 404'd until t+60s. A CONFIRMED-looking failure for a correct release is the worst mode for the one check standing between a green run and a reported success. Scope is `.claude/release-profile.md` only, per the ticket.

- **`verify` now re-polls before failing:** each target that fails is retried for **180s from its own first failure** (per-target budget — a slow serialized round cannot shortchange a target first observed failing late), in rounds of serialized `npm view` with 20s sleeps. After a target's budget expires, its next failing check prints the definitive `MISSING:`/`STALE TAG:` line and the block exits non-zero. No pass-on-exhaustion path exists. The two-part assertion (version exists AND `dist-tags.latest` matches) and the filesystem enumeration are unchanged.
- **Incident note (v1.8.0):** new package names can 404 for ~60s post-publish; the publish log's `+ <name>@<version>` line is the authoritative publish signal; a `verify` miss right after publish must be re-polled — and no raw HTTP: 38 rapid requests during the same release self-inflicted rate limiting that parsed as "all 38 missing."
- **Trusted-publisher confirmation recorded:** the maintainer's 2026-08-08 confirmation that trusted publishing IS configured for existing `@adlc/*` packages, stated as a dated observation about mutable npmjs.com settings (not something an in-repo check proved). `tokenException` and its exit condition unchanged.

## Acceptance criteria (all verified against the live registry)

- AC1/AC2 ✔ fixture with `@adlc/definitely-not-a-real-package`: exits 1 after **183s** — the budget is real, and it fails closed.
- AC3 ✔ run with the current latest substituted (`1.10.0`): exit 0, **38 `ok:` lines** = all non-private targets. (The ticket's literal `1.8.0` example predates v1.9/v1.10 — running `1.8.0` today correctly reports STALE TAG for all 38, which is AC4's scenario.)
- AC4 ✔ run with `1.7.0`: exit 1 with **35 `STALE TAG:` + 3 `MISSING:`** definitive lines (the 3 are the packages first published in 1.8.0 — the incident trio), after 200+ re-poll lines proving the rounds ran.
- AC5 ✔ no `curl` in the verify block; checks remain serialized `npm view`.
- AC6 ✔ frontmatter parses as YAML with all 14 fields intact.
- AC7 ✔ both prose additions present, naming v1.8.0 and the 2026-08-08 confirmation.

## Review

4 codex rounds (`adversarial-review --base origin/main`). Fixed from findings: per-target retry budgets (a shared deadline could shortchange late-observed failures under slow rounds), budget start moved to the first observed failure, and the trusted-publisher prose reworded from an imperative to a dated factual record. Final round: gate-approve with one residual MEDIUM — bounding individual `npm view` calls with short fetch timeouts — deliberately not taken: per-call patience is npm's own client behavior (the same exposure the original single-shot block had), and short per-call timeouts would reintroduce the false-failure mode this ticket removes; an outage still exits non-zero.

## Gates

Full suite 54/54 green; rail-freeze passes (no trust root touched); mutation gate: no mutable source in the diff; **not trust-root tier** per tier-check — no cross-model attestation required.
