### PR TITLE
test(docs): pin the install card inside the hero (I3 guard hardening)

### DIFF
--- a/apps/docs/test/install-cta.test.mjs
+++ b/apps/docs/test/install-cta.test.mjs
@@ -36,8 +36,13 @@ function indexOf(source, needle, where) {
 test('the integration hero leads with install, above the surfaces section', () => {
   const source = read(DETAIL);
   const heroInstall = indexOf(source, '<IntegrationCard integration={integration} />', DETAIL);
+  const heroOpen = indexOf(source, '<MarketingSection headingLevel={1}', DETAIL);
   const surfaces = indexOf(source, 'integration.surfacesSection.kicker', DETAIL);
 
+  assert.ok(
+    heroInstall > heroOpen,
+    'the install card must sit inside the hero section, not above it',
+  );
   assert.ok(
     heroInstall < surfaces,
     'the install card must render in the hero, before the Native surfaces section',


### PR DESCRIPTION
One-line guard hardening required before ticket I3 can complete (accuracy-review finding on the Group-2 verification): the AC3.1 guard was half-width — two acceptance-criterion-violating mutations left all 7 cases green. New assertion: heroInstall > hero MarketingSection opening. Proven load-bearing per the specified reopening gate: M-a (card above hero open) → fail 1 on the new assertion; M-b (card relocated into NativeBundle, textually above the hero) → fail 1 on the new assertion; restores clean; full docs suite 164/164.

https://claude.ai/code/session_011Fbv2GiKerPz67RapZigRM