### PR TITLE
docs(quartermaster): the threat model now states the shipped #395 containment, not the pre-fix hole

### DIFF
--- a/apps/docs/content/docs/toolkit/quartermaster.mdx
+++ b/apps/docs/content/docs/toolkit/quartermaster.mdx
@@ -28,15 +28,26 @@ the tree is ignored with a notice; a configured path that is relative or inside
 the repo *disables* loading rather than reading it.
 
 <Callout type="warn">
-  **"Operator-local" means "not selected by the candidate", not "unreachable by
-  it."** Fleet's model-plane worker is deliberately not filesystem-sandboxed (it
-  must authenticate with its provider), and the repo's own `fleet.gate` commands
-  run inside that worker. Candidate-authored code therefore executes with the
-  operator's filesystem privileges and could rewrite the registry itself. Moving
-  supply out of the tree turns a *declarative* downgrade into a *code-execution*
-  one; it does not close it. Closing it means isolating the model plane's
-  filesystem while keeping network egress — a change to fleet's containment
-  architecture, tracked in [#395](https://github.com/voodootikigod/adlc/issues/395).
+  **"Operator-local" now means "not selected by the candidate" *and* "not writable
+  by it" — but still not "unreadable by it."** The repo's own `fleet.gate` commands
+  run inside fleet's model-plane worker, so candidate-authored code executes there.
+  Since [#395](https://github.com/voodootikigod/adlc/issues/395) that worker runs
+  inside an OS filesystem sandbox — `bwrap` on Linux, Seatbelt on macOS — with
+  **network egress preserved**, because it must still reach its provider. Its
+  **writes** are bounded to the ticket's worktree, the state directories its
+  harness declares, and the OS temp dir; the registry's default home
+  (`$XDG_CONFIG_HOME/adlc/`) is none of those, and the worker is not even told
+  where the file is (`ADLC_QUARTERMASTER_REGISTRY` is withheld from the model-plane
+  env). What that does *not* cover, stated plainly: **reads** are unbounded and
+  egress is open, so read-and-exfiltrate remains; the bound holds only while the
+  registry sits outside those roots, so a registry parked under the temp dir — or
+  handed to the model plane with `--model-plane-writable` — is writable again; and
+  `--i-am-in-a-disposable-container`, the override for a host with no sandbox
+  backend, switches the OS enforcement off on both planes and rests entirely on the
+  container you asserted. Moving supply
+  out of the tree closed the *declarative* downgrade; the sandbox closed the
+  *code-execution* one. Running a fleet over a repo you do not trust is still
+  outside the design's assumptions.
 </Callout>
 
 The second half is that a registry label proves nothing about what ran. The
@@ -45,13 +56,21 @@ dispatcher forces the registry's model onto the harness command line explicitly
 the model the records claim.
 
 <Callout type="warn">
-  **`transport` does not yet get that treatment.** It constrains validation and is
-  reported in the plan, but dispatch does not use it to select credentials — so
-  `frontier` (`subscription:*`) and `frontier-metered` (`api:*`), being the same
-  adapter and model, execute identically today. Work routed to the metered channel
-  may consume the subscription instead. Treat a declared transport as intent and a
-  validation constraint, not as a guarantee about which credential paid.
-  Tracked in [#396](https://github.com/voodootikigod/adlc/issues/396).
+  **`transport` selects the credential — but the guarantee is asymmetric.** Since
+  [#396](https://github.com/voodootikigod/adlc/issues/396) dispatch derives the
+  worker's credential context from the seat's transport, and each adapter declares
+  which transport *classes* it can serve, so a seat bound to a class its adapter
+  does not declare is rejected at load. **Withholding is provable:** a
+  `subscription:` seat is dispatched with every provider API key removed, so no
+  metered credential reaches it through its environment — a fact about that
+  environment, not a claim about what a harness does with credentials it already
+  stores. **Supplying is not:** an `api:` or `gateway:` seat is
+  handed the adapter's declared credential, but a harness holding its own session
+  may still prefer that — the label says what was offered, never what served the
+  call. So a record carries `transportStatus: "selected"`; `"attested"` — the
+  harness reporting which transport actually paid — is not built yet. Read a
+  `subscription:` label as a guarantee, of the negative kind, and any other label
+  as intent plus a credential grant.
 </Callout>
 
 ## The registry

--- a/docs/tools/quartermaster.md
+++ b/docs/tools/quartermaster.md
@@ -1,0 +1,57 @@
+---
+title: quartermaster
+description: Documentation for the quartermaster tool in the ADLC toolkit.
+---
+
+# @adlc/quartermaster
+
+The ADLC **supply layer**: which model runs which lifecycle job, decided by the
+operator — never by the repo under review, and never by a model at run time.
+
+Implements [`docs/specs/operating-stack.md`](../../docs/specs/operating-stack.md)
+§4–§5. No LLM calls. No defaults.
+
+Two seams, nothing else:
+
+**1. The operator-local channel registry (§4b).** `quartermaster.json` lives
+outside every candidate tree. A configured path that is relative or inside the
+repo under review *disables* loading with a loud notice rather than reading it,
+mirroring how `adversarial-review` treats `ADVERSARIAL_REVIEW_CONFIG`. Load-time
+validation enforces rules 1–7 — closed channel names, an adapter allowlist drawn
+from `packages/fleet/lib/adapters/`, no argv-shaped fields at any depth, distinct
+fallback transports, a closed transport taxonomy, concrete model IDs for reviewer
+seats, and a complete `(adapter, model) → provider` table. Every failure is fail
+closed; there are no default channels.
+
+**2. The lifecycle-job routing contract (§5).** `routeJob` is a total function
+over a closed job enum that does not trust its caller: for `build.*` jobs the
+class is *derived* from `ticket.category` and `assignment.float`, and a
+caller-supplied label that disagrees with the derivation throws.
+
+```js
+import { loadRegistry, routeJob, resolveRoute } from '@adlc/quartermaster';
+
+const { registry, notices } = loadRegistry({ repoDir, adapters });
+const route = routeJob({ job: 'build.critical-path', assignment, ticket });
+const seat = resolveRoute(registry, route); // { adapter, model, transport, provider }
+```
+
+`assignment` is `@adlc/model-router`'s `assignTicket` output, consumed exactly as
+emitted. Float comes from the **assignment**, never from the ticket: stored
+tickets have no `float` field, and defaulting an absent one would silently
+downgrade critical-path work to the cheap channel.
+
+The adapter catalog is **injected** rather than imported. `@adlc/fleet` owns the
+adapter modules and consumes this package, so importing it here would make the
+publish graph circular — and injection keeps the alias contract adapter-owned
+instead of restating harness knowledge in the validator.
+
+## Schema reference
+
+[`docs/integrations/quartermaster-registry.md`](../../docs/integrations/quartermaster-registry.md)
+— annotated example, field reference, and the full rule table. The repo carries
+no registry of its own; dispatch never reads one from the tree.
+
+## License
+
+MIT


### PR DESCRIPTION
Delivers the last open acceptance criterion (AC7) of ticket
**T-01M0DF85FK1J0ZK3B46GK81YKV** — *"Contain the model plane: filesystem-isolate the
fleet worker while preserving provider egress (#395)"*.

7 of 8 ACs shipped in #530 and are verified in
`docs/reviews/group2-completion-verification-2026-08-24.md` (Appendix A, entry A6).
AC7 has two halves: AC7(a) `docs/integrations/quartermaster-registry.md` passed —
#530 updated it. AC7(b) failed: #530 never touched the docs-site toolkit page, so
the published page still described the pre-fix hole.

## The three false claims

The `#395` callout in `apps/docs/content/docs/toolkit/quartermaster.mdx` asserted,
verbatim:

| # | Before (published, now false) | After (the shipped truth) |
|---|---|---|
| 1 | Fleet's model-plane worker "is deliberately not filesystem-sandboxed (it must authenticate with its provider)" | The worker runs inside an OS filesystem sandbox — `bwrap` on Linux, Seatbelt on macOS — **with network egress preserved**, because it must still reach its provider. Filesystem and network isolation are independent axes; #530 applied only the filesystem one. |
| 2 | Candidate-authored code "executes with the operator's filesystem privileges and could rewrite the registry itself" | Writes are bounded to the ticket's worktree, the harness's declared state dirs, and the OS temp dir. The registry's default home (`$XDG_CONFIG_HOME/adlc/`) is none of those, and `ADLC_QUARTERMASTER_REGISTRY` is withheld from the model-plane env, so the worker is not even told where the file is. |
| 3 | Closing the hole is "a change to fleet's containment architecture, tracked in [#395]" | #395 is closed; the containment shipped. It is stated as done, with its residuals named rather than implied. |

Proven by the 23 containment tests in
`packages/fleet/test/model-plane-sandbox.test.mjs` (23 pass, 0 skip on this host —
`bwrap` present), whose AC1/AC2 assertions redden under a
`--ro-bind / /` → `--bind / /` mutation.

## Residuals are stated, not smoothed over (AC8)

The page overstated once already; that is why this ticket exists. So the rewrite
does not trade a false "it's open" for a tidy "it's closed". Three qualifications
came out of the adversarial-review rounds, each verified against shipped code:

- **Reads are unbounded and egress is open**, so read-and-exfiltrate remains
  possible. Spec §7.3 says this; the page did not.
- **The OS temp dir is a model-plane writable root**, as is any
  `--model-plane-writable` grant (`live-deps.mjs:264` → `model-plane.mjs:74-84`).
  The write bound therefore holds only while the registry sits outside those roots.
- **`--i-am-in-a-disposable-container`** — the override for a host with no sandbox
  backend — downgrades both planes to env-scrub-only with no OS enforcement
  (`sandbox.mjs` `SANDBOX_MODES`), resting entirely on the container the operator
  asserted.

## Also fixed: the adjacent transport callout (same failure class)

Not named by AC7, but the task required this page not to contradict
`docs/integrations/quartermaster-registry.md`, and it did. The neighbouring callout
said "`transport` does not yet get that treatment … dispatch does not use it to
select credentials", pointing at #396 as open.

#396 closed 2026-08-03 and dispatch derives the credential from the seat
(`live-deps.mjs:360` → `adapters/transport-credential.mjs`). Its ticket
`T-01KZ2504DRN6XXWTEAE0FFGA2V` scoped `docs/integrations/quartermaster-registry.md`
but **not** `apps/docs`, so the page was left contradicting its own schema
reference — the identical miss #530 made with #395.

The callout now mirrors the registry doc's asymmetric guarantee, including its
scoping of the subscription proof to the worker's **environment** rather than to
harness behaviour: every adapter declares its credential file as model-plane-writable
state (`.claude/.credentials.json`, `.codex/auth.json`,
`.config/opencode/auth.json`, …), so the stronger reading would not hold.

## `docs/tools/quartermaster.md` (new)

Every other shipped package carries a `docs/tools` mirror; quartermaster never had
one (no such file in git history). It is **byte-identical to
`scripts/generate-tool-docs.mjs` output** — frontmatter plus
`packages/quartermaster/README.md` verbatim, no `phaseMap` entry so no diagram —
and carries no hand-added content. No other `docs/tools` file was touched.

An earlier revision restated the threat model there. Review pointed out the
generator would silently delete it on the next run, which is precisely the
stale-published-claim failure this ticket exists to fix, and the durable remedies
(editing the README, or the generator) are outside the ticket's scope. The threat
model therefore lives only on durable surfaces: the hand-authored docs-site page
and `docs/integrations/quartermaster-registry.md`, which the mirror's own *Schema
reference* section links.

## Ticket-text defect (not fixed here — base-ticket immutability)

**AC3 cites the wrong test file.** It says
`Verify: node --test packages/fleet/test/env-scrub.test.mjs`, but the load-bearing
assertions live in `packages/fleet/test/model-plane-sandbox.test.mjs`. Under a
mutation that restores `ADLC_QUARTERMASTER_REGISTRY` passthrough, `env-scrub.test.mjs`
stays **green** while `model-plane-sandbox.test.mjs` reddens twice. Following AC3's
cited command would report a pass on a reintroduced hole. Base-ticket immutability
forbids editing the shard, so it is recorded here.

A second scope defect: AC7 requires updating "the `quartermaster` toolkit page
callout", but the ticket's `scope` array lists
`packages/fleet/**`, `docs/specs/fleet-orchestration.md`,
`docs/integrations/quartermaster-registry.md`, and `docs/tools/quartermaster.md` —
`apps/docs/**` is absent, so the file AC7 actually requires changing is out of the
declared scope.

## Verification

- `node --test apps/docs/test/*.test.mjs` — 164 pass, 0 fail
- Full suite `node scripts/run-tests.mjs` — **54/54 segments passed**
- `node scripts/claude-code-plugin-smoke.mjs` — exit 0 (`docs/tools/` already on the
  exclusion list)
- Mutation gate vs merge-base — "nothing to mutate": docs-only diff, no eligible
  source files
- `adlc prosecute tier-check --base origin/main --author-provider anthropic` —
  `trustRootTier: false`, `crossModelRequired: false`, `satisfied: true`; no
  attestation required
- `adlc rails-guard` — not applicable; the ticket declares no rails
- `npx adversarial-review --base origin/main --provider codex` — **6 rounds to
  APPROVE.** Rounds 1–5 raised 7 findings; 5 were true of shipped code and are now
  reflected in the text, 1 (generator durability) drove the mirror back to pure
  generated output. Round 6: `approve`, two LOW findings left standing, both
  adjudicated below.

### LOW findings left standing

1. *"Gateway transport wording overstates credential injection"* — my wording
   ("an `api:` or `gateway:` seat is handed the adapter's declared credential")
   matches `docs/integrations/quartermaster-registry.md` line 130 verbatim
   ("an `api:` or `gateway:` label as intent plus a credential grant") and is
   consistent with `transportCredential()`, which returns the adapter's declared
   `env` for the class or `null` when none is declared. Changing it here would put
   this page back out of step with the doc it is required to match.
2. *"New package documentation is not indexed in `docs/package-reference.md`"* —
   a real, **pre-existing** gap: quartermaster has shipped for months with no row
   there. `docs/package-reference.md` is outside this ticket's scope.

## Follow-ups worth their own tickets

- **`scripts/generate-tool-docs.mjs` silently discards hand-added content.**
  `docs/tools/model-router.md:84` carries a hand-added *Recommended Models by Phase*
  pointer that the next regeneration deletes. The generator should preserve marked
  regions, or a test should fail when generated output diverges.
- **`@adlc/quartermaster` is missing from `docs/package-reference.md`**, which
  CONTRIBUTING.md requires for every tool.
- **Harness credential files are model-plane-writable.** Every adapter declares its
  auth file in `homeState.files`, so candidate gate code can rewrite the credentials
  a later strike authenticates with. `model-plane.mjs`'s own stated principle is
  "a harness's state DIRECTORY is granted, its config directory is not"; an auth
  file sits on the other side of that line. Worth a design decision, not a doc edit.

Completion of the ticket follows in a separate PR, per the sequencing rule.
