### PR TITLE
chore: gitignore operator-local release scratch at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,11 @@ node_modules/
 apps/docs/.impeccable/questions/
 apps/docs/.impeccable/live/
 apps/docs/.impeccable/mocks/mobile.html
+
+# Operator-local release scratch that lives at the repo root (kept on disk,
+# never committed): the /release-audit report and session handoff notes. Both
+# have twice been swept into commits by a `git add -A` running in the main
+# checkout from a worktree agent whose cwd reset; ignoring them makes that
+# impossible.
+/release-blockers.md
+/HANDOFF.md


### PR DESCRIPTION
Adds /release-blockers.md and /HANDOFF.md to .gitignore. Both are operator-local session scratch that live at the repo root and are kept on disk deliberately; both have TWICE been swept into a commit by a `git add -A` running in the main checkout from a worktree agent whose cwd reset between bash calls (most recently the b4d51255 amend, since unwound). Ignoring them makes that class of corruption impossible while keeping the files present. No behavior change; docs-hygiene only.

https://claude.ai/code/session_011Fbv2GiKerPz67RapZigRM