### PR TITLE
chore(adlc): author the two accepted-residual follow-ups from #577's re-review

### DIFF
--- a/.adlc/tickets/t-01m0wnx6p09hwkdk429xq8ggrj--3bcd5fcbf0b0f1ebadb717ccc6096ce3ef9d3791ee7b434d291203c6f2a113fc.json
+++ b/.adlc/tickets/t-01m0wnx6p09hwkdk429xq8ggrj--3bcd5fcbf0b0f1ebadb717ccc6096ce3ef9d3791ee7b434d291203c6f2a113fc.json
@@ -1,0 +1,12 @@
+{
+  "body": "## Context\n\nFollow-up accepted by Chris (2026-08-25) as the tracked closure for finding [1] on PR #577 (bypassed-mutation audit), a PRE-EXISTING property of the prune path (not a #577 regression). packages/ticket-prune/lib/run.mjs:319-320: the legacy prune path appends audit evidence BEFORE renaming the staged store, with no journal or startup recovery. A crash or power loss after the manifest append and before the rename leaves tickets.json at the before-hash while the append-only manifest claims the after-hash. The in-process compensation only runs when the rename throws synchronously, so the inconsistency can persist.\n\nWhy the current ordering is deliberate (do NOT simply flip it): recording AFTER the write risks a real mutation with NO record, which is undetectable. The current order keeps the crash residual DETECTABLE — storeHashAfter will not match the store — which is why #577 shipped it as a documented residual rather than a silent hole. The real fix is durability, not reordering.\n\n## What to build\n\nA durable journal/outbox for the prune commit with startup reconciliation: fsync the staged store file and its parent directory before the audit append; fsync the directory after the rename; on startup, reconcile any recorded transition whose after-hash was not actually reached by appending an abandoned/corrected entry. Mirror the recoverability the gate-manifest ledger expects.\n\n## Acceptance criteria\n\n1. A simulated crash between manifest-append and store-rename is detected and corrected on the next run (an abandoned-transition entry is appended; the manifest no longer claims an unreached after-hash). verify: a test injects the crash window (e.g. a rename that throws asynchronously / a killed process fixture) and asserts reconciliation on restart; `node --test packages/ticket-prune/test/*.test.mjs` exits 0.\n2. The normal (no-crash) path records exactly one transition with matching before/after hashes. verify: same suite.\n3. The residual note added to run.mjs and packages/tickets README by #577 is removed/updated to reference the shipped mechanism. verify: reviewer confirms code and docs agree.\n4. Full suite green incl. the ticket-store-platform matrix. verify: `npm test` exits 0.",
+  "category": "feature",
+  "duration": 2,
+  "edges": [],
+  "id": "T-01M0WNX6P09HWKDK429XQ8GGRJ",
+  "rails": [],
+  "scope": [
+    "packages/ticket-prune/**"
+  ],
+  "title": "ticket-prune: durable journal + startup reconciliation so a crash between manifest-append and store-rename cannot leave a false audit"
+}

--- a/.adlc/tickets/t-01m0wnx6za0d94hw2vqkzapgq2--45ad55697a7a8231af76504d1d113e0109bcb8500761ba06099b26cbf278fadb.json
+++ b/.adlc/tickets/t-01m0wnx6za0d94hw2vqkzapgq2--45ad55697a7a8231af76504d1d113e0109bcb8500761ba06099b26cbf278fadb.json
@@ -1,0 +1,12 @@
+{
+  "body": "## Context\n\nFollow-up accepted by Chris (2026-08-25) as the tracked closure for finding [3] on PR #577. packages/tickets/lib/migrate.mjs:525-540: the export guard resolves and checks the destination before writing, but the subsequent mkdir + temp-file write + rename use path STRINGS without holding a directory handle or revalidating. A concurrent local writer can replace a checked parent directory with a symlink after validation and redirect the export into a ticket store, archive, or manifest.\n\nNarrow by threat model (why #577 shipped it as a tracked residual, not a blocker): the attacker needs write access to a PARENT of the operator's export destination AND must win a race during export; if they already have repo write they can write .adlc directly and need no race; on /tmp the sticky bit blocks renaming another user's directory. Real in principle, very narrow in practice. Also not cleanly fixable with current Node: there is no openat/O_NOFOLLOW for the mkdir+rename sequence, so the naive 'use directory handles' fix is unavailable and needs a real design pass.\n\n## What to build\n\nA symlink-safe final-write path for export: lock and re-validate every parent immediately before the rename (lstat each component, refuse if any is a symlink or changed identity since the check), or adopt whatever no-follow primitive is available (fs.opendir + dirfd-relative ops where the platform/Node version allows), failing closed on any component that cannot be proven safe. Refuse rather than follow when safety cannot be established.\n\n## Acceptance criteria\n\n1. An export whose parent directory is swapped for a symlink between validation and write is REFUSED, not followed (the target store/archive/manifest is untouched). verify: a test that plants the swap in the window asserts refusal + target intact; `node --test packages/tickets/test/*.test.mjs` exits 0.\n2. A normal export to a legitimate destination still succeeds. verify: same suite.\n3. If the mitigation is partial (Node-primitive-limited), the residual is documented factually in code + README with this ticket's disposition (no 'accepted/don't-scrutinize' framing per issue #579). verify: reviewer confirms.\n4. Full suite green. verify: `npm test` exits 0.",
+  "category": "bugfix",
+  "duration": 1,
+  "edges": [],
+  "id": "T-01M0WNX6ZA0D94HW2VQKZAPGQ2",
+  "rails": [],
+  "scope": [
+    "packages/tickets/**"
+  ],
+  "title": "ticket store export: symlink-safe final write so a TOCTOU parent-swap cannot redirect the export into a store/archive/manifest"
+}


### PR DESCRIPTION
Tracks findings [1] and [3] from PR #577's final cross-model re-review, which Chris accepted as bounded follow-ups (2026-08-25). #577 ships with finding [2] — the real keyless-unaudited-write regression — FIXED; these two carry the remaining residuals so they're tracked, not forgotten:

- **T-01M0WNX6P09HWKDK429XQ8GGRJ** — ticket-prune durable journal + startup reconciliation. Finding [1]: crash between manifest-append and store-rename leaves a false audit. Pre-existing (not a #577 regression); residual stays detectable (storeHashAfter mismatch); real fix is a journal feature.
- **T-01M0WNX6ZA0D94HW2VQKZAPGQ2** — export symlink-safe final write. Finding [3]: TOCTOU parent-swap can redirect an export. Narrow threat model (needs parent-write + a race; /tmp sticky bit blocks it) and not cleanly fixable with current Node primitives.

Ticket-only, additive, no ceremony.

https://claude.ai/code/session_011Fbv2GiKerPz67RapZigRM