### PR TITLE
chore(adlc): acknowledge config-integrity fields in .adlc/config.json (trust-root ceremony)

### DIFF
--- a/.adlc/config.json
+++ b/.adlc/config.json
@@ -1,4 +1,7 @@
 {
+  "version": 1,
+  "securityMode": "unsigned-fallback",
+  "acknowledgedNewRailBypass": true,
   "fleet": {
     "gate": { "build": "npm run build --workspaces --if-present", "test": "npm test" },
     "init": "npm ci --ignore-scripts",


### PR DESCRIPTION
## Summary

Adds the three config-integrity fields the `rails-guard` CI job requires on the **base** branch to `.adlc/config.json`:

```json
"version": 1,
"securityMode": "unsigned-fallback",
"acknowledgedNewRailBypass": true,
```

**Why now.** #900 landed `.adlc/config.json` (fleet/autopilot/ticketSync blocks) without these fields. `packages/rails-guard/lib/ci/rail-freeze.mjs` runs `validateConfigIntegrity` whenever the base tracks `.adlc/config.json`, and that check fails closed on the base's own config:

```
$ node scripts/rails-guard-ci.mjs origin/main      # on ANY branch, even a whitespace-only README change
rails-guard-ci: acknowledgedNewRailBypass must already be set on the base branch
exit 1
```

So every PR against `main` currently fails the required `rails-guard` check, and — by design — a PR cannot self-acknowledge (`a PR cannot self-acknowledge this limitation`). This is the protected-base ceremony that `packages/init/lib/scaffold.mjs` documents as deliberately NOT self-set.

**Values.** `securityMode: "unsigned-fallback"` is the `adlc init` scaffold default (`packages/init/lib/scaffold.mjs`) and is the only value the bootstrap step accepts without the signed runner pool; upgrading to `signed` later is its own protected-base runner ceremony. `version: 1` matches the scaffold. `acknowledgedNewRailBypass: true` is the acknowledgement of the documented limitation that a PR can add a NEW rail path it also authors (sanctioned first addition — `sanctionedRailAdditions`).

**Verified locally** on a scratch worktree: with these three lines committed on a simulated base, a lane-shaped PR (new ticket shard declaring a new rail + a code change) gets `rails-guard: all checks passed`, exit 0; against current `origin/main` the same diff exits 1 with the message above. Fleet still loads the file: `node packages/fleet/bin/fleet.mjs run --dry-run --json` exits 0 with zero `SECURITY` lines on stderr (#900 AC2).

**This is a trust-root ceremony PR.** `.adlc/config.json` is in `DEFAULT_IMMUTABLE_TRUST_ROOTS`, and the base does not yet carry the acknowledgement, so the `rails-guard` job on this PR is expected to fail with exactly the message above. Merge deliberately as the admin CODEOWNER under the `trust-root-change` label, the same way #900 was landed.

One file changed; staged with `git add -f` because `.adlc/*` is ignored (a tracked file is unaffected afterwards).

## Unblocks

The four issue lanes opened alongside this PR (#622, #712, #697, #594) — re-run their failed `rails-guard` jobs after this merges; no new commit is needed.

https://claude.ai/code/session_0189zbyhWR8tbZyjPFYqkYYv
