### PR TITLE
fix(mutation-gate): size the hollow-test draw by the measured suite cost — an honest cap, never a timeout (T-01M19V5SCKQYRPYXYZHQ0AEZBT)

### DIFF
--- a/.adlc/tickets/t-01m19v5sckqyrpyxyzhq0aezbt--4c550b70a8701510ba86f2e399718e80cbe12533ee2357a4c714939ca20b3b0f.json
+++ b/.adlc/tickets/t-01m19v5sckqyrpyxyzhq0aezbt--4c550b70a8701510ba86f2e399718e80cbe12533ee2357a4c714939ca20b3b0f.json
@@ -1,0 +1,14 @@
+{
+  "body": "CONTEXT. scripts/mutation-gate.mjs hands hollow-test a draw of max(requested, 2 x changed mutable files) inside a fixed 30-minute spawnSync window. A 67-file diff (PR #913) needs ~134 draws at ~80 s per run: the job dies ETIMEDOUT (exit 1) regardless of test quality, three times locally and once in CI. GOAL. The gate stays a fail-closed, per-file-coverage gate for ordinary diffs and degrades LOUDLY (a printed cap, never a timeout) for large ones. ACCEPTANCE. (1) mutantBudget(decision, { runMs, windowMs }) is pure: with no measurement it returns todays max(requested, 2 x files); with a measurement it returns the largest draw such that (draws + 1 baseline) x runMs fits the window, never above 2 x files and never below the requested floor; (2) when even the floor does not fit, or a single run exceeds the per-run timeout, main() fails loudly naming the measured cost and the window, before hollow-test starts; (3) when the draw is capped below 2 x files the job log says so with the ratio, so reduced per-file coverage is visible; (4) the window is 45 minutes with the hollow-test spawnSync timeout derived from it; (5) the measured run reuses the baseline: a red fast-target run fails the gate with the suites output before any mutant is drawn; (6) all existing mutation-gate tests keep passing; the slow path is unchanged. VERIFY. scripts/test/mutation-gate.test.mjs covers 1-4 with an injectable spawn; node scripts/mutation-gate.mjs origin/main --max 12 on this branch and on feat/autopilot (must print the cap and finish inside the window).",
+  "budget": "direct",
+  "category": "chore",
+  "duration": 1,
+  "edges": [],
+  "id": "T-01M19V5SCKQYRPYXYZHQ0AEZBT",
+  "rails": [],
+  "scope": [
+    "scripts/mutation-gate.mjs",
+    "scripts/test/mutation-gate.test.mjs"
+  ],
+  "title": "mutation-gate: size the hollow-test draw by the measured suite cost so large diffs fit the window (honest green, never a timeout)"
+}

--- a/scripts/mutation-gate.mjs
+++ b/scripts/mutation-gate.mjs
@@ -313,10 +313,53 @@ export function classify(changed, requestedMax, root = ROOT) {
  */
 export const MUTANTS_PER_CHANGED_FILE = 2;
 
-export function mutantBudget(decision) {
+/** The ONE spawnSync window hollow-test gets: its baseline run plus every mutant run must fit. */
+export const HOLLOW_WINDOW_MS = 45 * 60_000;
+/** Per-run timeout hollow-test is handed on the fast path (the slow path keeps its own 10 minutes). */
+export const FAST_RUN_TIMEOUT_MS = 180_000;
+export const SLOW_RUN_TIMEOUT_MS = 600_000;
+
+/**
+ * Size the hollow-test draw. Without a measurement this is exactly the historical rule
+ * (every changed file gets more than one draw; a bare-minimum `max` otherwise). WITH a
+ * measured run cost the draw is the largest that fits the window — hollow-test runs the
+ * suite once as a baseline and once per mutant — never above 2 × files and never below
+ * the requested floor. A floor that cannot fit is `ok:false` with the reason: a draw that
+ * cannot finish is not coverage, it is a guaranteed ETIMEDOUT (PR #913: 67 files × 2 at
+ * ~80 s a run inside a 30-minute window). `capped` says per-file coverage was reduced.
+ *
+ * @returns {{ ok: boolean, draw: number, want: number, fits: number|null, capped: boolean, reason?: string }}
+ */
+export function mutantBudget(decision, { runMs = null, windowMs = HOLLOW_WINDOW_MS, perRunTimeoutMs = FAST_RUN_TIMEOUT_MS } = {}) {
   const files = decision.files ?? [];
-  if (decision.kind === 'slow') return decision.max;
-  return Math.max(decision.max, files.length * MUTANTS_PER_CHANGED_FILE);
+  if (decision.kind === 'slow') return { ok: true, draw: decision.max, want: decision.max, fits: null, capped: false };
+  const want = Math.max(decision.max, files.length * MUTANTS_PER_CHANGED_FILE);
+  if (runMs == null) return { ok: true, draw: want, want, fits: null, capped: false };
+  if (runMs > perRunTimeoutMs) {
+    return { ok: false, draw: 0, want, fits: 0, capped: true, reason: `one run of the fast target command takes ${runMs} ms, past the ${perRunTimeoutMs} ms per-run timeout hollow-test is handed — every run would time out` };
+  }
+  const fits = Math.max(0, Math.floor(windowMs / runMs) - 1); // minus the baseline run
+  if (fits < decision.max) {
+    return { ok: false, draw: 0, want, fits, capped: true, reason: `one run of the fast target command takes ${runMs} ms; ${fits} draw(s) fit the ${windowMs} ms window after the baseline, fewer than the requested floor of ${decision.max}` };
+  }
+  const draw = Math.min(want, fits);
+  return { ok: true, draw, want, fits, capped: draw < want };
+}
+
+/**
+ * Time ONE run of the fast target command — the same shell command hollow-test will run —
+ * so the draw can be sized to what actually fits. A red run is the gate's own baseline
+ * failure, reported with the suite's output before any mutant is drawn.
+ */
+export function measureRun(testCmd, { spawn = spawnSync, now = Date.now, cwd = ROOT, timeoutMs = FAST_RUN_TIMEOUT_MS } = {}) {
+  const t0 = now();
+  const r = spawn(testCmd, [], { shell: true, cwd, encoding: 'utf8', timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024 });
+  const runMs = Math.max(1, now() - t0);
+  const output = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+  if (r.error) return { ok: false, runMs, output, reason: `could not run the fast target command: ${r.error.message}` };
+  if (r.signal || r.status == null) return { ok: false, runMs, output, reason: `the fast target command timed out (${timeoutMs} ms) or was killed by ${r.signal ?? 'a signal'}` };
+  if (r.status !== 0) return { ok: false, runMs, output, reason: `the fast target command exited ${r.status}` };
+  return { ok: true, runMs, output };
 }
 
 function isMain() {
@@ -379,20 +422,40 @@ export function main() {
 
   // NO --target. hollow-test independently re-derives the same file set from
   // the same --base and hunk-scopes each one from the diff itself.
+  // The draw is sized by what fits the window (T-01M19V5SCKQYRPYXYZHQ0AEZBT): one measured run of
+  // the fast target command first — a red one is the baseline failure, reported with its output.
+  let budget;
+  if (decision.kind === 'fast') {
+    const measured = measureRun(decision.testCmd);
+    if (!measured.ok) {
+      process.stderr.write(measured.output.slice(-8000));
+      fail(`${measured.reason} — the baseline suite is not green; fix the suite / the fast target command first`);
+    }
+    budget = mutantBudget(decision, { runMs: measured.runMs });
+    console.log(`mutation-gate: one run of the fast target command took ${(measured.runMs / 1000).toFixed(1)} s; window ${HOLLOW_WINDOW_MS / 60_000} min → ${budget.ok ? `${budget.draw} draw(s)` : 'does not fit'} (wanted ${budget.want} = ${MUTANTS_PER_CHANGED_FILE} × ${decision.files.length} file(s))`);
+    if (!budget.ok) fail(`${budget.reason}. Make the fast target command cheaper or split the change.`);
+    if (budget.capped) {
+      console.log(`mutation-gate: BUDGET-CAPPED — ${budget.draw} of ${budget.want} draws: changed files may receive fewer than ${MUTANTS_PER_CHANGED_FILE} draws each (${decision.files.length} files); per-file coverage is reduced for this diff, not silently skipped.`);
+    }
+  } else {
+    budget = mutantBudget(decision);
+  }
+
   const bin = join(ROOT, 'packages', 'hollow-test', 'bin', 'hollow-test.mjs');
   const result = spawnSync(process.execPath, [
     bin,
     '--base', base,
     '--test-cmd', decision.testCmd,
-    // Enough mutants that every changed file gets more than one draw — see
-    // mutantBudget: a single draw can be spent on an unparseable mutant, which
-    // leaves that file unprosecuted while the run still reports zero survivors.
-    '--max', String(mutantBudget(decision)),
-    '--timeout-ms', decision.kind === 'fast' ? '180000' : '600000',
+    // The draw: every changed file gets more than one draw when that fits the window — see
+    // mutantBudget: a single draw can be spent on an unparseable mutant, which leaves that
+    // file unprosecuted while the run still reports zero survivors. When it does not fit,
+    // the cap was printed above; the run is bounded either way.
+    '--max', String(budget.draw),
+    '--timeout-ms', String(decision.kind === 'fast' ? FAST_RUN_TIMEOUT_MS : SLOW_RUN_TIMEOUT_MS),
     // Mirror the wrapper's own source declaration into the tool, so the two
     // cannot disagree about the ambiguous product names (see SOURCE_GLOBS).
     ...SOURCE_GLOBS.flatMap((g) => ['--source-glob', g]),
-  ], { stdio: 'inherit', cwd: ROOT, timeout: 1800000 });
+  ], { stdio: 'inherit', cwd: ROOT, timeout: HOLLOW_WINDOW_MS + 60_000 });
 
   if (result.error) fail(`could not run hollow-test: ${result.error.message}`);
   if (result.signal) fail(`hollow-test timed out or was killed by ${result.signal}`);

--- a/scripts/test/mutation-gate.test.mjs
+++ b/scripts/test/mutation-gate.test.mjs
@@ -17,7 +17,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { testTargetFor, hollowTestWouldMutate, classify, mutableChangedFiles, SURVIVOR_GUIDANCE, mutantBudget, MUTANTS_PER_CHANGED_FILE } from '../mutation-gate.mjs';
+import { testTargetFor, hollowTestWouldMutate, classify, mutableChangedFiles, SURVIVOR_GUIDANCE, mutantBudget, MUTANTS_PER_CHANGED_FILE, HOLLOW_WINDOW_MS, FAST_RUN_TIMEOUT_MS, measureRun } from '../mutation-gate.mjs';
 import { generateMutants } from '../../packages/core/lib/mutate.mjs';
 import { isMutableSource } from '../../packages/hollow-test/lib/targets.mjs';
 
@@ -712,27 +712,27 @@ test('the survivor message is honest: a comment-prefixed line really is prosecut
 
 test('the fast path budgets MORE than one mutant per changed file', () => {
   const decision = { kind: 'fast', max: 12, files: Array.from({ length: 16 }, (_, i) => `src/f${i}.mjs`) };
-  assert.equal(mutantBudget(decision), 32);
-  assert.ok(mutantBudget(decision) > decision.files.length,
+  assert.equal(mutantBudget(decision).draw, 32);
+  assert.ok(mutantBudget(decision).draw > decision.files.length,
     'one-per-file is the starvation case this exists to prevent');
 });
 
 test('the fast path never budgets BELOW the requested max', () => {
   // A narrow diff must not lose budget just because it touches few files.
   const decision = { kind: 'fast', max: 12, files: ['src/one.mjs'] };
-  assert.equal(mutantBudget(decision), 12);
+  assert.equal(mutantBudget(decision).draw, 12);
 });
 
 test('the SLOW path keeps its deliberate cap — widening it would unbound CI', () => {
   // The slow fallback re-runs the whole suite per mutant; classify() already
   // caps it at 3 for that reason, and the budget rule must not undo that.
   const decision = { kind: 'slow', max: 3, files: Array.from({ length: 16 }, (_, i) => `src/f${i}.mjs`) };
-  assert.equal(mutantBudget(decision), 3);
+  assert.equal(mutantBudget(decision).draw, 3);
 });
 
 test('a decision with no file list is handled without inventing budget', () => {
-  assert.equal(mutantBudget({ kind: 'fast', max: 12 }), 12);
-  assert.equal(mutantBudget({ kind: 'fast', max: 12, files: [] }), 12);
+  assert.equal(mutantBudget({ kind: 'fast', max: 12 }).draw, 12);
+  assert.equal(mutantBudget({ kind: 'fast', max: 12, files: [] }).draw, 12);
 });
 
 test('MUTANTS_PER_CHANGED_FILE is the knob, and it is greater than one', () => {
@@ -740,4 +740,68 @@ test('MUTANTS_PER_CHANGED_FILE is the knob, and it is greater than one', () => {
   // number, and so lowering it back to 1 is a visible edit rather than a silent
   // arithmetic change.
   assert.ok(MUTANTS_PER_CHANGED_FILE > 1);
+});
+
+// ── budget-aware draw (T-01M19V5SCKQYRPYXYZHQ0AEZBT) ─────────────────────────────
+// hollow-test runs the suite once as a baseline and once per mutant inside ONE spawnSync
+// window. A draw of 2 × files that cannot fit the window is not coverage — it is a guaranteed
+// ETIMEDOUT (PR #913: 67 files, ~80 s a run). The draw is sized by the MEASURED run cost:
+// small diffs keep today's 2 × files exactly; large ones get the largest draw that fits,
+// never below the requested floor; a floor that cannot fit fails loudly BEFORE hollow-test.
+const fast = (n, max = 12) => ({ kind: 'fast', max, files: Array.from({ length: n }, (_, i) => `packages/x/lib/f${i}.mjs`), testCmd: 'node --test packages/x/test/*.test.mjs' });
+
+test('mutantBudget without a measurement is byte-identical to today: max(requested, 2 × files)', () => {
+  assert.equal(mutantBudget(fast(3)).draw, 12);
+  assert.equal(mutantBudget(fast(20)).draw, 40);
+  assert.equal(mutantBudget(fast(3)).capped, false);
+  assert.equal(mutantBudget({ kind: 'slow', max: 3, files: ['a', 'b'] }).draw, 3, 'the slow path keeps its own cap');
+  assert.equal(typeof mutantBudget(fast(3)), 'object', 'returns a document, not a bare number');
+});
+
+test('with a measured run cost the draw is the largest that fits the window (baseline + draws), capped at 2 × files, floored at the request', () => {
+  // 67 files × 2 = 134 wanted; 80 s a run in a 45-minute window: (45 × 60) / 80 = 33.75 runs → 33 − 1 baseline = 32 draws.
+  const big = mutantBudget(fast(67), { runMs: 80_000, windowMs: 45 * 60_000 });
+  assert.equal(big.want, 134); assert.equal(big.draw, 32); assert.equal(big.capped, true);
+  // A small diff fits with room to spare: exactly today's 2 × files, uncapped.
+  const small = mutantBudget(fast(5), { runMs: 80_000, windowMs: 45 * 60_000 });
+  assert.equal(small.draw, 12); assert.equal(small.capped, false);
+  const mid = mutantBudget(fast(15), { runMs: 80_000, windowMs: 45 * 60_000 });
+  assert.equal(mid.draw, 30); assert.equal(mid.capped, false, '30 of 30 wanted fit (33 would)');
+  // The floor is the request: a run cost that fits fewer than the requested draws is NOT silently shrunk below it.
+  const tight = mutantBudget(fast(67), { runMs: 210_000, windowMs: 45 * 60_000 });
+  assert.equal(tight.ok, false, '210 s a run → 12 runs → 11 draws: fewer than the requested 12 fit');
+});
+
+test('the floor exactly fitting is ok; one run more expensive than that is a loud refusal naming the cost and the window', () => {
+  // 120 s a run in a 26-minute window: 13 runs → 12 draws: the floor fits exactly (capped: 12 of 134 wanted).
+  const exact = mutantBudget(fast(67), { runMs: 120_000, windowMs: 13 * 120_000 });
+  assert.equal(exact.ok, true); assert.equal(exact.draw, 12); assert.equal(exact.capped, true);
+  // A slightly smaller window: 11 runs → 10 draws, fewer than the requested 12 → a loud refusal.
+  const no = mutantBudget(fast(67), { runMs: 120_000, windowMs: 1_400_000 });
+  assert.equal(no.ok, false);
+  assert.match(no.reason, /takes 120000 ms/, 'the refusal names the measured cost');
+  assert.match(no.reason, /1400000 ms window/, 'and the window');
+  assert.match(no.reason, /floor of 12/, 'and the floor that does not fit');
+  // A single run past the per-run timeout can never be green either, whatever the window.
+  const slowRun = mutantBudget(fast(3), { runMs: FAST_RUN_TIMEOUT_MS + 1, windowMs: HOLLOW_WINDOW_MS });
+  assert.equal(slowRun.ok, false); assert.match(slowRun.reason, /per-run timeout/);
+});
+
+test('the window is 45 minutes and the per-run timeout is what hollow-test is handed', () => {
+  assert.equal(HOLLOW_WINDOW_MS, 45 * 60_000);
+  assert.equal(FAST_RUN_TIMEOUT_MS, 180_000);
+});
+
+test('measureRun times ONE run of the fast target command through an injectable spawn and reports a red run with its output', () => {
+  const calls = [];
+  const spawn = (cmd, args, opts) => { calls.push({ cmd, args, opts }); return { status: 0, stdout: 'ok', stderr: '' }; };
+  const clock = [1000, 81_000]; const now = () => clock.shift();
+  const r = measureRun('node --test packages/x/test/*.test.mjs', { spawn, now, cwd: '/repo', timeoutMs: 180_000 });
+  assert.equal(r.ok, true); assert.equal(r.runMs, 80_000);
+  assert.equal(calls.length, 1); assert.equal(calls[0].opts.cwd, '/repo'); assert.equal(calls[0].opts.timeout, 180_000);
+  assert.ok(calls[0].opts.shell === true || calls[0].cmd === 'sh', 'the command string runs as the shell command hollow-test itself will run');
+  const red = measureRun('node --test x', { spawn: () => ({ status: 1, stdout: '', stderr: 'not ok 3 - AC9' }), now: () => 0 });
+  assert.equal(red.ok, false); assert.match(red.output, /not ok 3/);
+  const timedOut = measureRun('node --test x', { spawn: () => ({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' }), now: () => 0 });
+  assert.equal(timedOut.ok, false); assert.match(timedOut.reason, /timed out/);
 });

--- a/scripts/test/mutation-gate.test.mjs
+++ b/scripts/test/mutation-gate.test.mjs
@@ -805,3 +805,19 @@ test('measureRun times ONE run of the fast target command through an injectable 
   const timedOut = measureRun('node --test x', { spawn: () => ({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' }), now: () => 0 });
   assert.equal(timedOut.ok, false); assert.match(timedOut.reason, /timed out/);
 });
+
+test('every field of the budget document is pinned on every path (the gate on its own change found the unasserted ones)', () => {
+  assert.deepEqual(mutantBudget({ kind: 'slow', max: 3, files: ['a', 'b'] }), { ok: true, draw: 3, want: 3, fits: null, capped: false });
+  assert.deepEqual(mutantBudget(fast(20)), { ok: true, draw: 40, want: 40, fits: null, capped: false });
+  const slowRun = mutantBudget(fast(3), { runMs: FAST_RUN_TIMEOUT_MS + 1, windowMs: HOLLOW_WINDOW_MS });
+  assert.equal(slowRun.ok, false); assert.equal(slowRun.draw, 0); assert.equal(slowRun.fits, 0); assert.equal(slowRun.capped, true); assert.equal(slowRun.want, 12);
+  const no = mutantBudget(fast(67), { runMs: 120_000, windowMs: 1_400_000 });
+  assert.equal(no.ok, false); assert.equal(no.draw, 0); assert.equal(no.fits, 10, '11 runs − 1 baseline'); assert.equal(no.capped, true); assert.equal(no.want, 134);
+  // A window that cannot even hold two runs: fits is 0 (never negative, never 1).
+  const tiny = mutantBudget(fast(3), { runMs: 100_000, windowMs: 150_000 });
+  assert.equal(tiny.ok, false); assert.equal(tiny.fits, 0); assert.match(tiny.reason, /0 draw\(s\) fit/);
+  const big = mutantBudget(fast(67), { runMs: 80_000, windowMs: 45 * 60_000 });
+  assert.deepEqual(big, { ok: true, draw: 32, want: 134, fits: 32, capped: true });
+  const small = mutantBudget(fast(5), { runMs: 80_000, windowMs: 45 * 60_000 });
+  assert.deepEqual(small, { ok: true, draw: 12, want: 12, fits: 32, capped: false });
+});


### PR DESCRIPTION
## Summary

Ticket `T-01M19V5SCKQYRPYXYZHQ0AEZBT`. `scripts/mutation-gate.mjs` handed hollow-test a draw of `max(requested, 2 × changed mutable files)` inside a fixed 30-minute `spawnSync` window. A 67-file diff (#913) needs ~134 runs at ~80 s a run: the CI job dies `ETIMEDOUT` (exit 1) regardless of test quality — three local runs and one CI run did exactly that. The honest fix is a gate that *knows* what fits, not an override of the red check.

**What changes** (one script, its tests; the slow path is untouched):
- **One measured run first.** `measureRun(testCmd)` times a single run of the fast target command — the same shell command hollow-test will run. A red run is the gate's own baseline failure, reported with the suite's output *before* any mutant is drawn (previously that surfaced only as hollow-test's `baseline suite is not green` with no test names).
- **A budget-aware draw.** `mutantBudget(decision, { runMs, windowMs })` returns the largest draw such that `baseline + draws` runs fit the window, never above `2 × files` and never below the requested floor. Without a measurement it is byte-identical to the old rule.
- **Loud, never silent.** A floor that cannot fit, or a single run past the per-run timeout, fails the gate naming the measured cost and the window. A draw capped below `2 × files` prints `BUDGET-CAPPED — N of M draws` so reduced per-file coverage is visible in the job log rather than implied by a timeout.
- **Headroom.** The window is 45 minutes; the `spawnSync` timeout is derived from it.

For #913 (67 files, ~80 s a run on a fast host): 32 draws instead of 134, capped and printed; on a slower runner the draw shrinks with the measured cost instead of timing out.

## Verification
- `node --test scripts/test/mutation-gate.test.mjs` — 65/65 (document shape on every path, cap/floor/refusal arithmetic incl. the exact-fit boundary and a window too small for two runs, per-run timeout, constants, `measureRun` through an injectable spawn incl. red and timed-out runs).
- `node scripts/mutation-gate.mjs origin/main --max 12` on this branch — the gate run on its own change: first pass left 6 survivors (unasserted `ok`/`capped`/`fits`/`draw` fields and the `fits` floor), each pinned; second pass **12/12 killed**. The measured-run line prints (`took 0.1 s; window 45 min → 12 draw(s)`).
- `node scripts/run-tests.mjs` — 48 segments, 8229 tests, 0 failures (4 skipped: the loud host-capability skips), exit 0.
- `scripts/rails-guard-ci.mjs origin/main` — all checks passed; findings-ledger / append-only / reviewer-directed-comment gates clean.
- `adlc prosecute tier-check` — NOT trust-root tier (the wrapper is not in the rails/trust-root set), so no cross-model attestation is required; the agy review below is the P5 record.
- agy Gemini 3.7 Flash (Medium) review of the diff: one chunk (3 files, 19 KB), exit 0, verdict approve, zero findings — "math, timeouts, error propagation, and tests are sound and fail-closed".

## Follow-through
After this merges, #913's `mutation-gate` check re-runs against the new wrapper and should finish inside the window with the cap printed; #908 (fleet, 23 files) is unaffected (it already fits).

https://claude.ai/code/session_01AAe6MSetYkucvqmtaVrUzm
