### PR TITLE
docs(skills): issue-lanes — scope forks explicitly; tiering is per-candidate, not blanket

### DIFF
--- a/.claude/skills/issue-lanes/SKILL.md
+++ b/.claude/skills/issue-lanes/SKILL.md
@@ -61,10 +61,24 @@ Selection rules, in order:
 1. `bug` + `P1-high` (or the user's `--label`), class **false-green** first — that is the
    product's signature risk.
 2. **One lane per package.** Two issues in the same package go in ONE lane or wait.
-3. **Skip the trust-root tier** unless the user explicitly wants the cross-model ceremony:
-   `packages/{rails-guard,prosecute,gate-manifest,build-gate,ticket-prune,ticket-sync}`,
-   `scripts/rails-guard-ci.mjs`, `docs/ci/rails-guard.yml`, root `package.json`/lockfile,
-   `.adlc/tickets.json`, `scripts/preflight.mjs` (see `packages/prosecute/lib/tier.mjs`).
+3. **Check tiering per candidate — it is not just `packages/**`.** `packages/prosecute/lib/tier.mjs`
+   tiers a change on ANY ticket's declared rail globs, COMPLETED tickets included (issue #905).
+   Grep every completed ticket for a rail matching the candidate's exact path before assuming a
+   plugin or script is untiered:
+   ```bash
+   for f in $(grep -l '"rails"' .adlc/tickets/*.json); do node -e '
+   (function(){const t=JSON.parse(require("fs").readFileSync(process.argv[1]));
+   if(t.completed!==true) return; const rails=(t.rails||[]).join(" ");
+   if(/<candidate-path-fragment>/.test(rails)) console.log(t.id,"|",rails);})();' "$f"; done
+   ```
+   In this repo, `packages/**` and `.github/workflows/**` are ALWAYS tiered (T37/T38), so any
+   `packages/*` lane needs the 4b ceremony — but plugin directories vary PER PLUGIN: T37 also
+   rails `plugins/{pi,opencode,codex,claude-code}/**` specifically (NOT copilot/cursor/gemini/
+   herdr), so a plugin lane may or may not need the ceremony depending on which plugin it is.
+   Verified empirically: `adlc-copilot`/`adlc-gemini`/`adlc-herdr` lanes shipped WITHOUT the
+   ceremony (`gate` passed clean, 19/19); an `adlc-codex` lane needed it (T37 rails
+   `plugins/adlc-codex/**`) despite looking superficially identical to the other three. Do not
+   generalize "plugins are untiered" from one or two examples — check every candidate.
 4. Skip packages under an active rail (`.adlc/tickets/*.json` with `rails` and no
    `completed: true`) and areas with an in-flight program (e.g. `area:autopilot`).
 5. **Re-verify the premise at HEAD** for every candidate: `grep -n` the cited line in the
@@ -128,7 +142,12 @@ never conflict; a plain create records no manifest entry — by design).
 
 One `Agent` call per lane, all in ONE message, `subagent_type: "fork"` (inherits the tickets,
 gates and lessons you just loaded). Prompt from `references/lane-prompt.md` with the lane's
-worktree, branch, ticket id, issue number, package, rails, and new-test filename filled in.
+worktree, branch, ticket id, issue number, package, rails, and new-test filename filled in —
+**including the "you are lane N of M, siblings already launched" preamble**: a fork inherits
+this whole skill's text (including this very "launch the lanes" step) and can mistake itself
+for the parent, attempting to Agent-call the other sibling issues itself. Nested fork calls
+fail closed ("Fork is not available inside a forked worker") with no side effect, but cost a
+wasted turn — state the preamble explicitly rather than relying on "do not re-delegate" alone.
 Then do not touch lane files; work on the relay/skill/memory until the notifications arrive.
 
 The lane sequence the prompt enforces: P2 `adlc coldstart <id> --prompt-only` (self-audit) →

--- a/.claude/skills/issue-lanes/references/lane-prompt.md
+++ b/.claude/skills/issue-lanes/references/lane-prompt.md
@@ -5,7 +5,14 @@ All lanes go in ONE message so they run concurrently. The fork inherits the pare
 (tickets, gates, lessons), so the prompt is the contract plus the mechanics, not a tutorial.
 
 ```
-You are lane-<n>. Resolve GitHub issue #<n> through the ADLC gates, exactly per the ticket you (as the parent) authored.
+You are lane-<n>, ONE of <N> sibling lanes the parent ALREADY LAUNCHED in parallel (lanes for
+issues <list the other issue numbers>). You inherited the parent's full conversation, including
+the issue-lanes skill's own "launch the lanes" step — that step is the PARENT's job and it is
+DONE; the other lanes already exist as separate forked agents. Never call the Agent tool
+yourself, for any reason, in this task — a nested fork call fails ("Fork is not available inside
+a forked worker") and, more importantly, is not your job. Resolve ONLY issue #<n>.
+
+Resolve GitHub issue #<n> through the ADLC gates, exactly per the ticket you (as the parent) authored.
 
 LANE FACTS
 - Worktree: <repo>/.worktrees/fix-<n> (branch fix/<n>-<slug>, base refs/remotes/origin/main = <sha>). node_modules is installed there. NEVER touch the main checkout or any other worktree.
@@ -38,3 +45,4 @@ REPORT BACK (this is what the parent relays; be concrete): ticket coldstart verd
 | commit `-F file` | the block-no-verify hook rejects `grep -n` in a commit chain |
 | cap at 8 rounds | large diffs do not converge; the residual is the human's call |
 | stop on permission denial | the classifier owns push/PR; an agent must not route around it |
+| state "you are lane N of M, siblings already launched" up front | a fork inherits the whole skill text (incl. "launch the lanes") and can mistake itself for the parent — two of four lanes independently tried to Agent-call the other three sibling issues before self-correcting (harmless: nested fork calls fail closed with no side effect, but wastes a turn) |


### PR DESCRIPTION
## Summary

Docs-only update to `.claude/skills/issue-lanes/` after running the third batch (#808/#822/#833/#807, PRs #917–#920):

- **Fork-scope fix**: two of the four lanes independently tried to launch Agent calls for their sibling issues, apparently confused by inheriting this skill's own "launch the lanes" instructions in their forked context. Both nested calls failed closed ("Fork is not available inside a forked worker") with no side effect, but cost a wasted turn each. The lane prompt template now opens with an explicit "you are lane N of M, siblings already launched, never call Agent yourself" preamble instead of relying on the closing "do not re-delegate" line alone.
- **Tiering correction**: the trust-root selection rule previously implied plugins were generally untiered. Verified empirically this batch that tiering is decided per candidate PATH against every completed ticket's declared rails — `adlc-copilot`/`adlc-gemini`/`adlc-herdr` shipped without the cross-model ceremony, but `adlc-codex` needed it because completed ticket T37 specifically rails `plugins/adlc-codex/**` (not the other three). §1 now gives the exact grep to check any candidate before assuming.

No code changes; `.claude/skills/issue-lanes/{SKILL.md,references/lane-prompt.md}` only.

https://claude.ai/code/session_0189zbyhWR8tbZyjPFYqkYYv
