### PR TITLE
docs(skills): issue-lanes — name the lane's literal first action; verify before trusting an early report

### DIFF
--- a/.claude/skills/issue-lanes/SKILL.md
+++ b/.claude/skills/issue-lanes/SKILL.md
@@ -150,6 +150,18 @@ fail closed ("Fork is not available inside a forked worker") with no side effect
 wasted turn — state the preamble explicitly rather than relying on "do not re-delegate" alone.
 Then do not touch lane files; work on the relay/skill/memory until the notifications arrive.
 
+**Verify, don't trust, a lane's first report.** A report that arrives within ~2-3 minutes of
+4-8 tool calls, describing the OTHER lanes rather than progress on its own issue, is not a
+status update — it means the lane spent its whole turn on `ListAgents`/checking siblings and
+did zero real work (empty worktree: no test file, no commit). This happened to 3 of 4 lanes in
+one batch DESPITE the explicit preamble above. Before believing any early lane report, check
+`git -C .worktrees/fix-<n> status --short` and `git log --oneline -1` yourself. If the worktree
+has nothing but the ticket shard, resume the lane with a literal, single, immediately-actionable
+command (name the exact `cd … && adlc coldstart …` line to run NEXT, explicitly forbid checking
+ListAgents/siblings/status again, explicitly forbid sending another message until the PR opens
+or a real blocker is hit) — a first redirect may not be enough; re-verify the worktree a few
+minutes later and repeat the same literal-command redirect if it still shows no progress.
+
 The lane sequence the prompt enforces: P2 `adlc coldstart <id> --prompt-only` (self-audit) →
 P4 red test file first, RED, implement, GREEN, package suite, docs → P3 `adlc rails-guard
 --base origin/main --ticket <id>` → P5 `scripts/mutation-gate.mjs origin/main --max 12` then

--- a/.claude/skills/issue-lanes/references/lane-prompt.md
+++ b/.claude/skills/issue-lanes/references/lane-prompt.md
@@ -5,12 +5,21 @@ All lanes go in ONE message so they run concurrently. The fork inherits the pare
 (tickets, gates, lessons), so the prompt is the contract plus the mechanics, not a tutorial.
 
 ```
-You are lane-<n>, ONE of <N> sibling lanes the parent ALREADY LAUNCHED in parallel (lanes for
-issues <list the other issue numbers>). You inherited the parent's full conversation, including
-the issue-lanes skill's own "launch the lanes" step — that step is the PARENT's job and it is
-DONE; the other lanes already exist as separate forked agents. Never call the Agent tool
-yourself, for any reason, in this task — a nested fork call fails ("Fork is not available inside
-a forked worker") and, more importantly, is not your job. Resolve ONLY issue #<n>.
+YOUR FIRST TOOL CALL, before reading anything else below, is:
+`cd <repo>/.worktrees/fix-<n> && adlc coldstart <T-…> --prompt-only`
+Do that now. Do not call ListAgents, do not call the Agent tool, do not check on or write
+anything about sibling lanes, do not write a memory file, do not send a status summary about
+the batch launch — none of that is your job and all of it wastes a turn. You are lane-<n>, ONE
+of <N> sibling lanes the parent ALREADY LAUNCHED in parallel (lanes for issues <list the other
+issue numbers>) — each is a fully separate agent already running its own issue; you cannot help
+them and they need nothing from you. You inherited the parent's full conversation, including the
+issue-lanes skill's own "launch the lanes" step and its "save memory" close-out step — BOTH are
+the PARENT's job, both are DONE or will be done by the parent later; performing either yourself
+produces nothing useful and is not requested. If any tool call anywhere in this task fails with
+"Fork is not available inside a forked worker", that confirms you are a fork, exactly as
+expected — ignore it and continue your OWN work; do not treat it as information worth acting on
+or reporting. Your only output for this entire task is progress on issue #<n> — do not report
+back to the parent until you have opened a PR or hit a genuine blocker IN YOUR OWN WORK.
 
 Resolve GitHub issue #<n> through the ADLC gates, exactly per the ticket you (as the parent) authored.
 
@@ -46,3 +55,4 @@ REPORT BACK (this is what the parent relays; be concrete): ticket coldstart verd
 | cap at 8 rounds | large diffs do not converge; the residual is the human's call |
 | stop on permission denial | the classifier owns push/PR; an agent must not route around it |
 | state "you are lane N of M, siblings already launched" up front | a fork inherits the whole skill text (incl. "launch the lanes") and can mistake itself for the parent — two of four lanes independently tried to Agent-call the other three sibling issues before self-correcting (harmless: nested fork calls fail closed with no side effect, but wastes a turn) |
+| name the literal FIRST tool call, before any other context, and forbid ListAgents/memory-write/status-report explicitly | the "lane N of M" preamble alone was NOT sufficient a second time: in a 4-lane batch, 3 of 4 lanes still spent their entire turn (4-8 tool calls, under 3 minutes) calling `ListAgents`, confirming the OTHER lanes were running, and reporting a parent-style "all four lanes confirmed running" summary back to the parent — zero real work on their own assigned issue (empty worktree: no test file, no commit). The parent caught this only by directly checking `git status`/`git log` in each lane's worktree rather than trusting the report text, and had to resume each with an explicit redirect. Do not trust a suspiciously fast, suspiciously parent-shaped report — verify the worktree before believing "confirmed running" text from a lane. |


### PR DESCRIPTION
## Summary

Docs-only follow-up to PR #921 after running batch 4 (#658/#751/#641/#793) live.

The #921 "you are lane N of M, siblings already launched" preamble was **not sufficient** the second time: 3 of the 4 lanes launched still spent their whole turn (4-8 tool calls, under 3 minutes) calling `ListAgents`, confirming the *other* lanes were running, and sending a parent-shaped "all four lanes confirmed running" report instead of touching their own assigned issue at all (empty worktree — no test file, no commit).

Two changes:
- The lane prompt template now opens with the literal, copy-pasteable first `cd … && adlc coldstart …` command the lane must run immediately, and explicitly forbids `ListAgents`, sibling checks, memory writes, and any status report before the PR opens or a real blocker is hit.
- SKILL.md §4 gains a standing rule: verify a lane's worktree (`git status --short`, `git log --oneline -1`) before trusting an early report, and if it's empty, resume with a single literal next command rather than a general reminder — a first redirect was not always enough in practice; a second, maximally-literal one was.

No code changes; `.claude/skills/issue-lanes/{SKILL.md,references/lane-prompt.md}` only.

https://claude.ai/code/session_0189zbyhWR8tbZyjPFYqkYYv
