### PR TITLE
docs(skills): issue-lanes — derive each attestation digest with a visible pwd/HEAD check

### DIFF
--- a/.claude/skills/issue-lanes/SKILL.md
+++ b/.claude/skills/issue-lanes/SKILL.md
@@ -204,6 +204,13 @@ worktree right before attesting (its stderr already prints the exact `git-change
 <digest>` string the gate expects) rather than trusting an older CI log — a lane rebase
 changes the digest, so always re-derive it fresh.
 
+**When attesting multiple lanes, derive each digest as its OWN command with an explicit `cd`
+AND a visible `pwd && git rev-parse HEAD` in the SAME command** — do not fire off several
+digest-derivation commands back to back and read the outputs by position. A `cd`-less command
+silently inherits the previous call's leftover cwd (a real near-miss: one digest came back
+belonging to the wrong lane, caught only by cross-checking `pwd`/HEAD before trusting it).
+Confirm the printed path and HEAD sha match the lane you intend BEFORE recording, never after.
+
 Record AFTER the lane's final commit (a rebase changes the digest; recording does not). Use
 provider FAMILY tokens, not CLI names. Do not re-run the reviewer after attesting — it flags
 its own attestation shard as a pre-approval (known false positive; see the ceremony memory


### PR DESCRIPTION
## Summary

A follow-up commit meant for PR #922 landed on that branch after #922 had already merged, so it never reached `main`. Cherry-picking it here as its own small PR.

Adds a note to the attestation ceremony section (§4b): derive each lane's `tier-check` digest as its own command with an explicit `cd` and a visible `pwd && git rev-parse HEAD` check in the same command — not several digest-derivation calls read by position. A real near-miss this session: a `cd`-less command silently inherited the previous call's leftover cwd, and two digests were briefly read out of order and mislabeled before being caught by a `pwd`/HEAD cross-check.

No code changes; `.claude/skills/issue-lanes/SKILL.md` only.

https://claude.ai/code/session_0189zbyhWR8tbZyjPFYqkYYv
